### PR TITLE
TypeScript fix `InferModel` location in bun example

### DIFF
--- a/examples/bun-sqlite/src/schema.ts
+++ b/examples/bun-sqlite/src/schema.ts
@@ -1,4 +1,4 @@
-import type { InferModel} from 'drizzle-orm/sqlite-core';
+import type { InferModel } from 'drizzle-orm';
 import { foreignKey, integer, numeric, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 export const customers = sqliteTable('customer', {


### PR DESCRIPTION
Type declarations location changed.

### Before

<img width="606" alt="Screenshot showing red line under method name to indicate a typescript error" src="https://user-images.githubusercontent.com/27637/230718459-3dc88eb4-3500-4325-8fcc-2aeaa90a283f.png">

### After

<img width="595" alt="Screenshot showing previous image without red line" src="https://user-images.githubusercontent.com/27637/230718453-cc7c0ff1-f25e-4a52-af50-0872f9c1bdda.png">
