### PR TITLE
Add import line to quickstart docs for mysql-core

### DIFF
--- a/drizzle-orm/src/mysql-core/README.md
+++ b/drizzle-orm/src/mysql-core/README.md
@@ -65,6 +65,8 @@ With `drizzle-orm` you declare SQL schema in TypeScript. You can have either one
 
 ```typescript
 // schema.ts
+import { mysqlTable, serial, varchar } from "drizzle-orm/mysql-core";
+
 export const users = mysqlTable('users', {
   id: serial('id').primaryKey(),
   fullName: text('full_name'),


### PR DESCRIPTION
Added an import line to quickstart docs - I had to fish around a bit to find this when I was first getting started.