### PR TITLE
Fix libsql/client type import

### DIFF
--- a/drizzle-orm/src/libsql/session.ts
+++ b/drizzle-orm/src/libsql/session.ts
@@ -1,4 +1,4 @@
-import { type Client, type InArgs, type InStatement, type ResultSet, type Transaction } from '@libsql/client';
+import type { Client, InArgs, InStatement, ResultSet, Transaction } from '@libsql/client';
 import { entityKind } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { NoopLogger } from '~/logger.ts';


### PR DESCRIPTION
`import { type }` structure was actually importing `'@libsql/client'` while we just wanna import its types.
This is specially important for `'@libsql/client'` package since it isn't supposed to be imported for environments other than node. Browser for instance should import `'@libsql/client/web'`. So basically it's up to final user to decide which one to use