### PR TITLE
Return records when no mapped fields present.

### DIFF
--- a/drizzle-orm/src/aws-data-api/pg/session.ts
+++ b/drizzle-orm/src/aws-data-api/pg/session.ts
@@ -58,7 +58,8 @@ export class AwsDataApiPreparedQuery<T extends PreparedQueryConfig> extends Prep
 
 		const { fields, rawQuery, client, joinsNotNullableMap } = this;
 		if (!fields) {
-			return await client.send(rawQuery);
+			const result = await client.send(rawQuery);
+			return result.records;
 		}
 
 		const result = await client.send(rawQuery);

--- a/drizzle-orm/src/aws-data-api/pg/session.ts
+++ b/drizzle-orm/src/aws-data-api/pg/session.ts
@@ -59,7 +59,7 @@ export class AwsDataApiPreparedQuery<T extends PreparedQueryConfig> extends Prep
 		const { fields, rawQuery, client, joinsNotNullableMap } = this;
 		if (!fields) {
 			const result = await client.send(rawQuery);
-			return result.records;
+			return result.records ?? [];
 		}
 
 		const result = await client.send(rawQuery);


### PR DESCRIPTION
Running migrate() when using a AWS Data API connection fails, as it attempts to re-run the most recently applied migration.

Addresses https://github.com/drizzle-team/drizzle-orm/issues/509