### PR TITLE
shows use of AnySQLiteColumn for self-referencing foreign key

### DIFF
--- a/drizzle-orm/src/mysql-core/README.md
+++ b/drizzle-orm/src/mysql-core/README.md
@@ -237,7 +237,7 @@ export async function insertUser(user: NewUser): Promise<MySqlRawQueryResult> {
 
 ```typescript
 // db.ts
-import { foreignKey, index, int, mysqlTable, serial, uniqueIndex, varchar } from 'drizzle-orm/mysql-core';
+import { foreignKey, index, int, mysqlTable, serial, uniqueIndex, varchar, AnyMySqlColumn } from 'drizzle-orm/mysql-core';
 
 export const countries = mysqlTable('countries', {
     id: serial('id').primaryKey(),
@@ -255,6 +255,7 @@ export const cities = mysqlTable('cities', {
   name: varchar('name', { length: 256 }),
   countryId: int('country_id').references(() => countries.id), // inline foreign key
   countryName: varchar('country_id', { length: 256 }),
+  sisterCityId: integer('sister_city_id').references((): AnyMySqlColumn => cities.id), // self-referencing foreign key
 }, (cities) => ({
   // explicit foreign key with 1 column
   countryFk: foreignKey(({

--- a/drizzle-orm/src/pg-core/README.md
+++ b/drizzle-orm/src/pg-core/README.md
@@ -226,7 +226,7 @@ export async function insertUser(user: NewUser): Promise<User> {
 ### Declaring indexes, foreign keys and composite primary keys
 
 ```typescript
-import { foreignKey, index, uniqueIndex, integer, pgTable, serial, varchar } from 'drizzle-orm/pg-core';
+import { foreignKey, index, uniqueIndex, integer, pgTable, serial, varchar, AnyPgColumn } from 'drizzle-orm/pg-core';
 
 export const countries = pgTable('countries', {
     id: serial('id').primaryKey(),
@@ -246,6 +246,7 @@ export const cities = pgTable('cities', {
   name: varchar('name', { length: 256 }),
   countryId: integer('country_id').references(() => countries.id), // inline foreign key
   countryName: varchar('country_id'),
+  sisterCityId: integer('sister_city_id').references((): AnyPgColumn => cities.id), // self-referencing foreign key
 }, (cities) => {
   return {
     // explicit foreign key with 1 column

--- a/drizzle-orm/src/sqlite-core/README.md
+++ b/drizzle-orm/src/sqlite-core/README.md
@@ -246,7 +246,7 @@ const users = sqliteTable('users', {
 Declaring indexes, foreign keys and composite primary keys
 
 ```typescript
-import { sqliteTable, foreignKey, primaryKey, text, integer, index, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { sqliteTable, foreignKey, primaryKey, text, integer, index, uniqueIndex, AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 
 export const countries = sqliteTable('countries', {
     id: integer('id').primaryKey(),
@@ -264,6 +264,7 @@ export const cities = sqliteTable('cities', {
   name: text('name', { length: 256 }),
   countryId: integer('country_id').references(() => countries.id), // inline foreign key
   countryName: text('country_id'),
+  sisterCityId: integer('sister_city_id').references((): AnySQLiteColumn => cities.id), // self-referencing foreign key
 }, (cities) => ({
   // explicit foreign key with 1 column
   countryFk: foreignKey(() => ({


### PR DESCRIPTION
Didn't know this was possible until seeing [this discord thread](https://discordapp.com/channels/1043890932593987624/1092514104201195521/1092515993034686495). Thought it would be helpful to have an example in docs (was previously resorting to separate FK because due to type error).