### PR TITLE
docs: Add D1 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ Drizzle ORM is being battle-tested on production projects by multiple teams 🚀
 | PostgreSQL  | ✅ | [Docs](./drizzle-orm/src/pg-core/README.md)|
 | MySQL       | ✅      |[Docs](./drizzle-orm/src/mysql-core/README.md)|
 | SQLite      | ✅      |[Docs](./drizzle-orm/src/sqlite-core/README.md)|
+| [Cloudflare D1](https://developers.cloudflare.com/d1) | ✅      |            | [Docs](./examples/cloudflare-d1/README.md)
 | DynamoDB    | ⏳      |            |
 | MS SQL      | ⏳      |            |
 | CockroachDB | ⏳      |            |
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Drizzle ORM is being battle-tested on production projects by multiple teams 🚀
 
 | Database    | Status | |
 |:------------|:-------:|:---|
-| PostgreSQL  | ✅ | [Docs](./drizzle-orm/src/pg-core/README.md)|
+| PostgreSQL  | ✅      | [Docs](./drizzle-orm/src/pg-core/README.md)|
 | MySQL       | ✅      |[Docs](./drizzle-orm/src/mysql-core/README.md)|
 | SQLite      | ✅      |[Docs](./drizzle-orm/src/sqlite-core/README.md)|
-| [Cloudflare D1](https://developers.cloudflare.com/d1) | ✅      |            | [Docs](./examples/cloudflare-d1/README.md)
+| [Cloudflare D1](https://developers.cloudflare.com/d1) | ✅      | [Docs](./examples/cloudflare-d1/README.md) |
 | DynamoDB    | ⏳      |            |
 | MS SQL      | ⏳      |            |
 | CockroachDB | ⏳      |            |


### PR DESCRIPTION
Added D1 to the README to distinguish from "native" SQLite, since D1 doesn't expose a raw SQLite connector (by design)

_Disclaimer_: I work at Cloudflare and we were talking about this project internally — fantastic work.