### PR TITLE
[feat] Add method for retrieving 1 record from database.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .vscode
+.idea
 dist
 *.tsbuildinfo
 *.tgz

--- a/drizzle-orm/src/mysql-core/query-builders/select.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.ts
@@ -389,6 +389,12 @@ export class MySqlSelect<
 	};
 
 	iterator = this.createIterator();
+
+	async first(): Promise<SelectResult<TSelection, TSelectMode, TNullabilityMap> | undefined> {
+		this.config.limit = 1;
+		const result = await this.prepare().execute();
+		return result[0];
+	}
 }
 
 applyMixins(MySqlSelect, [QueryPromise]);

--- a/integration-tests/tests/mysql.test.ts
+++ b/integration-tests/tests/mysql.test.ts
@@ -244,6 +244,24 @@ test.serial('select typed sql', async (t) => {
 	t.deepEqual(users, [{ name: 'JOHN' }]);
 });
 
+test.serial('select first', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' });
+
+	const result = await db.select().from(usersTable).first();
+
+	t.deepEqual(result, { id: 1, name: 'John', verified: false, jsonb: null, createdAt: result!.createdAt });
+});
+
+test.serial('select first undefined', async (t) => {
+	const { db } = t.context;
+
+	const result = await db.select().from(usersTable).first();
+
+	t.assert(result === undefined);
+});
+
 test.serial('insert returning sql', async (t) => {
 	const { db } = t.context;
 


### PR DESCRIPTION
Would resolve #538.

Usage:
```ts
const user: User | undefined = await db
    .select()
    .from(users)
    .where(eq(users.id, 1))
    .first();
```