### PR TITLE
Disable OTEL integration

### DIFF
--- a/changelogs/drizzle-orm/0.26.3.md
+++ b/changelogs/drizzle-orm/0.26.3.md
@@ -1,0 +1,1 @@
+- Disabled OTEL integration due to the top-level await issues

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-orm",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Drizzle ORM package for SQL databases",
   "type": "module",
   "scripts": {

--- a/drizzle-orm/src/tracing.ts
+++ b/drizzle-orm/src/tracing.ts
@@ -4,13 +4,13 @@ import { npmVersion } from '~/version';
 
 let otel: typeof import('@opentelemetry/api') | undefined;
 let rawTracer: Tracer | undefined;
-try {
-	otel = await import('@opentelemetry/api');
-} catch (err: any) {
-	if (err.code !== 'MODULE_NOT_FOUND' && err.code !== 'ERR_MODULE_NOT_FOUND') {
-		throw err;
-	}
-}
+// try {
+// 	otel = await import('@opentelemetry/api');
+// } catch (err: any) {
+// 	if (err.code !== 'MODULE_NOT_FOUND' && err.code !== 'ERR_MODULE_NOT_FOUND') {
+// 		throw err;
+// 	}
+// }
 
 type SpanName =
 	| 'drizzle.operation'


### PR DESCRIPTION
It was implemented using a top-level await,
that is not supported in some bundlers by default