### PR TITLE
[MYSQL] default value type on customType

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ Example
 [Pg] Add PostGIS extension support
 ```
 
-2. PR should contain detailed description with everyting, that was changed
+2. PR should contain detailed description with everything, that was changed
 
 3. Each PR should contain
     - Tests on feature, that was created;

--- a/drizzle-orm/src/column-builder.ts
+++ b/drizzle-orm/src/column-builder.ts
@@ -97,7 +97,7 @@ export abstract class ColumnBuilder<
 	}
 
 	default(
-		value: T['data'] | SQL,
+		value: T['driverParam'] | T['data'] | SQL,
 	): ColumnBuilderKind<THKT, UpdateCBConfig<T, { hasDefault: true }>> {
 		this.config.default = value;
 		this.config.hasDefault = true;


### PR DESCRIPTION
I have the following column in an existing database

```
`public` tinyint(1) NOT NULL DEFAULT '1'
```

in the code `public` is handed as a boolean so I have created a custom type 

```
export const customTinyInt = (name: string) =>
  customType<{ data: boolean; driverData: 0 | 1 }>({
    toDriver: value => (value ? 1 : 0),
    fromDriver: value => Boolean(value),
    dataType: () => 'tinyint',
  })(name);
```


I would like to write `customTinyInt('public').default(1)` to match my schema

Currently the type parameter of `default` method  is forced to boolean `customTinyInt('public').default(true)` leading to a useless data migration 
 
