### PR TITLE
[Pg] aws data api additional array values

### DIFF
--- a/drizzle-orm/src/aws-data-api/common/index.ts
+++ b/drizzle-orm/src/aws-data-api/common/index.ts
@@ -2,7 +2,11 @@ import type { Field } from '@aws-sdk/client-rds-data';
 import { TypeHint } from '@aws-sdk/client-rds-data';
 import type { QueryTypingsValue } from '~/sql/index.ts';
 
-export function getValueFromDataApi(field: Field) {
+type ValueFromDataApi = string | number | boolean | Uint8Array
+	| string[] | boolean[] | number[] | null
+	| ValueFromDataApi[];
+
+export function getValueFromDataApi(field: Field): ValueFromDataApi {
 	if (field.stringValue !== undefined) {
 		return field.stringValue;
 	} else if (field.booleanValue !== undefined) {
@@ -19,6 +23,18 @@ export function getValueFromDataApi(field: Field) {
 	} else if (field.arrayValue !== undefined) {
 		if (field.arrayValue.stringValues !== undefined) {
 			return field.arrayValue.stringValues;
+		}
+		if (field.arrayValue.booleanValues !== undefined) {
+			return field.arrayValue.booleanValues;
+		}
+		if (field.arrayValue.longValues !== undefined) {
+			return field.arrayValue.longValues;
+		}
+		if (field.arrayValue.doubleValues !== undefined) {
+			return field.arrayValue.doubleValues;
+		}
+		if (field.arrayValue.arrayValues !== undefined) {
+			return field.arrayValue.arrayValues.map((arrayValue => getValueFromDataApi({ arrayValue })));
 		}
 		throw new Error('Unknown array type');
 	} else {


### PR DESCRIPTION
extending support from just string[] to all type of arrays, including array of arrays.

using AWS RDS data api before this with a query that returns rows with for example an array of long, results in:
``` ts
throw new Error('Unknown array type');
```

Example (error before this fix):

```
Query:
    SELECT con.*
      FROM pg_catalog.pg_constraint con
           INNER JOIN pg_catalog.pg_class rel
                      ON rel.oid = con.conrelid
           INNER JOIN pg_catalog.pg_namespace nsp
                      ON nsp.oid = connamespace
      WHERE nsp.nspname = 'public'
            AND rel.relname = 'example_table_name';

file:///Users/examplerepo/node_modules/drizzle-orm/aws-data-api/pg/index.mjs:30
        throw new Error('Unknown array type');
              ^

Error: Unknown array type
    at getValueFromDataApi (file:///Users/examplerepo/node_modules/drizzle-orm/aws-data-api/pg/index.mjs:30:15)
    at file:///Users/examplerepo/node_modules/drizzle-orm/aws-data-api/pg/index.mjs:160:38
    at Array.map (<anonymous>)
    at AwsDataApiPreparedQuery.mapResultRows (file:///Users/examplereponode_modules/drizzle-orm/aws-data-api/pg/index.mjs:156:24)
    at AwsDataApiPreparedQuery.values (file:///Users/examplerepo/node_modules/drizzle-orm/aws-data-api/pg/index.mjs:145:29)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async AwsDataApiPreparedQuery.execute (file:///Users/examplerepo/node_modules/drizzle-orm/aws-data-api/pg/index.mjs:123:22)
    at async file:///Users/examplerepo/packages/database/src/run.js:27:21
```

given the `conkey` column has an array of longValues, after this fix the return value is an array of number as expected `  conkey: [ 1, 2 ],`