### PR TITLE
[AwsDataApi] Handle timestamp

### DIFF
--- a/drizzle-orm/src/aws-data-api/common/index.ts
+++ b/drizzle-orm/src/aws-data-api/common/index.ts
@@ -53,9 +53,21 @@ export function toValueParam(value: any, typings?: QueryTypingsValue): { value: 
 	if (value === null) {
 		response.value = { isNull: true };
 	} else if (typeof value === 'string') {
-		response.value = response.typeHint === 'DATE'
-			? { stringValue: value.split('T')[0]! }
-			: { stringValue: value };
+    switch (true) {
+      case response.typeHint === TypeHint.DATE: {
+        response.value = { stringValue: value.split("T")[0]! };
+        break;
+      }
+      case response.typeHint === TypeHint.TIMESTAMP: {
+        response.value = {
+          stringValue: new Date(value).toISOString().replace("T", " ").replace("Z", ""),
+        };
+        break;
+      }
+      default: {
+        response.value = { stringValue: value };
+      }
+    }
 	} else if (typeof value === 'number' && Number.isInteger(value)) {
 		response.value = { longValue: value };
 	} else if (typeof value === 'number' && !Number.isInteger(value)) {


### PR DESCRIPTION
Convert ISO or UTC datetime string to AWS Data API date format

AWS Data API requires a specific date formatting that is different than the ISO or UTC date string. Per this document: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#:~:text=Certain%20types%2C%20such%20as%20DECIMAL,UUID%20type%20to%20the%20database.

pg-core converts JS Date types using toISOString() or toUTCString() so I believe they will always get to the AWS Data API driver as a string. Converting to a Date and then calling toISOString() before replacing substrings seems like the most reliable way to solve this short of using a date formatting library.

Because pg-core converts timestamps to strings before it gets to this driver, I'm not even sure how the `else if (value instanceof Date)` on line 77 will ever be used.

Someone please let me know if there is a better approach to fix this. I could not figure out how to run the awsdatapi tests despite filling in the ENV vars for them. I am not sure how the awsdatapi insert test passes (or if it does) because I can't figure out how to run it to test it. I would gladly write a test case for this if someone can point me in the right direction to run those tests.
