### PR TITLE
[MySql] Update `binary` and `varbinary` Column Types to `Buffer`

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -15,8 +15,8 @@ export interface MySqlBinaryHKT extends ColumnHKTBase {
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
 	name: TName;
-	data: string;
-	driverParam: number | string;
+	data: Buffer;
+	driverParam: Buffer | string;
 	notNull: false;
 	hasDefault: false;
 }>;

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -15,8 +15,8 @@ export interface MySqlVarBinaryHKT extends ColumnHKTBase {
 
 export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
 	name: TName;
-	data: number;
-	driverParam: number | string;
+	data: Buffer;
+	driverParam: Buffer | string;
 	notNull: false;
 	hasDefault: false;
 }>;


### PR DESCRIPTION
The mysql2 library [parses `binary` & `varbinary` columns as `Buffer`](https://github.com/mysqljs/mysql#buffer). 

They also automatically convert [Buffers to hex strings](https://github.com/mysqljs/mysql#escaping-query-values), so passing those in to a query is escaped correctly.