### PR TITLE
Unsigned Ints; Custom names for PrimaryKeys and ForeignKeys

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/bigint.ts
+++ b/drizzle-orm/src/mysql-core/columns/bigint.ts
@@ -14,12 +14,13 @@ export type MySqlBigInt53BuilderInitial<TName extends string> = MySqlBigInt53Bui
 }>;
 
 export class MySqlBigInt53Builder<T extends ColumnBuilderBaseConfig<'number', 'MySqlBigInt53'>>
-	extends MySqlColumnBuilderWithAutoIncrement<T>
+	extends MySqlColumnBuilderWithAutoIncrement<T, { unsigned: boolean }>
 {
 	static readonly [entityKind]: string = 'MySqlBigInt53Builder';
 
-	constructor(name: T['name']) {
+	constructor(name: T['name'], unsigned: boolean = false) {
 		super(name, 'number', 'MySqlBigInt53');
+		this.config.unsigned = unsigned;
 	}
 
 	/** @internal */
@@ -34,12 +35,12 @@ export class MySqlBigInt53Builder<T extends ColumnBuilderBaseConfig<'number', 'M
 }
 
 export class MySqlBigInt53<T extends ColumnBaseConfig<'number', 'MySqlBigInt53'>>
-	extends MySqlColumnWithAutoIncrement<T>
+	extends MySqlColumnWithAutoIncrement<T, { unsigned: boolean }>
 {
 	static readonly [entityKind]: string = 'MySqlBigInt53';
 
 	getSQLType(): string {
-		return 'bigint';
+		return `bigint${this.config.unsigned ? ' unsigned' : ''}`;
 	}
 
 	override mapFromDriverValue(value: number | string): number {
@@ -60,12 +61,13 @@ export type MySqlBigInt64BuilderInitial<TName extends string> = MySqlBigInt64Bui
 }>;
 
 export class MySqlBigInt64Builder<T extends ColumnBuilderBaseConfig<'bigint', 'MySqlBigInt64'>>
-	extends MySqlColumnBuilderWithAutoIncrement<T>
+	extends MySqlColumnBuilderWithAutoIncrement<T, { unsigned: boolean }>
 {
 	static readonly [entityKind]: string = 'MySqlBigInt64Builder';
 
-	constructor(name: T['name']) {
+	constructor(name: T['name'], unsigned: boolean = false) {
 		super(name, 'bigint', 'MySqlBigInt64');
+		this.config.unsigned = unsigned;
 	}
 
 	/** @internal */
@@ -80,12 +82,12 @@ export class MySqlBigInt64Builder<T extends ColumnBuilderBaseConfig<'bigint', 'M
 }
 
 export class MySqlBigInt64<T extends ColumnBaseConfig<'bigint', 'MySqlBigInt64'>>
-	extends MySqlColumnWithAutoIncrement<T>
+	extends MySqlColumnWithAutoIncrement<T, { unsigned: boolean }>
 {
 	static readonly [entityKind]: string = 'MySqlBigInt64';
 
 	getSQLType(): string {
-		return 'bigint';
+		return `bigint${this.config.unsigned ? ' unsigned' : ''}`;
 	}
 
 	// eslint-disable-next-line unicorn/prefer-native-coercion-functions
@@ -96,6 +98,7 @@ export class MySqlBigInt64<T extends ColumnBaseConfig<'bigint', 'MySqlBigInt64'>
 
 interface MySqlBigIntConfig<T extends 'number' | 'bigint' = 'number' | 'bigint'> {
 	mode: T;
+	unsigned?: boolean;
 }
 
 export function bigint<TName extends string, TMode extends MySqlBigIntConfig['mode']>(
@@ -104,7 +107,7 @@ export function bigint<TName extends string, TMode extends MySqlBigIntConfig['mo
 ): TMode extends 'number' ? MySqlBigInt53BuilderInitial<TName> : MySqlBigInt64BuilderInitial<TName>;
 export function bigint(name: string, config: MySqlBigIntConfig) {
 	if (config.mode === 'number') {
-		return new MySqlBigInt53Builder(name);
+		return new MySqlBigInt53Builder(name, config.unsigned);
 	}
-	return new MySqlBigInt64Builder(name);
+	return new MySqlBigInt64Builder(name, config.unsigned);
 }

--- a/drizzle-orm/src/mysql-core/columns/int.ts
+++ b/drizzle-orm/src/mysql-core/columns/int.ts
@@ -14,12 +14,13 @@ export type MySqlIntBuilderInitial<TName extends string> = MySqlIntBuilder<{
 }>;
 
 export class MySqlIntBuilder<T extends ColumnBuilderBaseConfig<'number', 'MySqlInt'>>
-	extends MySqlColumnBuilderWithAutoIncrement<T>
+	extends MySqlColumnBuilderWithAutoIncrement<T, MySqlIntConfig>
 {
 	static readonly [entityKind]: string = 'MySqlIntBuilder';
 
-	constructor(name: T['name']) {
+	constructor(name: T['name'], config?: MySqlIntConfig) {
 		super(name, 'number', 'MySqlInt');
+		this.config.unsigned = config ? config.unsigned : false;
 	}
 
 	/** @internal */
@@ -30,11 +31,13 @@ export class MySqlIntBuilder<T extends ColumnBuilderBaseConfig<'number', 'MySqlI
 	}
 }
 
-export class MySqlInt<T extends ColumnBaseConfig<'number', 'MySqlInt'>> extends MySqlColumnWithAutoIncrement<T> {
+export class MySqlInt<T extends ColumnBaseConfig<'number', 'MySqlInt'>>
+	extends MySqlColumnWithAutoIncrement<T, MySqlIntConfig>
+{
 	static readonly [entityKind]: string = 'MySqlInt';
 
 	getSQLType(): string {
-		return 'int';
+		return `int${this.config.unsigned ? ' unsigned' : ''}`;
 	}
 
 	override mapFromDriverValue(value: number | string): number {
@@ -45,6 +48,10 @@ export class MySqlInt<T extends ColumnBaseConfig<'number', 'MySqlInt'>> extends 
 	}
 }
 
-export function int<TName extends string>(name: TName): MySqlIntBuilderInitial<TName> {
-	return new MySqlIntBuilder(name);
+export interface MySqlIntConfig {
+	unsigned?: boolean;
+}
+
+export function int<TName extends string>(name: TName, config?: MySqlIntConfig): MySqlIntBuilderInitial<TName> {
+	return new MySqlIntBuilder(name, config);
 }

--- a/drizzle-orm/src/mysql-core/columns/mediumint.ts
+++ b/drizzle-orm/src/mysql-core/columns/mediumint.ts
@@ -3,6 +3,7 @@ import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
 import { MySqlColumnBuilderWithAutoIncrement, MySqlColumnWithAutoIncrement } from './common.ts';
+import type { MySqlIntConfig } from './int.ts';
 
 export type MySqlMediumIntBuilderInitial<TName extends string> = MySqlMediumIntBuilder<{
 	name: TName;
@@ -14,12 +15,13 @@ export type MySqlMediumIntBuilderInitial<TName extends string> = MySqlMediumIntB
 }>;
 
 export class MySqlMediumIntBuilder<T extends ColumnBuilderBaseConfig<'number', 'MySqlMediumInt'>>
-	extends MySqlColumnBuilderWithAutoIncrement<T>
+	extends MySqlColumnBuilderWithAutoIncrement<T, MySqlIntConfig>
 {
 	static readonly [entityKind]: string = 'MySqlMediumIntBuilder';
 
-	constructor(name: T['name']) {
+	constructor(name: T['name'], config?: MySqlIntConfig) {
 		super(name, 'number', 'MySqlMediumInt');
+		this.config.unsigned = config ? config.unsigned : false;
 	}
 
 	/** @internal */
@@ -34,12 +36,12 @@ export class MySqlMediumIntBuilder<T extends ColumnBuilderBaseConfig<'number', '
 }
 
 export class MySqlMediumInt<T extends ColumnBaseConfig<'number', 'MySqlMediumInt'>>
-	extends MySqlColumnWithAutoIncrement<T>
+	extends MySqlColumnWithAutoIncrement<T, MySqlIntConfig>
 {
 	static readonly [entityKind]: string = 'MySqlMediumInt';
 
 	getSQLType(): string {
-		return 'mediumint';
+		return `mediumint${this.config.unsigned ? ' unsigned' : ''}`;
 	}
 
 	override mapFromDriverValue(value: number | string): number {
@@ -50,6 +52,9 @@ export class MySqlMediumInt<T extends ColumnBaseConfig<'number', 'MySqlMediumInt
 	}
 }
 
-export function mediumint<TName extends string>(name: TName): MySqlMediumIntBuilderInitial<TName> {
-	return new MySqlMediumIntBuilder(name);
+export function mediumint<TName extends string>(
+	name: TName,
+	config?: MySqlIntConfig,
+): MySqlMediumIntBuilderInitial<TName> {
+	return new MySqlMediumIntBuilder(name, config);
 }

--- a/drizzle-orm/src/mysql-core/columns/smallint.ts
+++ b/drizzle-orm/src/mysql-core/columns/smallint.ts
@@ -3,6 +3,7 @@ import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
 import { MySqlColumnBuilderWithAutoIncrement, MySqlColumnWithAutoIncrement } from './common.ts';
+import type { MySqlIntConfig } from './int.ts';
 
 export type MySqlSmallIntBuilderInitial<TName extends string> = MySqlSmallIntBuilder<{
 	name: TName;
@@ -14,12 +15,13 @@ export type MySqlSmallIntBuilderInitial<TName extends string> = MySqlSmallIntBui
 }>;
 
 export class MySqlSmallIntBuilder<T extends ColumnBuilderBaseConfig<'number', 'MySqlSmallInt'>>
-	extends MySqlColumnBuilderWithAutoIncrement<T>
+	extends MySqlColumnBuilderWithAutoIncrement<T, MySqlIntConfig>
 {
 	static readonly [entityKind]: string = 'MySqlSmallIntBuilder';
 
-	constructor(name: T['name']) {
+	constructor(name: T['name'], config?: MySqlIntConfig) {
 		super(name, 'number', 'MySqlSmallInt');
+		this.config.unsigned = config ? config.unsigned : false;
 	}
 
 	/** @internal */
@@ -34,12 +36,12 @@ export class MySqlSmallIntBuilder<T extends ColumnBuilderBaseConfig<'number', 'M
 }
 
 export class MySqlSmallInt<T extends ColumnBaseConfig<'number', 'MySqlSmallInt'>>
-	extends MySqlColumnWithAutoIncrement<T>
+	extends MySqlColumnWithAutoIncrement<T, MySqlIntConfig>
 {
 	static readonly [entityKind]: string = 'MySqlSmallInt';
 
 	getSQLType(): string {
-		return 'smallint';
+		return `smallint${this.config.unsigned ? ' unsigned' : ''}`;
 	}
 
 	override mapFromDriverValue(value: number | string): number {
@@ -50,6 +52,6 @@ export class MySqlSmallInt<T extends ColumnBaseConfig<'number', 'MySqlSmallInt'>
 	}
 }
 
-export function smallint<TName extends string>(name: TName): MySqlSmallIntBuilderInitial<TName> {
-	return new MySqlSmallIntBuilder(name);
+export function smallint<TName extends string>(name: TName, config?: MySqlIntConfig): MySqlSmallIntBuilderInitial<TName> {
+	return new MySqlSmallIntBuilder(name, config);
 }

--- a/drizzle-orm/src/mysql-core/columns/tinyint.ts
+++ b/drizzle-orm/src/mysql-core/columns/tinyint.ts
@@ -3,6 +3,7 @@ import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
 import { MySqlColumnBuilderWithAutoIncrement, MySqlColumnWithAutoIncrement } from './common.ts';
+import type { MySqlIntConfig } from './int.ts';
 
 export type MySqlTinyIntBuilderInitial<TName extends string> = MySqlTinyIntBuilder<{
 	name: TName;
@@ -14,12 +15,13 @@ export type MySqlTinyIntBuilderInitial<TName extends string> = MySqlTinyIntBuild
 }>;
 
 export class MySqlTinyIntBuilder<T extends ColumnBuilderBaseConfig<'number', 'MySqlTinyInt'>>
-	extends MySqlColumnBuilderWithAutoIncrement<T>
+	extends MySqlColumnBuilderWithAutoIncrement<T, MySqlIntConfig>
 {
 	static readonly [entityKind]: string = 'MySqlTinyIntBuilder';
 
-	constructor(name: T['name']) {
+	constructor(name: T['name'], config?: MySqlIntConfig) {
 		super(name, 'number', 'MySqlTinyInt');
+		this.config.unsigned = config ? config.unsigned : false;
 	}
 
 	/** @internal */
@@ -34,12 +36,12 @@ export class MySqlTinyIntBuilder<T extends ColumnBuilderBaseConfig<'number', 'My
 }
 
 export class MySqlTinyInt<T extends ColumnBaseConfig<'number', 'MySqlTinyInt'>>
-	extends MySqlColumnWithAutoIncrement<T>
+	extends MySqlColumnWithAutoIncrement<T, MySqlIntConfig>
 {
 	static readonly [entityKind]: string = 'MySqlTinyInt';
 
 	getSQLType(): string {
-		return 'tinyint';
+		return `tinyint${this.config.unsigned ? ' unsigned' : ''}`;
 	}
 
 	override mapFromDriverValue(value: number | string): number {
@@ -50,6 +52,6 @@ export class MySqlTinyInt<T extends ColumnBaseConfig<'number', 'MySqlTinyInt'>>
 	}
 }
 
-export function tinyint<TName extends string>(name: TName): MySqlTinyIntBuilderInitial<TName> {
-	return new MySqlTinyIntBuilder(name);
+export function tinyint<TName extends string>(name: TName, config?: MySqlIntConfig): MySqlTinyIntBuilderInitial<TName> {
+	return new MySqlTinyIntBuilder(name, config);
 }

--- a/drizzle-orm/src/mysql-core/foreign-keys.ts
+++ b/drizzle-orm/src/mysql-core/foreign-keys.ts
@@ -5,6 +5,7 @@ import { MySqlTable } from './table.ts';
 export type UpdateDeleteAction = 'cascade' | 'restrict' | 'no action' | 'set null' | 'set default';
 
 export type Reference = () => {
+	readonly name?: string;
 	readonly columns: MySqlColumn[];
 	readonly foreignTable: MySqlTable;
 	readonly foreignColumns: MySqlColumn[];
@@ -24,6 +25,7 @@ export class ForeignKeyBuilder {
 
 	constructor(
 		config: () => {
+			name?: string;
 			columns: MySqlColumn[];
 			foreignColumns: MySqlColumn[];
 		},
@@ -33,8 +35,8 @@ export class ForeignKeyBuilder {
 		} | undefined,
 	) {
 		this.reference = () => {
-			const { columns, foreignColumns } = config();
-			return { columns, foreignTable: foreignColumns[0]!.table as MySqlTable, foreignColumns };
+			const { name, columns, foreignColumns } = config();
+			return { name, columns, foreignTable: foreignColumns[0]!.table as MySqlTable, foreignColumns };
 		};
 		if (actions) {
 			this._onUpdate = actions.onUpdate;
@@ -74,7 +76,7 @@ export class ForeignKey {
 	}
 
 	getName(): string {
-		const { columns, foreignColumns } = this.reference();
+		const { name, columns, foreignColumns } = this.reference();
 		const columnNames = columns.map((column) => column.name);
 		const foreignColumnNames = foreignColumns.map((column) => column.name);
 		const chunks = [
@@ -83,7 +85,7 @@ export class ForeignKey {
 			foreignColumns[0]!.table[MySqlTable.Symbol.Name],
 			...foreignColumnNames,
 		];
-		return `${chunks.join('_')}_fk`;
+		return name ?? `${chunks.join('_')}_fk`;
 	}
 }
 
@@ -105,13 +107,15 @@ export function foreignKey<
 	TColumns extends [AnyMySqlColumn<{ tableName: TTableName }>, ...AnyMySqlColumn<{ tableName: TTableName }>[]],
 >(
 	config: {
+		name?: string,
 		columns: TColumns;
 		foreignColumns: ColumnsWithTable<TForeignTableName, TColumns>;
 	},
 ): ForeignKeyBuilder {
 	function mappedConfig() {
-		const { columns, foreignColumns } = config;
+		const { name, columns, foreignColumns } = config;
 		return {
+			name,
 			columns,
 			foreignColumns,
 		};

--- a/drizzle-orm/src/mysql-core/primary-keys.ts
+++ b/drizzle-orm/src/mysql-core/primary-keys.ts
@@ -16,8 +16,8 @@ export function primaryKey<
 	TColumns extends AnyMySqlColumn<{ tableName: TTableName }>[],
 >(...columns: TColumns): PrimaryKeyBuilder;
 export function primaryKey(...config: any) {
-	if (config.columns) {
-		return new PrimaryKeyBuilder(config.columns, config.name);
+	if (config[0].columns) {
+		return new PrimaryKeyBuilder(config[0].columns, config[0].name);
 	}
 	return new PrimaryKeyBuilder(config);
 }

--- a/drizzle-orm/src/mysql-core/primary-keys.ts
+++ b/drizzle-orm/src/mysql-core/primary-keys.ts
@@ -4,8 +4,9 @@ import { MySqlTable } from './table.ts';
 
 export function primaryKey<
 	TTableName extends string,
-	TColumns extends AnyMySqlColumn<{ tableName: TTableName }>,
->(config: { name?: string; columns: [TColumns, ...TColumns[]] }): PrimaryKeyBuilder;
+	TColumn extends AnyMySqlColumn<{ tableName: TTableName }>,
+	TColumns extends AnyMySqlColumn<{ tableName: TTableName }>[],
+>(config: { name?: string; columns: [TColumn, ...TColumns] }): PrimaryKeyBuilder;
 /**
  * @deprecated: Please use primaryKey({ columns: [] }) instead of this function
  * @param columns

--- a/drizzle-orm/src/mysql-core/primary-keys.ts
+++ b/drizzle-orm/src/mysql-core/primary-keys.ts
@@ -15,8 +15,8 @@ export function primaryKey<
 	TTableName extends string,
 	TColumns extends AnyMySqlColumn<{ tableName: TTableName }>[],
 >(...columns: TColumns): PrimaryKeyBuilder;
-export function primaryKey(config: any) {
-	if (config.name) {
+export function primaryKey(...config: any) {
+	if (config.columns) {
 		return new PrimaryKeyBuilder(config.columns, config.name);
 	}
 	return new PrimaryKeyBuilder(config);

--- a/drizzle-orm/src/pg-core/foreign-keys.ts
+++ b/drizzle-orm/src/pg-core/foreign-keys.ts
@@ -5,6 +5,7 @@ import { PgTable } from './table.ts';
 export type UpdateDeleteAction = 'cascade' | 'restrict' | 'no action' | 'set null' | 'set default';
 
 export type Reference = () => {
+	readonly name?: string;
 	readonly columns: PgColumn[];
 	readonly foreignTable: PgTable;
 	readonly foreignColumns: PgColumn[];
@@ -24,6 +25,7 @@ export class ForeignKeyBuilder {
 
 	constructor(
 		config: () => {
+			name?: string,
 			columns: PgColumn[];
 			foreignColumns: PgColumn[];
 		},
@@ -33,8 +35,8 @@ export class ForeignKeyBuilder {
 		} | undefined,
 	) {
 		this.reference = () => {
-			const { columns, foreignColumns } = config();
-			return { columns, foreignTable: foreignColumns[0]!.table as PgTable, foreignColumns };
+			const { name, columns, foreignColumns } = config();
+			return { name, columns, foreignTable: foreignColumns[0]!.table as PgTable, foreignColumns };
 		};
 		if (actions) {
 			this._onUpdate = actions.onUpdate;
@@ -74,7 +76,7 @@ export class ForeignKey {
 	}
 
 	getName(): string {
-		const { columns, foreignColumns } = this.reference();
+		const { name, columns, foreignColumns } = this.reference();
 		const columnNames = columns.map((column) => column.name);
 		const foreignColumnNames = foreignColumns.map((column) => column.name);
 		const chunks = [
@@ -83,7 +85,7 @@ export class ForeignKey {
 			foreignColumns[0]!.table[PgTable.Symbol.Name],
 			...foreignColumnNames,
 		];
-		return `${chunks.join('_')}_fk`;
+		return name ?? `${chunks.join('_')}_fk`;
 	}
 }
 

--- a/drizzle-orm/src/pg-core/foreign-keys.ts
+++ b/drizzle-orm/src/pg-core/foreign-keys.ts
@@ -100,13 +100,15 @@ export function foreignKey<
 	TColumns extends [AnyPgColumn<{ tableName: TTableName }>, ...AnyPgColumn<{ tableName: TTableName }>[]],
 >(
 	config: {
+		name?: string;
 		columns: TColumns;
 		foreignColumns: ColumnsWithTable<TForeignTableName, TColumns>;
 	},
 ): ForeignKeyBuilder {
 	function mappedConfig() {
-		const { columns, foreignColumns } = config;
+		const { name, columns, foreignColumns } = config;
 		return {
+			name,
 			columns,
 			foreignColumns,
 		};

--- a/drizzle-orm/src/pg-core/primary-keys.ts
+++ b/drizzle-orm/src/pg-core/primary-keys.ts
@@ -4,8 +4,9 @@ import { PgTable } from './table.ts';
 
 export function primaryKey<
 	TTableName extends string,
-	TColumns extends AnyPgColumn<{ tableName: TTableName }>,
->(config: { name?: string; columns: [TColumns, ...TColumns[]] }): PrimaryKeyBuilder;
+	TColumn extends AnyPgColumn<{ tableName: TTableName }>,
+	TColumns extends AnyPgColumn<{ tableName: TTableName }>[],
+>(config: { name?: string; columns: [TColumn, ...TColumns] }): PrimaryKeyBuilder;
 /**
  * @deprecated: Please use primaryKey({ columns: [] }) instead of this function
  * @param columns 

--- a/drizzle-orm/src/pg-core/primary-keys.ts
+++ b/drizzle-orm/src/pg-core/primary-keys.ts
@@ -16,8 +16,8 @@ export function primaryKey<
 	TColumns extends AnyPgColumn<{ tableName: TTableName }>[],
 >(...columns: TColumns): PrimaryKeyBuilder;
 export function primaryKey(...config: any) {
-	if (config.columns) {
-		return new PrimaryKeyBuilder(config.columns, config.name);
+	if (config[0].columns) {
+		return new PrimaryKeyBuilder(config[0].columns, config[0].name);
 	}
 	return new PrimaryKeyBuilder(config);
 }

--- a/drizzle-orm/src/pg-core/primary-keys.ts
+++ b/drizzle-orm/src/pg-core/primary-keys.ts
@@ -15,8 +15,8 @@ export function primaryKey<
 	TTableName extends string,
 	TColumns extends AnyPgColumn<{ tableName: TTableName }>[],
 >(...columns: TColumns): PrimaryKeyBuilder;
-export function primaryKey(config: any) {
-	if (config.name) {
+export function primaryKey(...config: any) {
+	if (config.columns) {
 		return new PrimaryKeyBuilder(config.columns, config.name);
 	}
 	return new PrimaryKeyBuilder(config);

--- a/drizzle-orm/src/pg-core/primary-keys.ts
+++ b/drizzle-orm/src/pg-core/primary-keys.ts
@@ -4,9 +4,21 @@ import { PgTable } from './table.ts';
 
 export function primaryKey<
 	TTableName extends string,
+	TColumns extends AnyPgColumn<{ tableName: TTableName }>,
+>(config: { name?: string; columns: [TColumns, ...TColumns[]] }): PrimaryKeyBuilder;
+/**
+ * @deprecated: Please use primaryKey({ columns: [] }) instead of this function
+ * @param columns 
+ */
+export function primaryKey<
+	TTableName extends string,
 	TColumns extends AnyPgColumn<{ tableName: TTableName }>[],
->(...columns: TColumns): PrimaryKeyBuilder {
-	return new PrimaryKeyBuilder(columns);
+>(...columns: TColumns): PrimaryKeyBuilder;
+export function primaryKey(config: any) {
+	if (config.name) {
+		return new PrimaryKeyBuilder(config.columns, config.name);
+	}
+	return new PrimaryKeyBuilder(config);
 }
 
 export class PrimaryKeyBuilder {
@@ -15,15 +27,20 @@ export class PrimaryKeyBuilder {
 	/** @internal */
 	columns: PgColumn[];
 
+	/** @internal */
+	name?: string;
+
 	constructor(
 		columns: PgColumn[],
+		name?: string,
 	) {
 		this.columns = columns;
+		this.name = name;
 	}
 
 	/** @internal */
 	build(table: PgTable): PrimaryKey {
-		return new PrimaryKey(table, this.columns);
+		return new PrimaryKey(table, this.columns, this.name);
 	}
 }
 
@@ -31,12 +48,14 @@ export class PrimaryKey {
 	static readonly [entityKind]: string = 'PgPrimaryKey';
 
 	readonly columns: AnyPgColumn<{}>[];
+	readonly name?: string;
 
-	constructor(readonly table: PgTable, columns: AnyPgColumn<{}>[]) {
+	constructor(readonly table: PgTable, columns: AnyPgColumn<{}>[], name?: string) {
 		this.columns = columns;
+		this.name = name;
 	}
 
 	getName(): string {
-		return `${this.table[PgTable.Symbol.Name]}_${this.columns.map((column) => column.name).join('_')}_pk`;
+		return this.name ?? `${this.table[PgTable.Symbol.Name]}_${this.columns.map((column) => column.name).join('_')}_pk`;
 	}
 }

--- a/drizzle-orm/src/sqlite-core/foreign-keys.ts
+++ b/drizzle-orm/src/sqlite-core/foreign-keys.ts
@@ -5,6 +5,7 @@ import { SQLiteTable } from './table.ts';
 export type UpdateDeleteAction = 'cascade' | 'restrict' | 'no action' | 'set null' | 'set default';
 
 export type Reference = () => {
+	readonly name?: string;
 	readonly columns: SQLiteColumn[];
 	readonly foreignTable: SQLiteTable;
 	readonly foreignColumns: SQLiteColumn[];
@@ -29,6 +30,7 @@ export class ForeignKeyBuilder {
 
 	constructor(
 		config: () => {
+			name?: string;
 			columns: SQLiteColumn[];
 			foreignColumns: SQLiteColumn[];
 		},
@@ -38,8 +40,8 @@ export class ForeignKeyBuilder {
 		} | undefined,
 	) {
 		this.reference = () => {
-			const { columns, foreignColumns } = config();
-			return { columns, foreignTable: foreignColumns[0]!.table as SQLiteTable, foreignColumns };
+			const { name, columns, foreignColumns } = config();
+			return { name, columns, foreignTable: foreignColumns[0]!.table as SQLiteTable, foreignColumns };
 		};
 		if (actions) {
 			this._onUpdate = actions.onUpdate;
@@ -77,7 +79,7 @@ export class ForeignKey {
 	}
 
 	getName(): string {
-		const { columns, foreignColumns } = this.reference();
+		const { name, columns, foreignColumns } = this.reference();
 		const columnNames = columns.map((column) => column.name);
 		const foreignColumnNames = foreignColumns.map((column) => column.name);
 		const chunks = [
@@ -86,7 +88,7 @@ export class ForeignKey {
 			foreignColumns[0]!.table[SQLiteTable.Symbol.Name],
 			...foreignColumnNames,
 		];
-		return `${chunks.join('_')}_fk`;
+		return name ?? `${chunks.join('_')}_fk`;
 	}
 }
 

--- a/drizzle-orm/src/sqlite-core/foreign-keys.ts
+++ b/drizzle-orm/src/sqlite-core/foreign-keys.ts
@@ -97,22 +97,46 @@ type ColumnsWithTable<
 	TColumns extends SQLiteColumn[],
 > = { [Key in keyof TColumns]: AnySQLiteColumn<{ tableName: TTableName }> };
 
+/**
+ * @deprecated please use `foreignKey({ columns: [], foreignColumns: [] })` syntax without callback
+ * @param config
+ * @returns
+ */
 export function foreignKey<
 	TTableName extends string,
 	TForeignTableName extends string,
 	TColumns extends [AnySQLiteColumn<{ tableName: TTableName }>, ...AnySQLiteColumn<{ tableName: TTableName }>[]],
 >(
 	config: () => {
+		name?: string;
 		columns: TColumns;
 		foreignColumns: ColumnsWithTable<TForeignTableName, TColumns>;
 	},
+): ForeignKeyBuilder;
+export function foreignKey<
+	TTableName extends string,
+	TForeignTableName extends string,
+	TColumns extends [AnySQLiteColumn<{ tableName: TTableName }>, ...AnySQLiteColumn<{ tableName: TTableName }>[]],
+>(
+	config: {
+		name?: string;
+		columns: TColumns;
+		foreignColumns: ColumnsWithTable<TForeignTableName, TColumns>;
+	},
+): ForeignKeyBuilder;
+export function foreignKey(
+	config: any,
 ): ForeignKeyBuilder {
 	function mappedConfig() {
-		const { columns, foreignColumns } = config();
-		return {
-			columns,
-			foreignColumns,
-		};
+		if (typeof config === 'function') {
+			const { name, columns, foreignColumns } = config();
+			return {
+				name,
+				columns,
+				foreignColumns,
+			};
+		}
+		return config;
 	}
 
 	return new ForeignKeyBuilder(mappedConfig);

--- a/drizzle-orm/src/sqlite-core/primary-keys.ts
+++ b/drizzle-orm/src/sqlite-core/primary-keys.ts
@@ -4,13 +4,22 @@ import { SQLiteTable } from './table.ts';
 
 export function primaryKey<
 	TTableName extends string,
+	TColumns extends AnySQLiteColumn<{ tableName: TTableName }>,
+>(config: { name?: string; columns: [TColumns, ...TColumns[]] }): PrimaryKeyBuilder;
+/**
+ * @deprecated: Please use primaryKey({ columns: [] }) instead of this function
+ * @param columns
+ */
+export function primaryKey<
+	TTableName extends string,
 	TColumns extends AnySQLiteColumn<{ tableName: TTableName }>[],
->(
-	...columns: TColumns
-): PrimaryKeyBuilder {
-	return new PrimaryKeyBuilder(columns);
+>(...columns: TColumns): PrimaryKeyBuilder;
+export function primaryKey(config: any) {
+	if (config.name) {
+		return new PrimaryKeyBuilder(config.columns, config.name);
+	}
+	return new PrimaryKeyBuilder(config);
 }
-
 export class PrimaryKeyBuilder {
 	static readonly [entityKind]: string = 'SQLitePrimaryKeyBuilder';
 
@@ -21,15 +30,20 @@ export class PrimaryKeyBuilder {
 	/** @internal */
 	columns: SQLiteColumn[];
 
+	/** @internal */
+	name?: string;
+
 	constructor(
 		columns: SQLiteColumn[],
+		name?: string,
 	) {
 		this.columns = columns;
+		this.name = name;
 	}
 
 	/** @internal */
 	build(table: SQLiteTable): PrimaryKey {
-		return new PrimaryKey(table, this.columns);
+		return new PrimaryKey(table, this.columns, this.name);
 	}
 }
 
@@ -37,12 +51,14 @@ export class PrimaryKey {
 	static readonly [entityKind]: string = 'SQLitePrimaryKey';
 
 	readonly columns: SQLiteColumn[];
+	readonly name?: string;
 
-	constructor(readonly table: SQLiteTable, columns: SQLiteColumn[]) {
+	constructor(readonly table: SQLiteTable, columns: SQLiteColumn[], name?: string) {
 		this.columns = columns;
+		this.name = name;
 	}
 
 	getName(): string {
-		return `${this.table[SQLiteTable.Symbol.Name]}_${this.columns.map((column) => column.name).join('_')}_pk`;
+		return this.name ?? `${this.table[SQLiteTable.Symbol.Name]}_${this.columns.map((column) => column.name).join('_')}_pk`;
 	}
 }

--- a/drizzle-orm/src/sqlite-core/primary-keys.ts
+++ b/drizzle-orm/src/sqlite-core/primary-keys.ts
@@ -15,8 +15,8 @@ export function primaryKey<
 	TTableName extends string,
 	TColumns extends AnySQLiteColumn<{ tableName: TTableName }>[],
 >(...columns: TColumns): PrimaryKeyBuilder;
-export function primaryKey(config: any) {
-	if (config.name) {
+export function primaryKey(...config: any) {
+	if (config.columns) {
 		return new PrimaryKeyBuilder(config.columns, config.name);
 	}
 	return new PrimaryKeyBuilder(config);

--- a/drizzle-orm/src/sqlite-core/primary-keys.ts
+++ b/drizzle-orm/src/sqlite-core/primary-keys.ts
@@ -4,8 +4,9 @@ import { SQLiteTable } from './table.ts';
 
 export function primaryKey<
 	TTableName extends string,
-	TColumns extends AnySQLiteColumn<{ tableName: TTableName }>,
->(config: { name?: string; columns: [TColumns, ...TColumns[]] }): PrimaryKeyBuilder;
+	TColumn extends AnySQLiteColumn<{ tableName: TTableName }>,
+	TColumns extends AnySQLiteColumn<{ tableName: TTableName }>[],
+>(config: { name?: string; columns: [TColumn, ...TColumns] }): PrimaryKeyBuilder;
 /**
  * @deprecated: Please use primaryKey({ columns: [] }) instead of this function
  * @param columns

--- a/drizzle-orm/src/sqlite-core/primary-keys.ts
+++ b/drizzle-orm/src/sqlite-core/primary-keys.ts
@@ -16,8 +16,8 @@ export function primaryKey<
 	TColumns extends AnySQLiteColumn<{ tableName: TTableName }>[],
 >(...columns: TColumns): PrimaryKeyBuilder;
 export function primaryKey(...config: any) {
-	if (config.columns) {
-		return new PrimaryKeyBuilder(config.columns, config.name);
+	if (config[0].columns) {
+		return new PrimaryKeyBuilder(config[0].columns, config[0].name);
 	}
 	return new PrimaryKeyBuilder(config);
 }

--- a/integration-tests/tests/mysql.test.ts
+++ b/integration-tests/tests/mysql.test.ts
@@ -221,7 +221,7 @@ test.beforeEach(async (t) => {
 	);
 });
 
-test.serial.only('table config: unsigned ints', async (t) => {
+test.serial('table config: unsigned ints', async (t) => {
 	const unsignedInts = mysqlTable('cities1', {
 		bigint: bigint('bigint', { mode: 'number', unsigned: true }),
 		int: int('int', { unsigned: true }),
@@ -245,7 +245,7 @@ test.serial.only('table config: unsigned ints', async (t) => {
 	t.is(tinyintColumn.getSQLType(), 'tinyint unsigned');
 });
 
-test.serial.only('table config: signed ints', async (t) => {
+test.serial('table config: signed ints', async (t) => {
 	const unsignedInts = mysqlTable('cities1', {
 		bigint: bigint('bigint', { mode: 'number' }),
 		int: int('int'),
@@ -269,7 +269,7 @@ test.serial.only('table config: signed ints', async (t) => {
 	t.is(tinyintColumn.getSQLType(), 'tinyint');
 });
 
-test.serial.only('table config: foreign keys name', async (t) => {
+test.serial('table config: foreign keys name', async (t) => {
 	const table = mysqlTable('cities', {
 		id: serial('id').primaryKey(),
 		name: text('name').notNull(),
@@ -284,7 +284,7 @@ test.serial.only('table config: foreign keys name', async (t) => {
 	t.is(tableConfig.foreignKeys[0]!.getName(), 'custom_fk');
 });
 
-test.serial.only('table config: primary keys name', async (t) => {
+test.serial('table config: primary keys name', async (t) => {
 	const table = mysqlTable('cities', {
 		id: serial('id').primaryKey(),
 		name: text('name').notNull(),

--- a/integration-tests/tests/mysql.test.ts
+++ b/integration-tests/tests/mysql.test.ts
@@ -17,21 +17,27 @@ import {
 } from 'drizzle-orm';
 import {
 	alias,
+	bigint,
 	boolean,
 	date,
 	datetime,
+	foreignKey,
 	getTableConfig,
 	getViewConfig,
 	int,
 	json,
+	mediumint,
 	mysqlEnum,
 	mysqlTable,
 	mysqlTableCreator,
 	mysqlView,
+	primaryKey,
 	serial,
+	smallint,
 	text,
 	time,
 	timestamp,
+	tinyint,
 	unique,
 	uniqueIndex,
 	uniqueKeyName,
@@ -213,6 +219,84 @@ test.beforeEach(async (t) => {
 			)
 		`,
 	);
+});
+
+test.serial.only('table config: unsigned ints', async (t) => {
+	const unsignedInts = mysqlTable('cities1', {
+		bigint: bigint('bigint', { mode: 'number', unsigned: true }),
+		int: int('int', { unsigned: true }),
+		smallint: smallint('smallint', { unsigned: true }),
+		mediumint: mediumint('mediumint', { unsigned: true }),
+		tinyint: tinyint('tinyint', { unsigned: true }),
+	});
+
+	const tableConfig = getTableConfig(unsignedInts);
+
+	const bigintColumn = tableConfig.columns.find((c) => c.name === 'bigint')!;
+	const intColumn = tableConfig.columns.find((c) => c.name === 'int')!;
+	const smallintColumn = tableConfig.columns.find((c) => c.name === 'smallint')!;
+	const mediumintColumn = tableConfig.columns.find((c) => c.name === 'mediumint')!;
+	const tinyintColumn = tableConfig.columns.find((c) => c.name === 'tinyint')!;
+
+	t.is(bigintColumn.getSQLType(), 'bigint unsigned');
+	t.is(intColumn.getSQLType(), 'int unsigned');
+	t.is(smallintColumn.getSQLType(), 'smallint unsigned');
+	t.is(mediumintColumn.getSQLType(), 'mediumint unsigned');
+	t.is(tinyintColumn.getSQLType(), 'tinyint unsigned');
+});
+
+test.serial.only('table config: signed ints', async (t) => {
+	const unsignedInts = mysqlTable('cities1', {
+		bigint: bigint('bigint', { mode: 'number' }),
+		int: int('int'),
+		smallint: smallint('smallint'),
+		mediumint: mediumint('mediumint'),
+		tinyint: tinyint('tinyint'),
+	});
+
+	const tableConfig = getTableConfig(unsignedInts);
+
+	const bigintColumn = tableConfig.columns.find((c) => c.name === 'bigint')!;
+	const intColumn = tableConfig.columns.find((c) => c.name === 'int')!;
+	const smallintColumn = tableConfig.columns.find((c) => c.name === 'smallint')!;
+	const mediumintColumn = tableConfig.columns.find((c) => c.name === 'mediumint')!;
+	const tinyintColumn = tableConfig.columns.find((c) => c.name === 'tinyint')!;
+
+	t.is(bigintColumn.getSQLType(), 'bigint');
+	t.is(intColumn.getSQLType(), 'int');
+	t.is(smallintColumn.getSQLType(), 'smallint');
+	t.is(mediumintColumn.getSQLType(), 'mediumint');
+	t.is(tinyintColumn.getSQLType(), 'tinyint');
+});
+
+test.serial.only('table config: foreign keys name', async (t) => {
+	const table = mysqlTable('cities', {
+		id: serial('id').primaryKey(),
+		name: text('name').notNull(),
+		state: text('state'),
+	}, (t) => ({
+		f: foreignKey({ foreignColumns: [t.id], columns: [t.id], name: 'custom_fk' }),
+	}));
+
+	const tableConfig = getTableConfig(table);
+
+	t.is(tableConfig.foreignKeys.length, 1);
+	t.is(tableConfig.foreignKeys[0]!.getName(), 'custom_fk');
+});
+
+test.serial.only('table config: primary keys name', async (t) => {
+	const table = mysqlTable('cities', {
+		id: serial('id').primaryKey(),
+		name: text('name').notNull(),
+		state: text('state'),
+	}, (t) => ({
+		f: primaryKey({ columns: [t.id, t.name], name: 'custom_pk' }),
+	}));
+
+	const tableConfig = getTableConfig(table);
+
+	t.is(tableConfig.primaryKeys.length, 1);
+	t.is(tableConfig.primaryKeys[0]!.getName(), 'custom_pk');
 });
 
 test.serial('table configs: unique third param', async (t) => {

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -5,6 +5,9 @@ import anyTest from 'ava';
 import Docker from 'dockerode';
 import {
 	and,
+	arrayContained,
+	arrayContains,
+	arrayOverlaps,
 	asc,
 	eq,
 	gt,
@@ -17,9 +20,6 @@ import {
 	sql,
 	type SQLWrapper,
 	TransactionRollbackError,
-	arrayContains,
-	arrayContained,
-	arrayOverlaps
 } from 'drizzle-orm';
 import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
@@ -2465,7 +2465,7 @@ test.serial('array operators', async (t) => {
 
 	const posts = pgTable('posts', {
 		id: serial('id').primaryKey(),
-		tags: text('tags').array()
+		tags: text('tags').array(),
 	});
 
 	await db.execute(sql`drop table if exists ${posts}`);
@@ -2475,17 +2475,17 @@ test.serial('array operators', async (t) => {
 	);
 
 	await db.insert(posts).values([{
-		tags: ['ORM']
+		tags: ['ORM'],
 	}, {
-		tags: ['Typescript']
+		tags: ['Typescript'],
 	}, {
-		tags: ['Typescript', 'ORM']
+		tags: ['Typescript', 'ORM'],
 	}, {
-		tags: ['Typescript', 'Frontend', 'React']
+		tags: ['Typescript', 'Frontend', 'React'],
 	}, {
-		tags: ['Typescript', 'ORM', 'Database', 'Postgres']
+		tags: ['Typescript', 'ORM', 'Database', 'Postgres'],
 	}, {
-		tags: ['Java', 'Spring', 'OOP']
+		tags: ['Java', 'Spring', 'OOP'],
 	}]);
 
 	const contains = await db.select({ id: posts.id }).from(posts)
@@ -2497,11 +2497,11 @@ test.serial('array operators', async (t) => {
 	const withSubQuery = await db.select({ id: posts.id }).from(posts)
 		.where(arrayContains(
 			posts.tags,
-			db.select({ tags: posts.tags  }).from(posts).where(eq(posts.id, 1))
+			db.select({ tags: posts.tags }).from(posts).where(eq(posts.id, 1)),
 		));
 
 	t.deepEqual(contains, [{ id: 3 }, { id: 5 }]);
 	t.deepEqual(contained, [{ id: 1 }, { id: 2 }, { id: 3 }]);
 	t.deepEqual(overlaps, [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]);
-	t.deepEqual(withSubQuery, [{ id: 1 }, { id: 3 }, { id: 5 }])
+	t.deepEqual(withSubQuery, [{ id: 1 }, { id: 3 }, { id: 5 }]);
 });

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -49,6 +49,8 @@ import {
 	uniqueKeyName,
 	uuid as pgUuid,
 	varchar,
+	primaryKey,
+	foreignKey,
 } from 'drizzle-orm/pg-core';
 import getPort from 'get-port';
 import pg from 'pg';
@@ -326,6 +328,36 @@ test.serial('table configs: unique in column', async (t) => {
 	t.assert(columnField?.uniqueName === 'custom_field');
 	t.assert(columnField?.isUnique);
 	t.assert(columnField?.uniqueType === 'not distinct');
+});
+
+test.serial('table config: foreign keys name', async (t) => {
+	const table = pgTable('cities', {
+		id: serial('id').primaryKey(),
+		name: text('name').notNull(),
+		state: text('state'),
+	}, (t) => ({
+		f: foreignKey({ foreignColumns: [t.id], columns: [t.id], name: 'custom_fk' }),
+	}));
+
+	const tableConfig = getTableConfig(table);
+
+	t.is(tableConfig.foreignKeys.length, 1);
+	t.is(tableConfig.foreignKeys[0]!.getName(), 'custom_fk');
+});
+
+test.serial('table config: primary keys name', async (t) => {
+	const table = pgTable('cities', {
+		id: serial('id').primaryKey(),
+		name: text('name').notNull(),
+		state: text('state'),
+	}, (t) => ({
+		f: primaryKey({ columns: [t.id, t.name], name: 'custom_pk' }),
+	}));
+
+	const tableConfig = getTableConfig(table);
+
+	t.is(tableConfig.primaryKeys.length, 1);
+	t.is(tableConfig.primaryKeys[0]!.getName(), 'custom_pk');
 });
 
 test.serial('select all fields', async (t) => {

--- a/integration-tests/tests/relational/pg.schema.ts
+++ b/integration-tests/tests/relational/pg.schema.ts
@@ -30,7 +30,7 @@ export const usersToGroupsTable = pgTable('users_to_groups', {
 	userId: integer('user_id').notNull().references(() => usersTable.id),
 	groupId: integer('group_id').notNull().references(() => groupsTable.id),
 }, (t) => ({
-	pk: primaryKey(t.userId, t.groupId),
+	pk: primaryKey(t.groupId,t.userId),
 }));
 
 export const usersToGroupsConfig = relations(usersToGroupsTable, ({ one }) => ({


### PR DESCRIPTION
Added unsigned option for all ints in MySQL
```ts
column: int('column_name', { unsigned: true })
```

Add custom names for primary keys and foreign keys for all dialects
```ts
const table = sqliteTable('cities', {
    // ...
}, (t) => ({
	pk: primaryKey({ columns: [t.id, t.name], name: 'custom_pk' }),
	fk: foreignKey({ foreignColumns: [t.id], columns: [t.id], name: 'custom_fk' }),
}));
```
Deprecated old syntax for `primaryKey`
```ts
pkDeprecated: primaryKey(t.id, t.name)
```

More explanations will be included in the release notes