### PR TITLE
Add batch support for d1 driver

### DIFF
--- a/changelogs/drizzle-orm/0.28.7.md
+++ b/changelogs/drizzle-orm/0.28.7.md
@@ -1,0 +1,65 @@
+## New Features
+
+### 🎉 `D1` batch api support
+
+Reference: https://developers.cloudflare.com/d1/platform/client-api/#dbbatch
+
+Batch API usage example:
+
+```ts
+const batchResponse = await db.batch([
+	db.insert(usersTable).values({ id: 1, name: 'John' }).returning({
+		id: usersTable.id,
+	}),
+	db.update(usersTable).set({ name: 'Dan' }).where(eq(usersTable.id, 1)),
+	db.query.usersTable.findMany({}),
+	db.select().from(usersTable).where(eq(usersTable.id, 1)),
+	db.select({ id: usersTable.id, invitedBy: usersTable.invitedBy }).from(
+		usersTable,
+	),
+]);
+```
+
+Type for `batchResponse` in this example would be:
+
+```ts
+type BatchResponse = [
+	{
+		id: number;
+	}[],
+	D1Result,
+	{
+		id: number;
+		name: string;
+		verified: number;
+		invitedBy: number | null;
+	}[],
+	{
+		id: number;
+		name: string;
+		verified: number;
+		invitedBy: number | null;
+	}[],
+	{
+		id: number;
+		invitedBy: number | null;
+	}[],
+];
+```
+
+All possible builders that can be used inside `db.batch`:
+
+```ts
+`db.all()`,
+`db.get()`,
+`db.values()`,
+`db.run()`,
+`db.query.<table>.findMany()`,
+`db.query.<table>.findFirst()`,
+`db.select()...`,
+`db.update()...`,
+`db.delete()...`,
+`db.insert()...`,
+```
+
+More usage examples here: [integration-tests/tests/d1-batch.test.ts](https://github.com/drizzle-team/drizzle-orm/blob/beta/integration-tests/tests/d1-batch.test.ts) and in [docs](https://orm.drizzle.team/docs/batch-api)

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-orm",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "description": "Drizzle ORM package for SQL databases",
   "type": "module",
   "scripts": {
@@ -124,7 +124,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-rds-data": "^3.344.0",
-    "@cloudflare/workers-types": "^4.20230518.0",
+    "@cloudflare/workers-types": "^4.20230904.0",
     "@libsql/client": "^0.1.6",
     "@neondatabase/serverless": "^0.4.24",
     "@opentelemetry/api": "^1.4.1",

--- a/drizzle-orm/src/batch.ts
+++ b/drizzle-orm/src/batch.ts
@@ -1,0 +1,33 @@
+import type { SelectResult } from './query-builders/select.types.ts';
+import type { SQLiteDelete, SQLiteInsert, SQLiteSelect, SQLiteUpdate } from './sqlite-core/index.ts';
+import type { SQLiteRelationalQuery } from './sqlite-core/query-builders/query.ts';
+import type { SQLiteRaw } from './sqlite-core/query-builders/raw.ts';
+
+export type BatchParameters<TDriverResult = any> =
+	| SQLiteUpdate<any, 'async', TDriverResult, any>
+	| SQLiteSelect<any, 'async', TDriverResult, any, any>
+	| SQLiteDelete<any, 'async', TDriverResult, any>
+	| Omit<SQLiteDelete<any, 'async', TDriverResult, any>, 'where'>
+	| Omit<SQLiteUpdate<any, 'async', TDriverResult, any>, 'where'>
+	| SQLiteInsert<any, 'async', TDriverResult, any>
+	| SQLiteRelationalQuery<'async', any>
+	| SQLiteRaw<any>;
+
+export type BatchResponse<U extends BatchParameters, TQuery extends Readonly<[U, ...U[]]>> = {
+	[K in keyof TQuery]: TQuery[K] extends
+		SQLiteSelect<infer _TTable, 'async', infer _TRes, infer TSelection, infer TSelectMode, infer TNullabilityMap>
+		? SelectResult<TSelection, TSelectMode, TNullabilityMap>[]
+		: TQuery[K] extends SQLiteUpdate<infer _TTable, 'async', infer _TRunResult, infer _TReturning>
+			? _TReturning extends undefined ? _TRunResult : _TReturning[]
+		: TQuery[K] extends Omit<SQLiteUpdate<infer _TTable, 'async', infer _TRunResult, infer _TReturning>, 'where'>
+			? _TReturning extends undefined ? _TRunResult : _TReturning[]
+		: TQuery[K] extends SQLiteInsert<infer _TTable, 'async', infer _TRunResult, infer _TReturning>
+			? _TReturning extends undefined ? _TRunResult : _TReturning[]
+		: TQuery[K] extends SQLiteDelete<infer _TTable, 'async', infer _TRunResult, infer _TReturning>
+			? _TReturning extends undefined ? _TRunResult : _TReturning[]
+		: TQuery[K] extends Omit<SQLiteDelete<infer _TTable, 'async', infer _TRunResult, infer _TReturning>, 'where'>
+			? _TReturning extends undefined ? _TRunResult : _TReturning[]
+		: TQuery[K] extends SQLiteRelationalQuery<'async', infer TResult> ? TResult
+		: TQuery[K] extends SQLiteRaw<infer TResult> ? TResult
+		: never;
+};

--- a/drizzle-orm/src/d1/session.ts
+++ b/drizzle-orm/src/d1/session.ts
@@ -1,13 +1,17 @@
 /// <reference types="@cloudflare/workers-types" />
 
-import { entityKind } from '~/entity.ts';
+import type { BatchParameters } from '~/batch.ts';
+import { entityKind, is } from '~/entity.ts';
+import { DrizzleError } from '~/errors.ts';
 import type { Logger } from '~/logger.ts';
 import { NoopLogger } from '~/logger.ts';
 import { type RelationalSchemaConfig, type TablesRelationalConfig } from '~/relations.ts';
 import { type Query, sql } from '~/sql/index.ts';
 import { fillPlaceholders } from '~/sql/index.ts';
 import type { SQLiteAsyncDialect } from '~/sqlite-core/dialect.ts';
-import { SQLiteTransaction } from '~/sqlite-core/index.ts';
+import { SQLiteDelete, SQLiteInsert, SQLiteSelect, SQLiteTransaction, SQLiteUpdate } from '~/sqlite-core/index.ts';
+import { SQLiteRelationalQuery } from '~/sqlite-core/query-builders/query.ts';
+import { SQLiteRaw } from '~/sqlite-core/query-builders/raw.ts';
 import type { SelectedFieldsOrdered } from '~/sqlite-core/query-builders/select.types.ts';
 import {
 	type PreparedQueryConfig as PreparedQueryConfigBase,
@@ -49,6 +53,97 @@ export class SQLiteD1Session<
 	): PreparedQuery {
 		const stmt = this.client.prepare(query.sql);
 		return new PreparedQuery(stmt, query.sql, query.params, this.logger, fields, executeMethod, customResultMapper);
+	}
+
+	private d1ToRawMapping(results: any) {
+		const rows: unknown[][] = [];
+		for (const row of results) {
+			const entry = Object.keys(row).map((k) => row[k]);
+			rows.push(entry);
+		}
+		return rows;
+	}
+
+	/*override */ batch<U extends BatchParameters, T extends Readonly<[U, ...U[]]>>(queries: T) {
+		const queryToType: (
+			| { mode: 'all' }
+			| {
+				mode: 'all_mapped';
+				config: { fields: SelectedFieldsOrdered; joinsNotNullableMap?: Record<string, boolean> };
+			}
+			| { mode: 'get' }
+			| { mode: 'values' }
+			| { mode: 'raw' }
+			| { mode: 'rqb'; mapper: any }
+		)[] = [];
+
+		const builtQueries: D1PreparedStatement[] = queries.map((query) => {
+			if (is(query, SQLiteSelect<any, 'async', any, any, any>)) {
+				const prepared = query.prepare() as PreparedQuery;
+				prepared.fields === undefined
+					? queryToType.push({ mode: 'all' })
+					: queryToType.push({
+						mode: 'all_mapped',
+						config: { fields: prepared.fields, joinsNotNullableMap: prepared.joinsNotNullableMap },
+					});
+				return prepared.stmt.bind(...prepared.params);
+			} else if (
+				is(query, SQLiteInsert<any, 'async', any, any>) || is(query, SQLiteUpdate<any, 'async', any, any>)
+				|| is(query, SQLiteDelete<any, 'async', any, any>)
+			) {
+				const prepared = query.prepare() as PreparedQuery;
+				queryToType.push(
+					query.config.returning
+						? {
+							mode: 'all_mapped',
+							config: { fields: query.config.returning },
+						}
+						: { mode: 'raw' },
+				);
+				return prepared.stmt.bind(...prepared.params);
+			} else if (is(query, SQLiteRaw)) {
+				const builtQuery = this.dialect.sqlToQuery(query.getSQL());
+				queryToType.push(
+					query.config.action === 'run' ? { mode: 'raw' } : { mode: query.config.action },
+				);
+				return this.client.prepare(builtQuery.sql).bind(...builtQuery.params);
+			} else if (is(query, SQLiteRelationalQuery)) {
+				const preparedRqb = query.prepare() as PreparedQuery;
+				queryToType.push({ mode: 'rqb', mapper: preparedRqb.customResultMapper });
+				return preparedRqb.stmt.bind(...preparedRqb.params);
+			}
+			throw new DrizzleError('You can use only drizzle queries in D1 batch api');
+		});
+
+		const res = this.client.batch<any>(builtQueries).then((stmt) =>
+			stmt.map(({ results }, index) => {
+				const action = queryToType[index]!;
+				if (action.mode === 'all') {
+					return results![0];
+				}
+				if (action.mode === 'all_mapped') {
+					const mappedRows = this.d1ToRawMapping(results);
+					return mappedRows!.map((row) => {
+						return mapResultRow(
+							action.config.fields,
+							row,
+							action.config.joinsNotNullableMap,
+						);
+					});
+				}
+				if (action.mode === 'get') {
+					return results[0] as unknown[];
+				}
+				if (action.mode === 'values') {
+					return this.d1ToRawMapping(results);
+				}
+				if (action.mode === 'raw') {
+					return stmt[index];
+				}
+				return action.mapper(this.d1ToRawMapping(results));
+			})
+		);
+		return res;
 	}
 
 	override async transaction<T>(
@@ -94,16 +189,32 @@ export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> 
 > {
 	static readonly [entityKind]: string = 'D1PreparedQuery';
 
+	/** @internal */
+	customResultMapper?: (rows: unknown[][], mapColumnValue?: (value: unknown) => unknown) => unknown;
+
+	/** @internal */
+	fields?: SelectedFieldsOrdered;
+
+	/** @internal */
+	params: unknown[];
+
+	/** @internal */
+	stmt: D1PreparedStatement;
+
 	constructor(
-		private stmt: D1PreparedStatement,
+		stmt: D1PreparedStatement,
 		private queryString: string,
-		private params: unknown[],
+		params: unknown[],
 		private logger: Logger,
-		private fields: SelectedFieldsOrdered | undefined,
+		fields: SelectedFieldsOrdered | undefined,
 		executeMethod: SQLiteExecuteMethod,
-		private customResultMapper?: (rows: unknown[][]) => unknown,
+		customResultMapper?: (rows: unknown[][]) => unknown,
 	) {
 		super('async', executeMethod);
+		this.customResultMapper = customResultMapper;
+		this.fields = fields;
+		this.stmt = stmt;
+		this.params = params;
 	}
 
 	run(placeholderValues?: Record<string, unknown>): Promise<D1Result> {

--- a/drizzle-orm/src/d1/session.ts
+++ b/drizzle-orm/src/d1/session.ts
@@ -119,7 +119,7 @@ export class SQLiteD1Session<
 			stmt.map(({ results }, index) => {
 				const action = queryToType[index]!;
 				if (action.mode === 'all') {
-					return results![0];
+					return results;
 				}
 				if (action.mode === 'all_mapped') {
 					const mappedRows = this.d1ToRawMapping(results);

--- a/drizzle-orm/src/d1/session.ts
+++ b/drizzle-orm/src/d1/session.ts
@@ -55,6 +55,12 @@ export class SQLiteD1Session<
 		return new PreparedQuery(stmt, query.sql, query.params, this.logger, fields, executeMethod, customResultMapper);
 	}
 
+	/**
+	 * This function was taken from the D1 implementation: https://github.com/cloudflare/workerd/blob/4aae9f4c7ae30a59a88ca868c4aff88bda85c956/src/cloudflare/internal/d1-api.ts#L287
+	 * It may cause issues with duplicated column names in join queries, which should be fixed on the D1 side.
+	 * @param results
+	 * @returns
+	 */
 	private d1ToRawMapping(results: any) {
 		const rows: unknown[][] = [];
 		for (const row of results) {

--- a/drizzle-orm/src/libsql/driver.ts
+++ b/drizzle-orm/src/libsql/driver.ts
@@ -1,7 +1,6 @@
 import type { Client, ResultSet } from '@libsql/client';
 import { entityKind } from '~/entity.ts';
 import { DefaultLogger } from '~/logger.ts';
-import type { SelectResult } from '~/query-builders/select.types.ts';
 import {
 	createTableRelationsHelpers,
 	extractTablesRelationalConfig,
@@ -10,52 +9,16 @@ import {
 } from '~/relations.ts';
 import { BaseSQLiteDatabase } from '~/sqlite-core/db.ts';
 import { SQLiteAsyncDialect } from '~/sqlite-core/dialect.ts';
-import type {
-	SQLiteDelete,
-	SQLiteInsert,
-	SQLiteSelect,
-	SQLiteUpdate,
-} from '~/sqlite-core/index.ts';
-import type { SQLiteRelationalQuery } from '~/sqlite-core/query-builders/query.ts';
-import type { SQLiteRaw } from '~/sqlite-core/query-builders/raw.ts';
 import { type DrizzleConfig } from '~/utils.ts';
 import { LibSQLSession } from './session.ts';
-
-export type BatchParameters =
-	| SQLiteUpdate<any, 'async', ResultSet, any>
-	| SQLiteSelect<any, 'async', ResultSet, any, any>
-	| SQLiteDelete<any, 'async', ResultSet, any>
-	| Omit<SQLiteDelete<any, 'async', ResultSet, any>, 'where'>
-	| Omit<SQLiteUpdate<any, 'async', ResultSet, any>, 'where'>
-	| SQLiteInsert<any, 'async', ResultSet, any>
-	| SQLiteRelationalQuery<'async', any>
-	| SQLiteRaw<any>;
-
-export type BatchResponse<U extends BatchParameters, TQuery extends Readonly<[U, ...U[]]>> = {
-	[K in keyof TQuery]: TQuery[K] extends
-		SQLiteSelect<infer _TTable, 'async', infer _TRes, infer TSelection, infer TSelectMode, infer TNullabilityMap>
-		? SelectResult<TSelection, TSelectMode, TNullabilityMap>[]
-		: TQuery[K] extends SQLiteUpdate<infer _TTable, 'async', infer _TRunResult, infer _TReturning>
-			? _TReturning extends undefined ? _TRunResult : _TReturning[]
-		: TQuery[K] extends Omit<SQLiteUpdate<infer _TTable, 'async', infer _TRunResult, infer _TReturning>, 'where'>
-			? _TReturning extends undefined ? _TRunResult : _TReturning[]
-		: TQuery[K] extends SQLiteInsert<infer _TTable, 'async', infer _TRunResult, infer _TReturning>
-			? _TReturning extends undefined ? _TRunResult : _TReturning[]
-		: TQuery[K] extends SQLiteDelete<infer _TTable, 'async', infer _TRunResult, infer _TReturning>
-			? _TReturning extends undefined ? _TRunResult : _TReturning[]
-		: TQuery[K] extends Omit<SQLiteDelete<infer _TTable, 'async', infer _TRunResult, infer _TReturning>, 'where'>
-			? _TReturning extends undefined ? _TRunResult : _TReturning[]
-		: TQuery[K] extends SQLiteRelationalQuery<'async', infer TResult> ? TResult
-		: TQuery[K] extends SQLiteRaw<infer TResult> ? TResult
-		: never;
-};
+import type { BatchParameters, BatchResponse } from '~/batch.ts';
 
 export class LibSQLDatabase<
 	TSchema extends Record<string, unknown> = Record<string, never>,
 > extends BaseSQLiteDatabase<'async', ResultSet, TSchema> {
 	static readonly [entityKind]: string = 'LibSQLDatabase';
 
-	async batch<U extends BatchParameters, T extends Readonly<[U, ...U[]]>>(
+	async batch<U extends BatchParameters<ResultSet>, T extends Readonly<[U, ...U[]]>>(
 		batch: T,
 	): Promise<BatchResponse<U, T>> {
 		return await (this.session as LibSQLSession<TSchema, any>).batch(batch) as BatchResponse<U, T>;

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -21,7 +21,8 @@
       "!tests/bun/**/*",
       "!tests/vercel-pg.test.ts",
       "!tests/relational/**/*",
-      "!tests/libsql-batch.test.ts"
+      "!tests/libsql-batch.test.ts",
+      "!tests/d1-batch.test.ts"
     ],
     "extensions": {
       "ts": "module"

--- a/integration-tests/tests/d1-batch.test.ts
+++ b/integration-tests/tests/d1-batch.test.ts
@@ -1,0 +1,552 @@
+import 'dotenv/config';
+import { D1Database, D1DatabaseAPI } from '@miniflare/d1';
+import { createSQLiteDB } from '@miniflare/shared';
+import { eq, relations, sql } from 'drizzle-orm';
+import type { DrizzleD1Database } from 'drizzle-orm/d1';
+import { drizzle } from 'drizzle-orm/d1';
+import { type AnySQLiteColumn, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { afterAll, beforeAll, beforeEach, expect, expectTypeOf, test } from 'vitest';
+
+const ENABLE_LOGGING = false;
+
+export const usersTable = sqliteTable('users', {
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	name: text('name').notNull(),
+	verified: integer('verified').notNull().default(0),
+	invitedBy: integer('invited_by').references((): AnySQLiteColumn => usersTable.id),
+});
+export const usersConfig = relations(usersTable, ({ one, many }) => ({
+	invitee: one(usersTable, {
+		fields: [usersTable.invitedBy],
+		references: [usersTable.id],
+	}),
+	usersToGroups: many(usersToGroupsTable),
+	posts: many(postsTable),
+}));
+
+export const groupsTable = sqliteTable('groups', {
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	name: text('name').notNull(),
+	description: text('description'),
+});
+export const groupsConfig = relations(groupsTable, ({ many }) => ({
+	usersToGroups: many(usersToGroupsTable),
+}));
+
+export const usersToGroupsTable = sqliteTable(
+	'users_to_groups',
+	{
+		id: integer('id').primaryKey({ autoIncrement: true }),
+		userId: integer('user_id', { mode: 'number' }).notNull().references(
+			() => usersTable.id,
+		),
+		groupId: integer('group_id', { mode: 'number' }).notNull().references(
+			() => groupsTable.id,
+		),
+	},
+	(t) => ({
+		pk: primaryKey(t.userId, t.groupId),
+	}),
+);
+export const usersToGroupsConfig = relations(usersToGroupsTable, ({ one }) => ({
+	group: one(groupsTable, {
+		fields: [usersToGroupsTable.groupId],
+		references: [groupsTable.id],
+	}),
+	user: one(usersTable, {
+		fields: [usersToGroupsTable.userId],
+		references: [usersTable.id],
+	}),
+}));
+
+export const postsTable = sqliteTable('posts', {
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	content: text('content').notNull(),
+	ownerId: integer('owner_id', { mode: 'number' }).references(
+		() => usersTable.id,
+	),
+	createdAt: integer('created_at', { mode: 'timestamp_ms' })
+		.notNull().default(sql`current_timestamp`),
+});
+export const postsConfig = relations(postsTable, ({ one, many }) => ({
+	author: one(usersTable, {
+		fields: [postsTable.ownerId],
+		references: [usersTable.id],
+	}),
+	comments: many(commentsTable),
+}));
+
+export const commentsTable = sqliteTable('comments', {
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	content: text('content').notNull(),
+	creator: integer('creator', { mode: 'number' }).references(
+		() => usersTable.id,
+	),
+	postId: integer('post_id', { mode: 'number' }).references(() => postsTable.id),
+	createdAt: integer('created_at', { mode: 'timestamp_ms' })
+		.notNull().default(sql`current_timestamp`),
+});
+export const commentsConfig = relations(commentsTable, ({ one, many }) => ({
+	post: one(postsTable, {
+		fields: [commentsTable.postId],
+		references: [postsTable.id],
+	}),
+	author: one(usersTable, {
+		fields: [commentsTable.creator],
+		references: [usersTable.id],
+	}),
+	likes: many(commentLikesTable),
+}));
+
+export const commentLikesTable = sqliteTable('comment_likes', {
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	creator: integer('creator', { mode: 'number' }).references(
+		() => usersTable.id,
+	),
+	commentId: integer('comment_id', { mode: 'number' }).references(
+		() => commentsTable.id,
+	),
+	createdAt: integer('created_at', { mode: 'timestamp_ms' })
+		.notNull().default(sql`current_timestamp`),
+});
+export const commentLikesConfig = relations(commentLikesTable, ({ one }) => ({
+	comment: one(commentsTable, {
+		fields: [commentLikesTable.commentId],
+		references: [commentsTable.id],
+	}),
+	author: one(usersTable, {
+		fields: [commentLikesTable.creator],
+		references: [usersTable.id],
+	}),
+}));
+
+const schema = {
+	usersTable,
+	postsTable,
+	commentsTable,
+	usersToGroupsTable,
+	groupsTable,
+	commentLikesConfig,
+	commentsConfig,
+	postsConfig,
+	usersToGroupsConfig,
+	groupsConfig,
+	usersConfig,
+};
+
+let db: DrizzleD1Database<typeof schema>;
+
+beforeAll(async () => {
+	const sqliteDb = await createSQLiteDB(':memory:');
+	db = drizzle(new D1Database(new D1DatabaseAPI(sqliteDb)) as any, { schema, logger: ENABLE_LOGGING });
+});
+
+beforeEach(async () => {
+	await db.run(sql`drop table if exists \`groups\``);
+	await db.run(sql`drop table if exists \`users\``);
+	await db.run(sql`drop table if exists \`users_to_groups\``);
+	await db.run(sql`drop table if exists \`posts\``);
+	await db.run(sql`drop table if exists \`comments\``);
+	await db.run(sql`drop table if exists \`comment_likes\``);
+
+	await db.run(
+		sql`
+			CREATE TABLE \`users\` (
+			    \`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+			    \`name\` text NOT NULL,
+			    \`verified\` integer DEFAULT 0 NOT NULL,
+			    \`invited_by\` integer
+			);
+		`,
+	);
+	await db.run(
+		sql`
+			CREATE TABLE \`groups\` (
+			    \`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+			    \`name\` text NOT NULL,
+			    \`description\` text
+			);
+		`,
+	);
+	await db.run(
+		sql`
+			CREATE TABLE \`users_to_groups\` (
+			    \`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+			    \`user_id\` integer NOT NULL,
+			    \`group_id\` integer NOT NULL
+			);
+		`,
+	);
+	await db.run(
+		sql`
+			CREATE TABLE \`posts\` (
+			    \`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+			    \`content\` text NOT NULL,
+			    \`owner_id\` integer,
+			    \`created_at\` integer DEFAULT current_timestamp NOT NULL
+			);
+		`,
+	);
+	await db.run(
+		sql`
+			CREATE TABLE \`comments\` (
+			    \`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+			    \`content\` text NOT NULL,
+			    \`creator\` integer,
+			    \`post_id\` integer,
+			    \`created_at\` integer DEFAULT current_timestamp NOT NULL
+			);
+		`,
+	);
+	await db.run(
+		sql`
+			CREATE TABLE \`comment_likes\` (
+			    \`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+			    \`creator\` integer,
+			    \`comment_id\` integer,
+			    \`created_at\` integer DEFAULT current_timestamp NOT NULL
+			);
+		`,
+	);
+});
+
+afterAll(async () => {
+	await db.run(sql`drop table if exists \`groups\``);
+	await db.run(sql`drop table if exists \`users\``);
+	await db.run(sql`drop table if exists \`users_to_groups\``);
+	await db.run(sql`drop table if exists \`posts\``);
+	await db.run(sql`drop table if exists \`comments\``);
+	await db.run(sql`drop table if exists \`comment_likes\``);
+});
+
+test('batch api example', async () => {
+	const batchResponse = await db.batch([
+		db.insert(usersTable).values({ id: 1, name: 'John' }).returning({
+			id: usersTable.id,
+			invitedBy: usersTable.invitedBy,
+		}),
+		db.insert(usersTable).values({ id: 2, name: 'Dan' }),
+		db.select().from(usersTable),
+	]);
+
+	console.log('batchResponse', batchResponse);
+
+	expectTypeOf(batchResponse).toEqualTypeOf<[
+		{
+			id: number;
+			invitedBy: number | null;
+		}[],
+		D1Result,
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		}[],
+	]>();
+
+	expect(batchResponse.length).eq(3);
+
+	expect(batchResponse[0]).toEqual([{
+		id: 1,
+		invitedBy: null,
+	}]);
+
+	// expect(batchResponse[1]).toEqual({
+	// 	results: [],
+	// 	success: true,
+	// 	meta: {
+	// 		duration: 0.027083873748779297,
+	// 		last_row_id: 2,
+	// 		changes: 1,
+	// 		served_by: 'miniflare.db',
+	// 		internal_stats: null,
+	// 	},
+	// });
+
+	expect(batchResponse[2]).toEqual([
+		{ id: 1, name: 'John', verified: 0, invitedBy: null },
+		{ id: 2, name: 'Dan', verified: 0, invitedBy: null },
+	]);
+});
+
+// batch api only relational many
+test('insert + findMany', async () => {
+	const batchResponse = await db.batch([
+		db.insert(usersTable).values({ id: 1, name: 'John' }).returning({ id: usersTable.id }),
+		db.insert(usersTable).values({ id: 2, name: 'Dan' }),
+		db.query.usersTable.findMany({}),
+	]);
+
+	expectTypeOf(batchResponse).toEqualTypeOf<[
+		{
+			id: number;
+		}[],
+		D1Result,
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		}[],
+	]>();
+
+	expect(batchResponse.length).eq(3);
+
+	expect(batchResponse[0]).toEqual([{
+		id: 1,
+	}]);
+
+	// expect(batchResponse[1]).toEqual({ columns: [], rows: [], rowsAffected: 1, lastInsertRowid: 2n });
+
+	expect(batchResponse[2]).toEqual([
+		{ id: 1, name: 'John', verified: 0, invitedBy: null },
+		{ id: 2, name: 'Dan', verified: 0, invitedBy: null },
+	]);
+});
+
+// batch api relational many + one
+test('insert + findMany + findFirst', async () => {
+	const batchResponse = await db.batch([
+		db.insert(usersTable).values({ id: 1, name: 'John' }).returning({ id: usersTable.id }),
+		db.insert(usersTable).values({ id: 2, name: 'Dan' }),
+		db.query.usersTable.findMany({}),
+		db.query.usersTable.findFirst({}),
+	]);
+
+	expectTypeOf(batchResponse).toEqualTypeOf<[
+		{
+			id: number;
+		}[],
+		D1Result,
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		}[],
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		} | undefined,
+	]>();
+
+	expect(batchResponse.length).eq(4);
+
+	expect(batchResponse[0]).toEqual([{
+		id: 1,
+	}]);
+
+	// expect(batchResponse[1]).toEqual({ columns: [], rows: [], rowsAffected: 1, lastInsertRowid: 2n });
+
+	expect(batchResponse[2]).toEqual([
+		{ id: 1, name: 'John', verified: 0, invitedBy: null },
+		{ id: 2, name: 'Dan', verified: 0, invitedBy: null },
+	]);
+
+	expect(batchResponse[3]).toEqual(
+		{ id: 1, name: 'John', verified: 0, invitedBy: null },
+	);
+});
+
+test('insert + db.all + db.get + db.values + db.run', async () => {
+	const batchResponse = await db.batch([
+		db.insert(usersTable).values({ id: 1, name: 'John' }).returning({ id: usersTable.id }),
+		db.run(sql`insert into users (id, name) values (2, 'Dan')`),
+		db.all<typeof usersTable.$inferSelect>(sql`select * from users`),
+		db.values(sql`select * from users`),
+		db.get<typeof usersTable.$inferSelect>(sql`select * from users`),
+	]);
+
+	expectTypeOf(batchResponse).toEqualTypeOf<[
+		{
+			id: number;
+		}[],
+		D1Result,
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		}[],
+		unknown[][],
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		},
+	]>();
+
+	expect(batchResponse.length).eq(5);
+
+	expect(batchResponse[0], 'insert').toEqual([{
+		id: 1,
+	}]);
+
+	// expect(batchResponse[1]).toEqual({ columns: [], rows: [], rowsAffected: 1, lastInsertRowid: 2n });
+
+	expect(batchResponse[2], 'all').toEqual([
+		{ id: 1, name: 'John', verified: 0, invited_by: null },
+		{ id: 2, name: 'Dan', verified: 0, invited_by: null },
+	]);
+
+	expect(batchResponse[3], 'values').toEqual([[1, 'John', 0, null], [2, 'Dan', 0, null]]);
+
+	expect(batchResponse[4], 'get').toEqual(
+		{ id: 1, name: 'John', verified: 0, invited_by: null },
+	);
+});
+
+// batch api combined rqb + raw call
+test('insert + findManyWith + db.all', async () => {
+	const batchResponse = await db.batch([
+		db.insert(usersTable).values({ id: 1, name: 'John' }).returning({ id: usersTable.id }),
+		db.insert(usersTable).values({ id: 2, name: 'Dan' }),
+		db.query.usersTable.findMany({}),
+		db.all<typeof usersTable.$inferSelect>(sql`select * from users`),
+	]);
+
+	expectTypeOf(batchResponse).toEqualTypeOf<[
+		{
+			id: number;
+		}[],
+		D1Result,
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		}[],
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		}[],
+	]>();
+
+	expect(batchResponse.length).eq(4);
+
+	expect(batchResponse[0]).toEqual([{
+		id: 1,
+	}]);
+
+	// expect(batchResponse[1]).toEqual({ columns: [], rows: [], rowsAffected: 1, lastInsertRowid: 2n });
+
+	expect(batchResponse[2]).toEqual([
+		{ id: 1, name: 'John', verified: 0, invitedBy: null },
+		{ id: 2, name: 'Dan', verified: 0, invitedBy: null },
+	]);
+
+	expect(batchResponse[3]).toEqual([
+		{ id: 1, name: 'John', verified: 0, invited_by: null },
+		{ id: 2, name: 'Dan', verified: 0, invited_by: null },
+	]);
+});
+
+// batch api for insert + update + select
+test('insert + update + select + select partial', async () => {
+	const batchResponse = await db.batch([
+		db.insert(usersTable).values({ id: 1, name: 'John' }).returning({ id: usersTable.id }),
+		db.update(usersTable).set({ name: 'Dan' }).where(eq(usersTable.id, 1)),
+		db.query.usersTable.findMany({}),
+		db.select().from(usersTable).where(eq(usersTable.id, 1)),
+		db.select({ id: usersTable.id, invitedBy: usersTable.invitedBy }).from(usersTable),
+	]);
+
+	expectTypeOf(batchResponse).toEqualTypeOf<[
+		{
+			id: number;
+		}[],
+		D1Result,
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		}[],
+		{
+			id: number;
+			name: string;
+			verified: number;
+			invitedBy: number | null;
+		}[],
+		{
+			id: number;
+			invitedBy: number | null;
+		}[],
+	]>();
+
+	expect(batchResponse.length).eq(5);
+
+	expect(batchResponse[0]).toEqual([{
+		id: 1,
+	}]);
+
+	// expect(batchResponse[1]).toEqual({ columns: [], rows: [], rowsAffected: 1, lastInsertRowid: 1n });
+
+	expect(batchResponse[2]).toEqual([
+		{ id: 1, name: 'Dan', verified: 0, invitedBy: null },
+	]);
+
+	expect(batchResponse[3]).toEqual([
+		{ id: 1, name: 'Dan', verified: 0, invitedBy: null },
+	]);
+
+	expect(batchResponse[4]).toEqual([
+		{ id: 1, invitedBy: null },
+	]);
+});
+
+// batch api for insert + delete + select
+test('insert + delete + select + select partial', async () => {
+	const batchResponse = await db.batch([
+		db.insert(usersTable).values({ id: 1, name: 'John' }).returning({ id: usersTable.id }),
+		db.insert(usersTable).values({ id: 2, name: 'Dan' }),
+		db.delete(usersTable).where(eq(usersTable.id, 1)).returning({ id: usersTable.id, invitedBy: usersTable.invitedBy }),
+		db.query.usersTable.findFirst({
+			columns: {
+				id: true,
+				invitedBy: true,
+			},
+		}),
+	]);
+
+	expectTypeOf(batchResponse).toEqualTypeOf<[
+		{
+			id: number;
+		}[],
+		D1Result,
+		{
+			id: number;
+			invitedBy: number | null;
+		}[],
+		{
+			id: number;
+			invitedBy: number | null;
+		} | undefined,
+	]>();
+
+	expect(batchResponse.length).eq(4);
+
+	expect(batchResponse[0]).toEqual([{
+		id: 1,
+	}]);
+
+	// expect(batchResponse[1]).toEqual({ columns: [], rows: [], rowsAffected: 1, lastInsertRowid: 2n });
+
+	expect(batchResponse[2]).toEqual([
+		{ id: 1, invitedBy: null },
+	]);
+
+	expect(batchResponse[3]).toEqual(
+		{ id: 2, invitedBy: null },
+	);
+});
+
+// * additionally
+// batch for all libsql cases, just replace simple calls with batch calls
+// batch for all rqb cases, just replace simple calls with batch calls

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['tests/relational/**/*.test.ts', 'tests/libsql-batch.test.ts'],
+		include: ['tests/relational/**/*.test.ts', 'tests/libsql-batch.test.ts', 'tests/d1-batch.test.ts'],
 		exclude: [
 			...(process.env.SKIP_PLANETSCALE_TESTS ? ['tests/relational/mysql.planetscale.test.ts'] : []),
 			'tests/relational/vercel.test.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: ^3.344.0
         version: 3.344.0
       '@cloudflare/workers-types':
-        specifier: ^4.20230518.0
-        version: 4.20230518.0
+        specifier: ^4.20230904.0
+        version: 4.20230904.0
       '@libsql/client':
         specifier: ^0.1.6
         version: 0.1.6
@@ -174,10 +174,10 @@ importers:
         version: 3.12.7
       vite-tsconfig-paths:
         specifier: ^4.2.0
-        version: 4.2.0(typescript@5.1.6)
+        version: 4.2.0(typescript@5.1.6)(vite@4.3.9)
       vitest:
         specifier: ^0.31.4
-        version: 0.31.4
+        version: 0.31.4(@vitest/ui@0.31.4)
       zod:
         specifier: ^3.20.2
         version: 3.21.4
@@ -1581,8 +1581,8 @@ packages:
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
     dev: false
 
-  /@cloudflare/workers-types@4.20230518.0:
-    resolution: {integrity: sha512-A0w1V+5SUawGaaPRlhFhSC/SCDT9oQG8TMoWOKFLA4qbqagELqEAFD4KySBIkeVOvCBLT1DZSYBMCxbXddl0kw==}
+  /@cloudflare/workers-types@4.20230904.0:
+    resolution: {integrity: sha512-IX4oJCe14ctblSPZBlW64BVZ9nYLUo6sD2I5gu3hX0ywByYWm1OuoKm9Xb/Zpbj8Ph18Z7Ryii6u2/ocnncXdA==}
     dev: true
 
   /@dprint/darwin-arm64@0.40.2:
@@ -8358,22 +8358,6 @@ packages:
       - supports-color
       - terser
 
-  /vite-tsconfig-paths@4.2.0(typescript@5.1.6):
-    resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-      globrex: 0.1.2
-      tsconfck: 2.1.1(typescript@5.1.6)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /vite-tsconfig-paths@4.2.0(typescript@5.1.6)(vite@4.3.9):
     resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
     peerDependencies:
@@ -8422,71 +8406,6 @@ packages:
       rollup: 3.27.2
     optionalDependencies:
       fsevents: 2.3.3
-
-  /vitest@0.31.4:
-    resolution: {integrity: sha512-GoV0VQPmWrUFOZSg3RpQAPN+LPmHg2/gxlMNJlyxJihkz6qReHDV6b0pPDcqFLNEPya4tWJ1pgwUNP9MLmUfvQ==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.5
-      '@types/chai-subset': 1.3.3
-      '@types/node': 20.2.5
-      '@vitest/expect': 0.31.4
-      '@vitest/runner': 0.31.4
-      '@vitest/snapshot': 0.31.4
-      '@vitest/spy': 0.31.4
-      '@vitest/utils': 0.31.4
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      cac: 6.7.14
-      chai: 4.3.7
-      concordance: 5.0.4
-      debug: 4.3.4
-      local-pkg: 0.4.3
-      magic-string: 0.30.0
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      std-env: 3.3.3
-      strip-literal: 1.0.1
-      tinybench: 2.5.0
-      tinypool: 0.5.0
-      vite: 4.3.9(@types/node@20.2.5)
-      vite-node: 0.31.4(@types/node@20.2.5)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
 
   /vitest@0.31.4(@vitest/ui@0.31.4):
     resolution: {integrity: sha512-GoV0VQPmWrUFOZSg3RpQAPN+LPmHg2/gxlMNJlyxJihkz6qReHDV6b0pPDcqFLNEPya4tWJ1pgwUNP9MLmUfvQ==}


### PR DESCRIPTION
todo list(only test cases left)

- [x] Add a few more test cases for d1 batch
- [ ] Add test cases for D1Result in runtime

---

Reference: https://developers.cloudflare.com/d1/platform/client-api/#dbbatch

Batch API usage example:
```ts
const batchResponse = await db.batch([
	db.insert(usersTable).values({ id: 1, name: 'John' }).returning({ id: usersTable.id }),
	db.update(usersTable).set({ name: 'Dan' }).where(eq(usersTable.id, 1)),
	db.query.usersTable.findMany({}),
	db.select().from(usersTable).where(eq(usersTable.id, 1)),
	db.select({ id: usersTable.id, invitedBy: usersTable.invitedBy }).from(usersTable),
]);
```

Type for batchResponse in this example would be:
```ts
type BatchResponse = [
	{
		id: number;
	}[],
	D1Result,
	{
		id: number;
		name: string;
		verified: number;
		invitedBy: number | null;
	}[],
	{
		id: number;
		name: string;
		verified: number;
		invitedBy: number | null;
	}[],
	{
		id: number;
		invitedBy: number | null;
	}[],
]
```
All possible builders that can be used inside db.batch:
```ts
`db.all()`,
`db.get()`,
`db.values()`,
`db.run()`,
`db.query.<table>.findMany()`,
`db.query.<table>.findFirst()`,
`db.select()...`,
`db.update()...`,
`db.delete()...`,
`db.insert()...`,
```
More usage examples here: https://github.com/drizzle-team/drizzle-orm/pull/1202/files#diff-82174886188b2c44151a7a9e3f476ec093cea0d5edd8f521d8bf3cee77b9e609