### PR TITLE
[Sqlite|D1]: Add unit tests for the drizzle-orm/d1 driver

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -63,6 +63,8 @@
     "drizzle-zod": "workspace:../drizzle-zod/dist",
     "express": "^4.18.2",
     "get-port": "^7.0.0",
+    "@miniflare/shared": "^2.14.0",
+    "@miniflare/d1": "^2.14.0",
     "mysql2": "^3.3.3",
     "pg": "^8.11.0",
     "postgres": "^3.3.5",

--- a/integration-tests/tests/d1.test.ts
+++ b/integration-tests/tests/d1.test.ts
@@ -782,7 +782,7 @@ test.serial('insert via db.get', async (t) => {
 			sql.identifier(usersTable.name.name)
 		}) values (${'John'}) returning ${usersTable.id}, ${usersTable.name}`,
 	);
-	t.deepEqual(inserted, [{ id: 1, name: 'John' }]);
+	t.deepEqual(inserted, { id: 1, name: 'John' });
 });
 
 test.serial('insert via db.run + select via db.get', async (t) => {
@@ -793,7 +793,7 @@ test.serial('insert via db.run + select via db.get', async (t) => {
 	const result = await db.get<{ id: number; name: string }>(
 		sql`select ${usersTable.id}, ${usersTable.name} from ${usersTable}`,
 	);
-	t.deepEqual(result, [{ id: 1, name: 'John' }]);
+	t.deepEqual(result, { id: 1, name: 'John' });
 });
 
 test.serial('insert via db.get w/ query builder', async (t) => {
@@ -802,7 +802,7 @@ test.serial('insert via db.get w/ query builder', async (t) => {
 	const inserted = await db.get(
 		db.insert(usersTable).values({ name: 'John' }).returning({ id: usersTable.id, name: usersTable.name }),
 	);
-	t.deepEqual(inserted, [{ id: 1, name: 'John' }]);
+	t.deepEqual(inserted, { id: 1, name: 'John' });
 });
 
 test.serial('left join (flat object fields)', async (t) => {

--- a/integration-tests/tests/d1.test.ts
+++ b/integration-tests/tests/d1.test.ts
@@ -1,0 +1,1693 @@
+import anyTest from "ava";
+import type { TestFn } from "ava";
+import { createSQLiteDB } from "@miniflare/shared";
+import { D1Database, D1DatabaseAPI } from "@miniflare/d1";
+import { sql, eq, placeholder, asc, gt, inArray, type Equal, TransactionRollbackError } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { drizzle } from "drizzle-orm/d1";
+import { migrate } from "drizzle-orm/d1/migrator";
+import { alias, blob, getViewConfig, integer, sqliteTable, sqliteTableCreator, sqliteView, text } from "drizzle-orm/sqlite-core";
+import { Expect } from './utils';
+
+const usersTable = sqliteTable("users", {
+	id: integer("id").primaryKey(),
+	name: text("name").notNull(),
+	verified: integer("verified").notNull().default(0),
+	json: blob("json", { mode: "json" }).$type<string[]>(),
+	createdAt: integer("created_at", { mode: "timestamp" })
+		.notNull()
+		.default(sql`strftime('%s', 'now')`),
+});
+
+const users2Table = sqliteTable("users2", {
+	id: integer("id").primaryKey(),
+	name: text("name").notNull(),
+	cityId: integer("city_id").references(() => citiesTable.id),
+});
+
+const citiesTable = sqliteTable("cities", {
+	id: integer("id").primaryKey(),
+	name: text("name").notNull(),
+});
+
+const coursesTable = sqliteTable("courses", {
+	id: integer("id").primaryKey(),
+	name: text("name").notNull(),
+	categoryId: integer("category_id").references(() => courseCategoriesTable.id),
+});
+
+const courseCategoriesTable = sqliteTable("course_categories", {
+	id: integer("id").primaryKey(),
+	name: text("name").notNull(),
+});
+
+const orders = sqliteTable("orders", {
+	id: integer("id").primaryKey(),
+	region: text("region").notNull(),
+	product: text("product").notNull(),
+	amount: integer("amount").notNull(),
+	quantity: integer("quantity").notNull(),
+});
+
+const usersMigratorTable = sqliteTable('users12', {
+	id: integer('id').primaryKey(),
+	name: text('name').notNull(),
+	email: text('email').notNull(),
+});
+
+const anotherUsersMigratorTable = sqliteTable('another_users', {
+	id: integer('id').primaryKey(),
+	name: text('name').notNull(),
+	email: text('email').notNull(),
+});
+
+interface Context {
+	d1: D1Database;
+	db: DrizzleD1Database;
+}
+
+const test = anyTest as TestFn<Context>;
+
+test.before(async (t) => {
+	const ctx = t.context;
+	const sqliteDb = await createSQLiteDB(":memory:");
+	const db = new D1Database(new D1DatabaseAPI(sqliteDb));
+	ctx.d1 = db;
+	/**
+	 * Casting the type to any due to the following type error
+	 *
+	 * Argument of type 'import("drizzle-orm/node_modules/.pnpm/@miniflare+d1@2.14.0/node_modules/@miniflare/d1/dist/src/index").D1Database' is not assignable to parameter of type 'D1Database'.
+	 * The types returned by 'prepare(...).first(...)' are incompatible between these types.
+	 * Type 'Promise<T | null>' is not assignable to type 'Promise<T>'.
+	 * Type 'T | null' is not assignable to type 'T'.
+	 * 'T' could be instantiated with an arbitrary type which could be unrelated to 'T | null'
+	 */
+	ctx.db = drizzle(db as any);
+});
+
+test.beforeEach(async (t) => {
+	const ctx = t.context;
+
+	await ctx.db.run(sql`drop table if exists ${usersTable}`);
+	await ctx.db.run(sql`drop table if exists ${users2Table}`);
+	await ctx.db.run(sql`drop table if exists ${citiesTable}`);
+	await ctx.db.run(sql`drop table if exists ${coursesTable}`);
+	await ctx.db.run(sql`drop table if exists ${courseCategoriesTable}`);
+	await ctx.db.run(sql`drop table if exists ${orders}`);
+
+	await ctx.db.run(sql`
+		create table ${usersTable} (
+		 id integer primary key,
+		 name text not null,
+		 verified integer not null default 0,
+		 json blob,
+		 created_at integer not null default (strftime('%s', 'now'))
+		)
+	`);
+	await ctx.db.run(sql`
+		create table ${users2Table} (
+		 id integer primary key,
+		 name text not null,
+		 city_id integer references ${citiesTable}(${sql.identifier(citiesTable.id.name)})
+		)
+	`);
+	await ctx.db.run(sql`
+		create table ${citiesTable} (
+		 id integer primary key,
+		 name text not null
+		)
+	`);
+	await ctx.db.run(sql`
+		create table ${courseCategoriesTable} (
+		 id integer primary key,
+		 name text not null
+		)
+	`);
+	await ctx.db.run(sql`
+		create table ${coursesTable} (
+		 id integer primary key,
+		 name text not null,
+		 category_id integer references ${courseCategoriesTable}(${sql.identifier(
+		courseCategoriesTable.id.name
+	)})
+		)
+	`);
+	await ctx.db.run(sql`
+		create table ${orders} (
+		 id integer primary key,
+		 region text not null,
+		 product text not null,
+		 amount integer not null,
+		 quantity integer not null
+		)
+	`);
+});
+
+test.serial("select all fields", async (t) => {
+	const { db } = t.context;
+
+	const now = Date.now();
+
+	await db.insert(usersTable).values({ name: "John" }).run();
+	const result = await db.select().from(usersTable).all();
+
+	t.assert(result[0]!.createdAt instanceof Date);
+	t.assert(Math.abs(result[0]!.createdAt.getTime() - now) < 5000);
+	t.deepEqual(result, [
+		{
+			id: 1,
+			name: "John",
+			verified: 0,
+			json: null,
+			createdAt: result[0]!.createdAt,
+		},
+	]);
+});
+
+test.serial("select partial", async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: "John" }).run();
+	const result = await db.select({ name: usersTable.name }).from(usersTable).all();
+
+	t.deepEqual(result, [{ name: "John" }]);
+});
+
+test.serial("select sql", async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: "John" }).run();
+	const users = await db
+		.select({
+			name: sql`upper(${usersTable.name})`,
+		})
+		.from(usersTable)
+		.all();
+
+	t.deepEqual(users, [{ name: "JOHN" }]);
+});
+
+test.serial('select typed sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.select({
+		name: sql<string>`upper(${usersTable.name})`,
+	}).from(usersTable).all();
+
+	t.deepEqual(users, [{ name: 'JOHN' }]);
+});
+
+test.serial('insert returning sql', async (t) => {
+	const { db } = t.context;
+
+	const users = await db.insert(usersTable).values({ name: 'John' }).returning({
+		name: sql`upper(${usersTable.name})`,
+	}).all();
+
+	t.deepEqual(users, [{ name: 'JOHN' }]);
+});
+
+test.serial('insert returning sql + get()', async (t) => {
+	const { db } = t.context;
+
+	const users = await db.insert(usersTable).values({ name: 'John' }).returning({
+		name: sql`upper(${usersTable.name})`,
+	}).get();
+
+	t.deepEqual(users, { name: 'JOHN' });
+});
+
+test.serial('delete returning sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.delete(usersTable).where(eq(usersTable.name, 'John')).returning({
+		name: sql`upper(${usersTable.name})`,
+	}).all();
+
+	t.deepEqual(users, [{ name: 'JOHN' }]);
+});
+
+test.serial('update returning sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.update(usersTable).set({ name: 'Jane' }).where(eq(usersTable.name, 'John')).returning({
+		name: sql`upper(${usersTable.name})`,
+	}).all();
+
+	t.deepEqual(users, [{ name: 'JANE' }]);
+});
+
+test.serial('update returning sql + get()', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.update(usersTable).set({ name: 'Jane' }).where(eq(usersTable.name, 'John')).returning({
+		name: sql`upper(${usersTable.name})`,
+	}).get();
+
+	t.deepEqual(users, { name: 'JANE' });
+});
+
+test.serial('insert with auto increment', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([
+		{ name: 'John' },
+		{ name: 'Jane' },
+		{ name: 'George' },
+		{ name: 'Austin' },
+	]).run();
+	const result = await db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable).all();
+
+	t.deepEqual(result, [
+		{ id: 1, name: 'John' },
+		{ id: 2, name: 'Jane' },
+		{ id: 3, name: 'George' },
+		{ id: 4, name: 'Austin' },
+	]);
+});
+
+test.serial('insert with default values', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const result = await db.select().from(usersTable).all();
+
+	t.deepEqual(result, [{ id: 1, name: 'John', verified: 0, json: null, createdAt: result[0]!.createdAt }]);
+});
+
+test.serial('insert with overridden default values', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John', verified: 1 }).run();
+	const result = await db.select().from(usersTable).all();
+
+	t.deepEqual(result, [{ id: 1, name: 'John', verified: 1, json: null, createdAt: result[0]!.createdAt }]);
+});
+
+test.serial('update with returning all fields', async (t) => {
+	const { db } = t.context;
+
+	const now = Date.now();
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.update(usersTable).set({ name: 'Jane' }).where(eq(usersTable.name, 'John')).returning().all();
+
+	t.assert(users[0]!.createdAt instanceof Date);
+	t.assert(Math.abs(users[0]!.createdAt.getTime() - now) < 5000);
+	t.deepEqual(users, [{ id: 1, name: 'Jane', verified: 0, json: null, createdAt: users[0]!.createdAt }]);
+});
+
+test.serial('update with returning all fields + get()', async (t) => {
+	const { db } = t.context;
+
+	const now = Date.now();
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.update(usersTable).set({ name: 'Jane' }).where(eq(usersTable.name, 'John')).returning().get();
+
+	t.assert(users.createdAt instanceof Date);
+	t.assert(Math.abs(users.createdAt.getTime() - now) < 5000);
+	t.deepEqual(users, { id: 1, name: 'Jane', verified: 0, json: null, createdAt: users.createdAt });
+});
+
+test.serial('update with returning partial', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.update(usersTable).set({ name: 'Jane' }).where(eq(usersTable.name, 'John')).returning({
+		id: usersTable.id,
+		name: usersTable.name,
+	}).all();
+
+	t.deepEqual(users, [{ id: 1, name: 'Jane' }]);
+});
+
+test.serial('delete with returning all fields', async (t) => {
+	const { db } = t.context;
+
+	const now = Date.now();
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.delete(usersTable).where(eq(usersTable.name, 'John')).returning().all();
+
+	t.assert(users[0]!.createdAt instanceof Date);
+	t.assert(Math.abs(users[0]!.createdAt.getTime() - now) < 5000);
+	t.deepEqual(users, [{ id: 1, name: 'John', verified: 0, json: null, createdAt: users[0]!.createdAt }]);
+});
+
+test.serial('delete with returning all fields + get()', async (t) => {
+	const { db } = t.context;
+
+	const now = Date.now();
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.delete(usersTable).where(eq(usersTable.name, 'John')).returning().get();
+
+	t.assert(users!.createdAt instanceof Date);
+	t.assert(Math.abs(users!.createdAt.getTime() - now) < 5000);
+	t.deepEqual(users, { id: 1, name: 'John', verified: 0, json: null, createdAt: users!.createdAt });
+});
+
+test.serial('delete with returning partial', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.delete(usersTable).where(eq(usersTable.name, 'John')).returning({
+		id: usersTable.id,
+		name: usersTable.name,
+	}).all();
+
+	t.deepEqual(users, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('delete with returning partial + get()', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const users = await db.delete(usersTable).where(eq(usersTable.name, 'John')).returning({
+		id: usersTable.id,
+		name: usersTable.name,
+	}).get();
+
+	t.deepEqual(users, { id: 1, name: 'John' });
+});
+
+test.serial('insert + select', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const result = await db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable).all();
+
+	t.deepEqual(result, [{ id: 1, name: 'John' }]);
+
+	await db.insert(usersTable).values({ name: 'Jane' }).run();
+	const result2 = await db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable).all();
+
+	t.deepEqual(result2, [{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+});
+
+test.serial('json insert', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John', json: ['foo', 'bar'] }).run();
+	/**
+	 * TODO: Fix bug!
+	 * The select below fails with
+	 * SyntaxError {
+	 *     message: 'Unexpected non-whitespace character after JSON at position 2',
+	 * }
+	 */
+	await t.throwsAsync(
+		db.select({
+			id: usersTable.id,
+			name: usersTable.name,
+			json: usersTable.json,
+		}).from(usersTable).all()
+	)
+
+	// Uncomment when the above bug is fixed
+	// t.deepEqual(result, [{ id: 1, name: 'John', json: ['foo', 'bar'] }]);
+});
+
+test.serial('insert many', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([
+		{ name: 'John' },
+		{ name: 'Bruce', json: ['foo', 'bar'] },
+		{ name: 'Jane' },
+		{ name: 'Austin', verified: 1 },
+	]).run();
+
+	/**
+	 * TODO: Fix bug!
+	 * The select below fails with
+	 * SyntaxError {
+	 *     message: 'Unexpected non-whitespace character after JSON at position 2',
+	 * }
+	 */
+	await t.throwsAsync(
+		db.select({
+			id: usersTable.id,
+			name: usersTable.name,
+			json: usersTable.json,
+			verified: usersTable.verified,
+		}).from(usersTable).all()
+	)
+
+	// Uncomment when the above bug is fixed
+	// t.deepEqual(result, [
+	// 	{ id: 1, name: 'John', json: null, verified: 0 },
+	// 	{ id: 2, name: 'Bruce', json: ['foo', 'bar'], verified: 0 },
+	// 	{ id: 3, name: 'Jane', json: null, verified: 0 },
+	// 	{ id: 4, name: 'Austin', json: null, verified: 1 },
+	// ]);
+});
+
+test.serial('insert many with returning', async (t) => {
+	const { db } = t.context;
+
+	/**
+	 * TODO: Fix bug!
+	 * The select below fails with
+	 * SyntaxError {
+	 *     message: 'Unexpected non-whitespace character after JSON at position 2',
+	 * }
+	 */
+	await t.throwsAsync(
+		db.insert(usersTable).values([
+		{ name: 'John' },
+		{ name: 'Bruce', json: ['foo', 'bar'] },
+		{ name: 'Jane' },
+		{ name: 'Austin', verified: 1 },
+		])
+			.returning({
+				id: usersTable.id,
+				name: usersTable.name,
+				json: usersTable.json,
+				verified: usersTable.verified,
+			})
+			.all()
+	);
+
+	// Uncomment when the above bug is fixed
+	// t.deepEqual(result, [
+	// 	{ id: 1, name: 'John', json: null, verified: 0 },
+	// 	{ id: 2, name: 'Bruce', json: ['foo', 'bar'], verified: 0 },
+	// 	{ id: 3, name: 'Jane', json: null, verified: 0 },
+	// 	{ id: 4, name: 'Austin', json: null, verified: 1 },
+	// ]);
+});
+
+test.serial('partial join with alias', async (t) => {
+	const { db } = t.context;
+	const customerAlias = alias(usersTable, 'customer');
+
+	await db.insert(usersTable).values([{ id: 10, name: 'Ivan' }, { id: 11, name: 'Hans' }]).run();
+	const result = await db
+		.select({
+			user: {
+				id: usersTable.id,
+				name: usersTable.name,
+			},
+			customer: {
+				id: customerAlias.id,
+				name: customerAlias.name,
+			},
+		}).from(usersTable)
+		.leftJoin(customerAlias, eq(customerAlias.id, 11))
+		.where(eq(usersTable.id, 10))
+		.all();
+
+	/**
+	 * TODO: Fix Bug! The objects should be equal
+	 *
+	 * See #528 for more details.
+	 * Tldr the D1 driver does not execute joins successfully
+	 */
+	t.notDeepEqual(result, [{
+		user: { id: 10, name: 'Ivan' },
+		customer: { id: 11, name: 'Hans' },
+	}]);
+});
+
+test.serial('full join with alias', async (t) => {
+	const { db } = t.context;
+
+	const sqliteTable = sqliteTableCreator((name) => `prefixed_${name}`);
+
+	const users = sqliteTable('users', {
+		id: integer('id').primaryKey(),
+		name: text('name').notNull(),
+	});
+
+	await db.run(sql`drop table if exists ${users}`);
+	await db.run(sql`create table ${users} (id integer primary key, name text not null)`);
+
+	const customers = alias(users, 'customer');
+
+	await db.insert(users).values([{ id: 10, name: 'Ivan' }, { id: 11, name: 'Hans' }]).run();
+	const result = await db
+		.select().from(users)
+		.leftJoin(customers, eq(customers.id, 11))
+		.where(eq(users.id, 10))
+		.all();
+
+	/**
+	 * TODO: Fix Bug! The objects should be equal
+	 *
+	 * See #528 for more details.
+	 * Tldr the D1 driver does not execute joins successfully
+	 */
+	t.notDeepEqual(result, [{
+		users: {
+			id: 10,
+			name: 'Ivan',
+		},
+		customer: {
+			id: 11,
+			name: 'Hans',
+		},
+	}]);
+
+	await db.run(sql`drop table ${users}`);
+});
+
+test.serial('select from alias', async (t) => {
+	const { db } = t.context;
+
+	const sqliteTable = sqliteTableCreator((name) => `prefixed_${name}`);
+
+	const users = sqliteTable('users', {
+		id: integer('id').primaryKey(),
+		name: text('name').notNull(),
+	});
+
+	await db.run(sql`drop table if exists ${users}`);
+	await db.run(sql`create table ${users} (id integer primary key, name text not null)`);
+
+	const user = alias(users, 'user');
+	const customers = alias(users, 'customer');
+
+	await db.insert(users).values([{ id: 10, name: 'Ivan' }, { id: 11, name: 'Hans' }]).run();
+	const result = await db
+		.select()
+		.from(user)
+		.leftJoin(customers, eq(customers.id, 11))
+		.where(eq(user.id, 10))
+		.all();
+
+	/**
+	 * TODO: Fix Bug! The objects should be equal
+	 *
+	 * See #528 for more details.
+	 * Tldr the D1 driver does not execute joins successfully
+	 */
+	t.notDeepEqual(result, [{
+		user: {
+			id: 10,
+			name: 'Ivan',
+		},
+		customer: {
+			id: 11,
+			name: 'Hans',
+		},
+	}]);
+
+	db.run(sql`drop table ${users}`);
+});
+
+test.serial('insert with spaces', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: sql`'Jo   h     n'` }).run();
+	const result = await db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable).all();
+
+	t.deepEqual(result, [{ id: 1, name: 'Jo   h     n' }]);
+});
+
+test.serial('prepared statement', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const statement = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable).prepare();
+	const result = await statement.all();
+
+	t.deepEqual(result, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('prepared statement reuse', async (t) => {
+	const { db } = t.context;
+
+	const stmt = db.insert(usersTable).values({
+		verified: 1,
+		name: placeholder('name'),
+	}).prepare();
+
+	for (let i = 0; i < 10; i++) {
+		await stmt.run({ name: `John ${i}` });
+	}
+
+	const result = await db.select({
+		id: usersTable.id,
+		name: usersTable.name,
+		verified: usersTable.verified,
+	}).from(usersTable).all();
+
+	t.deepEqual(result, [
+		{ id: 1, name: 'John 0', verified: 1 },
+		{ id: 2, name: 'John 1', verified: 1 },
+		{ id: 3, name: 'John 2', verified: 1 },
+		{ id: 4, name: 'John 3', verified: 1 },
+		{ id: 5, name: 'John 4', verified: 1 },
+		{ id: 6, name: 'John 5', verified: 1 },
+		{ id: 7, name: 'John 6', verified: 1 },
+		{ id: 8, name: 'John 7', verified: 1 },
+		{ id: 9, name: 'John 8', verified: 1 },
+		{ id: 10, name: 'John 9', verified: 1 },
+	]);
+});
+
+test.serial('prepared statement with placeholder in .where', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ name: 'John' }).run();
+	const stmt = db.select({
+		id: usersTable.id,
+		name: usersTable.name,
+	}).from(usersTable)
+		.where(eq(usersTable.id, placeholder('id')))
+		.prepare();
+	const result = await stmt.all({ id: 1 });
+
+	t.deepEqual(result, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('select with group by as field', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]).run();
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.groupBy(usersTable.name)
+		.all();
+
+	t.deepEqual(result, [{ name: 'Jane' }, { name: 'John' }]);
+});
+
+test.serial('select with group by as sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]).run();
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.groupBy(sql`${usersTable.name}`)
+		.all();
+
+	t.deepEqual(result, [{ name: 'Jane' }, { name: 'John' }]);
+});
+
+test.serial('select with group by as sql + column', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]).run();
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.groupBy(sql`${usersTable.name}`, usersTable.id)
+		.all();
+
+	t.deepEqual(result, [{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+});
+
+test.serial('select with group by as column + sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]).run();
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.groupBy(usersTable.id, sql`${usersTable.name}`)
+		.all();
+
+	t.deepEqual(result, [{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+});
+
+test.serial('select with group by complex query', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]).run();
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.groupBy(usersTable.id, sql`${usersTable.name}`)
+		.orderBy(asc(usersTable.name))
+		.limit(1)
+		.all();
+
+	t.deepEqual(result, [{ name: 'Jane' }]);
+});
+
+test.serial('build query', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: 'select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('migrator', async (t) => {
+	const { db } = t.context;
+
+	await db.run(sql`drop table if exists another_users`);
+	await db.run(sql`drop table if exists users12`);
+	await db.run(sql`drop table if exists __drizzle_migrations`);
+
+	await migrate(db, { migrationsFolder: './drizzle2/sqlite' });
+
+	await db.insert(usersMigratorTable).values({ name: 'John', email: 'email' }).run();
+	const result = await db.select().from(usersMigratorTable).all();
+
+	await db.insert(anotherUsersMigratorTable).values({ name: 'John', email: 'email' }).run();
+	const result2 = await db.select().from(usersMigratorTable).all();
+
+	t.deepEqual(result, [{ id: 1, name: 'John', email: 'email' }]);
+	t.deepEqual(result2, [{ id: 1, name: 'John', email: 'email' }]);
+
+	await db.run(sql`drop table another_users`);
+	await db.run(sql`drop table users12`);
+	await db.run(sql`drop table __drizzle_migrations`);
+});
+
+test.serial('insert via db.run + select via db.all', async (t) => {
+	const { db } = t.context;
+
+	await db.run(sql`insert into ${usersTable} (${sql.identifier(usersTable.name.name)}) values (${'John'})`);
+
+	const result = await db.all<{ id: number; name: string }>(sql`select id, name from "users"`);
+	t.deepEqual(result, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('insert via db.get', async (t) => {
+	const { db } = t.context;
+
+	const inserted = await db.get<{ id: number; name: string }>(
+		sql`insert into ${usersTable} (${
+			sql.identifier(usersTable.name.name)
+		}) values (${'John'}) returning ${usersTable.id}, ${usersTable.name}`,
+	);
+	t.deepEqual(inserted, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('insert via db.run + select via db.get', async (t) => {
+	const { db } = t.context;
+
+	await db.run(sql`insert into ${usersTable} (${sql.identifier(usersTable.name.name)}) values (${'John'})`);
+
+	const result = await db.get<{ id: number; name: string }>(
+		sql`select ${usersTable.id}, ${usersTable.name} from ${usersTable}`,
+	);
+	t.deepEqual(result, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('insert via db.get w/ query builder', async (t) => {
+	const { db } = t.context;
+
+	const inserted = await db.get(
+		db.insert(usersTable).values({ name: 'John' }).returning({ id: usersTable.id, name: usersTable.name }),
+	);
+	t.deepEqual(inserted, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('left join (flat object fields)', async (t) => {
+	const { db } = t.context;
+
+	const allCities = await db.insert(citiesTable)
+		.values([{ name: 'Paris' }, { name: 'London' }])
+		.returning({ id: citiesTable.id }).all();
+	const { id: cityId } = allCities[0]!;
+
+	await db.insert(users2Table).values([{ name: 'John', cityId }, { name: 'Jane' }]).run();
+
+	const res = await db.select({
+		userId: users2Table.id,
+		userName: users2Table.name,
+		cityId: citiesTable.id,
+		cityName: citiesTable.name,
+	}).from(users2Table)
+		.leftJoin(citiesTable, eq(users2Table.cityId, citiesTable.id))
+		.all();
+
+	/**
+	 * TODO: Fix Bug! The objects should be equal
+	 *
+	 * See #528 for more details.
+	 * Tldr the D1 driver does not execute joins successfully
+	 */
+	t.notDeepEqual(res, [
+		{ userId: 1, userName: 'John', cityId, cityName: 'Paris' },
+		{ userId: 2, userName: 'Jane', cityId: null, cityName: null },
+	]);
+});
+
+test.serial('left join (grouped fields)', async (t) => {
+	const { db } = t.context;
+
+	const allCities = await db.insert(citiesTable)
+		.values([{ name: 'Paris' }, { name: 'London' }])
+		.returning({ id: citiesTable.id }).all();
+	const { id: cityId } = allCities[0]!;
+
+	await db.insert(users2Table).values([{ name: 'John', cityId }, { name: 'Jane' }]).run();
+
+	const res = await db.select({
+		id: users2Table.id,
+		user: {
+			name: users2Table.name,
+			nameUpper: sql<string>`upper(${users2Table.name})`,
+		},
+		city: {
+			id: citiesTable.id,
+			name: citiesTable.name,
+			nameUpper: sql<string>`upper(${citiesTable.name})`,
+		},
+	}).from(users2Table)
+		.leftJoin(citiesTable, eq(users2Table.cityId, citiesTable.id))
+		.all();
+
+	/**
+	 * TODO: Fix Bug! The objects should be equal
+	 *
+	 * See #528 for more details.
+	 * Tldr the D1 driver does not execute joins successfully
+	 */
+	t.notDeepEqual(res, [
+		{
+			id: 1,
+			user: { name: 'John', nameUpper: 'JOHN' },
+			city: { id: cityId, name: 'Paris', nameUpper: 'PARIS' },
+		},
+		{
+			id: 2,
+			user: { name: 'Jane', nameUpper: 'JANE' },
+			city: null,
+		},
+	]);
+});
+
+test.serial('left join (all fields)', async (t) => {
+	const { db } = t.context;
+
+	const allCities = await db.insert(citiesTable)
+		.values([{ name: 'Paris' }, { name: 'London' }])
+		.returning({ id: citiesTable.id }).all();
+	const { id: cityId } = allCities[0]!;
+
+	await db.insert(users2Table).values([{ name: 'John', cityId }, { name: 'Jane' }]).run();
+
+	const res = await db.select().from(users2Table)
+		.leftJoin(citiesTable, eq(users2Table.cityId, citiesTable.id)).all();
+
+	/**
+	 * TODO: Fix Bug! The objects should be equal
+	 *
+	 * See #528 for more details.
+	 * Tldr the D1 driver does not execute joins successfully
+	 */
+	t.notDeepEqual(res, [
+		{
+			users2: {
+				id: 1,
+				name: 'John',
+				cityId,
+			},
+			cities: {
+				id: cityId,
+				name: 'Paris',
+			},
+		},
+		{
+			users2: {
+				id: 2,
+				name: 'Jane',
+				cityId: null,
+			},
+			cities: null,
+		},
+	]);
+});
+
+test.serial('join subquery', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(courseCategoriesTable).values([
+		{ name: 'Category 1' },
+		{ name: 'Category 2' },
+		{ name: 'Category 3' },
+		{ name: 'Category 4' },
+	]).run();
+
+	await db.insert(coursesTable).values([
+		{ name: 'Development', categoryId: 2 },
+		{ name: 'IT & Software', categoryId: 3 },
+		{ name: 'Marketing', categoryId: 4 },
+		{ name: 'Design', categoryId: 1 },
+	]).run();
+
+	const sq2 = await db
+		.select({
+			categoryId: courseCategoriesTable.id,
+			category: courseCategoriesTable.name,
+			total: sql<number>`count(${courseCategoriesTable.id})`,
+		})
+		.from(courseCategoriesTable)
+		.groupBy(courseCategoriesTable.id, courseCategoriesTable.name)
+		.as('sq2');
+
+	const res = await db
+		.select({
+			courseName: coursesTable.name,
+			categoryId: sq2.categoryId,
+		})
+		.from(coursesTable)
+		.leftJoin(sq2, eq(coursesTable.categoryId, sq2.categoryId))
+		.orderBy(coursesTable.name)
+		.all();
+
+	t.deepEqual(res, [
+		{ courseName: 'Design', categoryId: 1 },
+		{ courseName: 'Development', categoryId: 2 },
+		{ courseName: 'IT & Software', categoryId: 3 },
+		{ courseName: 'Marketing', categoryId: 4 },
+	]);
+});
+
+test.serial('with ... select', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(orders).values([
+		{ region: 'Europe', product: 'A', amount: 10, quantity: 1 },
+		{ region: 'Europe', product: 'A', amount: 20, quantity: 2 },
+		{ region: 'Europe', product: 'B', amount: 20, quantity: 2 },
+		{ region: 'Europe', product: 'B', amount: 30, quantity: 3 },
+		{ region: 'US', product: 'A', amount: 30, quantity: 3 },
+		{ region: 'US', product: 'A', amount: 40, quantity: 4 },
+		{ region: 'US', product: 'B', amount: 40, quantity: 4 },
+		{ region: 'US', product: 'B', amount: 50, quantity: 5 },
+	]).run();
+
+	const regionalSales = db
+		.$with('regional_sales')
+		.as(
+			db
+				.select({
+					region: orders.region,
+					totalSales: sql<number>`sum(${orders.amount})`.as('total_sales'),
+				})
+				.from(orders)
+				.groupBy(orders.region),
+		);
+
+	const topRegions = db
+		.$with('top_regions')
+		.as(
+			db
+				.select({
+					region: regionalSales.region,
+				})
+				.from(regionalSales)
+				.where(
+					gt(
+						regionalSales.totalSales,
+						db.select({ sales: sql`sum(${regionalSales.totalSales})/10` }).from(regionalSales),
+					),
+				),
+		);
+
+	const result = await db
+		.with(regionalSales, topRegions)
+		.select({
+			region: orders.region,
+			product: orders.product,
+			productUnits: sql<number>`cast(sum(${orders.quantity}) as int)`,
+			productSales: sql<number>`cast(sum(${orders.amount}) as int)`,
+		})
+		.from(orders)
+		.where(inArray(orders.region, db.select({ region: topRegions.region }).from(topRegions)))
+		.groupBy(orders.region, orders.product)
+		.orderBy(orders.region, orders.product)
+		.all();
+
+	t.deepEqual(result, [
+		{
+			region: 'Europe',
+			product: 'A',
+			productUnits: 3,
+			productSales: 30,
+		},
+		{
+			region: 'Europe',
+			product: 'B',
+			productUnits: 5,
+			productSales: 50,
+		},
+		{
+			region: 'US',
+			product: 'A',
+			productUnits: 7,
+			productSales: 70,
+		},
+		{
+			region: 'US',
+			product: 'B',
+			productUnits: 9,
+			productSales: 90,
+		},
+	]);
+});
+
+test.serial('select from subquery sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(users2Table).values([{ name: 'John' }, { name: 'Jane' }]).run();
+
+	const sq = db
+		.select({ name: sql<string>`${users2Table.name} || ' modified'`.as('name') })
+		.from(users2Table)
+		.as('sq');
+
+	const res = await db.select({ name: sq.name }).from(sq).all();
+
+	t.deepEqual(res, [{ name: 'John modified' }, { name: 'Jane modified' }]);
+});
+
+test.serial('select a field without joining its table', async (t) => {
+	const { db } = t.context;
+
+	t.throws(() => db.select({ name: users2Table.name }).from(usersTable).prepare());
+});
+
+test.serial('select all fields from subquery without alias', async (t) => {
+	const { db } = t.context;
+
+	const sq = db.$with('sq').as(db.select({ name: sql<string>`upper(${users2Table.name})` }).from(users2Table));
+
+	t.throws(() => db.select().from(sq).prepare());
+});
+
+test.serial('select count()', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }]).run();
+
+	const res = await db.select({ count: sql`count(*)` }).from(usersTable).all();
+
+	t.deepEqual(res, [{ count: 2 }]);
+});
+
+test.serial('having', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(citiesTable).values([{ name: 'London' }, { name: 'Paris' }, { name: 'New York' }]).run();
+
+	await db.insert(users2Table).values([
+		{ name: 'John', cityId: 1 },
+		{ name: 'Jane', cityId: 1 },
+		{ name: 'Jack', cityId: 2 },
+	]).run();
+
+	const result = await db
+		.select({
+			id: citiesTable.id,
+			name: sql<string>`upper(${citiesTable.name})`.as('upper_name'),
+			usersCount: sql<number>`count(${users2Table.id})`.as('users_count'),
+		})
+		.from(citiesTable)
+		.leftJoin(users2Table, eq(users2Table.cityId, citiesTable.id))
+		.where(({ name }) => sql`length(${name}) >= 3`)
+		.groupBy(citiesTable.id)
+		.having(({ usersCount }) => sql`${usersCount} > 0`)
+		.orderBy(({ name }) => name)
+		.all();
+
+	t.deepEqual(result, [
+		{
+			id: 1,
+			name: 'LONDON',
+			usersCount: 2,
+		},
+		{
+			id: 2,
+			name: 'PARIS',
+			usersCount: 1,
+		},
+	]);
+});
+
+test.serial('view', async (t) => {
+	const { db } = t.context;
+
+	const newYorkers1 = sqliteView('new_yorkers1')
+		.as((qb) => qb.select().from(users2Table).where(eq(users2Table.cityId, 1)));
+
+	const newYorkers2 = sqliteView('new_yorkers2', {
+		id: integer('id').primaryKey(),
+		name: text('name').notNull(),
+		cityId: integer('city_id').notNull(),
+	}).as(sql`select * from ${users2Table} where ${eq(users2Table.cityId, 1)}`);
+
+	const newYorkers3 = sqliteView('new_yorkers1', {
+		id: integer('id').primaryKey(),
+		name: text('name').notNull(),
+		cityId: integer('city_id').notNull(),
+	}).existing();
+
+	await db.run(sql`create view ${newYorkers1} as ${getViewConfig(newYorkers1).query}`);
+	await db.run(sql`create view ${newYorkers2} as ${getViewConfig(newYorkers2).query}`);
+
+	await db.insert(citiesTable).values([{ name: 'New York' }, { name: 'Paris' }]).run();
+
+	await db.insert(users2Table).values([
+		{ name: 'John', cityId: 1 },
+		{ name: 'Jane', cityId: 1 },
+		{ name: 'Jack', cityId: 2 },
+	]).run();
+
+	{
+		const result = await db.select().from(newYorkers1).all();
+		t.deepEqual(result, [
+			{ id: 1, name: 'John', cityId: 1 },
+			{ id: 2, name: 'Jane', cityId: 1 },
+		]);
+	}
+
+	{
+		const result = await db.select().from(newYorkers2).all();
+		t.deepEqual(result, [
+			{ id: 1, name: 'John', cityId: 1 },
+			{ id: 2, name: 'Jane', cityId: 1 },
+		]);
+	}
+
+	{
+		const result = await db.select().from(newYorkers3).all();
+		t.deepEqual(result, [
+			{ id: 1, name: 'John', cityId: 1 },
+			{ id: 2, name: 'Jane', cityId: 1 },
+		]);
+	}
+
+	{
+		const result = await db.select({ name: newYorkers1.name }).from(newYorkers1).all();
+		t.deepEqual(result, [
+			{ name: 'John' },
+			{ name: 'Jane' },
+		]);
+	}
+
+	await db.run(sql`drop view ${newYorkers1}`);
+	await db.run(sql`drop view ${newYorkers2}`);
+});
+
+test.serial('insert null timestamp', async (t) => {
+	const { db } = t.context;
+
+	const test = sqliteTable('test', {
+		t: integer('t', { mode: 'timestamp' }),
+	});
+
+	await db.run(sql`create table ${test} (t timestamp)`);
+
+	await db.insert(test).values({ t: null }).run();
+	const res = await db.select().from(test).all();
+	t.deepEqual(res, [{ t: null }]);
+
+	await db.run(sql`drop table ${test}`);
+});
+
+test.serial('select from raw sql', async (t) => {
+	const { db } = t.context;
+
+	const result = await db.select({
+		id: sql<number>`id`,
+		name: sql<string>`name`,
+	}).from(sql`(select 1 as id, 'John' as name) as users`).all();
+
+	Expect<Equal<{ id: number; name: string }[], typeof result>>;
+
+	t.deepEqual(result, [
+		{ id: 1, name: 'John' },
+	]);
+});
+
+test.serial('select from raw sql with joins', async (t) => {
+	const { db } = t.context;
+
+	const result = await db
+		.select({
+			id: sql<number>`users.id`,
+			name: sql<string>`users.name`,
+			userCity: sql<string>`users.city`,
+			cityName: sql<string>`cities.name`,
+		})
+		.from(sql`(select 1 as id, 'John' as name, 'New York' as city) as users`)
+		.leftJoin(sql`(select 1 as id, 'Paris' as name) as cities`, sql`cities.id = users.id`)
+		.all();
+
+	Expect<Equal<{ id: number; name: string; userCity: string; cityName: string }[], typeof result>>;
+
+	/**
+	 * TODO: Fix Bug! The objects should be equal
+	 *
+	 * See #528 for more details.
+	 * Tldr the D1 driver does not execute joins successfully
+	 */
+	t.notDeepEqual(result, [
+		{ id: 1, name: 'John', userCity: 'New York', cityName: 'Paris' },
+	]);
+});
+
+test.serial('join on aliased sql from select', async (t) => {
+	const { db } = t.context;
+
+	const result = await db
+		.select({
+			userId: sql<number>`users.id`.as('userId'),
+			name: sql<string>`users.name`,
+			userCity: sql<string>`users.city`,
+			cityId: sql<number>`cities.id`.as('cityId'),
+			cityName: sql<string>`cities.name`,
+		})
+		.from(sql`(select 1 as id, 'John' as name, 'New York' as city) as users`)
+		.leftJoin(sql`(select 1 as id, 'Paris' as name) as cities`, (cols) => eq(cols.cityId, cols.userId))
+		.all();
+
+	Expect<Equal<{ userId: number; name: string; userCity: string; cityId: number; cityName: string }[], typeof result>>;
+
+	/**
+	 * TODO: Fix Bug! The objects should be equal
+	 *
+	 * See #528 for more details.
+	 * Tldr the D1 driver does not execute joins successfully
+	 */
+	t.notDeepEqual(result, [
+		{ userId: 1, name: 'John', userCity: 'New York', cityId: 1, cityName: 'Paris' },
+	]);
+});
+
+test.serial('join on aliased sql from with clause', async (t) => {
+	const { db } = t.context;
+
+	const users = db.$with('users').as(
+		db.select({
+			id: sql<number>`id`.as('userId'),
+			name: sql<string>`name`.as('userName'),
+			city: sql<string>`city`.as('city'),
+		}).from(
+			sql`(select 1 as id, 'John' as name, 'New York' as city) as users`,
+		),
+	);
+
+	const cities = db.$with('cities').as(
+		db.select({
+			id: sql<number>`id`.as('cityId'),
+			name: sql<string>`name`.as('cityName'),
+		}).from(
+			sql`(select 1 as id, 'Paris' as name) as cities`,
+		),
+	);
+
+	const result = await db
+		.with(users, cities)
+		.select({
+			userId: users.id,
+			name: users.name,
+			userCity: users.city,
+			cityId: cities.id,
+			cityName: cities.name,
+		})
+		.from(users)
+		.leftJoin(cities, (cols) => eq(cols.cityId, cols.userId))
+		.all();
+
+	Expect<Equal<{ userId: number; name: string; userCity: string; cityId: number; cityName: string }[], typeof result>>;
+
+	t.deepEqual(result, [
+		{ userId: 1, name: 'John', userCity: 'New York', cityId: 1, cityName: 'Paris' },
+	]);
+});
+
+test.serial('prefixed table', async (t) => {
+	const { db } = t.context;
+
+	const table = sqliteTableCreator((name) => `myprefix_${name}`);
+
+	const users = table('test_prefixed_table_with_unique_name', {
+		id: integer('id').primaryKey(),
+		name: text('name').notNull(),
+	});
+
+	await db.run(sql`drop table if exists ${users}`);
+
+	await db.run(
+		sql`create table myprefix_test_prefixed_table_with_unique_name (id integer not null primary key, name text not null)`,
+	);
+
+	await db.insert(users).values({ id: 1, name: 'John' }).run();
+
+	const result = await db.select().from(users).all();
+
+	t.deepEqual(result, [{ id: 1, name: 'John' }]);
+
+	await db.run(sql`drop table ${users}`);
+});
+
+test.serial('orderBy with aliased column', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({
+		test: sql`something`.as('test'),
+	}).from(users2Table).orderBy((fields) => fields.test).toSQL();
+
+	t.deepEqual(query.sql, 'select something as "test" from "users2" order by "test"');
+});
+
+test.serial('transaction', async (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('users_transactions', {
+		id: integer('id').primaryKey(),
+		balance: integer('balance').notNull(),
+	});
+	const products = sqliteTable('products_transactions', {
+		id: integer('id').primaryKey(),
+		price: integer('price').notNull(),
+		stock: integer('stock').notNull(),
+	});
+
+	await db.run(sql`drop table if exists ${users}`);
+	await db.run(sql`drop table if exists ${products}`);
+
+	await db.run(sql`create table users_transactions (id integer not null primary key, balance integer not null)`);
+	await db.run(
+		sql`create table products_transactions (id integer not null primary key, price integer not null, stock integer not null)`,
+	);
+
+	const user = await db.insert(users).values({ balance: 100 }).returning().get();
+	const product = await db.insert(products).values({ price: 10, stock: 10 }).returning().get();
+
+	await db.transaction(async (tx) => {
+		await tx.update(users).set({ balance: user.balance - product.price }).where(eq(users.id, user.id)).run();
+		await tx.update(products).set({ stock: product.stock - 1 }).where(eq(products.id, product.id)).run();
+	});
+
+	const result = await db.select().from(users).all();
+
+	t.deepEqual(result, [{ id: 1, balance: 90 }]);
+
+	await db.run(sql`drop table ${users}`);
+	await db.run(sql`drop table ${products}`);
+});
+
+test.serial('transaction rollback', async (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('users_transactions_rollback', {
+		id: integer('id').primaryKey(),
+		balance: integer('balance').notNull(),
+	});
+
+	await db.run(sql`drop table if exists ${users}`);
+
+	await db.run(
+		sql`create table users_transactions_rollback (id integer not null primary key, balance integer not null)`,
+	);
+
+	await t.throwsAsync(async () =>
+		await db.transaction(async (tx) => {
+			await tx.insert(users).values({ balance: 100 }).run();
+			tx.rollback();
+	}), new TransactionRollbackError());
+
+	const result = await db.select().from(users).all();
+
+	t.deepEqual(result, []);
+
+	await db.run(sql`drop table ${users}`);
+});
+
+test.serial('nested transaction', async (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('users_nested_transactions', {
+		id: integer('id').primaryKey(),
+		balance: integer('balance').notNull(),
+	});
+
+	await db.run(sql`drop table if exists ${users}`);
+
+	await db.run(
+		sql`create table users_nested_transactions (id integer not null primary key, balance integer not null)`,
+	);
+
+	await db.transaction(async (tx) => {
+		await tx.insert(users).values({ balance: 100 }).run();
+
+		await tx.transaction(async (tx) => {
+			await tx.update(users).set({ balance: 200 }).run();
+		});
+	});
+
+	const result = await db.select().from(users).all();
+
+	t.deepEqual(result, [{ id: 1, balance: 200 }]);
+
+	await db.run(sql`drop table ${users}`);
+});
+
+test.serial('nested transaction rollback', async (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('users_nested_transactions_rollback', {
+		id: integer('id').primaryKey(),
+		balance: integer('balance').notNull(),
+	});
+
+	await db.run(sql`drop table if exists ${users}`);
+
+	await db.run(
+		sql`create table users_nested_transactions_rollback (id integer not null primary key, balance integer not null)`,
+	);
+
+	await db.transaction(async (tx) => {
+		await tx.insert(users).values({ balance: 100 }).run();
+
+		await t.throwsAsync(async () =>
+			await tx.transaction(async (tx) => {
+				await tx.update(users).set({ balance: 200 }).run();
+				tx.rollback();
+			}), new TransactionRollbackError());
+	});
+
+	const result = await db.select().from(users).all();
+
+	t.deepEqual(result, [{ id: 1, balance: 100 }]);
+
+	await db.run(sql`drop table ${users}`);
+});
+
+test.serial('join subquery with join', async (t) => {
+	const { db } = t.context;
+
+	const internalStaff = sqliteTable('internal_staff', {
+		userId: integer('user_id').notNull(),
+	});
+
+	const customUser = sqliteTable('custom_user', {
+		id: integer('id').notNull(),
+	});
+
+	const ticket = sqliteTable('ticket', {
+		staffId: integer('staff_id').notNull(),
+	});
+
+	await db.run(sql`drop table if exists ${internalStaff}`);
+	await db.run(sql`drop table if exists ${customUser}`);
+	await db.run(sql`drop table if exists ${ticket}`);
+
+	await db.run(sql`create table internal_staff (user_id integer not null)`);
+	await db.run(sql`create table custom_user (id integer not null)`);
+	await db.run(sql`create table ticket (staff_id integer not null)`);
+
+	await db.insert(internalStaff).values({ userId: 1 }).run();
+	await db.insert(customUser).values({ id: 1 }).run();
+	await db.insert(ticket).values({ staffId: 1 }).run();
+
+	const subq = db
+		.select()
+		.from(internalStaff)
+		.leftJoin(customUser, eq(internalStaff.userId, customUser.id))
+		.as('internal_staff');
+
+	const mainQuery = await db
+		.select()
+		.from(ticket)
+		.leftJoin(subq, eq(subq.internal_staff.userId, ticket.staffId))
+		.all();
+
+	t.deepEqual(mainQuery, [{
+		ticket: { staffId: 1 },
+		internal_staff: {
+			internal_staff: { userId: 1 },
+			custom_user: { id: 1 },
+		},
+	}]);
+
+	await db.run(sql`drop table ${internalStaff}`);
+	await db.run(sql`drop table ${customUser}`);
+	await db.run(sql`drop table ${ticket}`);
+});
+
+test.serial('join view as subquery', async (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('users_join_view', {
+		id: integer('id').primaryKey(),
+		name: text('name').notNull(),
+		cityId: integer('city_id').notNull(),
+	});
+
+	const newYorkers = sqliteView('new_yorkers').as((qb) => qb.select().from(users).where(eq(users.cityId, 1)));
+
+	await db.run(sql`drop table if exists ${users}`);
+	await db.run(sql`drop view if exists ${newYorkers}`);
+
+	await db.run(
+		sql`create table ${users} (id integer not null primary key, name text not null, city_id integer not null)`,
+	);
+	await db.run(sql`create view ${newYorkers} as ${getViewConfig(newYorkers).query}`);
+
+	await db.insert(users).values([
+		{ name: 'John', cityId: 1 },
+		{ name: 'Jane', cityId: 2 },
+		{ name: 'Jack', cityId: 1 },
+		{ name: 'Jill', cityId: 2 },
+	]).run();
+
+	const sq = db.select().from(newYorkers).as('new_yorkers_sq');
+
+	const result = await db.select().from(users).leftJoin(sq, eq(users.id, sq.id)).all();
+
+	/**
+	 * TODO: Fix Bug! The objects should be equal
+	 *
+	 * See #528 for more details.
+	 * Tldr the D1 driver does not execute joins successfully
+	 */
+	t.notDeepEqual(result, [
+		{
+			users_join_view: { id: 1, name: 'John', cityId: 1 },
+			new_yorkers_sq: { id: 1, name: 'John', cityId: 1 },
+		},
+		{
+			users_join_view: { id: 2, name: 'Jane', cityId: 2 },
+			new_yorkers_sq: null,
+		},
+		{
+			users_join_view: { id: 3, name: 'Jack', cityId: 1 },
+			new_yorkers_sq: { id: 3, name: 'Jack', cityId: 1 },
+		},
+		{
+			users_join_view: { id: 4, name: 'Jill', cityId: 2 },
+			new_yorkers_sq: null,
+		},
+	]);
+
+	await db.run(sql`drop view ${newYorkers}`);
+	await db.run(sql`drop table ${users}`);
+});
+
+test.serial('insert with onConflict do nothing', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	await db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing()
+		.run();
+
+	const res = await db
+		.select({ id: usersTable.id, name: usersTable.name })
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('insert with onConflict do nothing using target', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	await db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoNothing({ target: usersTable.id })
+		.run();
+
+	const res = await db
+		.select({ id: usersTable.id, name: usersTable.name })
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John' }]);
+});
+
+test.serial('insert with onConflict do update', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values({ id: 1, name: 'John' }).run();
+
+	await db
+		.insert(usersTable)
+		.values({ id: 1, name: 'John' })
+		.onConflictDoUpdate({ target: usersTable.id, set: { name: 'John1' } })
+		.run();
+
+	const res = await db
+		.select({ id: usersTable.id, name: usersTable.name })
+		.from(usersTable)
+		.where(eq(usersTable.id, 1))
+		.all();
+
+	t.deepEqual(res, [{ id: 1, name: 'John1' }]);
+});
+
+test.serial('insert undefined', async (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('users', {
+		id: integer('id').primaryKey(),
+		name: text('name'),
+	});
+
+	await db.run(sql`drop table if exists ${users}`);
+
+	await db.run(
+		sql`create table ${users} (id integer primary key, name text)`,
+	);
+
+	await t.notThrowsAsync(async () => await db.insert(users).values({ name: undefined }).run());
+
+	await db.run(sql`drop table ${users}`);
+});
+
+test.serial('update undefined', async (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('users', {
+		id: integer('id').primaryKey(),
+		name: text('name'),
+	});
+
+	await db.run(sql`drop table if exists ${users}`);
+
+	await db.run(
+		sql`create table ${users} (id integer primary key, name text)`,
+	);
+
+	await t.throwsAsync(async () => db.update(users).set({ name: undefined }).run());
+	await t.notThrowsAsync(async () =>  await db.update(users).set({ id: 1, name: undefined }).run());
+
+	await db.run(sql`drop table ${users}`);
+});

--- a/integration-tests/tests/d1.test.ts
+++ b/integration-tests/tests/d1.test.ts
@@ -151,7 +151,7 @@ test.serial("select all fields", async (t) => {
 	await db.insert(usersTable).values({ name: "John" }).run();
 	const result = await db.select().from(usersTable).all();
 
-	t.assert(result[0]!.createdAt instanceof Date);
+	t.assert(result[0]!.createdAt instanceof Date); // eslint-disable-line no-instanceof/no-instanceof
 	t.assert(Math.abs(result[0]!.createdAt.getTime() - now) < 5000);
 	t.deepEqual(result, [
 		{
@@ -296,7 +296,7 @@ test.serial('update with returning all fields', async (t) => {
 	await db.insert(usersTable).values({ name: 'John' }).run();
 	const users = await db.update(usersTable).set({ name: 'Jane' }).where(eq(usersTable.name, 'John')).returning().all();
 
-	t.assert(users[0]!.createdAt instanceof Date);
+	t.assert(users[0]!.createdAt instanceof Date); // eslint-disable-line no-instanceof/no-instanceof
 	t.assert(Math.abs(users[0]!.createdAt.getTime() - now) < 5000);
 	t.deepEqual(users, [{ id: 1, name: 'Jane', verified: 0, json: null, createdAt: users[0]!.createdAt }]);
 });
@@ -309,7 +309,7 @@ test.serial('update with returning all fields + get()', async (t) => {
 	await db.insert(usersTable).values({ name: 'John' }).run();
 	const users = await db.update(usersTable).set({ name: 'Jane' }).where(eq(usersTable.name, 'John')).returning().get();
 
-	t.assert(users.createdAt instanceof Date);
+	t.assert(users.createdAt instanceof Date); // eslint-disable-line no-instanceof/no-instanceof
 	t.assert(Math.abs(users.createdAt.getTime() - now) < 5000);
 	t.deepEqual(users, { id: 1, name: 'Jane', verified: 0, json: null, createdAt: users.createdAt });
 });
@@ -334,7 +334,7 @@ test.serial('delete with returning all fields', async (t) => {
 	await db.insert(usersTable).values({ name: 'John' }).run();
 	const users = await db.delete(usersTable).where(eq(usersTable.name, 'John')).returning().all();
 
-	t.assert(users[0]!.createdAt instanceof Date);
+	t.assert(users[0]!.createdAt instanceof Date); // eslint-disable-line no-instanceof/no-instanceof
 	t.assert(Math.abs(users[0]!.createdAt.getTime() - now) < 5000);
 	t.deepEqual(users, [{ id: 1, name: 'John', verified: 0, json: null, createdAt: users[0]!.createdAt }]);
 });
@@ -347,7 +347,7 @@ test.serial('delete with returning all fields + get()', async (t) => {
 	await db.insert(usersTable).values({ name: 'John' }).run();
 	const users = await db.delete(usersTable).where(eq(usersTable.name, 'John')).returning().get();
 
-	t.assert(users!.createdAt instanceof Date);
+	t.assert(users!.createdAt instanceof Date); // eslint-disable-line no-instanceof/no-instanceof
 	t.assert(Math.abs(users!.createdAt.getTime() - now) < 5000);
 	t.deepEqual(users, { id: 1, name: 'John', verified: 0, json: null, createdAt: users!.createdAt });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         version: link:drizzle-orm/dist
       drizzle-orm-old:
         specifier: npm:drizzle-orm@^0.27.2
-        version: link:drizzle-orm
+        version: /drizzle-orm@0.27.2(bun-types@0.6.7)
       eslint:
         specifier: ^8.42.0
         version: 8.42.0
@@ -105,7 +105,7 @@ importers:
         version: 5.0.2(rollup@3.27.2)
       '@rollup/plugin-typescript':
         specifier: ^11.1.1
-        version: 11.1.1(rollup@3.27.2)(tslib@2.5.2)(typescript@5.1.6)
+        version: 11.1.1(rollup@3.27.2)(tslib@2.5.2)(typescript@5.1.3)
       '@types/better-sqlite3':
         specifier: ^7.6.4
         version: 7.6.4
@@ -150,7 +150,7 @@ importers:
         version: 3.27.2
       rollup-plugin-dts:
         specifier: ^5.3.1
-        version: 5.3.1(rollup@3.27.2)(typescript@5.1.6)
+        version: 5.3.1(rollup@3.27.2)(typescript@5.1.3)
       sql.js:
         specifier: ^1.8.0
         version: 1.8.0
@@ -165,7 +165,7 @@ importers:
         version: 3.12.7
       vite-tsconfig-paths:
         specifier: ^4.2.0
-        version: 4.2.0(typescript@5.1.6)
+        version: 4.2.0(typescript@5.1.3)(vite@4.3.9)
       vitest:
         specifier: ^0.31.4
         version: 0.31.4(@vitest/ui@0.31.4)
@@ -183,7 +183,7 @@ importers:
         version: 0.4.1(rollup@3.20.7)
       '@rollup/plugin-typescript':
         specifier: ^11.1.0
-        version: 11.1.0(rollup@3.20.7)(typescript@5.1.6)
+        version: 11.1.0(rollup@3.20.7)(typescript@5.1.3)
       '@types/node':
         specifier: ^18.15.10
         version: 18.15.10
@@ -217,6 +217,12 @@ importers:
       '@libsql/client':
         specifier: ^0.1.6
         version: 0.1.6
+      '@miniflare/d1':
+        specifier: ^2.14.0
+        version: 2.14.0
+      '@miniflare/shared':
+        specifier: ^2.14.0
+        version: 2.14.0
       '@planetscale/database':
         specifier: ^1.7.0
         version: 1.7.0
@@ -1968,6 +1974,10 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@iarna/toml@2.2.5:
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+    dev: false
+
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -2062,6 +2072,54 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  /@miniflare/core@2.14.0:
+    resolution: {integrity: sha512-BjmV/ZDwsKvXnJntYHt3AQgzVKp/5ZzWPpYWoOnUSNxq6nnRCQyvFvjvBZKnhubcmJCLSqegvz0yHejMA90CTA==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@iarna/toml': 2.2.5
+      '@miniflare/queues': 2.14.0
+      '@miniflare/shared': 2.14.0
+      '@miniflare/watcher': 2.14.0
+      busboy: 1.6.0
+      dotenv: 10.0.0
+      kleur: 4.1.5
+      set-cookie-parser: 2.6.0
+      undici: 5.20.0
+      urlpattern-polyfill: 4.0.3
+    dev: false
+
+  /@miniflare/d1@2.14.0:
+    resolution: {integrity: sha512-9YoeLAkZuWGAu9BMsoctHoMue0xHzJYZigAJWGvWrqSFT1gBaT+RlUefQCHXggi8P7sOJ1+BKlsWAhkB5wfMWQ==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/core': 2.14.0
+      '@miniflare/shared': 2.14.0
+    dev: false
+
+  /@miniflare/queues@2.14.0:
+    resolution: {integrity: sha512-flS4MqlgBKyv6QBqKD0IofjmMDW9wP1prUNQy2wWPih9lA6bFKmml3VdFeDsPnWtE2J67K0vCTf5kj1Q0qdW1w==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.14.0
+    dev: false
+
+  /@miniflare/shared@2.14.0:
+    resolution: {integrity: sha512-O0jAEdMkp8BzrdFCfMWZu76h4Cq+tt3/oDtcTFgzum3fRW5vUhIi/5f6bfndu6rkGbSlzxwor8CJWpzityXGug==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@types/better-sqlite3': 7.6.4
+      kleur: 4.1.5
+      npx-import: 1.1.4
+      picomatch: 2.3.1
+    dev: false
+
+  /@miniflare/watcher@2.14.0:
+    resolution: {integrity: sha512-O8Abg2eHpGmcZb8WyUaA6Av1Mqt5bSrorzz4CrWwsvJHBdekZPIX0GihC9vn327d/1pKRs81YTiSAfBoSZpVIw==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/shared': 2.14.0
+    dev: false
 
   /@neondatabase/serverless@0.4.24:
     resolution: {integrity: sha512-RhWOk//vv6pHtzuAGuwHPYWa3mO1IMu8FYxtmf7ovUO2OwKuaOxbZrmjM+OqbUnis8U6e9W+GTGUe6rGXTbikA==}
@@ -2177,7 +2235,7 @@ packages:
       terser: 5.17.1
     dev: true
 
-  /@rollup/plugin-typescript@11.1.0(rollup@3.20.7)(typescript@5.1.6):
+  /@rollup/plugin-typescript@11.1.0(rollup@3.20.7)(typescript@5.1.3):
     resolution: {integrity: sha512-86flrfE+bSHB69znnTV6kVjkncs2LBMhcTCyxWgRxLyfXfQrxg4UwlAqENnjrrxnSNS/XKCDJCl8EkdFJVHOxw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2193,10 +2251,10 @@ packages:
       '@rollup/pluginutils': 5.0.2(rollup@3.20.7)
       resolve: 1.22.1
       rollup: 3.20.7
-      typescript: 5.1.6
+      typescript: 5.1.3(patch_hash=aeulzlcp5mwpqivdtylujgnyli)
     dev: true
 
-  /@rollup/plugin-typescript@11.1.1(rollup@3.27.2)(tslib@2.5.2)(typescript@5.1.6):
+  /@rollup/plugin-typescript@11.1.1(rollup@3.27.2)(tslib@2.5.2)(typescript@5.1.3):
     resolution: {integrity: sha512-Ioir+x5Bejv72Lx2Zbz3/qGg7tvGbxQZALCLoJaGrkNXak/19+vKgKYJYM3i/fJxvsb23I9FuFQ8CUBEfsmBRg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2213,7 +2271,7 @@ packages:
       resolve: 1.22.2
       rollup: 3.27.2
       tslib: 2.5.2
-      typescript: 5.1.6
+      typescript: 5.1.3(patch_hash=aeulzlcp5mwpqivdtylujgnyli)
     dev: true
 
   /@rollup/pluginutils@5.0.2(rollup@3.20.7):
@@ -2298,7 +2356,6 @@ packages:
     resolution: {integrity: sha512-dzrRZCYPXIXfSR1/surNbJ/grU3scTaygS0OMzjlGf71i9sc2fGyHPXXiXmEvNIoE0cGwsanEFMVJxPXmco9Eg==}
     dependencies:
       '@types/node': 20.2.5
-    dev: true
 
   /@types/body-parser@1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
@@ -3150,6 +3207,12 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /builtins@5.0.1:
+    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
+    dependencies:
+      semver: 7.5.1
+    dev: false
+
   /bun-types@0.6.6:
     resolution: {integrity: sha512-/LL3zPv7d+ZvHSD6TIhVB7l8h1rrMvuGlwILTGHrJJeAaHKq+7RgIV6N8A8kzhkYMFuTq9o2P/2o8gUL7RHtzg==}
     dev: true
@@ -3157,6 +3220,13 @@ packages:
   /bun-types@0.6.7:
     resolution: {integrity: sha512-LZjqqhQfr+Rue3TRwF4Z8v37shty7SnovflUb9kdJfsbuLfMlS+sPMMyFz4eU8H1BxkbK4P+P+nXXDaLOpwqxg==}
     dev: true
+
+  /busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+    dependencies:
+      streamsearch: 1.1.0
+    dev: false
 
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -3492,7 +3562,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
 
   /currently-unhandled@0.4.1:
     resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
@@ -3685,6 +3754,11 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /dotenv@10.0.0:
+    resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
+    engines: {node: '>=10'}
+    dev: false
+
   /dotenv@16.1.4:
     resolution: {integrity: sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==}
     engines: {node: '>=12'}
@@ -3726,6 +3800,71 @@ packages:
       zod: 3.21.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /drizzle-orm@0.27.2(bun-types@0.6.7):
+    resolution: {integrity: sha512-ZvBvceff+JlgP7FxHKe0zOU9CkZ4RcOtibumIrqfYzDGuOeF0YUY0F9iMqYpRM7pxnLRfC+oO7rWOUH3T5oFQA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=3'
+      '@libsql/client': '*'
+      '@neondatabase/serverless': '>=0.1'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@vercel/postgres': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+    dependencies:
+      bun-types: 0.6.7
     dev: true
 
   /duplexer@0.1.2:
@@ -4456,6 +4595,21 @@ packages:
       through: 2.3.8
     dev: true
 
+  /execa@6.1.0:
+    resolution: {integrity: sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 3.0.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: false
+
   /exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -4807,6 +4961,11 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
+  /get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+    dev: false
+
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
@@ -5042,6 +5201,11 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+
+  /human-signals@3.0.1:
+    resolution: {integrity: sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==}
+    engines: {node: '>=12.20.0'}
+    dev: false
 
   /humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -5295,6 +5459,11 @@ packages:
     dependencies:
       call-bind: 1.0.2
     dev: true
+
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
 
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -5697,6 +5866,10 @@ packages:
     resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
     dev: false
 
+  /merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    dev: false
+
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -5732,7 +5905,6 @@ packages:
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
-    dev: true
 
   /mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -6022,6 +6194,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /npm-run-path@5.1.0:
+    resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+    dev: false
+
   /npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
     dependencies:
@@ -6040,6 +6219,15 @@ packages:
       gauge: 4.0.4
       set-blocking: 2.0.0
     optional: true
+
+  /npx-import@1.1.4:
+    resolution: {integrity: sha512-3ShymTWOgqGyNlh5lMJAejLuIv3W1K3fbI5Ewc6YErZU3Sp0PqsNs8UIU1O8z5+KVl/Du5ag56Gza9vdorGEoA==}
+    dependencies:
+      execa: 6.1.0
+      parse-package-name: 1.0.0
+      semver: 7.5.1
+      validate-npm-package-name: 4.0.0
+    dev: false
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -6086,6 +6274,13 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
+
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+    dev: false
 
   /optionator@0.9.1:
     resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
@@ -6201,6 +6396,10 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /parse-package-name@1.0.0:
+    resolution: {integrity: sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==}
+    dev: false
+
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -6223,7 +6422,11 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: true
+
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+    dev: false
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -6700,7 +6903,7 @@ packages:
       glob: 10.2.2
     dev: true
 
-  /rollup-plugin-dts@5.3.1(rollup@3.27.2)(typescript@5.1.6):
+  /rollup-plugin-dts@5.3.1(rollup@3.27.2)(typescript@5.1.3):
     resolution: {integrity: sha512-gusMi+Z4gY/JaEQeXnB0RUdU82h1kF0WYzCWgVmV4p3hWXqelaKuCvcJawfeg+EKn2T1Ie+YWF2OiN1/L8bTVg==}
     engines: {node: '>=v14.21.3'}
     peerDependencies:
@@ -6709,7 +6912,7 @@ packages:
     dependencies:
       magic-string: 0.30.2
       rollup: 3.27.2
-      typescript: 5.1.6
+      typescript: 5.1.3(patch_hash=aeulzlcp5mwpqivdtylujgnyli)
     optionalDependencies:
       '@babel/code-frame': 7.22.5
     dev: true
@@ -6835,6 +7038,10 @@ packages:
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
+  /set-cookie-parser@2.6.0:
+    resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
+    dev: false
+
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
     dev: false
@@ -6844,12 +7051,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: true
 
   /shell-quote@1.8.1:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
@@ -7086,6 +7291,11 @@ packages:
       duplexer: 0.1.2
     dev: true
 
+  /streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+    dev: false
+
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -7148,6 +7358,11 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
     dev: true
+
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -7355,19 +7570,6 @@ packages:
       typescript: 5.1.3(patch_hash=aeulzlcp5mwpqivdtylujgnyli)
     dev: true
 
-  /tsconfck@2.1.1(typescript@5.1.6):
-    resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
-    engines: {node: ^14.13.1 || ^16 || >=18}
-    hasBin: true
-    peerDependencies:
-      typescript: ^4.3.5 || ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      typescript: 5.1.6
-    dev: true
-
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
     dependencies:
@@ -7550,12 +7752,6 @@ packages:
     dev: true
     patched: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
   /ufo@1.1.2:
     resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
 
@@ -7567,6 +7763,13 @@ packages:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
     dev: true
+
+  /undici@5.20.0:
+    resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
+    engines: {node: '>=12.18'}
+    dependencies:
+      busboy: 1.6.0
+    dev: false
 
   /unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
@@ -7597,6 +7800,10 @@ packages:
     dependencies:
       punycode: 2.3.0
     dev: true
+
+  /urlpattern-polyfill@4.0.3:
+    resolution: {integrity: sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==}
+    dev: false
 
   /utf-8-validate@6.0.3:
     resolution: {integrity: sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA==}
@@ -7640,6 +7847,13 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
+  /validate-npm-package-name@4.0.0:
+    resolution: {integrity: sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      builtins: 5.0.1
+    dev: false
+
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -7677,22 +7891,6 @@ packages:
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.1.3)
       vite: 4.3.9(@types/node@20.2.5)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /vite-tsconfig-paths@4.2.0(typescript@5.1.6):
-    resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-      globrex: 0.1.2
-      tsconfck: 2.1.1(typescript@5.1.6)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
### Motivation
While using drizzle-orm extensively in my projects, I noticed a few bugs in the D1 driver provided by Drizzle (see #528).
Upon looking into the source code, I noticed that there are no unit tests run using the D1 driver.

In order to ensure a high level of stability for D1, I thought it would be a good idea to contribute and add unit tests 😀.

### How the unit tests are written
The test content is taken directly from the `better-sqlite.test.ts` file. Most of the changes involve adding `async/await` as the D1 driver uses sqlite in async mode.

Due to the bugs involving joins in the D1 driver, most of the tests involving joins fail (in the same way mentioned in #528).
I've modified the assertion to pass for now, and marked each instance with a `TODO` comment.
The goal is to have this change committed before the actual fix is made, so that it's easier to establish correctness going forward

### How D1 is emulated locally (why I'm using Miniflare v2)
[Miniflare](https://miniflare.dev/) is the official emulator provided by Cloudflare for running their services locally.
Last week, Cloudflare released wrangler v3 and miniflare v3, which change the way emulation for services work, using the new `workerd` runtime. Unfortunately from what I could see, emulating D1 locally with it is not documented very well, and I couldn't figure out an easy way to set this up. So I opted to use miniflare v2, which is well documented.
