### PR TITLE
Update mysql migration docs

### DIFF
--- a/drizzle-orm/src/mysql-core/README.md
+++ b/drizzle-orm/src/mysql-core/README.md
@@ -718,6 +718,7 @@ const poolConnection = mysql.createPool({
   host: 'localhost',
   user: 'root',
   database: 'test',
+  multipleStatements: true,
 });
 
 const db = drizzle(poolConnection);


### PR DESCRIPTION
Without `multipleStatements: true`, any migrations that include multiple statements will fail (such as a migration that adds two tables, etc).