### PR TITLE
[Draft] Feature/recursive

### DIFF
--- a/drizzle-orm/src/mysql-core/db.ts
+++ b/drizzle-orm/src/mysql-core/db.ts
@@ -80,6 +80,23 @@ export class MySqlDatabase<
 		}
 	}
 
+	$withRecursive<TAlias extends string>(alias: TAlias) {
+		return {
+			as<TSelection extends ColumnsSelection>(
+				qb: TypedQueryBuilder<TSelection> | ((qb: QueryBuilder) => TypedQueryBuilder<TSelection>),
+			): WithSubqueryWithSelection<TSelection, TAlias, 'mysql'> {
+				if (typeof qb === 'function') {
+					qb = qb(new QueryBuilder());
+				}
+
+				return new Proxy(
+					new WithSubquery(qb.getSQL(), qb.getSelectedFields() as SelectedFields, alias, true, true),
+					new SelectionProxyHandler({ alias, sqlAliasedBehavior: 'alias', sqlBehavior: 'error' }),
+				) as WithSubqueryWithSelection<TSelection, TAlias, 'mysql'>;
+			},
+		};
+	}
+
 	$with<TAlias extends string>(alias: TAlias) {
 		return {
 			as<TSelection extends ColumnsSelection>(

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -237,6 +237,10 @@ export class MySqlDialect {
 		let withSql: SQL | undefined;
 		if (withList?.length) {
 			const withSqlChunks = [sql`with `];
+			if (withList[0] && withList[0][SubqueryConfig].isRecursive) {
+				withSqlChunks.push(sql`recursive `)
+			}
+
 			for (const [i, w] of withList.entries()) {
 				withSqlChunks.push(sql`${sql.identifier(w[SubqueryConfig].alias)} as (${w[SubqueryConfig].sql})`);
 				if (i < withList.length - 1) {

--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -76,6 +76,23 @@ export class PgDatabase<
 		}
 	}
 
+	$withRecursive<TAlias extends string>(alias: TAlias) {
+		return {
+			as<TSelection extends ColumnsSelection>(
+				qb: TypedQueryBuilder<TSelection> | ((qb: QueryBuilder) => TypedQueryBuilder<TSelection>),
+			): WithSubqueryWithSelection<TSelection, TAlias> {
+				if (typeof qb === 'function') {
+					qb = qb(new QueryBuilder());
+				}
+
+				return new Proxy(
+					new WithSubquery(qb.getSQL(), qb.getSelectedFields() as SelectedFields, alias, true, true),
+					new SelectionProxyHandler({ alias, sqlAliasedBehavior: 'alias', sqlBehavior: 'error' }),
+				) as WithSubqueryWithSelection<TSelection, TAlias>;
+			},
+		};
+	}
+
 	$with<TAlias extends string>(alias: TAlias) {
 		return {
 			as<TSelection extends ColumnsSelection>(

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -238,6 +238,10 @@ export class PgDialect {
 		let withSql: SQL | undefined;
 		if (withList?.length) {
 			const withSqlChunks = [sql`with `];
+			if (withList[0] && withList[0][SubqueryConfig].isRecursive) {
+				withSqlChunks.push(sql`recursive `)
+			}
+
 			for (const [i, w] of withList.entries()) {
 				withSqlChunks.push(sql`${sql.identifier(w[SubqueryConfig].alias)} as (${w[SubqueryConfig].sql})`);
 				if (i < withList.length - 1) {

--- a/drizzle-orm/src/sqlite-core/db.ts
+++ b/drizzle-orm/src/sqlite-core/db.ts
@@ -77,6 +77,23 @@ export class BaseSQLiteDatabase<
 		}
 	}
 
+	$withRecursive<TAlias extends string>(alias: TAlias) {
+		return {
+			as<TSelection extends ColumnsSelection>(
+				qb: TypedQueryBuilder<TSelection> | ((qb: QueryBuilder) => TypedQueryBuilder<TSelection>),
+			): WithSubqueryWithSelection<TSelection, TAlias> {
+				if (typeof qb === 'function') {
+					qb = qb(new QueryBuilder());
+				}
+
+				return new Proxy(
+					new WithSubquery(qb.getSQL(), qb.getSelectedFields() as SelectedFields, alias, true, true),
+					new SelectionProxyHandler({ alias, sqlAliasedBehavior: 'alias', sqlBehavior: 'error' }),
+				) as WithSubqueryWithSelection<TSelection, TAlias>;
+			},
+		};
+	}
+
 	$with<TAlias extends string>(alias: TAlias) {
 		return {
 			as<TSelection extends ColumnsSelection>(

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -185,6 +185,10 @@ export abstract class SQLiteDialect {
 		let withSql: SQL | undefined;
 		if (withList?.length) {
 			const withSqlChunks = [sql`with `];
+			if (withList[0] && withList[0][SubqueryConfig].isRecursive) {
+				withSqlChunks.push(sql`recursive `)
+			}
+
 			for (const [i, w] of withList.entries()) {
 				withSqlChunks.push(sql`${sql.identifier(w[SubqueryConfig].alias)} as (${w[SubqueryConfig].sql})`);
 				if (i < withList.length - 1) {

--- a/drizzle-orm/src/subquery.ts
+++ b/drizzle-orm/src/subquery.ts
@@ -21,14 +21,16 @@ export class Subquery<TAlias extends string = string, TSelectedFields = unknown>
 		selection: ColumnsSelection;
 		alias: string;
 		isWith: boolean;
+		isRecursive: boolean;
 	};
 
-	constructor(sql: SQL, selection: Record<string, unknown>, alias: string, isWith = false) {
+	constructor(sql: SQL, selection: Record<string, unknown>, alias: string, isWith = false, isRecursive = false) {
 		this[SubqueryConfig] = {
 			sql,
 			selection,
 			alias,
 			isWith,
+			isRecursive
 		};
 	}
 


### PR DESCRIPTION
# Description
This pr implements recursive queries through the use of the new `$withRecursive` method to be used as such
```typescript
const employeeHierarchy = db.$withRecursive('employeeHierarchy').as('recursive query here...');
 
const result = await db.with(employeeHierarchy).select().from(employeeHierarchy);
```
Comments and suggestions are welcome.

closes https://github.com/drizzle-team/drizzle-orm/issues/209
depends on PR https://github.com/drizzle-team/drizzle-orm/pull/1218