### PR TITLE
Fix bun sqlite returning when using get

### DIFF
--- a/drizzle-orm/src/bun-sqlite/session.ts
+++ b/drizzle-orm/src/bun-sqlite/session.ts
@@ -133,15 +133,16 @@ export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> 
 	get(placeholderValues?: Record<string, unknown>): T['get'] {
 		const params = fillPlaceholders(this.query.params, placeholderValues ?? {});
 		this.logger.logQuery(this.query.sql, params);
-		const row = this.stmt.get(...params);
+		
+		const { fields, joinsNotNullableMap, customResultMapper, stmt } = this;
+		if (!fields && !customResultMapper) {
+			return stmt.get(...params);
+		}
+
+		const row = stmt.values(...params)[0];
 
 		if (!row) {
 			return undefined;
-		}
-
-		const { fields, joinsNotNullableMap, customResultMapper } = this;
-		if (!fields && !customResultMapper) {
-			return row;
 		}
 
 		if (customResultMapper) {

--- a/integration-tests/tests/bun/sqlite.test.ts
+++ b/integration-tests/tests/bun/sqlite.test.ts
@@ -77,6 +77,14 @@ test('select all fields', (ctx) => {
 	);
 });
 
+test('returning get', (ctx) => {
+  const { db } = ctx;
+
+  const user = db.insert(usersTable).values({ name: 'John' }).returning({ id: usersTable.id }).get();
+
+  assert.equal(user, { id: 1 })
+})
+
 test.run();
 
 // test.serial('select partial', (t) => {


### PR DESCRIPTION
Fix returning with bun sqlite when using `get`.

Bun sqlite `get` returns an object, which is not handled well by the result mapper. By using `values` (but only the first index) we receive the needed array representation. 

Fixes #1153