### PR TITLE
[pg] fix typo in docs

### DIFF
--- a/drizzle-orm/src/pg-core/README.md
+++ b/drizzle-orm/src/pg-core/README.md
@@ -658,7 +658,7 @@ const users = pgTable('users', {
   cityId: integer('city_id').references(() => cities.id),
 });
 
-const result = db.select().from(cities).leftJoin(users, eq(cities2.id, users2.cityId));
+const result = db.select().from(cities).leftJoin(users, eq(cities.id, users.cityId));
 ```
 
 #### Many-to-many


### PR DESCRIPTION
In Joins section under Many-to-one there are typos cities2.id and users2.id
These should be cities.id and users.id