### PR TITLE
[SQLite] Fix onConflict targets

### DIFF
--- a/drizzle-orm/src/sqlite-core/README.md
+++ b/drizzle-orm/src/sqlite-core/README.md
@@ -514,6 +514,25 @@ const newUsers: NewUser[] = [
 db.insert(users).values(newUsers).run();
 ```
 
+### Upsert (Insert with on conflict statement)
+
+```typescript
+db.insert(users)
+  .values({ id: 1, name: 'Dan' })
+  .onConflictDoUpdate({ target: users.id, set: { name: 'John' } })
+  .run();
+
+db.insert(users)
+  .values({ id: 1, name: 'John' })
+  .onConflictDoNothing()
+  .run();
+
+db.insert(users)
+  .values({ id: 1, name: 'John' })
+  .onConflictDoNothing({ target: users.id })
+  .run();
+```
+
 ### Update and Delete
 
 ```typescript

--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -135,7 +135,7 @@ export class SQLiteInsert<
 	}): this {
 		const whereSql = config.where ? sql` where ${config.where}` : sql``;
 		const setSql = this.dialect.buildUpdateSet(this.config.table, mapUpdateSet(this.config.table, config.set));
-		this.config.onConflict = sql`${config.target}${whereSql} do update set ${setSql}`;
+		this.config.onConflict = sql`(${config.target})${whereSql} do update set ${setSql}`;
 		return this;
 	}
 

--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -123,7 +123,7 @@ export class SQLiteInsert<
 			this.config.onConflict = sql`do nothing`;
 		} else {
 			const whereSql = config.where ? sql` where ${config.where}` : sql``;
-			this.config.onConflict = sql`${config.target}${whereSql} do nothing`;
+			this.config.onConflict = sql`(${config.target})${whereSql} do nothing`;
 		}
 		return this;
 	}

--- a/integration-tests/tests/better-sqlite.test.ts
+++ b/integration-tests/tests/better-sqlite.test.ts
@@ -1466,3 +1466,23 @@ test.serial('join view as subquery', (t) => {
 	db.run(sql`drop view ${newYorkers}`);
 	db.run(sql`drop table ${users}`);
 });
+
+test.serial('insert with onConflict do update', (t) => {
+	const { db } = t.context;
+
+	db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoUpdate({ target: usersTable.id, set: { name: 'John1' }})
+		.run();
+
+	const res = db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John1' }]);
+});

--- a/integration-tests/tests/better-sqlite.test.ts
+++ b/integration-tests/tests/better-sqlite.test.ts
@@ -1467,6 +1467,46 @@ test.serial('join view as subquery', (t) => {
 	db.run(sql`drop table ${users}`);
 });
 
+test.serial('insert with onConflict do nothing', (t) => {
+	const { db } = t.context;
+
+	db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing()
+		.run();
+
+	const res = db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('insert with onConflict do nothing using target', (t) => {
+	const { db } = t.context;
+
+	db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing({ target: usersTable.id })
+		.run();
+
+	const res = db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
 test.serial('insert with onConflict do update', (t) => {
 	const { db } = t.context;
 

--- a/integration-tests/tests/libsql.test.ts
+++ b/integration-tests/tests/libsql.test.ts
@@ -1424,6 +1424,46 @@ test.serial('join view as subquery', async (t) => {
 	await db.run(sql`drop table ${users}`);
 });
 
+test.serial('insert with onConflict do nothing', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	await db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing()
+		.run();
+
+	const res = await db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('insert with onConflict do nothing using target', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	await db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing({ target: usersTable.id })
+		.run();
+
+	const res = await db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
 test.serial('insert with onConflict do update', async (t) => {
 	const { db } = t.context;
 

--- a/integration-tests/tests/libsql.test.ts
+++ b/integration-tests/tests/libsql.test.ts
@@ -1423,3 +1423,23 @@ test.serial('join view as subquery', async (t) => {
 	await db.run(sql`drop view ${newYorkers}`);
 	await db.run(sql`drop table ${users}`);
 });
+
+test.serial('insert with onConflict do update', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	await db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoUpdate({ target: usersTable.id, set: { name: 'John1' }})
+		.run();
+
+	const res = await db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John1' }]);
+});

--- a/integration-tests/tests/sql.js.test.ts
+++ b/integration-tests/tests/sql.js.test.ts
@@ -1404,3 +1404,23 @@ test.serial('join view as subquery', (t) => {
 	db.run(sql`drop view ${newYorkers}`);
 	db.run(sql`drop table ${users}`);
 });
+
+test.serial('insert with onConflict do update', (t) => {
+	const { db } = t.context;
+
+	db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoUpdate({ target: usersTable.id, set: { name: 'John1' }})
+		.run();
+
+	const res = db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John1' }]);
+});

--- a/integration-tests/tests/sql.js.test.ts
+++ b/integration-tests/tests/sql.js.test.ts
@@ -1405,6 +1405,46 @@ test.serial('join view as subquery', (t) => {
 	db.run(sql`drop table ${users}`);
 });
 
+test.serial('insert with onConflict do nothing', (t) => {
+	const { db } = t.context;
+
+	db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing()
+		.run();
+
+	const res = db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('insert with onConflict do nothing using target', (t) => {
+	const { db } = t.context;
+
+	db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing({ target: usersTable.id })
+		.run();
+
+	const res = db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
 test.serial('insert with onConflict do update', (t) => {
 	const { db } = t.context;
 

--- a/integration-tests/tests/sqlite-proxy.test.ts
+++ b/integration-tests/tests/sqlite-proxy.test.ts
@@ -708,6 +708,46 @@ test.after.always((t) => {
 	ctx.client?.close();
 });
 
+test.serial('insert with onConflict do nothing', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	await db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing()
+		.run();
+
+	const res = await db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('insert with onConflict do nothing using target', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	await db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing({ target: usersTable.id })
+		.run();
+
+	const res = await db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
 test.serial('insert with onConflict do update', async (t) => {
 	const { db } = t.context;
 

--- a/integration-tests/tests/sqlite-proxy.test.ts
+++ b/integration-tests/tests/sqlite-proxy.test.ts
@@ -707,3 +707,23 @@ test.after.always((t) => {
 	const ctx = t.context;
 	ctx.client?.close();
 });
+
+test.serial('insert with onConflict do update', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	await db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoUpdate({ target: usersTable.id, set: { name: 'John1' }})
+		.run();
+
+	const res = await db
+		.select({ id: usersTable.id, name: usersTable.name})
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+		t.deepEqual(res, [{ id: 1, name: 'John1' }]);
+});


### PR DESCRIPTION
As reported in #410 upserts are failing when using SQLite. @krzysztofciombor already identified the root cause (missing parentheses around the target), this PR delivers the proposed fix and corresponding tests.