### PR TITLE
Add sideEffects: false to package.json

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -14,6 +14,7 @@
   "main": "./index.cjs",
   "module": "./index.mjs",
   "types": "./index.d.ts",
+  "sideEffects": false,
   "publishConfig": {
     "provenance": true
   },


### PR DESCRIPTION
This adds the key `"sideEffects": false` to the package.json of drizzle-orm. The intent is that, when using Webpack, parcel, vite, or rollup, the `sideEffects` property allows the bundler to tree-shake unused parts of the module. Also, when using Remix, this key allows the [automatic server-code extraction](https://remix.run/docs/en/1.15.0/pages/gotchas#server-code-in-client-bundles) to omit drizzle-orm from bundles for the client.