### PR TITLE
[SQLite] Fix upsert targeting composite keys

### DIFF
--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -116,20 +116,22 @@ export class SQLiteInsert<
 		if (config.target === undefined) {
 			this.config.onConflict = sql`do nothing`;
 		} else {
+			const targetSql = Array.isArray(config.target) ? sql`${config.target}` : sql`${[config.target]}`;
 			const whereSql = config.where ? sql` where ${config.where}` : sql``;
-			this.config.onConflict = sql`(${config.target})${whereSql} do nothing`;
+			this.config.onConflict = sql`${targetSql}${whereSql} do nothing`;
 		}
 		return this;
 	}
 
 	onConflictDoUpdate(config: {
-		target?: IndexColumn | IndexColumn[];
+		target: IndexColumn | IndexColumn[];
 		where?: SQL;
 		set: SQLiteUpdateSetSource<TTable>;
 	}): this {
+		const targetSql = Array.isArray(config.target) ? sql`${config.target}` : sql`${[config.target]}`;
 		const whereSql = config.where ? sql` where ${config.where}` : sql``;
 		const setSql = this.dialect.buildUpdateSet(this.config.table, mapUpdateSet(this.config.table, config.set));
-		this.config.onConflict = sql`(${config.target})${whereSql} do update set ${setSql}`;
+		this.config.onConflict = sql`${targetSql}${whereSql} do update set ${setSql}`;
 		return this;
 	}
 

--- a/integration-tests/tests/better-sqlite.test.ts
+++ b/integration-tests/tests/better-sqlite.test.ts
@@ -71,8 +71,8 @@ const anotherUsersMigratorTable = sqliteTable('another_users', {
 	email: text('email').notNull(),
 });
 
-const _pkExample = sqliteTable('pk_example', {
-	id: integer('id').primaryKey(),
+const pkExampleTable = sqliteTable('pk_example', {
+	id: integer('id').notNull(),
 	name: text('name').notNull(),
 	email: text('email').notNull(),
 }, (table) => ({
@@ -113,6 +113,7 @@ test.beforeEach((t) => {
 	ctx.db.run(sql`drop table if exists ${coursesTable}`);
 	ctx.db.run(sql`drop table if exists ${courseCategoriesTable}`);
 	ctx.db.run(sql`drop table if exists ${orders}`);
+	ctx.db.run(sql`drop table if exists ${pkExampleTable}`);
 
 	ctx.db.run(sql`
 		create table ${usersTable} (
@@ -156,6 +157,14 @@ test.beforeEach((t) => {
 			product text not null,
 			amount integer not null,
 			quantity integer not null
+		)
+	`);
+	ctx.db.run(sql`
+		create table ${pkExampleTable} (
+			id integer not null,
+			name text not null,
+			email text not null,
+			primary key (id, name)
 		)
 	`);
 });
@@ -1531,6 +1540,29 @@ test.serial('insert with onConflict do nothing', (t) => {
 	t.deepEqual(res, [{ id: 1, name: 'John' }]);
 });
 
+test.serial('insert with onConflict do nothing using composite pk', (t) => {
+	const { db } = t.context;
+
+	db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john@example.com' })
+		.run();
+
+	db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john1@example.com' })
+		.onConflictDoNothing()
+		.run();
+
+	const res = db
+		.select({ id: pkExampleTable.id, name: pkExampleTable.name, email: pkExampleTable.email })
+		.from(pkExampleTable)
+		.where(eq(pkExampleTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John', email: 'john@example.com' }]);
+});
+
 test.serial('insert with onConflict do nothing using target', (t) => {
 	const { db } = t.context;
 
@@ -1551,6 +1583,29 @@ test.serial('insert with onConflict do nothing using target', (t) => {
 	t.deepEqual(res, [{ id: 1, name: 'John' }]);
 });
 
+test.serial('insert with onConflict do nothing using composite pk as target', (t) => {
+	const { db } = t.context;
+
+	db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john@example.com' })
+		.run();
+
+	db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john1@example.com' })
+		.onConflictDoNothing({ target: [pkExampleTable.id, pkExampleTable.name] })
+		.run();
+
+	const res = db
+		.select({ id: pkExampleTable.id, name: pkExampleTable.name, email: pkExampleTable.email })
+		.from(pkExampleTable)
+		.where(eq(pkExampleTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John', email: 'john@example.com' }]);
+});
+
 test.serial('insert with onConflict do update', (t) => {
 	const { db } = t.context;
 
@@ -1569,6 +1624,26 @@ test.serial('insert with onConflict do update', (t) => {
 		.all();
 
 	t.deepEqual(res, [{ id: 1, name: 'John1' }]);
+});
+
+test.serial('insert with onConflict do update using composite pk', (t) => {
+	const { db } = t.context;
+
+	db.insert(pkExampleTable).values({ id: 1, name: 'John', email: 'john@example.com' }).run();
+
+	db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john@example.com' })
+		.onConflictDoUpdate({ target: [pkExampleTable.id, pkExampleTable.name], set: { email: 'john1@example.com' } })
+		.run();
+
+	const res = db
+		.select({ id: pkExampleTable.id, name: pkExampleTable.name, email: pkExampleTable.email })
+		.from(pkExampleTable)
+		.where(eq(pkExampleTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John', email: 'john1@example.com' }]);
 });
 
 test.serial('insert undefined', (t) => {

--- a/integration-tests/tests/libsql.test.ts
+++ b/integration-tests/tests/libsql.test.ts
@@ -89,8 +89,8 @@ const anotherUsersMigratorTable = sqliteTable('another_users', {
 	email: text('email').notNull(),
 });
 
-const _pkExample = sqliteTable('pk_example', {
-	id: integer('id').primaryKey(),
+const pkExampleTable = sqliteTable('pk_example', {
+	id: integer('id').notNull(),
 	name: text('name').notNull(),
 	email: text('email').notNull(),
 }, (table) => ({
@@ -139,6 +139,7 @@ test.beforeEach(async (t) => {
 	await ctx.db.run(sql`drop table if exists ${coursesTable}`);
 	await ctx.db.run(sql`drop table if exists ${courseCategoriesTable}`);
 	await ctx.db.run(sql`drop table if exists ${orders}`);
+	await ctx.db.run(sql`drop table if exists ${pkExampleTable}`);
 
 	await ctx.db.run(sql`
 		create table ${usersTable} (
@@ -184,6 +185,14 @@ test.beforeEach(async (t) => {
 			product text not null,
 			amount integer not null,
 			quantity integer not null
+		)
+	`);
+	await ctx.db.run(sql`
+		create table ${pkExampleTable} (
+			id integer not null,
+			name text not null,
+			email text not null,
+			primary key (id, name)
 		)
 	`);
 });
@@ -1497,6 +1506,29 @@ test.serial('insert with onConflict do nothing', async (t) => {
 	t.deepEqual(res, [{ id: 1, name: 'John' }]);
 });
 
+test.serial('insert with onConflict do nothing using composite pk', async (t) => {
+	const { db } = t.context;
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john@example.com' })
+		.run();
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john1@example.com' })
+		.onConflictDoNothing()
+		.run();
+
+	const res = await db
+		.select({ id: pkExampleTable.id, name: pkExampleTable.name, email: pkExampleTable.email })
+		.from(pkExampleTable)
+		.where(eq(pkExampleTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John', email: 'john@example.com' }]);
+});
+
 test.serial('insert with onConflict do nothing using target', async (t) => {
 	const { db } = t.context;
 
@@ -1517,6 +1549,29 @@ test.serial('insert with onConflict do nothing using target', async (t) => {
 	t.deepEqual(res, [{ id: 1, name: 'John' }]);
 });
 
+test.serial('insert with onConflict do nothing using composite pk as target', async (t) => {
+	const { db } = t.context;
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john@example.com' })
+		.run();
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john1@example.com' })
+		.onConflictDoNothing({ target: [pkExampleTable.id, pkExampleTable.name] })
+		.run();
+
+	const res = await db
+		.select({ id: pkExampleTable.id, name: pkExampleTable.name, email: pkExampleTable.email })
+		.from(pkExampleTable)
+		.where(eq(pkExampleTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John', email: 'john@example.com' }]);
+});
+
 test.serial('insert with onConflict do update', async (t) => {
 	const { db } = t.context;
 
@@ -1535,6 +1590,26 @@ test.serial('insert with onConflict do update', async (t) => {
 		.all();
 
 	t.deepEqual(res, [{ id: 1, name: 'John1' }]);
+});
+
+test.serial('insert with onConflict do update using composite pk', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(pkExampleTable).values({ id: 1, name: 'John', email: 'john@example.com' }).run();
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john@example.com' })
+		.onConflictDoUpdate({ target: [pkExampleTable.id, pkExampleTable.name], set: { email: 'john1@example.com' } })
+		.run();
+
+	const res = await db
+		.select({ id: pkExampleTable.id, name: pkExampleTable.name, email: pkExampleTable.email })
+		.from(pkExampleTable)
+		.where(eq(pkExampleTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John', email: 'john1@example.com' }]);
 });
 
 test.serial('insert undefined', async (t) => {

--- a/integration-tests/tests/sqlite-proxy.test.ts
+++ b/integration-tests/tests/sqlite-proxy.test.ts
@@ -76,8 +76,8 @@ const anotherUsersMigratorTable = sqliteTable('another_users', {
 	email: text('email').notNull(),
 });
 
-const _pkExample = sqliteTable('pk_example', {
-	id: integer('id').primaryKey(),
+const pkExampleTable = sqliteTable('pk_example', {
+	id: integer('id').notNull(),
 	name: text('name').notNull(),
 	email: text('email').notNull(),
 }, (table) => ({
@@ -118,14 +118,24 @@ test.before((t) => {
 
 test.beforeEach(async (t) => {
 	const ctx = t.context;
-	ctx.db.run(sql`drop table if exists ${usersTable}`);
-	ctx.db.run(sql`
+	await ctx.db.run(sql`drop table if exists ${usersTable}`);
+	await ctx.db.run(sql`drop table if exists ${pkExampleTable}`);
+
+	await ctx.db.run(sql`
 		create table ${usersTable} (
 			id integer primary key,
 			name text not null,
 			verified integer not null default 0,
 			json blob,
 			created_at integer not null default (strftime('%s', 'now'))
+		)
+	`);
+	await ctx.db.run(sql`
+		create table ${pkExampleTable} (
+			id integer not null,
+			name text not null,
+			email text not null,
+			primary key (id, name)
 		)
 	`);
 });
@@ -764,6 +774,29 @@ test.serial('insert with onConflict do nothing', async (t) => {
 	t.deepEqual(res, [{ id: 1, name: 'John' }]);
 });
 
+test.serial('insert with onConflict do nothing using composite pk', async (t) => {
+	const { db } = t.context;
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john@example.com' })
+		.run();
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john1@example.com' })
+		.onConflictDoNothing()
+		.run();
+
+	const res = await db
+		.select({ id: pkExampleTable.id, name: pkExampleTable.name, email: pkExampleTable.email })
+		.from(pkExampleTable)
+		.where(eq(pkExampleTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John', email: 'john@example.com' }]);
+});
+
 test.serial('insert with onConflict do nothing using target', async (t) => {
 	const { db } = t.context;
 
@@ -784,6 +817,29 @@ test.serial('insert with onConflict do nothing using target', async (t) => {
 	t.deepEqual(res, [{ id: 1, name: 'John' }]);
 });
 
+test.serial('insert with onConflict do nothing using composite pk as target', async (t) => {
+	const { db } = t.context;
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john@example.com' })
+		.run();
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john1@example.com' })
+		.onConflictDoNothing({ target: [pkExampleTable.id, pkExampleTable.name] })
+		.run();
+
+	const res = await db
+		.select({ id: pkExampleTable.id, name: pkExampleTable.name, email: pkExampleTable.email })
+		.from(pkExampleTable)
+		.where(eq(pkExampleTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John', email: 'john@example.com' }]);
+});
+
 test.serial('insert with onConflict do update', async (t) => {
 	const { db } = t.context;
 
@@ -802,6 +858,26 @@ test.serial('insert with onConflict do update', async (t) => {
 		.all();
 
 	t.deepEqual(res, [{ id: 1, name: 'John1' }]);
+});
+
+test.serial('insert with onConflict do update using composite pk', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(pkExampleTable).values({ id: 1, name: 'John', email: 'john@example.com' }).run();
+
+	await db
+		.insert(pkExampleTable)
+		.values({ id: 1, name: 'John', email: 'john@example.com' })
+		.onConflictDoUpdate({ target: [pkExampleTable.id, pkExampleTable.name], set: { email: 'john1@example.com' } })
+		.run();
+
+	const res = await db
+		.select({ id: pkExampleTable.id, name: pkExampleTable.name, email: pkExampleTable.email })
+		.from(pkExampleTable)
+		.where(eq(pkExampleTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John', email: 'john1@example.com' }]);
 });
 
 test.serial('insert undefined', async (t) => {


### PR DESCRIPTION
Fix for #518.

If the target consisted of multiple columns, they were wrapped in two pairs for parentheses, which was invalid SQL. Thanks @hirvesh for identifying the root cause of the failed SQL queries.

Also a target is required with "DO UPDATE" upserts now as per the spec (cp. https://www.sqlite.org/lang_UPSERT.html). Should not break existing code bases since queries without a target would have failed.