### PR TITLE
drizzle-orm-sqlite: Migration fixes

### DIFF
--- a/changelogs/drizzle-orm-sqlite/0.14.3.md
+++ b/changelogs/drizzle-orm-sqlite/0.14.3.md
@@ -1,0 +1,19 @@
+# drizzle-orm-sqlite 0.14.3
+
+- `RangeError: The supplied SQL string contains more than one statement` error on migrations was fixed
+
+    Created `.exec()` method for session, that will run query without prepared statments
+
+- Fix `defaultNow()` method query generation by adding missin `"()"`.
+
+    Previously default value was generated as 
+    ```sql
+    cast((julianday('now') - 2440587.5)*86400000 as integer)
+    ``` 
+    
+    Currently default value looks like
+    ```sql
+    (cast((julianday('now') - 2440587.5)*86400000 as integer))
+    ```
+
+- Create test cases for both issues

--- a/drizzle-orm-sqlite/package.json
+++ b/drizzle-orm-sqlite/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drizzle-orm-sqlite",
-	"version": "0.14.2",
+	"version": "0.14.3",
 	"description": "Drizzle ORM package for SQLite database",
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/drizzle-orm-sqlite/src/better-sqlite3/session.ts
+++ b/drizzle-orm-sqlite/src/better-sqlite3/session.ts
@@ -28,6 +28,10 @@ export class BetterSQLiteSession extends SQLiteSession<'sync', RunResult> {
 		this.logger = options.logger ?? new NoopLogger();
 	}
 
+	exec(query: string): void {
+		this.client.exec(query);
+	}
+
 	prepareQuery<T extends Omit<PreparedQueryConfig, 'run'>>(
 		query: Query,
 		fields?: SelectFieldsOrdered,

--- a/drizzle-orm-sqlite/src/bun/session.ts
+++ b/drizzle-orm-sqlite/src/bun/session.ts
@@ -29,6 +29,10 @@ export class SQLiteBunSession extends SQLiteSession<'sync', void> {
 		this.logger = options.logger ?? new NoopLogger();
 	}
 
+	exec(query: string): void {
+		this.client.exec(query);
+	}
+
 	prepareQuery<T extends Omit<PreparedQueryConfig, 'run'>>(
 		query: Query,
 		fields?: SelectFieldsOrdered,

--- a/drizzle-orm-sqlite/src/columns/integer.ts
+++ b/drizzle-orm-sqlite/src/columns/integer.ts
@@ -111,7 +111,7 @@ export class SQLiteTimestampBuilder<
 	 * Adds `DEFAULT (cast((julianday('now') - 2440587.5)*86400000 as integer))` to the column, which is the current epoch timestamp in milliseconds.
 	 */
 	defaultNow(): SQLiteTimestampBuilder<UpdateCBConfig<T, { hasDefault: true }>> {
-		return this.default(sql`cast((julianday('now') - 2440587.5)*86400000 as integer)`);
+		return this.default(sql`(cast((julianday('now') - 2440587.5)*86400000 as integer))`);
 	}
 
 	build<TTableName extends string>(table: AnySQLiteTable<{ name: TTableName }>): SQLiteTimestamp<

--- a/drizzle-orm-sqlite/src/d1/session.ts
+++ b/drizzle-orm-sqlite/src/d1/session.ts
@@ -27,6 +27,11 @@ export class SQLiteD1Session extends SQLiteSession<'async', D1Result> {
 		this.logger = options.logger ?? new NoopLogger();
 	}
 
+	exec(query: string): void {
+		throw Error('To implement: D1 migrator')
+		// await this.client.exec(query.sql);
+	}
+
 	prepareQuery(query: Query, fields?: SelectFieldsOrdered): PreparedQuery {
 		const stmt = this.client.prepare(query.sql);
 		return new PreparedQuery(stmt, query.sql, query.params, this.logger, fields);

--- a/drizzle-orm-sqlite/src/dialect.ts
+++ b/drizzle-orm-sqlite/src/dialect.ts
@@ -246,7 +246,7 @@ export class SQLiteSyncDialect extends SQLiteDialect {
 		try {
 			for (const migration of migrations) {
 				if (!lastDbMigration || parseInt(lastDbMigration[2], 10)! < migration.folderMillis) {
-					session.run(sql.raw(migration.sql));
+					session.exec(migration.sql);
 					session.run(
 						sql`INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES(${migration.hash}, ${migration.folderMillis})`,
 					);

--- a/drizzle-orm-sqlite/src/session.ts
+++ b/drizzle-orm-sqlite/src/session.ts
@@ -31,6 +31,10 @@ export abstract class SQLiteSession<TResultKind extends 'sync' | 'async' = 'sync
 		fields?: SelectFieldsOrdered,
 	): PreparedQuery<PreparedQueryConfig & { type: TResultKind }>;
 
+	abstract exec(
+		query: string,
+	): void;
+
 	run(query: SQL): ResultKind<TResultKind, TRunResult> {
 		return this.prepareQuery(this.dialect.sqlToQuery(query)).run();
 	}

--- a/integration-tests/drizzle/sqlite/20221207173503/migration.sql
+++ b/integration-tests/drizzle/sqlite/20221207173503/migration.sql
@@ -3,3 +3,9 @@ CREATE TABLE users12 (
 	`name` text NOT NULL,
 	`email` text NOT NULL
 );
+
+CREATE TABLE another_users (
+	`id` integer PRIMARY KEY,
+	`name` text NOT NULL,
+	`email` text NOT NULL
+);

--- a/integration-tests/tests/better-sqlite.test.ts
+++ b/integration-tests/tests/better-sqlite.test.ts
@@ -21,6 +21,12 @@ const usersMigratorTable = sqliteTable('users12', {
 	email: text('email').notNull(),
 });
 
+const anotherUsersMigratorTable = sqliteTable('another_users', {
+	id: integer('id').primaryKey(),
+	name: text('name').notNull(),
+	email: text('email').notNull(),
+});
+
 interface Context {
 	db: BetterSQLite3Database;
 	client: Database.Database;
@@ -45,7 +51,7 @@ test.beforeEach((t) => {
 			name text not null,
 			verified integer not null default 0,
 			json blob,
-			created_at integer not null default (floor((julianday('now') - 2440587.5)*86400000))
+			created_at integer not null default (cast((julianday('now') - 2440587.5)*86400000 as integer))
 		)`);
 });
 
@@ -497,10 +503,13 @@ test.serial('migrator', async (t) => {
 	migrate(db, { migrationsFolder: './drizzle/sqlite' });
 
 	db.insert(usersMigratorTable).values({ name: 'John', email: 'email' }).run();
-
 	const result = db.select(usersMigratorTable).all();
 
+	db.insert(anotherUsersMigratorTable).values({ name: 'John', email: 'email' }).run();
+	const result2 = db.select(usersMigratorTable).all();
+
 	t.deepEqual(result, [{ id: 1, name: 'John', email: 'email' }]);
+	t.deepEqual(result2, [{ id: 1, name: 'John', email: 'email' }]);
 });
 
 test.serial('insert via db.run + select via db.all', (t) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
     dependencies:
       better-sqlite3: 7.6.2
       dockerode: 3.3.4
-      drizzle-orm: file:drizzle-orm/package.tgz_nvwmy5aq64fcweoad4n35iq4qm
+      drizzle-orm: file:drizzle-orm/package.tgz_vekj7t2ase3yniyj3mvcf6ksf4
       drizzle-orm-mysql: file:drizzle-orm-mysql/package.tgz_s767x5publrgh4vua53mkue7ym
       drizzle-orm-pg: file:drizzle-orm-pg/package.tgz_fzgt734cttlavllcbzxmgocscm
       drizzle-orm-sqlite: file:drizzle-orm-sqlite/package.tgz_vunorlot2cxbdd7ycmrhpdaraq
@@ -3138,15 +3138,15 @@ packages:
       mysql2:
         optional: true
     dependencies:
-      drizzle-orm: file:drizzle-orm/package.tgz_nvwmy5aq64fcweoad4n35iq4qm
+      drizzle-orm: file:drizzle-orm/package.tgz_vekj7t2ase3yniyj3mvcf6ksf4
       mysql2: 2.3.3
     dev: false
 
   file:drizzle-orm-pg/package.tgz_fzgt734cttlavllcbzxmgocscm:
-    resolution: {integrity: sha512-QdeQg1IeFtrkn/TazRea1xzBbA4tZL1KTyRFbkLX1R8eveHqcMVlxZRzYtzdn68RZtjj3haOCbdQydEvCRuRTg==, tarball: file:drizzle-orm-pg/package.tgz}
+    resolution: {integrity: sha512-0nHIqQDvpXBBAzMNJbHsi5GonLoRtbZfoqvfuUcDPZqqwMg8bOCXJwzuxBMk6M9nhNvU0/gNGzBkIk/sg+lVvg==, tarball: file:drizzle-orm-pg/package.tgz}
     id: file:drizzle-orm-pg/package.tgz
     name: drizzle-orm-pg
-    version: 0.14.2
+    version: 0.14.3
     peerDependencies:
       '@types/pg': '>=8 <9'
       drizzle-orm: '>=0.14 <0.15'
@@ -3158,12 +3158,12 @@ packages:
         optional: true
     dependencies:
       '@types/pg': 8.6.5
-      drizzle-orm: file:drizzle-orm/package.tgz_nvwmy5aq64fcweoad4n35iq4qm
+      drizzle-orm: file:drizzle-orm/package.tgz_vekj7t2ase3yniyj3mvcf6ksf4
       pg: 8.8.0
     dev: false
 
   file:drizzle-orm-sqlite/package.tgz_vunorlot2cxbdd7ycmrhpdaraq:
-    resolution: {integrity: sha512-U/Pqk+D0DJt+GbnC/mEU73Iy5ArXscvIjlN8nzGKEnDSQcw4t6PXvJbTMXFDz3N/Vj7uzkE27lZav8oUR74jFw==, tarball: file:drizzle-orm-sqlite/package.tgz}
+    resolution: {integrity: sha512-M0s0UOzhLzcKrK2z57/0oehmZjsb4SnYcnfcd4Fh93phe3rv6pDQ9PjFLajE7Dbm5B8ARfiY9rqVYPyNp2ZrIA==, tarball: file:drizzle-orm-sqlite/package.tgz}
     id: file:drizzle-orm-sqlite/package.tgz
     name: drizzle-orm-sqlite
     version: 0.14.2
@@ -3185,11 +3185,11 @@ packages:
     dependencies:
       '@types/better-sqlite3': 7.6.2
       better-sqlite3: 7.6.2
-      drizzle-orm: file:drizzle-orm/package.tgz_nvwmy5aq64fcweoad4n35iq4qm
+      drizzle-orm: file:drizzle-orm/package.tgz_vekj7t2ase3yniyj3mvcf6ksf4
       sqlite3: 5.1.2
     dev: false
 
-  file:drizzle-orm/package.tgz_nvwmy5aq64fcweoad4n35iq4qm:
+  file:drizzle-orm/package.tgz_vekj7t2ase3yniyj3mvcf6ksf4:
     resolution: {integrity: sha512-Ek72LUeJxGNDD5psyfKMww0BlZzRM12LKw1oFUgJS6fdeENNiwfg3dwWeGk1fQLAFz32YRmS8YiHNXzl8e9FaA==, tarball: file:drizzle-orm/package.tgz}
     id: file:drizzle-orm/package.tgz
     name: drizzle-orm


### PR DESCRIPTION
1. Add exec for migrations
2. Add () for defaultNow casting