### PR TITLE
[ALL] Add schema getter & setter to Table class

### DIFF
--- a/drizzle-orm/src/table.ts
+++ b/drizzle-orm/src/table.ts
@@ -106,6 +106,14 @@ export class Table<T extends TableConfig = TableConfig> implements SQLWrapper {
 	getSQL(): SQL<unknown> {
 		return new SQL([this]);
 	}
+
+  getSchema() {
+    return this[Schema];
+  }
+
+  setSbhema(schema: string) {
+		this[Schema] = schema;
+  }
 }
 
 export function isTable(table: unknown): table is Table {

--- a/drizzle-orm/src/table.ts
+++ b/drizzle-orm/src/table.ts
@@ -107,13 +107,13 @@ export class Table<T extends TableConfig = TableConfig> implements SQLWrapper {
 		return new SQL([this]);
 	}
 
-  getSchema() {
-    return this[Schema];
-  }
+  	getSchema() {
+    		return this[Schema];
+  	}
 
-  setSbhema(schema: string) {
+  	setSchema(schema: string) {
 		this[Schema] = schema;
-  }
+  	}
 }
 
 export function isTable(table: unknown): table is Table {

--- a/integration-tests/tests/pg-schema.test.ts
+++ b/integration-tests/tests/pg-schema.test.ts
@@ -191,6 +191,20 @@ test.serial('select sql', async (t) => {
 	t.deepEqual(users, [{ name: 'JOHN' }]);
 });
 
+
+test.serial('set new table schema', async (t) => {
+
+  const oldSchema = pgSchema('oldSchema');
+  const stateTable = oldSchema.table('states', {
+    id: serial('id').primaryKey(),
+    name: text('name').notNull(),
+    state: char('state', { length: 2 }),
+  });
+
+  stateTable.setSchema('newSchema');
+  t.deepEqual(stateTable.getSchema(), 'newSchema')
+});
+
 test.serial('select typed sql', async (t) => {
 	const { db } = t.context;
 


### PR DESCRIPTION
We have a use-case to be able to create new versions of our database at any given moment. To limit the downtime on the application we would like to create the data in a separate schema and do a schema switch after all data loading is finished. 

Drizzle-Orm did not seem to have an easy way to point a table object to a different schema at runtime without doing a huge refactor of all existing table definitions of our application. These changes would make pointing a table object to a different schema much simpler.

- added a getter and setter to the Table class
- added a test to pg-schema.ts 