### PR TITLE
[MySQL+Postgres] Add executeTakeFirst and executeTakeFirstOrThrow

### DIFF
--- a/drizzle-orm/src/mysql-core/query-builders/select.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.ts
@@ -363,6 +363,18 @@ export class MySqlSelect<
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {
 		return this._prepare().execute(placeholderValues);
 	};
+
+	executeTakeFirst = async (placeholderValues?: Record<string, unknown>) => {
+		return (await this.execute(placeholderValues)).at(0);
+	};
+
+	executeTakeFirstOrThrow = async (placeholderValues?: Record<string, unknown>) => {
+		const row = await this.executeTakeFirst(placeholderValues);
+		if (row === undefined) {
+			throw new Error('no result');
+		}
+		return row;
+	};
 }
 
 applyMixins(MySqlSelect, [QueryPromise]);

--- a/drizzle-orm/src/pg-core/query-builders/select.ts
+++ b/drizzle-orm/src/pg-core/query-builders/select.ts
@@ -356,6 +356,18 @@ export class PgSelect<
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {
 		return this._prepare().execute(placeholderValues);
 	};
+
+	executeTakeFirst = async (placeholderValues?: Record<string, unknown>) => {
+		return (await this.execute(placeholderValues)).at(0);
+	};
+
+	executeTakeFirstOrThrow = async (placeholderValues?: Record<string, unknown>) => {
+		const row = await this.executeTakeFirst(placeholderValues);
+		if (row === undefined) {
+			throw new Error('no result');
+		}
+		return row;
+	};
 }
 
 applyMixins(PgSelect, [QueryPromise]);

--- a/integration-tests/tests/mysql-schema.test.ts
+++ b/integration-tests/tests/mysql-schema.test.ts
@@ -138,7 +138,7 @@ test.beforeEach(async (t) => {
 		sql`create table \`mySchema\`.\`userstest\` (
 			\`id\` serial primary key,
 			\`name\` text not null,
-			\`verified\` boolean not null default false, 
+			\`verified\` boolean not null default false,
 			\`jsonb\` json,
 			\`created_at\` timestamp not null default now()
 		)`,
@@ -164,7 +164,7 @@ test.beforeEach(async (t) => {
 			\`date\` date,
 			\`date_as_string\` date,
 			\`time\` time,
-			\`datetime\` datetime, 
+			\`datetime\` datetime,
 			\`datetime_as_string\` datetime,
 			\`year\` year
 		)`,
@@ -183,6 +183,38 @@ test.serial('select all fields', async (t) => {
 	// not timezone based timestamp, thats why it should not work here
 	// t.assert(Math.abs(result[0]!.createdAt.getTime() - now) < 1000);
 	t.deepEqual(result, [{ id: 1, name: 'John', verified: false, jsonb: null, createdAt: result[0]!.createdAt }]);
+});
+
+test.serial('select empty executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, undefined);
+});
+
+test.serial('select full executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result!.createdAt });
+});
+
+test.serial('select empty executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await t.throwsAsync(() => db.select().from(usersTable).executeTakeFirstOrThrow());
+});
+
+test.serial('select full executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirstOrThrow();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result.createdAt });
 });
 
 test.serial('select sql', async (t) => {
@@ -647,7 +679,7 @@ test.serial('select from tables with same name from different schema using alias
 		sql`create table \`userstest\` (
 			\`id\` serial primary key,
 			\`name\` text not null,
-			\`verified\` boolean not null default false, 
+			\`verified\` boolean not null default false,
 			\`jsonb\` json,
 			\`created_at\` timestamp not null default now()
 		)`,

--- a/integration-tests/tests/mysql.custom.test.ts
+++ b/integration-tests/tests/mysql.custom.test.ts
@@ -198,7 +198,7 @@ test.beforeEach(async (t) => {
 		sql`create table \`userstest\` (
 			\`id\` serial primary key,
 			\`name\` text not null,
-			\`verified\` boolean not null default false, 
+			\`verified\` boolean not null default false,
 			\`jsonb\` json,
 			\`created_at\` timestamp not null default now()
 		)`,
@@ -209,7 +209,7 @@ test.beforeEach(async (t) => {
 			\`date\` date,
 			\`date_as_string\` date,
 			\`time\` time,
-			\`datetime\` datetime, 
+			\`datetime\` datetime,
 			\`datetime_as_string\` datetime,
 			\`year\` year
 		)`,
@@ -236,6 +236,38 @@ test.serial('select all fields', async (t) => {
 	// not timezone based timestamp, thats why it should not work here
 	// t.assert(Math.abs(result[0]!.createdAt.getTime() - now) < 1000);
 	t.deepEqual(result, [{ id: 1, name: 'John', verified: false, jsonb: null, createdAt: result[0]!.createdAt }]);
+});
+
+test.serial('select empty executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, undefined);
+});
+
+test.serial('select full executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result!.createdAt });
+});
+
+test.serial('select empty executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await t.throwsAsync(() => db.select().from(usersTable).executeTakeFirstOrThrow());
+});
+
+test.serial('select full executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirstOrThrow();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result.createdAt });
 });
 
 test.serial('select sql', async (t) => {

--- a/integration-tests/tests/mysql.test.ts
+++ b/integration-tests/tests/mysql.test.ts
@@ -172,7 +172,7 @@ test.beforeEach(async (t) => {
 		sql`create table \`userstest\` (
 			\`id\` serial primary key,
 			\`name\` text not null,
-			\`verified\` boolean not null default false, 
+			\`verified\` boolean not null default false,
 			\`jsonb\` json,
 			\`created_at\` timestamp not null default now()
 		)`,
@@ -206,6 +206,38 @@ test.serial('select all fields', async (t) => {
 	// not timezone based timestamp, thats why it should not work here
 	// t.assert(Math.abs(result[0]!.createdAt.getTime() - now) < 1000);
 	t.deepEqual(result, [{ id: 1, name: 'John', verified: false, jsonb: null, createdAt: result[0]!.createdAt }]);
+});
+
+test.serial('select empty executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, undefined);
+});
+
+test.serial('select full executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result!.createdAt });
+});
+
+test.serial('select empty executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await t.throwsAsync(() => db.select().from(usersTable).executeTakeFirstOrThrow());
+});
+
+test.serial('select full executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirstOrThrow();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result.createdAt });
 });
 
 test.serial('select sql', async (t) => {

--- a/integration-tests/tests/pg-schema.test.ts
+++ b/integration-tests/tests/pg-schema.test.ts
@@ -125,7 +125,7 @@ test.beforeEach(async (t) => {
 		sql`create table "mySchema".users (
 			id serial primary key,
 			name text not null,
-			verified boolean not null default false, 
+			verified boolean not null default false,
 			jsonb jsonb,
 			created_at timestamptz not null default now()
 		)`,
@@ -157,6 +157,38 @@ test.serial('select all fields', async (t) => {
 	t.assert(result[0]!.createdAt instanceof Date);
 	t.assert(Math.abs(result[0]!.createdAt.getTime() - now) < 100);
 	t.deepEqual(result, [{ id: 1, name: 'John', verified: false, jsonb: null, createdAt: result[0]!.createdAt }]);
+});
+
+test.serial('select empty executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, undefined);
+});
+
+test.serial('select full executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result!.createdAt });
+});
+
+test.serial('select empty executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await t.throwsAsync(() => db.select().from(usersTable).executeTakeFirstOrThrow());
+});
+
+test.serial('select full executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirstOrThrow();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result.createdAt });
 });
 
 test.serial('select sql', async (t) => {
@@ -695,7 +727,7 @@ test.serial('select from tables with same name from different schema using alias
 		sql`create table users (
 			id serial primary key,
 			name text not null,
-			verified boolean not null default false, 
+			verified boolean not null default false,
 			jsonb jsonb,
 			created_at timestamptz not null default now()
 		)`,

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -148,7 +148,7 @@ test.beforeEach(async (t) => {
 		sql`create table users (
 			id serial primary key,
 			name text not null,
-			verified boolean not null default false, 
+			verified boolean not null default false,
 			jsonb jsonb,
 			created_at timestamptz not null default now()
 		)`,
@@ -166,6 +166,38 @@ test.serial('select all fields', async (t) => {
 	t.assert(result[0]!.createdAt instanceof Date);
 	t.assert(Math.abs(result[0]!.createdAt.getTime() - now) < 100);
 	t.deepEqual(result, [{ id: 1, name: 'John', verified: false, jsonb: null, createdAt: result[0]!.createdAt }]);
+});
+
+test.serial('select empty executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, undefined);
+});
+
+test.serial('select full executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result!.createdAt });
+});
+
+test.serial('select empty executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await t.throwsAsync(() => db.select().from(usersTable).executeTakeFirstOrThrow());
+});
+
+test.serial('select full executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirstOrThrow();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result.createdAt });
 });
 
 test.serial('select sql', async (t) => {

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -176,7 +176,7 @@ test.beforeEach(async (t) => {
 		sql`create table users (
 			id serial primary key,
 			name text not null,
-			verified boolean not null default false, 
+			verified boolean not null default false,
 			jsonb jsonb,
 			created_at timestamptz not null default now()
 		)`,
@@ -252,6 +252,38 @@ test.serial('select all fields', async (t) => {
 	t.deepEqual(result, [
 		{ id: 1, name: 'John', verified: false, jsonb: null, createdAt: result[0]!.createdAt },
 	]);
+});
+
+test.serial('select empty executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, undefined);
+});
+
+test.serial('select full executeTakeFirst', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirst();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result!.createdAt });
+});
+
+test.serial('select empty executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await t.throwsAsync(() => db.select().from(usersTable).executeTakeFirstOrThrow());
+});
+
+test.serial('select full executeTakeFirstOrThrow', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db.select().from(usersTable).executeTakeFirstOrThrow();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result.createdAt });
 });
 
 test.serial('select sql', async (t) => {


### PR DESCRIPTION
This PR adds `executeTakeFirst ` and `executeTakeFirstOrThrow` methods to the Select query builder for both MySQL and Postgres. These are convenience methods for when you only want a single row, and for when you know that a row should always exist.

Tests have been added for cases where there both is and is not a row returned.