### PR TITLE
Fix error stack trace creation

### DIFF
--- a/orm/src/db/session.ts
+++ b/orm/src/db/session.ts
@@ -7,9 +7,19 @@ export abstract class ISession {
   public constructor() {
   }
 
-  public abstract execute(query: string, values?: Array<any>): Promise<QueryResult<any>>;
+  public async execute(query: string, values?: Array<any>): Promise<QueryResult<any>> {
+    const error = new Error();
+    try {
+      return await this._execute(query, values);
+    } catch (e) {
+      error.message = e.message;
+      throw error;
+    }
+  }
 
   public abstract parametrized(num: number): string;
+
+  protected abstract _execute(query: string, values?: Array<any>): Promise<QueryResult<any>>;
 }
 
 export default class Session extends ISession {
@@ -17,11 +27,11 @@ export default class Session extends ISession {
     super();
   }
 
-  public async execute(query: string, values?: Array<any>): Promise<QueryResult<any>> {
-    return this.pool.query(query, values || []);
-  }
-
   public parametrized(num: number): string {
     return `$${num}`;
+  }
+
+  protected async _execute(query: string, values?: Array<any>): Promise<QueryResult<any>> {
+    return this.pool.query(query, values || []);
   }
 }

--- a/orm/tests/lowLevelbuilders/filters/filters.test.ts
+++ b/orm/tests/lowLevelbuilders/filters/filters.test.ts
@@ -10,7 +10,7 @@ let usersTable: UsersTable;
 let testSession: TestSession;
 
 class TestSession extends ISession {
-  public execute(query: string, values?: any[]): Promise<QueryResult<any>> {
+  public _execute(query: string, values?: any[]): Promise<QueryResult<any>> {
     return { rows: [] } as any;
   }
 

--- a/orm/tests/lowLevelbuilders/updates/updates.test.ts
+++ b/orm/tests/lowLevelbuilders/updates/updates.test.ts
@@ -9,7 +9,7 @@ let usersTable: UsersTable;
 let testSession: TestSession;
 
 class TestSession extends ISession {
-  public execute(query: string, values?: any[]): Promise<QueryResult<any>> {
+  public _execute(query: string, values?: any[]): Promise<QueryResult<any>> {
     return { rows: [] } as any;
   }
 

--- a/orm/tsconfig.json
+++ b/orm/tsconfig.json
@@ -6,7 +6,7 @@
   },
   "include": [
     "src",
-    "tests",
+    // "tests",
   ],
   "exclude": [
     "dist"


### PR DESCRIPTION
As long as pg driver was getting errors sync, we didn't have a possibility to use current context stacktrace with pg stacktrace