### PR TITLE
[Mysql]: (Feature) Removed .fullJoin() from MySQL Api. #1125

### DIFF
--- a/drizzle-orm/src/mysql-core/query-builders/select.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.ts
@@ -16,7 +16,6 @@ import type {
 	GetSelectTableName,
 	GetSelectTableSelection,
 	JoinNullability,
-	JoinType,
 	SelectMode,
 	SelectResult,
 } from '~/query-builders/select.types.ts';
@@ -31,6 +30,7 @@ import type {
 	JoinFn,
 	LockConfig,
 	LockStrength,
+	MySqlJoinType,
 	MySqlSelectConfig,
 	MySqlSelectHKT,
 	MySqlSelectHKTBase,
@@ -177,7 +177,7 @@ export abstract class MySqlSelectQueryBuilder<
 		this.joinsNotNullableMap = typeof this.tableName === 'string' ? { [this.tableName]: true } : {};
 	}
 
-	private createJoin<TJoinType extends JoinType>(
+	private createJoin<TJoinType extends MySqlJoinType>(
 		joinType: TJoinType,
 	): JoinFn<THKT, TTableName, TSelectMode, TJoinType, TSelection, TNullabilityMap> {
 		return (
@@ -240,13 +240,6 @@ export abstract class MySqlSelectQueryBuilder<
 						this.joinsNotNullableMap[tableName] = true;
 						break;
 					}
-					case 'full': {
-						this.joinsNotNullableMap = Object.fromEntries(
-							Object.entries(this.joinsNotNullableMap).map(([key]) => [key, false]),
-						);
-						this.joinsNotNullableMap[tableName] = false;
-						break;
-					}
 				}
 			}
 
@@ -259,8 +252,6 @@ export abstract class MySqlSelectQueryBuilder<
 	rightJoin = this.createJoin('right');
 
 	innerJoin = this.createJoin('inner');
-
-	fullJoin = this.createJoin('full');
 
 	where(where: ((aliases: TSelection) => SQL | undefined) | SQL | undefined) {
 		if (typeof where === 'function') {

--- a/drizzle-orm/src/mysql-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.types.ts
@@ -23,11 +23,13 @@ import { type ColumnsSelection, type View } from '~/view.ts';
 import { type PreparedQueryHKTBase } from '../session.ts';
 import type { MySqlSelect, MySqlSelectQueryBuilder } from './select.ts';
 
+export type MySqlJoinType = Exclude<JoinType, 'full'>;
+
 export interface Join {
 	on: SQL | undefined;
 	table: MySqlTable | Subquery | MySqlViewBase | SQL;
 	alias: string | undefined;
-	joinType: JoinType;
+	joinType: MySqlJoinType;
 	lateral?: boolean;
 }
 
@@ -70,7 +72,7 @@ export type JoinFn<
 	THKT extends MySqlSelectHKTBase,
 	TTableName extends string | undefined,
 	TSelectMode extends SelectMode,
-	TJoinType extends JoinType,
+	TJoinType extends MySqlJoinType,
 	TSelection,
 	TNullabilityMap extends Record<string, JoinNullability>,
 > = <

--- a/drizzle-orm/type-tests/mysql/select.ts
+++ b/drizzle-orm/type-tests/mysql/select.ts
@@ -80,45 +80,6 @@ Expect<
 	>
 >;
 
-const join2 = await db
-	.select({
-		userId: users.id,
-		cityId: cities.id,
-	})
-	.from(users)
-	.fullJoin(cities, eq(users.id, cities.id));
-
-Expect<
-	Equal<
-		{
-			userId: number | null;
-			cityId: number | null;
-		}[],
-		typeof join2
-	>
->;
-
-const join3 = await db
-	.select({
-		userId: users.id,
-		cityId: cities.id,
-		classId: classes.id,
-	})
-	.from(users)
-	.fullJoin(cities, eq(users.id, cities.id))
-	.rightJoin(classes, eq(users.id, classes.id));
-
-Expect<
-	Equal<
-		{
-			userId: number | null;
-			cityId: number | null;
-			classId: number;
-		}[],
-		typeof join3
-	>
->;
-
 db
 	.select()
 	.from(users)


### PR DESCRIPTION
This PR addresses #1091.

- Added a new type `MySqlJoinType` which excludes the option for full joins.
- Used said type in the MySQL query builder `createJoin` function instead of the regular `JoinType`.
- Removed two MySQL select type-tests which included the fullJoin function as they are now redundant because `.fullJoin()` can no longer be used in a MySQL query.