### PR TITLE
Make migrators accept databases drizzle'd with schemas

### DIFF
--- a/drizzle-orm/src/aws-data-api/pg/migrator.ts
+++ b/drizzle-orm/src/aws-data-api/pg/migrator.ts
@@ -2,9 +2,10 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { AwsDataApiPgDatabase } from './driver';
 
-export async function migrate<
-	T extends AwsDataApiPgDatabase<Record<string, unknown>>,
->(db: T, config: string | MigrationConfig) {
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: AwsDataApiPgDatabase<TSchema>,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/aws-data-api/pg/migrator.ts
+++ b/drizzle-orm/src/aws-data-api/pg/migrator.ts
@@ -2,7 +2,9 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { AwsDataApiPgDatabase } from './driver';
 
-export async function migrate(db: AwsDataApiPgDatabase, config: string | MigrationConfig) {
+export async function migrate<
+	T extends AwsDataApiPgDatabase<Record<string, unknown>>,
+>(db: T, config: string | MigrationConfig) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/better-sqlite3/migrator.ts
+++ b/drizzle-orm/src/better-sqlite3/migrator.ts
@@ -1,8 +1,10 @@
-import type { MigrationConfig} from '~/migrator';
+import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { BetterSQLite3Database } from './driver';
 
-export function migrate(db: BetterSQLite3Database, config: string | MigrationConfig) {
+export function migrate<
+	T extends BetterSQLite3Database<Record<string, unknown>>,
+>(db: T, config: string | MigrationConfig) {
 	const migrations = readMigrationFiles(config);
 	db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/better-sqlite3/migrator.ts
+++ b/drizzle-orm/src/better-sqlite3/migrator.ts
@@ -2,9 +2,10 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { BetterSQLite3Database } from './driver';
 
-export function migrate<
-	T extends BetterSQLite3Database<Record<string, unknown>>,
->(db: T, config: string | MigrationConfig) {
+export function migrate<TSchema extends Record<string, unknown>>(
+	db: BetterSQLite3Database<TSchema>,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/bun-sqlite/migrator.ts
+++ b/drizzle-orm/src/bun-sqlite/migrator.ts
@@ -2,8 +2,8 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { BunSQLiteDatabase } from './driver';
 
-export function migrate<T extends BunSQLiteDatabase<Record<string, unknown>>>(
-	db: T,
+export function migrate<TSchema extends Record<string, unknown>>(
+	db: BunSQLiteDatabase<TSchema>,
 	config: string | MigrationConfig,
 ) {
 	const migrations = readMigrationFiles(config);

--- a/drizzle-orm/src/bun-sqlite/migrator.ts
+++ b/drizzle-orm/src/bun-sqlite/migrator.ts
@@ -1,8 +1,11 @@
-import type { MigrationConfig} from '~/migrator';
+import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { BunSQLiteDatabase } from './driver';
 
-export function migrate(db: BunSQLiteDatabase, config: string | MigrationConfig) {
+export function migrate<T extends BunSQLiteDatabase<Record<string, unknown>>>(
+	db: T,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/d1/migrator.ts
+++ b/drizzle-orm/src/d1/migrator.ts
@@ -2,9 +2,10 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { DrizzleD1Database } from './driver';
 
-export async function migrate<
-	T extends DrizzleD1Database<Record<string, unknown>>,
->(db: T, config: string | MigrationConfig) {
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: DrizzleD1Database<TSchema>,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/d1/migrator.ts
+++ b/drizzle-orm/src/d1/migrator.ts
@@ -1,8 +1,10 @@
-import type { MigrationConfig} from '~/migrator';
+import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { DrizzleD1Database } from './driver';
 
-export async function migrate(db: DrizzleD1Database, config: string | MigrationConfig) {
+export async function migrate<
+	T extends DrizzleD1Database<Record<string, unknown>>,
+>(db: T, config: string | MigrationConfig) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/libsql/migrator.ts
+++ b/drizzle-orm/src/libsql/migrator.ts
@@ -2,7 +2,10 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { LibSQLDatabase } from './driver';
 
-export function migrate(db: LibSQLDatabase, config: MigrationConfig) {
+export function migrate<T extends LibSQLDatabase<Record<string, unknown>>>(
+	db: T,
+	config: MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	return db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/libsql/migrator.ts
+++ b/drizzle-orm/src/libsql/migrator.ts
@@ -2,8 +2,8 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { LibSQLDatabase } from './driver';
 
-export function migrate<T extends LibSQLDatabase<Record<string, unknown>>>(
-	db: T,
+export function migrate<TSchema extends Record<string, unknown>>(
+	db: LibSQLDatabase<TSchema>,
 	config: MigrationConfig,
 ) {
 	const migrations = readMigrationFiles(config);

--- a/drizzle-orm/src/mysql2/migrator.ts
+++ b/drizzle-orm/src/mysql2/migrator.ts
@@ -2,9 +2,10 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { MySql2Database } from './driver';
 
-export async function migrate<
-	T extends MySql2Database<Record<string, unknown>>,
->(db: T, config: MigrationConfig) {
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: MySql2Database<TSchema>,
+	config: MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session, config);
 }

--- a/drizzle-orm/src/mysql2/migrator.ts
+++ b/drizzle-orm/src/mysql2/migrator.ts
@@ -2,7 +2,9 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { MySql2Database } from './driver';
 
-export async function migrate(db: MySql2Database, config: MigrationConfig) {
+export async function migrate<
+	T extends MySql2Database<Record<string, unknown>>,
+>(db: T, config: MigrationConfig) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session, config);
 }

--- a/drizzle-orm/src/neon-serverless/migrator.ts
+++ b/drizzle-orm/src/neon-serverless/migrator.ts
@@ -1,8 +1,11 @@
-import type { MigrationConfig} from '~/migrator';
+import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { NeonDatabase } from './driver';
 
-export async function migrate(db: NeonDatabase, config: string | MigrationConfig) {
+export async function migrate<T extends NeonDatabase<Record<string, unknown>>>(
+	db: T,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/neon-serverless/migrator.ts
+++ b/drizzle-orm/src/neon-serverless/migrator.ts
@@ -2,8 +2,8 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { NeonDatabase } from './driver';
 
-export async function migrate<T extends NeonDatabase<Record<string, unknown>>>(
-	db: T,
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: NeonDatabase<TSchema>,
 	config: string | MigrationConfig,
 ) {
 	const migrations = readMigrationFiles(config);

--- a/drizzle-orm/src/node-postgres/migrator.ts
+++ b/drizzle-orm/src/node-postgres/migrator.ts
@@ -2,9 +2,10 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { NodePgDatabase } from './driver';
 
-export async function migrate<
-	T extends NodePgDatabase<Record<string, unknown>>,
->(db: T, config: string | MigrationConfig) {
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: NodePgDatabase<TSchema>,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/node-postgres/migrator.ts
+++ b/drizzle-orm/src/node-postgres/migrator.ts
@@ -1,8 +1,10 @@
-import type { MigrationConfig} from '~/migrator';
+import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { NodePgDatabase } from './driver';
 
-export async function migrate(db: NodePgDatabase, config: string | MigrationConfig) {
+export async function migrate<
+	T extends NodePgDatabase<Record<string, unknown>>,
+>(db: T, config: string | MigrationConfig) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/planetscale-serverless/migrator.ts
+++ b/drizzle-orm/src/planetscale-serverless/migrator.ts
@@ -2,7 +2,9 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { PlanetScaleDatabase } from './driver';
 
-export async function migrate(db: PlanetScaleDatabase, config: MigrationConfig) {
+export async function migrate<
+	T extends PlanetScaleDatabase<Record<string, unknown>>,
+>(db: T, config: MigrationConfig) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session, config);
 }

--- a/drizzle-orm/src/planetscale-serverless/migrator.ts
+++ b/drizzle-orm/src/planetscale-serverless/migrator.ts
@@ -2,9 +2,10 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { PlanetScaleDatabase } from './driver';
 
-export async function migrate<
-	T extends PlanetScaleDatabase<Record<string, unknown>>,
->(db: T, config: MigrationConfig) {
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: PlanetScaleDatabase<TSchema>,
+	config: MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session, config);
 }

--- a/drizzle-orm/src/postgres-js/migrator.ts
+++ b/drizzle-orm/src/postgres-js/migrator.ts
@@ -1,8 +1,10 @@
-import type { MigrationConfig} from '~/migrator';
+import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { PostgresJsDatabase } from './driver';
 
-export async function migrate(db: PostgresJsDatabase, config: string | MigrationConfig) {
+export async function migrate<
+	T extends PostgresJsDatabase<Record<string, unknown>>,
+>(db: T, config: string | MigrationConfig) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/postgres-js/migrator.ts
+++ b/drizzle-orm/src/postgres-js/migrator.ts
@@ -2,9 +2,10 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { PostgresJsDatabase } from './driver';
 
-export async function migrate<
-	T extends PostgresJsDatabase<Record<string, unknown>>,
->(db: T, config: string | MigrationConfig) {
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: PostgresJsDatabase<TSchema>,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/sql-js/migrator.ts
+++ b/drizzle-orm/src/sql-js/migrator.ts
@@ -1,8 +1,11 @@
-import type { MigrationConfig} from '~/migrator';
+import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { SQLJsDatabase } from './driver';
 
-export function migrate(db: SQLJsDatabase, config: string | MigrationConfig) {
+export function migrate<T extends SQLJsDatabase<Record<string, unknown>>>(
+	db: T,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/sql-js/migrator.ts
+++ b/drizzle-orm/src/sql-js/migrator.ts
@@ -2,8 +2,8 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { SQLJsDatabase } from './driver';
 
-export function migrate<T extends SQLJsDatabase<Record<string, unknown>>>(
-	db: T,
+export function migrate<TSchema extends Record<string, unknown>>(
+	db: SQLJsDatabase<TSchema>,
 	config: string | MigrationConfig,
 ) {
 	const migrations = readMigrationFiles(config);

--- a/drizzle-orm/src/sqlite-proxy/migrator.ts
+++ b/drizzle-orm/src/sqlite-proxy/migrator.ts
@@ -5,7 +5,9 @@ import type { SqliteRemoteDatabase } from './driver';
 
 export type ProxyMigrator = (migrationQueries: string[]) => Promise<void>;
 
-export async function migrate(db: SqliteRemoteDatabase, callback: ProxyMigrator, config: string | MigrationConfig) {
+export async function migrate<
+	T extends SqliteRemoteDatabase<Record<string, unknown>>,
+>(db: T, callback: ProxyMigrator, config: string | MigrationConfig) {
 	const migrations = readMigrationFiles(config);
 
 	const migrationTableCreate = sql`
@@ -26,7 +28,10 @@ export async function migrate(db: SqliteRemoteDatabase, callback: ProxyMigrator,
 
 	const queriesToRun: string[] = [];
 	for (const migration of migrations) {
-		if (!lastDbMigration || Number(lastDbMigration[2])! < migration.folderMillis) {
+		if (
+			!lastDbMigration
+			|| Number(lastDbMigration[2])! < migration.folderMillis
+		) {
 			queriesToRun.push(
 				...migration.sql,
 				`INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES('${migration.hash}', '${migration.folderMillis}')`,

--- a/drizzle-orm/src/sqlite-proxy/migrator.ts
+++ b/drizzle-orm/src/sqlite-proxy/migrator.ts
@@ -5,9 +5,11 @@ import type { SqliteRemoteDatabase } from './driver';
 
 export type ProxyMigrator = (migrationQueries: string[]) => Promise<void>;
 
-export async function migrate<
-	T extends SqliteRemoteDatabase<Record<string, unknown>>,
->(db: T, callback: ProxyMigrator, config: string | MigrationConfig) {
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: SqliteRemoteDatabase<TSchema>,
+	callback: ProxyMigrator,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 
 	const migrationTableCreate = sql`

--- a/drizzle-orm/src/vercel-postgres/migrator.ts
+++ b/drizzle-orm/src/vercel-postgres/migrator.ts
@@ -2,9 +2,10 @@ import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { VercelPgDatabase } from './driver';
 
-export async function migrate<
-	T extends VercelPgDatabase<Record<string, unknown>>,
->(db: T, config: string | MigrationConfig) {
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: VercelPgDatabase<TSchema>,
+	config: string | MigrationConfig,
+) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }

--- a/drizzle-orm/src/vercel-postgres/migrator.ts
+++ b/drizzle-orm/src/vercel-postgres/migrator.ts
@@ -1,8 +1,10 @@
-import type { MigrationConfig} from '~/migrator';
+import type { MigrationConfig } from '~/migrator';
 import { readMigrationFiles } from '~/migrator';
 import type { VercelPgDatabase } from './driver';
 
-export async function migrate(db: VercelPgDatabase, config: string | MigrationConfig) {
+export async function migrate<
+	T extends VercelPgDatabase<Record<string, unknown>>,
+>(db: T, config: string | MigrationConfig) {
 	const migrations = readMigrationFiles(config);
 	await db.dialect.migrate(migrations, db.session);
 }


### PR DESCRIPTION
Fixes case where you specify your schemas when you use `drizzle()`, and `migrate()` wont accept the database type.

Screenshot of current behaviour:
![image](https://github.com/drizzle-team/drizzle-orm/assets/22679886/2e252ded-ea86-4b2c-a9c4-228c0e46bff3)
