### PR TITLE
Import Buffer from 'node:buffer'

### DIFF
--- a/drizzle-orm/src/libsql/session.ts
+++ b/drizzle-orm/src/libsql/session.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { type Client, type InArgs, type InStatement, type ResultSet, type Transaction } from '@libsql/client';
 import { entityKind } from '~/entity';
 import type { Logger } from '~/logger';

--- a/drizzle-orm/src/sql-js/session.ts
+++ b/drizzle-orm/src/sql-js/session.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import type { BindParams, Database, Statement } from 'sql.js';
 import { entityKind } from '~/entity';
 import type { Logger } from '~/logger';

--- a/drizzle-orm/src/sqlite-core/columns/blob.ts
+++ b/drizzle-orm/src/sqlite-core/columns/blob.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import type { ColumnBaseConfig, ColumnHKTBase } from '~/column';
 import type { ColumnBuilderBaseConfig, ColumnBuilderHKTBase, MakeColumnConfig } from '~/column-builder';
 import { entityKind } from '~/entity';


### PR DESCRIPTION
In their wisdom Cloudflare have decided to support node compatibility, but only if things that are global in node are imported from the 'node:' namespace. This is stopping me from using blob columns in D1 :(

So this PR adds `import { Buffer } from 'node:buffer'` where needed.

See: https://developers.cloudflare.com/workers/runtime-apis/nodejs/