### PR TITLE
[MySQL/Pg/SQLite] Fix drizzle-zod not enforcing string lengths

### DIFF
--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -256,7 +256,7 @@ export function createSelectSchema<
 }
 
 function isWithEnum(column: AnyColumn): column is typeof column & WithEnum {
-	return 'enumValues' in column && Array.isArray(column.enumValues);
+	return 'enumValues' in column && Array.isArray(column.enumValues) && column.enumValues.length > 0;
 }
 
 function mapColumnToSchema(column: AnyColumn): z.ZodTypeAny {
@@ -312,13 +312,25 @@ function mapColumnToSchema(column: AnyColumn): z.ZodTypeAny {
 			|| column instanceof MySqlVarBinary || column instanceof MySqlChar
 		) {
 			let sType = z.string();
-			if (
-				(column instanceof PgChar || column instanceof PgVarchar || column instanceof MySqlVarChar
-					|| column instanceof MySqlVarBinary || column instanceof MySqlChar || column instanceof SQLiteText)
-				&& (typeof column.length === 'number')
-			) {
-				sType = sType.length(column.length);
-			}
+
+            if (
+                (
+                    column instanceof PgChar ||
+                    column instanceof MySqlChar) &&
+                    typeof column.length === "number"
+            ) {
+                sType = sType.length(column.length);
+            } else if (
+                (
+                    column instanceof PgVarchar ||
+                    column instanceof MySqlVarChar ||
+                    column instanceof MySqlVarBinary ||
+                    column instanceof SQLiteText) &&
+                    typeof column.length === "number"
+            ) {
+                sType = sType.max(column.length);
+            }
+
 			type = sType;
 		} else if (column instanceof PgUUID) {
 			type = z.string().uuid();

--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -304,7 +304,8 @@ function mapColumnToSchema(column: AnyColumn): z.ZodTypeAny {
 		} else if (
 			column instanceof PgInterval || column instanceof PgNumeric || column instanceof PgChar
 			|| column instanceof PgCidr || column instanceof PgInet || column instanceof PgMacaddr
-			|| column instanceof PgMacaddr8 || column instanceof PgText || column instanceof PgTime || column instanceof PgDateString
+			|| column instanceof PgMacaddr8 || column instanceof PgText || column instanceof PgTime
+			|| column instanceof PgDateString
 			|| column instanceof PgVarchar || column instanceof SQLiteNumeric || column instanceof SQLiteText
 			|| column instanceof MySqlDateString || column instanceof MySqlDateTimeString || column instanceof MySqlDecimal
 			|| column instanceof MySqlText || column instanceof MySqlTime || column instanceof MySqlTimestampString
@@ -313,22 +314,24 @@ function mapColumnToSchema(column: AnyColumn): z.ZodTypeAny {
 		) {
 			let sType = z.string();
 
-            if (
-                (
-                    column instanceof PgChar ||
-                    column instanceof MySqlChar) &&
-                    typeof column.length === "number"
-            ) {
-                sType = sType.length(column.length);
-            } else if (
-                (
-                    column instanceof PgVarchar ||
-                    column instanceof MySqlVarChar ||
-                    column instanceof SQLiteText) &&
-                    typeof column.length === "number"
-            ) {
-                sType = sType.max(column.length);
-            }
+			if (
+				(
+					column instanceof PgChar
+					|| column instanceof MySqlChar
+				)
+				&& typeof column.length === 'number'
+			) {
+				sType = sType.length(column.length);
+			} else if (
+				(
+					column instanceof PgVarchar
+					|| column instanceof MySqlVarChar
+					|| column instanceof SQLiteText
+				)
+				&& typeof column.length === 'number'
+			) {
+				sType = sType.max(column.length);
+			}
 
 			type = sType;
 		} else if (column instanceof PgUUID) {

--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -324,7 +324,6 @@ function mapColumnToSchema(column: AnyColumn): z.ZodTypeAny {
                 (
                     column instanceof PgVarchar ||
                     column instanceof MySqlVarChar ||
-                    column instanceof MySqlVarBinary ||
                     column instanceof SQLiteText) &&
                     typeof column.length === "number"
             ) {

--- a/drizzle-zod/tests/mysql.test.ts
+++ b/drizzle-zod/tests/mysql.test.ts
@@ -81,62 +81,62 @@ const testTable = mysqlTable('test', {
 });
 
 const testTableRow = {
-    bigint: BigInt(1),
-    bigintNumber: 1,
-    binary: "binary",
-    boolean: true,
-    char: "char",
-    charEnum: "a",
-    customInt: { data: 1 },
-    date: new Date(),
-    dateString: new Date().toISOString(),
-    datetime: new Date(),
-    datetimeString: new Date().toISOString(),
-    decimal: "1.1",
-    double: 1.1,
-    enum: "a",
-    float: 1.1,
-    int: 1,
-    json: { data: 1 },
-    mediumint: 1,
-    real: 1.1,
-    serial: 1,
-    smallint: 1,
-    text: "text",
-    textEnum: "a",
-    tinytext: "tinytext",
-    tinytextEnum: "a",
-    mediumtext: "mediumtext",
-    mediumtextEnum: "a",
-    longtext: "longtext",
-    longtextEnum: "a",
-    time: "00:00:00",
-    timestamp: new Date(),
-    timestampString: new Date().toISOString(),
-    tinyint: 1,
-    varbinary: "A".repeat(200),
-    varchar: "A".repeat(200),
-    varcharEnum: "a",
-    year: 2021,
-    autoIncrement: 1,
+	bigint: BigInt(1),
+	bigintNumber: 1,
+	binary: 'binary',
+	boolean: true,
+	char: 'char',
+	charEnum: 'a',
+	customInt: { data: 1 },
+	date: new Date(),
+	dateString: new Date().toISOString(),
+	datetime: new Date(),
+	datetimeString: new Date().toISOString(),
+	decimal: '1.1',
+	double: 1.1,
+	enum: 'a',
+	float: 1.1,
+	int: 1,
+	json: { data: 1 },
+	mediumint: 1,
+	real: 1.1,
+	serial: 1,
+	smallint: 1,
+	text: 'text',
+	textEnum: 'a',
+	tinytext: 'tinytext',
+	tinytextEnum: 'a',
+	mediumtext: 'mediumtext',
+	mediumtextEnum: 'a',
+	longtext: 'longtext',
+	longtextEnum: 'a',
+	time: '00:00:00',
+	timestamp: new Date(),
+	timestampString: new Date().toISOString(),
+	tinyint: 1,
+	varbinary: 'A'.repeat(200),
+	varchar: 'A'.repeat(200),
+	varcharEnum: 'a',
+	year: 2021,
+	autoIncrement: 1,
 };
 
-test("insert valid row", (t) => {
-    const schema = createInsertSchema(testTable);
+test('insert valid row', (t) => {
+	const schema = createInsertSchema(testTable);
 
-    t.is(schema.safeParse(testTableRow).success, true);
+	t.is(schema.safeParse(testTableRow).success, true);
 });
 
-test("insert invalid varchar length", (t) => {
-    const schema = createInsertSchema(testTable);
+test('insert invalid varchar length', (t) => {
+	const schema = createInsertSchema(testTable);
 
-    t.is(schema.safeParse({ ...testTableRow, varchar: "A".repeat(201) }).success, false);
+	t.is(schema.safeParse({ ...testTableRow, varchar: 'A'.repeat(201) }).success, false);
 });
 
-test("insert invalid char length", (t) => {
-    const schema = createInsertSchema(testTable);
+test('insert invalid char length', (t) => {
+	const schema = createInsertSchema(testTable);
 
-    t.is(schema.safeParse({ ...testTableRow, char: "abc" }).success, false);
+	t.is(schema.safeParse({ ...testTableRow, char: 'abc' }).success, false);
 });
 
 test('insert schema', (t) => {

--- a/drizzle-zod/tests/mysql.test.ts
+++ b/drizzle-zod/tests/mysql.test.ts
@@ -44,7 +44,7 @@ const testTable = mysqlTable('test', {
 	bigintNumber: bigint('bigintNumber', { mode: 'number' }).notNull(),
 	binary: binary('binary').notNull(),
 	boolean: boolean('boolean').notNull(),
-	char: char('char').notNull(),
+	char: char('char', { length: 4 }).notNull(),
 	charEnum: char('char', { enum: ['a', 'b', 'c'] }).notNull(),
 	customInt: customInt('customInt').notNull(),
 	date: date('date').notNull(),
@@ -80,6 +80,65 @@ const testTable = mysqlTable('test', {
 	autoIncrement: int('autoIncrement').notNull().autoincrement(),
 });
 
+const testTableRow = {
+    bigint: BigInt(1),
+    bigintNumber: 1,
+    binary: "binary",
+    boolean: true,
+    char: "char",
+    charEnum: "a",
+    customInt: { data: 1 },
+    date: new Date(),
+    dateString: new Date().toISOString(),
+    datetime: new Date(),
+    datetimeString: new Date().toISOString(),
+    decimal: "1.1",
+    double: 1.1,
+    enum: "a",
+    float: 1.1,
+    int: 1,
+    json: { data: 1 },
+    mediumint: 1,
+    real: 1.1,
+    serial: 1,
+    smallint: 1,
+    text: "text",
+    textEnum: "a",
+    tinytext: "tinytext",
+    tinytextEnum: "a",
+    mediumtext: "mediumtext",
+    mediumtextEnum: "a",
+    longtext: "longtext",
+    longtextEnum: "a",
+    time: "00:00:00",
+    timestamp: new Date(),
+    timestampString: new Date().toISOString(),
+    tinyint: 1,
+    varbinary: "A".repeat(200),
+    varchar: "A".repeat(200),
+    varcharEnum: "a",
+    year: 2021,
+    autoIncrement: 1,
+};
+
+test("insert valid row", (t) => {
+    const schema = createInsertSchema(testTable);
+
+    t.is(schema.safeParse(testTableRow).success, true);
+});
+
+test("insert invalid varchar length", (t) => {
+    const schema = createInsertSchema(testTable);
+
+    t.is(schema.safeParse({ ...testTableRow, varchar: "A".repeat(201) }).success, false);
+});
+
+test("insert invalid char length", (t) => {
+    const schema = createInsertSchema(testTable);
+
+    t.is(schema.safeParse({ ...testTableRow, char: "abc" }).success, false);
+});
+
 test('insert schema', (t) => {
 	const actual = createInsertSchema(testTable);
 
@@ -88,7 +147,7 @@ test('insert schema', (t) => {
 		bigintNumber: z.number(),
 		binary: z.string(),
 		boolean: z.boolean(),
-		char: z.string(),
+		char: z.string().length(4),
 		charEnum: z.enum(['a', 'b', 'c']),
 		customInt: z.any(),
 		date: z.date(),
@@ -117,8 +176,8 @@ test('insert schema', (t) => {
 		timestamp: z.date(),
 		timestampString: z.string(),
 		tinyint: z.number(),
-		varbinary: z.string().length(200),
-		varchar: z.string().length(200),
+		varbinary: z.string().max(200),
+		varchar: z.string().max(200),
 		varcharEnum: z.enum(['a', 'b', 'c']),
 		year: z.number(),
 		autoIncrement: z.number().optional(),
@@ -135,7 +194,7 @@ test('select schema', (t) => {
 		bigintNumber: z.number(),
 		binary: z.string(),
 		boolean: z.boolean(),
-		char: z.string(),
+		char: z.string().length(4),
 		charEnum: z.enum(['a', 'b', 'c']),
 		customInt: z.any(),
 		date: z.date(),
@@ -164,8 +223,8 @@ test('select schema', (t) => {
 		timestamp: z.date(),
 		timestampString: z.string(),
 		tinyint: z.number(),
-		varbinary: z.string().length(200),
-		varchar: z.string().length(200),
+		varbinary: z.string().max(200),
+		varchar: z.string().max(200),
 		varcharEnum: z.enum(['a', 'b', 'c']),
 		year: z.number(),
 		autoIncrement: z.number(),
@@ -184,7 +243,7 @@ test('select schema w/ refine', (t) => {
 		bigintNumber: z.number(),
 		binary: z.string(),
 		boolean: z.boolean(),
-		char: z.string(),
+		char: z.string().length(5),
 		charEnum: z.enum(['a', 'b', 'c']),
 		customInt: z.any(),
 		date: z.date(),
@@ -213,8 +272,8 @@ test('select schema w/ refine', (t) => {
 		timestamp: z.date(),
 		timestampString: z.string(),
 		tinyint: z.number(),
-		varbinary: z.string().length(200),
-		varchar: z.string().length(200),
+		varbinary: z.string().max(200),
+		varchar: z.string().max(200),
 		varcharEnum: z.enum(['a', 'b', 'c']),
 		year: z.number(),
 		autoIncrement: z.number(),

--- a/drizzle-zod/tests/pg.test.ts
+++ b/drizzle-zod/tests/pg.test.ts
@@ -12,46 +12,46 @@ const users = pgTable('users', {
 	name: text('name'),
 	email: text('email').notNull(),
 	birthdayString: date('birthday_string').notNull(),
-	birthdayDate: date('birthday_date', {mode: "date"}).notNull(),
+	birthdayDate: date('birthday_date', { mode: 'date' }).notNull(),
 	createdAt: timestamp('created_at').notNull().defaultNow(),
 	role: roleEnum('role').notNull(),
 	roleText: text('role1', { enum: ['admin', 'user'] }).notNull(),
 	roleText2: text('role2', { enum: ['admin', 'user'] }).notNull().default('user'),
-    profession: varchar('profession', { length: 20 }).notNull(),
-    initials: char('initials', { length: 2 }).notNull(),
+	profession: varchar('profession', { length: 20 }).notNull(),
+	initials: char('initials', { length: 2 }).notNull(),
 });
 
 const testUser = {
-    a: [1, 2, 3],
-    id: 1,
-    name: 'John Doe',
-    email: 'john.doe@example.com',
-    birthdayString: '1990-01-01',
-    birthdayDate: new Date('1990-01-01'),
-    createdAt: new Date(),
-    role: 'admin',
-    roleText: 'admin',
-    roleText2: 'admin',
-    profession: 'Software Engineer',
-    initials: 'JD',
-}
+	a: [1, 2, 3],
+	id: 1,
+	name: 'John Doe',
+	email: 'john.doe@example.com',
+	birthdayString: '1990-01-01',
+	birthdayDate: new Date('1990-01-01'),
+	createdAt: new Date(),
+	role: 'admin',
+	roleText: 'admin',
+	roleText2: 'admin',
+	profession: 'Software Engineer',
+	initials: 'JD',
+};
 
-test("users insert valid user", (t) => {
-    const schema = createInsertSchema(users);
+test('users insert valid user', (t) => {
+	const schema = createInsertSchema(users);
 
-    t.is(schema.safeParse(testUser).success, true);
+	t.is(schema.safeParse(testUser).success, true);
 });
 
-test("users insert invalid varchar", (t) => {
-    const schema = createInsertSchema(users);
+test('users insert invalid varchar', (t) => {
+	const schema = createInsertSchema(users);
 
-    t.is(schema.safeParse({ ...testUser, profession: "Chief Executive Officer" }).success, false);
+	t.is(schema.safeParse({ ...testUser, profession: 'Chief Executive Officer' }).success, false);
 });
 
-test("users insert invalid char", (t) => {
-    const schema = createInsertSchema(users);
+test('users insert invalid char', (t) => {
+	const schema = createInsertSchema(users);
 
-    t.is(schema.safeParse({ ...testUser, initials: "JoDo" }).success, false);
+	t.is(schema.safeParse({ ...testUser, initials: 'JoDo' }).success, false);
 });
 
 test('users insert schema', (t) => {
@@ -78,19 +78,19 @@ test('users insert schema', (t) => {
 	});
 
 	const expected = z.object({
-        a: z.array(z.number()).nullable().optional(),
-        id: z.number().positive().optional(),
-        name: z.string().nullable().optional(),
-        email: z.string().email(),
-        birthdayString: z.string(),
-        birthdayDate: z.date(),
-        createdAt: z.date().optional(),
-        role: z.enum(["admin", "user"]),
-        roleText: z.enum(["user", "manager", "admin"]),
-        roleText2: z.enum(["admin", "user"]).optional(),
-        profession: z.string().max(20).min(1),
-        initials: z.string().max(2).min(1),
-    });
+		a: z.array(z.number()).nullable().optional(),
+		id: z.number().positive().optional(),
+		name: z.string().nullable().optional(),
+		email: z.string().email(),
+		birthdayString: z.string(),
+		birthdayDate: z.date(),
+		createdAt: z.date().optional(),
+		role: z.enum(['admin', 'user']),
+		roleText: z.enum(['user', 'manager', 'admin']),
+		roleText2: z.enum(['admin', 'user']).optional(),
+		profession: z.string().max(20).min(1),
+		initials: z.string().max(2).min(1),
+	});
 
 	expectSchemaShape(t, expected).from(actual);
 });
@@ -99,19 +99,19 @@ test('users insert schema w/ defaults', (t) => {
 	const actual = createInsertSchema(users);
 
 	const expected = z.object({
-        a: z.array(z.number()).nullable().optional(),
-        id: z.number().optional(),
-        name: z.string().nullable().optional(),
-        email: z.string(),
-        birthdayString: z.string(),
-        birthdayDate: z.date(),
-        createdAt: z.date().optional(),
-        role: z.enum(["admin", "user"]),
-        roleText: z.enum(["admin", "user"]),
-        roleText2: z.enum(["admin", "user"]).optional(),
-        profession: z.string().max(20).min(1),
-        initials: z.string().max(2).min(1),
-    });
+		a: z.array(z.number()).nullable().optional(),
+		id: z.number().optional(),
+		name: z.string().nullable().optional(),
+		email: z.string(),
+		birthdayString: z.string(),
+		birthdayDate: z.date(),
+		createdAt: z.date().optional(),
+		role: z.enum(['admin', 'user']),
+		roleText: z.enum(['admin', 'user']),
+		roleText2: z.enum(['admin', 'user']).optional(),
+		profession: z.string().max(20).min(1),
+		initials: z.string().max(2).min(1),
+	});
 
 	expectSchemaShape(t, expected).from(actual);
 });
@@ -124,19 +124,19 @@ test('users select schema', (t) => {
 	});
 
 	const expected = z.object({
-        a: z.array(z.number()).nullable(),
-        id: z.number().positive(),
-        name: z.string().nullable(),
-        email: z.string().email(),
-        birthdayString: z.string(),
-        birthdayDate: z.date(),
-        createdAt: z.date(),
-        role: z.enum(["admin", "user"]),
-        roleText: z.enum(["user", "manager", "admin"]),
-        roleText2: z.enum(["admin", "user"]),
-        profession: z.string().max(20).min(1),
-        initials: z.string().max(2).min(1),
-    });
+		a: z.array(z.number()).nullable(),
+		id: z.number().positive(),
+		name: z.string().nullable(),
+		email: z.string().email(),
+		birthdayString: z.string(),
+		birthdayDate: z.date(),
+		createdAt: z.date(),
+		role: z.enum(['admin', 'user']),
+		roleText: z.enum(['user', 'manager', 'admin']),
+		roleText2: z.enum(['admin', 'user']),
+		profession: z.string().max(20).min(1),
+		initials: z.string().max(2).min(1),
+	});
 
 	expectSchemaShape(t, expected).from(actual);
 });
@@ -145,19 +145,19 @@ test('users select schema w/ defaults', (t) => {
 	const actual = createSelectSchema(users);
 
 	const expected = z.object({
-        a: z.array(z.number()).nullable(),
-        id: z.number(),
-        name: z.string().nullable(),
-        email: z.string(),
-        birthdayString: z.string(),
-        birthdayDate: z.date(),
-        createdAt: z.date(),
-        role: z.enum(["admin", "user"]),
-        roleText: z.enum(["admin", "user"]),
-        roleText2: z.enum(["admin", "user"]),
-        profession: z.string().max(20).min(1),
-        initials: z.string().max(2).min(1),
-    });
+		a: z.array(z.number()).nullable(),
+		id: z.number(),
+		name: z.string().nullable(),
+		email: z.string(),
+		birthdayString: z.string(),
+		birthdayDate: z.date(),
+		createdAt: z.date(),
+		role: z.enum(['admin', 'user']),
+		roleText: z.enum(['admin', 'user']),
+		roleText2: z.enum(['admin', 'user']),
+		profession: z.string().max(20).min(1),
+		initials: z.string().max(2).min(1),
+	});
 
 	expectSchemaShape(t, expected).from(actual);
 });

--- a/drizzle-zod/tests/pg.test.ts
+++ b/drizzle-zod/tests/pg.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { integer, pgEnum, pgTable, serial, text, timestamp, date } from 'drizzle-orm/pg-core';
+import { char, date, integer, pgEnum, pgTable, serial, text, timestamp, varchar } from 'drizzle-orm/pg-core';
 import { z } from 'zod';
 import { createInsertSchema, createSelectSchema } from '../src';
 import { expectSchemaShape } from './utils';
@@ -17,6 +17,41 @@ const users = pgTable('users', {
 	role: roleEnum('role').notNull(),
 	roleText: text('role1', { enum: ['admin', 'user'] }).notNull(),
 	roleText2: text('role2', { enum: ['admin', 'user'] }).notNull().default('user'),
+    profession: varchar('profession', { length: 20 }).notNull(),
+    initials: char('initials', { length: 2 }).notNull(),
+});
+
+const testUser = {
+    a: [1, 2, 3],
+    id: 1,
+    name: 'John Doe',
+    email: 'john.doe@example.com',
+    birthdayString: '1990-01-01',
+    birthdayDate: new Date('1990-01-01'),
+    createdAt: new Date(),
+    role: 'admin',
+    roleText: 'admin',
+    roleText2: 'admin',
+    profession: 'Software Engineer',
+    initials: 'JD',
+}
+
+test("users insert valid user", (t) => {
+    const schema = createInsertSchema(users);
+
+    t.is(schema.safeParse(testUser).success, true);
+});
+
+test("users insert invalid varchar", (t) => {
+    const schema = createInsertSchema(users);
+
+    t.is(schema.safeParse({ ...testUser, profession: "Chief Executive Officer" }).success, false);
+});
+
+test("users insert invalid char", (t) => {
+    const schema = createInsertSchema(users);
+
+    t.is(schema.safeParse({ ...testUser, initials: "JoDo" }).success, false);
 });
 
 test('users insert schema', (t) => {
@@ -43,17 +78,19 @@ test('users insert schema', (t) => {
 	});
 
 	const expected = z.object({
-		a: z.array(z.number()).nullable().optional(),
-		id: z.number().positive().optional(),
-		name: z.string().nullable().optional(),
-		email: z.string().email(),
-		birthdayString: z.string(),
-		birthdayDate: z.date(),
-		createdAt: z.date().optional(),
-		role: z.enum(['admin', 'user']),
-		roleText: z.enum(['user', 'manager', 'admin']),
-		roleText2: z.enum(['admin', 'user']).optional(),
-	});
+        a: z.array(z.number()).nullable().optional(),
+        id: z.number().positive().optional(),
+        name: z.string().nullable().optional(),
+        email: z.string().email(),
+        birthdayString: z.string(),
+        birthdayDate: z.date(),
+        createdAt: z.date().optional(),
+        role: z.enum(["admin", "user"]),
+        roleText: z.enum(["user", "manager", "admin"]),
+        roleText2: z.enum(["admin", "user"]).optional(),
+        profession: z.string().max(20).min(1),
+        initials: z.string().max(2).min(1),
+    });
 
 	expectSchemaShape(t, expected).from(actual);
 });
@@ -62,17 +99,19 @@ test('users insert schema w/ defaults', (t) => {
 	const actual = createInsertSchema(users);
 
 	const expected = z.object({
-		a: z.array(z.number()).nullable().optional(),
-		id: z.number().optional(),
-		name: z.string().nullable().optional(),
-		email: z.string(),
-		birthdayString: z.string(),
-		birthdayDate: z.date(),
-		createdAt: z.date().optional(),
-		role: z.enum(['admin', 'user']),
-		roleText: z.enum(['admin', 'user']),
-		roleText2: z.enum(['admin', 'user']).optional(),
-	});
+        a: z.array(z.number()).nullable().optional(),
+        id: z.number().optional(),
+        name: z.string().nullable().optional(),
+        email: z.string(),
+        birthdayString: z.string(),
+        birthdayDate: z.date(),
+        createdAt: z.date().optional(),
+        role: z.enum(["admin", "user"]),
+        roleText: z.enum(["admin", "user"]),
+        roleText2: z.enum(["admin", "user"]).optional(),
+        profession: z.string().max(20).min(1),
+        initials: z.string().max(2).min(1),
+    });
 
 	expectSchemaShape(t, expected).from(actual);
 });
@@ -85,17 +124,19 @@ test('users select schema', (t) => {
 	});
 
 	const expected = z.object({
-		a: z.array(z.number()).nullable(),
-		id: z.number().positive(),
-		name: z.string().nullable(),
-		email: z.string().email(),
-		birthdayString: z.string(),
-		birthdayDate: z.date(),
-		createdAt: z.date(),
-		role: z.enum(['admin', 'user']),
-		roleText: z.enum(['user', 'manager', 'admin']),
-		roleText2: z.enum(['admin', 'user']),
-	});
+        a: z.array(z.number()).nullable(),
+        id: z.number().positive(),
+        name: z.string().nullable(),
+        email: z.string().email(),
+        birthdayString: z.string(),
+        birthdayDate: z.date(),
+        createdAt: z.date(),
+        role: z.enum(["admin", "user"]),
+        roleText: z.enum(["user", "manager", "admin"]),
+        roleText2: z.enum(["admin", "user"]),
+        profession: z.string().max(20).min(1),
+        initials: z.string().max(2).min(1),
+    });
 
 	expectSchemaShape(t, expected).from(actual);
 });
@@ -104,17 +145,19 @@ test('users select schema w/ defaults', (t) => {
 	const actual = createSelectSchema(users);
 
 	const expected = z.object({
-		a: z.array(z.number()).nullable(),
-		id: z.number(),
-		name: z.string().nullable(),
-		email: z.string(),
-		birthdayString: z.string(),
-		birthdayDate: z.date(),
-		createdAt: z.date(),
-		role: z.enum(['admin', 'user']),
-		roleText: z.enum(['admin', 'user']),
-		roleText2: z.enum(['admin', 'user']),
-	});
+        a: z.array(z.number()).nullable(),
+        id: z.number(),
+        name: z.string().nullable(),
+        email: z.string(),
+        birthdayString: z.string(),
+        birthdayDate: z.date(),
+        createdAt: z.date(),
+        role: z.enum(["admin", "user"]),
+        roleText: z.enum(["admin", "user"]),
+        roleText2: z.enum(["admin", "user"]),
+        profession: z.string().max(20).min(1),
+        initials: z.string().max(2).min(1),
+    });
 
 	expectSchemaShape(t, expected).from(actual);
 });

--- a/drizzle-zod/tests/sqlite.test.ts
+++ b/drizzle-zod/tests/sqlite.test.ts
@@ -21,27 +21,27 @@ const users = sqliteTable('users', {
 });
 
 const testUser = {
-    id: 1,
-    blobJson: { foo: 'bar' },
-    blobBigInt: BigInt(123),
-    numeric: '123.45',
-    createdAt: new Date(),
-    createdAtMs: new Date(),
-    real: 123.45,
-    text: 'foobar',
-    role: 'admin',
-}
+	id: 1,
+	blobJson: { foo: 'bar' },
+	blobBigInt: BigInt(123),
+	numeric: '123.45',
+	createdAt: new Date(),
+	createdAtMs: new Date(),
+	real: 123.45,
+	text: 'foobar',
+	role: 'admin',
+};
 
-test("users insert valid user", (t) => {
-    const schema = createInsertSchema(users);
+test('users insert valid user', (t) => {
+	const schema = createInsertSchema(users);
 
-    t.is(schema.safeParse(testUser).success, true);
-})
+	t.is(schema.safeParse(testUser).success, true);
+});
 
-test("users insert invalid text length", (t) => {
-    const schema = createInsertSchema(users);
+test('users insert invalid text length', (t) => {
+	const schema = createInsertSchema(users);
 
-    t.is(schema.safeParse({ ...testUser, text: "a".repeat(256) }).success, false);
+	t.is(schema.safeParse({ ...testUser, text: 'a'.repeat(256) }).success, false);
 });
 
 test('users insert schema', (t) => {

--- a/drizzle-zod/tests/sqlite.test.ts
+++ b/drizzle-zod/tests/sqlite.test.ts
@@ -16,8 +16,32 @@ const users = sqliteTable('users', {
 	createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 	createdAtMs: integer('created_at_ms', { mode: 'timestamp_ms' }).notNull(),
 	real: real('real').notNull(),
-	text: text('text'),
+	text: text('text', { length: 255 }),
 	role: text('role', { enum: ['admin', 'user'] }).notNull().default('user'),
+});
+
+const testUser = {
+    id: 1,
+    blobJson: { foo: 'bar' },
+    blobBigInt: BigInt(123),
+    numeric: '123.45',
+    createdAt: new Date(),
+    createdAtMs: new Date(),
+    real: 123.45,
+    text: 'foobar',
+    role: 'admin',
+}
+
+test("users insert valid user", (t) => {
+    const schema = createInsertSchema(users);
+
+    t.is(schema.safeParse(testUser).success, true);
+})
+
+test("users insert invalid text length", (t) => {
+    const schema = createInsertSchema(users);
+
+    t.is(schema.safeParse({ ...testUser, text: "a".repeat(256) }).success, false);
 });
 
 test('users insert schema', (t) => {


### PR DESCRIPTION
Every varchar/char was treated as an enum so the proper checks were never applied. Also split them up so chars have a fixed length and varchar's a max length. This should fix https://github.com/drizzle-team/drizzle-orm/issues/577

I'm not 100% sure what to do with `MySqlBinary` since as far as I understand the database will pad it in order for it to fit the required length. This shouldn't be an issue when just retrieving the data from the database, but there's no way to verify the length when inserting since the db will do that after you give it the string.

`MySqlVarBinary` is also tricky since MySQL checks for the bytes rather than string length when inserting this. Maybe zod already takes care of this, if it does it'd probably be fine to set the max length I'd imagine.