### PR TITLE
Add possibility to insert empty values objects in sqlite and postgres dialects

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -346,12 +346,11 @@ export class PgDialect {
 	}
 
 	buildInsertQuery({ table, values, onConflict, returning }: PgInsertConfig): SQL {
-		const isSingleValue = values.length === 1;
 		const valuesSqlList: ((SQLChunk | SQL)[] | SQL)[] = [];
 		const columns: Record<string, AnyPgColumn> = table[Table.Symbol.Columns];
-		const colEntries: [string, AnyPgColumn][] = isSingleValue
-			? Object.keys(values[0]!).map((fieldName) => [fieldName, columns[fieldName]!])
-			: Object.entries(columns);
+
+		const colEntries: [string, AnyPgColumn][] = Object.entries(columns);
+
 		const insertOrder = colEntries.map(([, column]) => sql.identifier(column.name));
 
 		for (const [valueIndex, value] of values.entries()) {
@@ -364,6 +363,7 @@ export class PgDialect {
 					valueList.push(colValue);
 				}
 			}
+			
 			valuesSqlList.push(valueList);
 			if (valueIndex < values.length - 1) {
 				valuesSqlList.push(sql`, `);

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -274,12 +274,13 @@ export abstract class SQLiteDialect {
 	}
 
 	buildInsertQuery({ table, values, onConflict, returning }: SQLiteInsertConfig): SQL {
-		const isSingleValue = values.length === 1;
+		// const isSingleValue = values.length === 1;
 		const valuesSqlList: ((SQLChunk | SQL)[] | SQL)[] = [];
 		const columns: Record<string, AnySQLiteColumn> = table[Table.Symbol.Columns];
-		const colEntries: [string, AnySQLiteColumn][] = isSingleValue
-			? Object.keys(values[0]!).map((fieldName) => [fieldName, columns[fieldName]!])
-			: Object.entries(columns);
+		// const colEntries: [string, AnySQLiteColumn][] = isSingleValue
+		// 	? Object.keys(values[0]!).map((fieldName) => [fieldName, columns[fieldName]!])
+		// 	: Object.entries(columns);
+		const colEntries: [string, AnySQLiteColumn][] = Object.entries(columns);
 		const insertOrder = colEntries.map(([, column]) => sql.identifier(column.name));
 
 		for (const [valueIndex, value] of values.entries()) {
@@ -311,6 +312,10 @@ export abstract class SQLiteDialect {
 			: undefined;
 
 		const onConflictSql = onConflict ? sql` on conflict ${onConflict}` : undefined;
+
+		// if (isSingleValue && valuesSqlList.length === 0){
+		// 	return sql`insert into ${table} default values ${onConflictSql}${returningSql}`;
+		// }
 
 		return sql`insert into ${table} ${insertOrder} values ${valuesSql}${onConflictSql}${returningSql}`;
 	}

--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -57,6 +57,12 @@ export class SQLiteInsertBuilder<
 			return result;
 		});
 
+		// if (mappedValues.length > 1 && mappedValues.some((t) => Object.keys(t).length === 0)) {
+		// 	throw new Error(
+		// 		`One of the values you want to insert is empty. In SQLite you can insert only one empty object per statement. For this case Drizzle with use "INSERT INTO ... DEFAULT VALUES" syntax`,
+		// 	);
+		// }
+
 		return new SQLiteInsert(this.table, mappedValues, this.session, this.dialect);
 	}
 }

--- a/integration-tests/tests/better-sqlite.test.ts
+++ b/integration-tests/tests/better-sqlite.test.ts
@@ -1108,6 +1108,90 @@ test.serial('with ... select', (t) => {
 	]);
 });
 
+test.serial('query check: insert single empty row', (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('users', {
+		id: integer('id').primaryKey(),
+		name: text('name').default('Dan'),
+		state: text('state'),
+	});
+
+	const query = db
+		.insert(users)
+		.values({})
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: 'insert into "users" ("id", "name", "state") values (null, ?, null)',
+		params: ['Dan'],
+	});
+});
+
+test.serial('query check: insert multiple empty rows', (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('users', {
+		id: integer('id').primaryKey(),
+		name: text('name').default('Dan'),
+		state: text('state'),
+	});
+
+	const query = db
+		.insert(users)
+		.values([{}, {}])
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: 'insert into "users" ("id", "name", "state") values (null, ?, null), (null, ?, null)',
+		params: ['Dan', 'Dan'],
+	});
+});
+
+test.serial('Insert all defaults in 1 row', async (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('empty_insert_single', {
+		id: integer('id').primaryKey(),
+		name: text('name').default('Dan'),
+		state: text('state'),
+	});
+
+	db.run(sql`drop table if exists ${users}`);
+
+	db.run(
+		sql`create table ${users} (id integer primary key, name text default 'Dan', state text)`,
+	);
+
+	db.insert(users).values({}).run();
+
+	const res = db.select().from(users).all();
+
+	t.deepEqual(res, [{ id: 1, name: 'Dan', state: null }]);
+});
+
+test.serial('Insert all defaults in multiple rows', async (t) => {
+	const { db } = t.context;
+
+	const users = sqliteTable('empty_insert_multiple', {
+		id: integer('id').primaryKey(),
+		name: text('name').default('Dan'),
+		state: text('state'),
+	});
+
+	db.run(sql`drop table if exists ${users}`);
+
+	db.run(
+		sql`create table ${users} (id integer primary key, name text default 'Dan', state text)`,
+	);
+
+	db.insert(users).values([{}, {}]).run()
+
+	const res = db.select().from(users).all();
+
+	t.deepEqual(res, [{ id: 1, name: 'Dan', state: null }, { id: 2, name: 'Dan', state: null }]);
+});
+
 test.serial('select from subquery sql', (t) => {
 	const { db } = t.context;
 

--- a/integration-tests/tests/pg-schema.test.ts
+++ b/integration-tests/tests/pg-schema.test.ts
@@ -693,7 +693,7 @@ test.serial('build query insert with onConflict do update', async (t) => {
 
 	t.deepEqual(query, {
 		sql:
-			'insert into "mySchema"."users" ("name", "jsonb") values ($1, $2) on conflict ("id") do update set "name" = $3',
+			'insert into "mySchema"."users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id") do update set "name" = $3',
 		params: ['John', '["foo","bar"]', 'John1'],
 	});
 });
@@ -708,7 +708,7 @@ test.serial('build query insert with onConflict do update / multiple columns', a
 
 	t.deepEqual(query, {
 		sql:
-			'insert into "mySchema"."users" ("name", "jsonb") values ($1, $2) on conflict ("id","name") do update set "name" = $3',
+			'insert into "mySchema"."users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id","name") do update set "name" = $3',
 		params: ['John', '["foo","bar"]', 'John1'],
 	});
 });
@@ -722,7 +722,7 @@ test.serial('build query insert with onConflict do nothing', async (t) => {
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "mySchema"."users" ("name", "jsonb") values ($1, $2) on conflict do nothing',
+		sql: 'insert into "mySchema"."users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict do nothing',
 		params: ['John', '["foo","bar"]'],
 	});
 });
@@ -736,7 +736,7 @@ test.serial('build query insert with onConflict do nothing + target', async (t) 
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "mySchema"."users" ("name", "jsonb") values ($1, $2) on conflict ("id") do nothing',
+		sql: 'insert into "mySchema"."users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id") do nothing',
 		params: ['John', '["foo","bar"]'],
 	});
 });

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -660,7 +660,7 @@ test.serial('build query insert with onConflict do update', async (t) => {
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "users" ("name", "jsonb") values ($1, $2) on conflict ("id") do update set "name" = $3',
+		sql: 'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id") do update set "name" = $3',
 		params: ['John', '["foo","bar"]', 'John1'],
 	});
 });
@@ -674,7 +674,7 @@ test.serial('build query insert with onConflict do update / multiple columns', a
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "users" ("name", "jsonb") values ($1, $2) on conflict ("id","name") do update set "name" = $3',
+		sql: 'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id","name") do update set "name" = $3',
 		params: ['John', '["foo","bar"]', 'John1'],
 	});
 });
@@ -688,7 +688,7 @@ test.serial('build query insert with onConflict do nothing', async (t) => {
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "users" ("name", "jsonb") values ($1, $2) on conflict do nothing',
+		sql: 'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict do nothing',
 		params: ['John', '["foo","bar"]'],
 	});
 });
@@ -702,7 +702,7 @@ test.serial('build query insert with onConflict do nothing + target', async (t) 
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "users" ("name", "jsonb") values ($1, $2) on conflict ("id") do nothing',
+		sql: 'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id") do nothing',
 		params: ['John', '["foo","bar"]'],
 	});
 });

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -314,11 +314,11 @@ test.serial('table configs: unique in column', async (t) => {
 	t.assert(columnName?.isUnique);
 
 	const columnState = tableConfig.columns.find((it) => it.name === 'state');
-	t.assert(columnState?.uniqueName === "custom");
+	t.assert(columnState?.uniqueName === 'custom');
 	t.assert(columnState?.isUnique);
 
 	const columnField = tableConfig.columns.find((it) => it.name === 'field');
-	t.assert(columnField?.uniqueName === "custom_field");
+	t.assert(columnField?.uniqueName === 'custom_field');
 	t.assert(columnField?.isUnique);
 	t.assert(columnField?.uniqueType === 'not distinct');
 });
@@ -1007,6 +1007,90 @@ test.serial('insert via db.execute w/ query builder', async (t) => {
 	t.deepEqual(inserted.rows, [{ id: 1, name: 'John' }]);
 });
 
+test.serial('Query check: Insert all defaults in 1 row', async (t) => {
+	const { db } = t.context;
+
+	const users = pgTable('users', {
+		id: serial('id').primaryKey(),
+		name: text('name').default('Dan'),
+		state: text('state'),
+	});
+
+	const query = db
+		.insert(users)
+		.values({})
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: 'insert into "users" ("id", "name", "state") values (default, default, default)',
+		params: [],
+	});
+});
+
+test.serial('Query check: Insert all defaults in multiple rows', async (t) => {
+	const { db } = t.context;
+
+	const users = pgTable('users', {
+		id: serial('id').primaryKey(),
+		name: text('name').default('Dan'),
+		state: text('state').default('UA'),
+	});
+
+	const query = db
+		.insert(users)
+		.values([{}, {}])
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: 'insert into "users" ("id", "name", "state") values (default, default, default), (default, default, default)',
+		params: [],
+	});
+});
+
+test.serial('Insert all defaults in 1 row', async (t) => {
+	const { db } = t.context;
+
+	const users = pgTable('empty_insert_single', {
+		id: serial('id').primaryKey(),
+		name: text('name').default('Dan'),
+		state: text('state'),
+	});
+
+	await db.execute(sql`drop table if exists ${users}`);
+
+	await db.execute(
+		sql`create table ${users} (id serial primary key, name text default 'Dan', state text)`,
+	);
+
+	await db.insert(users).values({});
+
+	const res = await db.select().from(users);
+
+	t.deepEqual(res, [{ id: 1, name: 'Dan', state: null }]);
+});
+
+test.serial('Insert all defaults in multiple rows', async (t) => {
+	const { db } = t.context;
+
+	const users = pgTable('empty_insert_multiple', {
+		id: serial('id').primaryKey(),
+		name: text('name').default('Dan'),
+		state: text('state'),
+	});
+
+	await db.execute(sql`drop table if exists ${users}`);
+
+	await db.execute(
+		sql`create table ${users} (id serial primary key, name text default 'Dan', state text)`,
+	);
+
+	await db.insert(users).values([{}, {}])
+
+	const res = await db.select().from(users);
+
+	t.deepEqual(res, [{ id: 1, name: 'Dan', state: null }, { id: 2, name: 'Dan', state: null }]);
+});
+
 test.serial('build query insert with onConflict do update', async (t) => {
 	const { db } = t.context;
 
@@ -1017,7 +1101,7 @@ test.serial('build query insert with onConflict do update', async (t) => {
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "users" ("name", "jsonb") values ($1, $2) on conflict ("id") do update set "name" = $3',
+		sql: 'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id") do update set "name" = $3',
 		params: ['John', '["foo","bar"]', 'John1'],
 	});
 });
@@ -1032,7 +1116,7 @@ test.serial('build query insert with onConflict do update / multiple columns', a
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "users" ("name", "jsonb") values ($1, $2) on conflict ("id","name") do update set "name" = $3',
+		sql: 'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id","name") do update set "name" = $3',
 		params: ['John', '["foo","bar"]', 'John1'],
 	});
 });
@@ -1047,7 +1131,7 @@ test.serial('build query insert with onConflict do nothing', async (t) => {
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "users" ("name", "jsonb") values ($1, $2) on conflict do nothing',
+		sql: 'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict do nothing',
 		params: ['John', '["foo","bar"]'],
 	});
 });
@@ -1062,7 +1146,7 @@ test.serial('build query insert with onConflict do nothing + target', async (t) 
 		.toSQL();
 
 	t.deepEqual(query, {
-		sql: 'insert into "users" ("name", "jsonb") values ($1, $2) on conflict ("id") do nothing',
+		sql: 'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id") do nothing',
 		params: ['John', '["foo","bar"]'],
 	});
 });


### PR DESCRIPTION
```ts
await db.insert(users).values({})
```
or
```ts
await db.insert(users).values([{}, {}])
```
are now possible