### PR TITLE
disable minifyInternalExports for dts bundle

### DIFF
--- a/drizzle-orm/rollup.dts.config.ts
+++ b/drizzle-orm/rollup.dts.config.ts
@@ -13,6 +13,7 @@ export default defineConfig([
 		}, {}),
 		output: {
 			dir: 'dist.new',
+			minifyInternalExports: false,
 		},
 		external,
 		plugins: [


### PR DESCRIPTION
The `dts()` bundle step was exporting types and functions from `.d.ts` aliased as single letter variables. This will break TS and forces developers to use strange workarounds or patches.
Disabling the rollup feature to export with the correct names.

**example:**
```ts
//old
export { PgInsert as $, AnyPgTable as A, BuildAliasTable as B, Check as C, IndexColumn as D, IndexBuilderOn as E, ForeignKey as F, AnyIndexBuilder as G, IndexBuilder as H, Index as I, GetColumnsTableName as J, index as K, uniqueIndex as L, primaryKey as M, PrimaryKeyBuilder as N, unique as O, PgColumnBuilder as P, uniqueKeyName as Q, ReferenceConfig as R, UniqueConstraintBuilder as S, UniqueOnConstraintBuilder as T, UniqueConstraint as U, ViewWithConfig as V, PgDeleteConfig as W, PgDelete as X, PgInsertConfig as Y, PgInsertValue as Z, PgInsertBuilder as _, PgColumn as a, QueryBuilder as a0, PgRefreshMaterializedView as a1, PgSelectBuilder as a2, PgSelectQueryBuilder as a3, PgSelect as a4, JoinsValue as a5, AnyPgSelect as a6, PgSelectConfig as a7, JoinFn as a8, SelectedFieldsFlat as a9, pgTable as aA, pgTableCreator as aB, DefaultViewBuilderCore as aC, ViewBuilder as aD, ManualViewBuilder as aE, MaterializedViewBuilderCore as aF, MaterializedViewBuilder as aG, ManualMaterializedViewBuilder as aH, PgViewBase as aI, PgViewConfig as aJ, PgViewWithSelection as aK, PgMaterializedViewConfig as aL, PgMaterializedViewWithSelection as aM, SelectedFields as aa, SelectedFieldsOrdered as ab, LockStrength as ac, LockConfig as ad, PgSelectHKTBase as ae, PgSelectKind as af, PgSelectQueryBuilderHKT as ag, PgSelectHKT as ah, PgUpdateConfig as ai, PgUpdateSetSource as aj, PgUpdateBuilder as ak, PgUpdate as al, PreparedQueryConfig as am, PreparedQuery as an, PgTransactionConfig as ao, PgSession as ap, PgTransaction as aq, QueryResultHKT as ar, QueryResultKind as as, SubqueryWithSelection as at, WithSubqueryWithSelection as au, PgTableExtraConfig as av, TableConfig as aw, PgTable as ax, AnyPgTableHKT as ay, PgTableWithColumns as az, PgTableFn as b, pgMaterializedView as c, AnyPgColumn as d, PrimaryKey as e, PgView as f, PgMaterializedView as g, PgMaterializedViewWithConfig as h, CheckBuilder as i, check as j, PgArrayBuilderHKT as k, PgArrayHKT as l, PgArrayBuilder as m, PgArray as n, PgColumnBuilderHKT as o, pgView as p, PgColumnHKT as q, AnyPgColumnBuilder as r, AnyPgColumnHKT as s, PgDatabase as t, PgDialect as u, UpdateDeleteAction as v, Reference as w, ForeignKeyBuilder as x, AnyForeignKeyBuilder as y, foreignKey as z };

//new
export { AnyForeignKeyBuilder, AnyIndexBuilder, AnyPgColumn, AnyPgColumnBuilder, AnyPgColumnHKT, AnyPgSelect, AnyPgTable, AnyPgTableHKT, BuildAliasTable, Check, CheckBuilder, DefaultViewBuilderCore, ForeignKey, ForeignKeyBuilder, GetColumnsTableName, Index, IndexBuilder, IndexBuilderOn, IndexColumn, JoinFn, JoinsValue, LockConfig, LockStrength, ManualMaterializedViewBuilder, ManualViewBuilder, MaterializedViewBuilder, MaterializedViewBuilderCore, PgArray, PgArrayBuilder, PgArrayBuilderHKT, PgArrayHKT, PgColumn, PgColumnBuilder, PgColumnBuilderHKT, PgColumnHKT, PgDatabase, PgDelete, PgDeleteConfig, PgDialect, PgInsert, PgInsertBuilder, PgInsertConfig, PgInsertValue, PgMaterializedView, PgMaterializedViewConfig, PgMaterializedViewWithConfig, PgMaterializedViewWithSelection, PgRefreshMaterializedView, PgSelect, PgSelectBuilder, PgSelectConfig, PgSelectHKT, PgSelectHKTBase, PgSelectKind, PgSelectQueryBuilder, PgSelectQueryBuilderHKT, PgSession, PgTable, PgTableExtraConfig, PgTableFn, PgTableWithColumns, PgTransaction, PgTransactionConfig, PgUpdate, PgUpdateBuilder, PgUpdateConfig, PgUpdateSetSource, PgView, PgViewBase, PgViewConfig, PgViewWithSelection, PreparedQuery, PreparedQueryConfig, PrimaryKey, PrimaryKeyBuilder, QueryBuilder, QueryResultHKT, QueryResultKind, Reference, ReferenceConfig, SelectedFields, SelectedFieldsFlat, SelectedFieldsOrdered, SubqueryWithSelection, TableConfig, UniqueConstraint, UniqueConstraintBuilder, UniqueOnConstraintBuilder, UpdateDeleteAction, ViewBuilder, ViewWithConfig, WithSubqueryWithSelection, check, foreignKey, index, pgMaterializedView, pgTable, pgTableCreator, pgView, primaryKey, unique, uniqueIndex, uniqueKeyName };
```

closes #529
closes #656
