### PR TITLE
Update custom types docs for requirement of HKT

### DIFF
--- a/docs/custom-types.md
+++ b/docs/custom-types.md
@@ -180,6 +180,7 @@ export function text<T extends string = string>(
 
 ```typescript
 export class PgCITextBuilder<TData extends string = string> extends PgColumnBuilder<
+  PgColumnBuilderHKT,
   ColumnBuilderConfig<{ data: TData; driverParam: string }>
 > {
   protected $pgColumnBuilderBrand: string = 'PgCITextBuilder';
@@ -190,7 +191,7 @@ export class PgCITextBuilder<TData extends string = string> extends PgColumnBuil
 }
 
 export class PgCIText<TTableName extends string, TData extends string>
-  extends PgColumn<ColumnConfig<{ tableName: TTableName; data: TData; driverParam: string }>>
+  extends PgColumn<PgColumnHKT, ColumnConfig<{ tableName: TTableName; data: TData; driverParam: string }>>
 {
   
 


### PR DESCRIPTION
Went to set up a citext column and I noticed that these docs no longer compile with TypeScript, because the generics require another type argument, the HKT. This should fix that issue.