### PR TITLE
upgrade better-sqlite to 8.0.0

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -109,7 +109,7 @@
     "@types/node": "^18.11.9",
     "@types/pg": "^8.6.5",
     "@types/sql.js": "^1.4.4",
-    "better-sqlite3": "^7.6.2",
+    "better-sqlite3": "^8.0.0",
     "bun-types": "^0.5.0",
     "knex": "^2.4.2",
     "kysely": "^0.23.5",

--- a/examples/sqlite-proxy/package-lock.json
+++ b/examples/sqlite-proxy/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/express": "^4.17.16",
         "axios": "^1.3.0",
-        "better-sqlite3": "^7.6.2",
+        "better-sqlite3": "8.0.0",
         "drizzle-orm": "latest",
         "express": "^4.18.2"
       },
@@ -212,9 +212,9 @@
       ]
     },
     "node_modules/better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.0.0.tgz",
+      "integrity": "sha512-DhIPmhV+F3NBb9oGCNqNON8Cg4nP3/7NOwx412SL6JJUclYjAKmqNtbL6xBfG2RcG0uZWUS/TEHRy4AFLeq5Zg==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
@@ -2214,9 +2214,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "better-sqlite3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
-      "integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.0.0.tgz",
+      "integrity": "sha512-DhIPmhV+F3NBb9oGCNqNON8Cg4nP3/7NOwx412SL6JJUclYjAKmqNtbL6xBfG2RcG0uZWUS/TEHRy4AFLeq5Zg==",
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.0"

--- a/examples/sqlite-proxy/package.json
+++ b/examples/sqlite-proxy/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@types/express": "^4.17.16",
     "axios": "^1.3.0",
-    "better-sqlite3": "^7.6.2",
+    "better-sqlite3": "8.0.0",
     "drizzle-orm": "latest",
     "express": "^4.18.2"
   }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -42,7 +42,7 @@
 		"@aws-sdk/client-rds-data": "^3.257.0",
 		"@aws-sdk/credential-providers": "^3.258.0",
 		"@planetscale/database": "^1.5.0",
-		"better-sqlite3": "^7.6.2",
+		"better-sqlite3": "^8.0.0",
 		"dockerode": "^3.3.4",
 		"dotenv": "^16.0.3",
 		"drizzle-orm": "workspace:../drizzle-orm/dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
       '@types/node': ^18.11.9
       '@types/pg': ^8.6.5
       '@types/sql.js': ^1.4.4
-      better-sqlite3: ^7.6.2
+      better-sqlite3: ^8.0.0
       bun-types: ^0.5.0
       knex: ^2.4.2
       kysely: ^0.23.5
@@ -63,7 +63,7 @@ importers:
       '@types/node': 18.11.18
       '@types/pg': 8.6.6
       '@types/sql.js': 1.4.4
-      better-sqlite3: 7.6.2
+      better-sqlite3: 8.0.1
       bun-types: 0.5.4
       knex: 2.4.2_uvf4rh4xmredyjbq46jtk67wnu
       kysely: 0.23.5
@@ -123,7 +123,7 @@ importers:
       '@types/uuid': ^8.3.4
       ava: ^5.1.0
       axios: ^1.3.0
-      better-sqlite3: ^7.6.2
+      better-sqlite3: ^8.0.0
       dockerode: ^3.3.4
       dotenv: ^16.0.3
       drizzle-orm: workspace:../drizzle-orm/dist
@@ -142,7 +142,7 @@ importers:
       '@aws-sdk/client-rds-data': 3.262.0
       '@aws-sdk/credential-providers': 3.263.0
       '@planetscale/database': 1.5.0
-      better-sqlite3: 7.6.2
+      better-sqlite3: 8.0.1
       dockerode: 3.3.4
       dotenv: 16.0.3
       drizzle-orm: link:../drizzle-orm/dist
@@ -1963,13 +1963,6 @@ packages:
     dependencies:
       tweetnacl: 0.14.5
     dev: false
-
-  /better-sqlite3/7.6.2:
-    resolution: {integrity: sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.1
 
   /better-sqlite3/8.0.1:
     resolution: {integrity: sha512-JhTZjpyapA1icCEjIZB4TSSgkGdFgpWZA2Wszg7Cf4JwJwKQmbvuNnJBeR+EYG/Z29OXvR4G//Rbg31BW/Z7Yg==}
@@ -4401,7 +4394,7 @@ packages:
       tedious:
         optional: true
     dependencies:
-      better-sqlite3: 7.6.2
+      better-sqlite3: 8.0.1
       colorette: 2.0.19
       commander: 9.5.0
       debug: 4.3.4


### PR DESCRIPTION
I was having problems building drizzle for integration tests, with the command `pnpm i`. It was trying to build better-sqlite3 with an older version, and following a suggestion on Discord, moving to 8.0.0 seems to fix the issue.