### PR TITLE
[sqlite] Implement `runInBatch` for d1

### DIFF
--- a/drizzle-orm/src/better-sqlite3/session.ts
+++ b/drizzle-orm/src/better-sqlite3/session.ts
@@ -71,7 +71,7 @@ export class BetterSQLiteTransaction<
 }
 
 export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends PreparedQueryBase<
-	{ type: 'sync'; run: RunResult; all: T['all']; get: T['get']; values: T['values'] }
+	{ type: 'sync'; run: RunResult; runBatch: T['runBatch']; all: T['all']; get: T['get']; values: T['values'] }
 > {
 	constructor(
 		private stmt: Statement,

--- a/drizzle-orm/src/bun-sqlite/session.ts
+++ b/drizzle-orm/src/bun-sqlite/session.ts
@@ -82,7 +82,7 @@ export class SQLiteBunTransaction<
 }
 
 export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends PreparedQueryBase<
-	{ type: 'sync'; run: void; all: T['all']; get: T['get']; values: T['values'] }
+	{ type: 'sync'; run: void; runBatch: T['runBatch']; all: T['all']; get: T['get']; values: T['values'] }
 > {
 	constructor(
 		private stmt: Statement,

--- a/drizzle-orm/src/d1/session.ts
+++ b/drizzle-orm/src/d1/session.ts
@@ -3,14 +3,13 @@
 import type { Logger } from '~/logger';
 import { NoopLogger } from '~/logger';
 import { type RelationalSchemaConfig, type TablesRelationalConfig } from '~/relations';
-import { type Query, sql } from '~/sql';
+import { type Query } from '~/sql';
 import { fillPlaceholders } from '~/sql';
-import { SQLiteTransaction } from '~/sqlite-core';
 import type { SQLiteAsyncDialect } from '~/sqlite-core/dialect';
 import type { SelectedFieldsOrdered } from '~/sqlite-core/query-builders/select.types';
 import {
+	Batch,
 	type PreparedQueryConfig as PreparedQueryConfigBase,
-	type SQLiteTransactionConfig,
 } from '~/sqlite-core/session';
 import { PreparedQuery as PreparedQueryBase, SQLiteSession } from '~/sqlite-core/session';
 import { mapResultRow } from '~/utils';
@@ -20,6 +19,54 @@ export interface SQLiteD1SessionOptions {
 }
 
 type PreparedQueryConfig = Omit<PreparedQueryConfigBase, 'statement' | 'run'>;
+
+export class D1Batch extends Batch<D1Database, D1PreparedStatement> {
+	private client: D1Database | null = null;
+	private statements: { statement: D1PreparedStatement, resolve: (reason?: unknown) => void, reject: (error: unknown) => void}[] = [];
+	private ran = false;
+
+	async registerQuery(client: D1Database, preparedStatement: D1PreparedStatement): Promise<unknown> {
+		if (this.ran) throw new Error('Cannot register a query after `run()` has been called.');
+
+		if (!this.client) {
+			this.client = client;
+		} else if (this.client !== client) {
+			throw new Error('All statements in a batch must use the same client.');
+		}
+
+		let resolve!: (value: unknown) => void;
+		let reject!: (reason?: unknown) => void;
+
+		const promise = new Promise((_resolve, _reject) => {
+			resolve = _resolve;
+			reject = _reject;
+		})
+		
+		this.statements.push({ statement: preparedStatement, resolve, reject });
+		return promise;
+	}
+
+	async run(): Promise<void> {
+		if (this.ran) return;
+		this.ran = true;
+
+		if (!this.client) return;
+
+		try {
+			const d1Results = await this.client.batch(this.statements.map(({ statement }) => statement));
+			for (let i = 0; i < this.statements.length; i++) {
+				const statement = this.statements[i]!;
+				const d1Result = d1Results[i]!;
+
+				statement.resolve(d1Result.results!);
+			}
+		} catch (e) {
+			for (const { reject } of this.statements) {
+				reject(e);
+			}
+		}
+	}
+}
 
 export class SQLiteD1Session<
 	TFullSchema extends Record<string, unknown>,
@@ -43,49 +90,19 @@ export class SQLiteD1Session<
 		customResultMapper?: (rows: unknown[][]) => unknown,
 	): PreparedQuery {
 		const stmt = this.client.prepare(query.sql);
-		return new PreparedQuery(stmt, query.sql, query.params, this.logger, fields, customResultMapper);
+		return new PreparedQuery(this.client, stmt, query.sql, query.params, this.logger, fields, customResultMapper);
 	}
 
-	override async transaction<T>(
-		transaction: (tx: D1Transaction<TFullSchema, TSchema>) => T | Promise<T>,
-		config?: SQLiteTransactionConfig,
-	): Promise<T> {
-		const tx = new D1Transaction('async', this.dialect, this, this.schema);
-		await this.run(sql.raw(`begin${config?.behavior ? ' ' + config.behavior : ''}`));
-		try {
-			const result = await transaction(tx);
-			await this.run(sql`commit`);
-			return result;
-		} catch (err) {
-			await this.run(sql`rollback`);
-			throw err;
-		}
-	}
-}
-
-export class D1Transaction<
-	TFullSchema extends Record<string, unknown>,
-	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'async', D1Result, TFullSchema, TSchema> {
-	override async transaction<T>(transaction: (tx: D1Transaction<TFullSchema, TSchema>) => Promise<T>): Promise<T> {
-		const savepointName = `sp${this.nestedIndex}`;
-		const tx = new D1Transaction('async', this.dialect, this.session, this.schema, this.nestedIndex + 1);
-		await this.session.run(sql.raw(`savepoint ${savepointName}`));
-		try {
-			const result = await transaction(tx);
-			await this.session.run(sql.raw(`release savepoint ${savepointName}`));
-			return result;
-		} catch (err) {
-			await this.session.run(sql.raw(`rollback to savepoint ${savepointName}`));
-			throw err;
-		}
+	override async transaction(): Promise<never> {
+		throw new Error('Native transactions are not supported on D1. See the `batch` api.');
 	}
 }
 
 export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends PreparedQueryBase<
-	{ type: 'async'; run: D1Result; all: T['all']; get: T['get']; values: T['values'] }
+	{ type: 'async'; run: D1Result; runBatch: T['runBatch']; all: T['all']; get: T['get']; values: T['values'] }
 > {
 	constructor(
+		private client: D1Database,
 		private stmt: D1PreparedStatement,
 		private queryString: string,
 		private params: unknown[],
@@ -97,9 +114,17 @@ export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> 
 	}
 
 	run(placeholderValues?: Record<string, unknown>): Promise<D1Result> {
+		return this.getPreparedStatement(placeholderValues).run();
+	}
+
+	override runInBatch(batch: D1Batch, placeholderValues?: Record<string, unknown>): Promise<T['runBatch']> {
+		return batch.registerQuery(this.client, this.getPreparedStatement(placeholderValues)) as unknown as Promise<T['runBatch']>;
+	}
+
+	private getPreparedStatement(placeholderValues?: Record<string, unknown>) {
 		const params = fillPlaceholders(this.params, placeholderValues ?? {});
 		this.logger.logQuery(this.queryString, params);
-		return this.stmt.bind(...params).run();
+		return this.stmt.bind(...params);
 	}
 
 	async all(placeholderValues?: Record<string, unknown>): Promise<T['all']> {

--- a/drizzle-orm/src/libsql/session.ts
+++ b/drizzle-orm/src/libsql/session.ts
@@ -91,7 +91,7 @@ export class LibSQLTransaction<
 }
 
 export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends PreparedQueryBase<
-	{ type: 'async'; run: ResultSet; all: T['all']; get: T['get']; values: T['values'] }
+	{ type: 'async'; run: ResultSet; runBatch: T['runBatch']; all: T['all']; get: T['get']; values: T['values'] }
 > {
 	constructor(
 		private client: Client,

--- a/drizzle-orm/src/sql-js/session.ts
+++ b/drizzle-orm/src/sql-js/session.ts
@@ -86,7 +86,7 @@ export class SQLJsTransaction<
 }
 
 export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends PreparedQueryBase<
-	{ type: 'sync'; run: void; all: T['all']; get: T['get']; values: T['values'] }
+	{ type: 'sync'; run: void; runBatch: T['runBatch']; all: T['all']; get: T['get']; values: T['values'] }
 > {
 	constructor(
 		private stmt: Statement,

--- a/drizzle-orm/src/sqlite-core/query-builders/delete.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/delete.ts
@@ -72,6 +72,7 @@ export class SQLiteDelete<
 	prepare(isOneTimeQuery?: boolean): PreparedQuery<{
 		type: TResultType;
 		run: TRunResult;
+		runBatch: TReturning[];
 		all: TReturning extends undefined ? never : TReturning[];
 		get: TReturning extends undefined ? never : TReturning | undefined;
 		values: TReturning extends undefined ? never : any[][];
@@ -84,6 +85,10 @@ export class SQLiteDelete<
 
 	run: ReturnType<this['prepare']>['run'] = (placeholderValues) => {
 		return this.prepare(true).run(placeholderValues);
+	};
+
+	runInBatch: ReturnType<this['prepare']>['runInBatch'] = (placeholderValues) => {
+		return this.prepare(true).runInBatch(placeholderValues);
 	};
 
 	all: ReturnType<this['prepare']>['all'] = (placeholderValues) => {

--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -149,6 +149,7 @@ export class SQLiteInsert<
 		{
 			type: TResultType;
 			run: TRunResult;
+			runBatch: TReturning[];
 			all: TReturning extends undefined ? never : TReturning[];
 			get: TReturning extends undefined ? never : TReturning;
 			values: TReturning extends undefined ? never : any[][];
@@ -162,6 +163,10 @@ export class SQLiteInsert<
 
 	run: ReturnType<this['prepare']>['run'] = (placeholderValues) => {
 		return this.prepare(true).run(placeholderValues);
+	};
+
+	runInBatch: ReturnType<this['prepare']>['runInBatch'] = (placeholderValues) => {
+		return this.prepare(true).runInBatch(placeholderValues);
 	};
 
 	all: ReturnType<this['prepare']>['all'] = (placeholderValues) => {

--- a/drizzle-orm/src/sqlite-core/query-builders/select.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/select.ts
@@ -370,6 +370,7 @@ export class SQLiteSelect<
 		{
 			type: TResultType;
 			run: TRunResult;
+			runBatch: SelectResult<TSelection, TSelectMode, TNullabilityMap>[];
 			all: SelectResult<TSelection, TSelectMode, TNullabilityMap>[];
 			get: SelectResult<TSelection, TSelectMode, TNullabilityMap>;
 			values: any[][];
@@ -389,6 +390,10 @@ export class SQLiteSelect<
 
 	run: ReturnType<this['prepare']>['run'] = (placeholderValues) => {
 		return this.prepare(true).run(placeholderValues);
+	};
+
+	runInBatch: ReturnType<this['prepare']>['runInBatch'] = (placeholderValues) => {
+		return this.prepare(true).runInBatch(placeholderValues);
 	};
 
 	all: ReturnType<this['prepare']>['all'] = (placeholderValues) => {

--- a/drizzle-orm/src/sqlite-core/query-builders/update.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/update.ts
@@ -114,6 +114,7 @@ export class SQLiteUpdate<
 		{
 			type: TResultType;
 			run: TRunResult;
+			runBatch: TReturning[];
 			all: TReturning extends undefined ? never : TReturning[];
 			get: TReturning extends undefined ? never : TReturning;
 			values: TReturning extends undefined ? never : any[][];
@@ -127,6 +128,10 @@ export class SQLiteUpdate<
 
 	run: ReturnType<this['prepare']>['run'] = (placeholderValues) => {
 		return this.prepare(true).run(placeholderValues);
+	};
+
+	runInBatch: ReturnType<this['prepare']>['runInBatch'] = (placeholderValues) => {
+		return this.prepare(true).runInBatch(placeholderValues);
 	};
 
 	all: ReturnType<this['prepare']>['all'] = (placeholderValues) => {

--- a/drizzle-orm/src/sqlite-core/session.ts
+++ b/drizzle-orm/src/sqlite-core/session.ts
@@ -5,9 +5,15 @@ import type { SQLiteAsyncDialect, SQLiteSyncDialect } from '~/sqlite-core/dialec
 import { BaseSQLiteDatabase } from './db';
 import type { SelectedFieldsOrdered } from './query-builders/select.types';
 
+export abstract class Batch<TDatabase, TStatement> {
+	abstract registerQuery(client: TDatabase, preparedStatement: TStatement): Promise<unknown>;
+	abstract run(): Promise<void>;
+}
+
 export interface PreparedQueryConfig {
 	type: 'sync' | 'async';
 	run: unknown;
+	runBatch: unknown[];
 	all: unknown[];
 	get: unknown;
 	values: unknown[][];
@@ -18,6 +24,10 @@ export abstract class PreparedQuery<T extends PreparedQueryConfig> {
 	joinsNotNullableMap?: Record<string, boolean>;
 
 	abstract run(placeholderValues?: Record<string, unknown>): Result<T['type'], T['run']>;
+
+	runInBatch(_batch: Batch<unknown, unknown>, _placeholderValues?: Record<string, unknown>): Result<T['type'], T['runBatch']> {
+		throw new Error('`runInBatch()` not supported');
+	}
 
 	abstract all(placeholderValues?: Record<string, unknown>): Result<T['type'], T['all']>;
 

--- a/drizzle-orm/src/sqlite-proxy/session.ts
+++ b/drizzle-orm/src/sqlite-proxy/session.ts
@@ -78,7 +78,7 @@ export class SQLiteProxyTransaction<
 }
 
 export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends PreparedQueryBase<
-	{ type: 'async'; run: SqliteRemoteResult; all: T['all']; get: T['get']; values: T['values'] }
+	{ type: 'async'; run: SqliteRemoteResult; runBatch: T['runBatch'], all: T['all']; get: T['get']; values: T['values'] }
 > {
 	constructor(
 		private client: RemoteCallback,

--- a/drizzle-orm/type-tests/sqlite/batch.ts
+++ b/drizzle-orm/type-tests/sqlite/batch.ts
@@ -1,0 +1,34 @@
+import type { Equal } from 'type-tests/utils';
+import { Expect } from 'type-tests/utils';
+import { d1Db } from './db';
+import { type NewUser, users } from './tables';
+import { D1Batch } from '~/d1';
+
+const batch = new D1Batch();
+
+const selectResult = d1Db
+	.select({ id: users.id })
+	.from(users)
+	.runInBatch(batch);
+
+Expect<Equal<Promise<{ id: number }[]>, typeof selectResult>>;
+
+const newUser: NewUser = {
+	homeCity: 1,
+	class: 'A',
+	age1: 1,
+	enumCol: 'a',
+	serialNotNull: 1,
+};
+
+const insertResult = d1Db.insert(users).values(newUser).runInBatch(batch)
+Expect<Equal<Promise<undefined[]>, typeof insertResult>>;
+
+const update1Result = d1Db.update(users).set({ class: 'C' }).runInBatch(batch)
+Expect<Equal<Promise<undefined[]>, typeof update1Result>>;
+
+const update2Result = d1Db.update(users).set({ class: 'C' }).returning({ id: users.id }).runInBatch(batch)
+Expect<Equal<Promise<{ id: number }[]>, typeof update2Result>>;
+
+const deleteResult = d1Db.delete(users).runInBatch(batch);
+Expect<Equal<Promise<undefined[]>, typeof deleteResult>>;


### PR DESCRIPTION
see #758

Happy to prepare a PR on the docs site to update those too if the approach here is ok.

Initially I wanted to just add it to `D1`, but that would mean having to do an `instanceof D1PreparedStatement` and doing that looses the generic. Therefore I added it directly to the sqlite base type. We could implement batch support for the none d1 dbs (by running all queries in a transaction) if we wanted but I wasn't sure it was worth it, so for now it throws an exception saying it's not supported.

I've tested this in a worker that I've deployed and it seems to work fine.

This also makes `.transaction` throw an error for d1 as native transactions are not supported. More info on https://blog.cloudflare.com/whats-new-with-d1/#sneak-peek-how-we-re-bringing-javascript-transactions-to-d1

## Usage
```ts
const batch = new D1Batch();

const selectResultPromise = d1Db
	.select({ id: users.id })
	.from(users)
	.runInBatch(batch);

const update1ResultPromise = d1Db.update(users).set({ class: 'C' }).where(eq(users.id, 1)).runInBatch(batch);
const update2ResultPromise = d1Db.update(users).set({ class: 'A' }).where(eq(users.id, 2)).runInBatch(batch);

// run all the queries now in a single batch call
batch.run();

const [ selectResult ] = await Promise.all([selectResultPromise, update1ResultPromise, update2ResultPromise ]);
console.log(selectResult.id);
```