### PR TITLE
Feat: custom select on customTypes

### DIFF
--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -1,6 +1,6 @@
 import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, ColumnDataType } from './column-builder.ts';
 import { entityKind } from './entity.ts';
-import type { DriverValueMapper, SQL, SQLWrapper } from './sql/sql.ts';
+import type { DriverValueMapper, Name, SQL, SQLWrapper } from './sql/sql.ts';
 import type { Table } from './table.ts';
 import type { Update } from './utils.ts';
 
@@ -31,6 +31,10 @@ export type ColumnRuntimeConfig<TData, TRuntimeConfig extends object> = ColumnBu
 	TData,
 	TRuntimeConfig
 >;
+
+export type AnyCustomColumn = AnyColumn & {
+	customSelect?: (value: Column | string | Name | SQL) => SQL;
+};
 
 export interface Column<
 	T extends ColumnBaseConfig<ColumnDataType, string> = ColumnBaseConfig<ColumnDataType, string>,

--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -1,6 +1,6 @@
 import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, ColumnDataType } from './column-builder.ts';
 import { entityKind } from './entity.ts';
-import type { DriverValueMapper, Name, SQL, SQLWrapper } from './sql/sql.ts';
+import type { DriverValueMapper, SQL, SQLWrapper } from './sql/sql.ts';
 import type { Table } from './table.ts';
 import type { Update } from './utils.ts';
 
@@ -33,7 +33,7 @@ export type ColumnRuntimeConfig<TData, TRuntimeConfig extends object> = ColumnBu
 >;
 
 export type AnyCustomColumn = AnyColumn & {
-	customSelect?: (value: Column | string | Name | SQL) => SQL;
+	customSelect?: (value: any) => SQL;
 };
 
 export interface Column<

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import type { Name, SQL } from '~/sql/sql.ts';
+import type { SQL } from '~/sql/sql.ts';
 import type { Equal } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
@@ -65,7 +65,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
-	customSelect?: (value: MySqlColumn | string | Name) => SQL;
+	customSelect?: (value: any) => SQL;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -210,7 +210,7 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * },
 	 * ```
 	 */
-	customSelect?: (value: MySqlColumn | string | Name | SQL) => SQL;
+	customSelect?: (value: MySqlColumn) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -150,6 +150,9 @@ export class MySqlDialect {
 							new SQL(
 								query.queryChunks.map((c) => {
 									if (is(c, MySqlColumn)) {
+										if (isCustomColumn(c) && c.customSelect) {
+											return c.customSelect(sql.identifier(c.name));
+										}
 										return sql.identifier(c.name);
 									}
 									return c;

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyPgTable } from '~/pg-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { Name, SQL } from '~/sql/sql.ts';
 import type { Equal } from '~/utils.ts';
 import { PgColumn, PgColumnBuilder } from './common.ts';
 
@@ -57,12 +57,15 @@ export class PgCustomColumnBuilder<T extends ColumnBuilderBaseConfig<'custom', '
 	}
 }
 
+export type AnyPgCustomColumn = PgCustomColumn<any>;
+
 export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn'>> extends PgColumn<T> {
 	static readonly [entityKind]: string = 'PgCustomColumn';
 
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	customSelect?: (value: PgColumn | string | Name) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -195,6 +198,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional custom sql when performing a select. This sql will automatically get aliased to the provided name.
+	 * @example
+	 * For example, when you want to always select a text value in lowercase:
+	 * ```
+	 * customSelect(value: PgColumn): SQL {
+	 * 	 return sql`LOWER(${value})`;  // <-- will be mapped to `LOWER(column) as "column_name"`
+	 * },
+	 * ```
+	 */
+	customSelect?: (value: PgColumn | string | Name | SQL) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyPgTable } from '~/pg-core/table.ts';
-import type { Name, SQL } from '~/sql/sql.ts';
+import type { SQL } from '~/sql/sql.ts';
 import type { Equal } from '~/utils.ts';
 import { PgColumn, PgColumnBuilder } from './common.ts';
 
@@ -65,7 +65,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
-	customSelect?: (value: PgColumn | string | Name) => SQL;
+	customSelect?: (value: any) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -210,7 +210,7 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * },
 	 * ```
 	 */
-	customSelect?: (value: PgColumn | string | Name | SQL) => SQL;
+	customSelect?: (value: PgColumn) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -75,6 +75,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.customSelect = config.customTypeParams.customSelect;
 	}
 
 	getSQLType(): string {

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -1,12 +1,12 @@
 import { entityKind, is } from '~/entity.ts';
+import type { SelectedFields } from '~/operations.ts';
 import { Relation } from '~/relations.ts';
 import { Subquery, SubqueryConfig } from '~/subquery.ts';
 import { tracer } from '~/tracing.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
-import type { AnyColumn } from '../column.ts';
+import type { AnyColumn, AnyCustomColumn } from '../column.ts';
 import { Column } from '../column.ts';
 import { Table } from '../table.ts';
-import type { SelectedFields } from '~/operations.ts';
 
 /**
  * This class is used to indicate a primitive param value that is used in `sql` tag.
@@ -184,7 +184,13 @@ export class SQL<T = unknown> implements SQLWrapper {
 			}
 
 			if (is(chunk, Column)) {
-				return { sql: escapeName(chunk.table[Table.Symbol.Name]) + '.' + escapeName(chunk.name), params: [] };
+				const value = escapeName(chunk.table[Table.Symbol.Name]) + '.' + escapeName(chunk.name);
+
+				if (isCustomColumn(chunk) && chunk.customSelect) {
+					return chunk.customSelect(sql.raw(value)).toQuery(config);
+				}
+
+				return { sql: value, params: [] };
 			}
 
 			if (is(chunk, View)) {
@@ -629,6 +635,9 @@ export abstract class View<
 		return new SQL([this]);
 	}
 }
+const isCustomColumn = (value: Column): value is AnyCustomColumn => {
+	return 'customSelect' in value;
+};
 
 // Defined separately from the Column class to resolve circular dependency
 Column.prototype.getSQL = function() {
@@ -644,3 +653,4 @@ Table.prototype.getSQL = function() {
 Subquery.prototype.getSQL = function() {
 	return new SQL([this]);
 };
+

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -75,6 +75,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.customSelect = config.customTypeParams.customSelect;
 	}
 
 	getSQLType(): string {

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -1,7 +1,7 @@
 import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnConfig } from '~/column-builder.ts';
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
-import type { Name, SQL } from '~/sql/sql.ts';
+import type { SQL } from '~/sql/sql.ts';
 import type { AnySQLiteTable } from '~/sqlite-core/table.ts';
 import type { Equal } from '~/utils.ts';
 import { SQLiteColumn, SQLiteColumnBuilder } from './common.ts';
@@ -65,7 +65,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
-	customSelect?: (value: SQLiteColumn | string | Name) => SQL;
+	customSelect?: (value: any) => SQL;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -210,7 +210,7 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * },
 	 * ```
 	 */
-	customSelect?: (value: SQLiteColumn | string | Name | SQL) => SQL;
+	customSelect?: (value: SQLiteColumn) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -1,7 +1,7 @@
 import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnConfig } from '~/column-builder.ts';
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { Name, SQL } from '~/sql/sql.ts';
 import type { AnySQLiteTable } from '~/sqlite-core/table.ts';
 import type { Equal } from '~/utils.ts';
 import { SQLiteColumn, SQLiteColumnBuilder } from './common.ts';
@@ -57,12 +57,15 @@ export class SQLiteCustomColumnBuilder<T extends ColumnBuilderBaseConfig<'custom
 	}
 }
 
+export type AnySQLiteCustomColumn = SQLiteCustomColumn<any>;
+
 export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCustomColumn'>> extends SQLiteColumn<T> {
 	static readonly [entityKind]: string = 'SQLiteCustomColumn';
 
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	customSelect?: (value: SQLiteColumn | string | Name) => SQL;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -195,6 +198,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional custom sql when performing a select. This sql will automatically get aliased to the provided name.
+	 * @example
+	 * For example, when you want to always select a text value in lowercase:
+	 * ```
+	 * customSelect(value: SQLiteColumn): SQL {
+	 * 	 return sql`LOWER(${value})`;  // <-- will be mapped to `LOWER(column) as "column_name"`
+	 * },
+	 * ```
+	 */
+	customSelect?: (value: SQLiteColumn | string | Name | SQL) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -16,10 +16,10 @@ import {
 	type TableRelationalConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
+import type { Name } from '~/sql/index.ts';
+import { and, eq } from '~/sql/index.ts';
 import { Param, type QueryWithTypings, SQL, sql, type SQLChunk } from '~/sql/sql.ts';
-import type { Name} from '~/sql/index.ts';
-import { and, eq } from '~/sql/index.ts'
-import { SQLiteColumn } from '~/sqlite-core/columns/index.ts';
+import { type AnySQLiteCustomColumn, SQLiteColumn } from '~/sqlite-core/columns/index.ts';
 import type { SQLiteDeleteConfig, SQLiteInsertConfig, SQLiteUpdateConfig } from '~/sqlite-core/query-builders/index.ts';
 import { SQLiteTable } from '~/sqlite-core/table.ts';
 import { Subquery, SubqueryConfig } from '~/subquery.ts';
@@ -119,6 +119,9 @@ export abstract class SQLiteDialect {
 							new SQL(
 								query.queryChunks.map((c) => {
 									if (is(c, Column)) {
+										if (isCustomColumn(c) && c.customSelect) {
+											return c.customSelect(sql.identifier(c.name));
+										}
 										return sql.identifier(c.name);
 									}
 									return c;
@@ -136,9 +139,17 @@ export abstract class SQLiteDialect {
 					const tableName = field.table[Table.Symbol.Name];
 					const columnName = field.name;
 					if (isSingleTable) {
-						chunk.push(sql.identifier(columnName));
+						if (isCustomColumn(field) && field.customSelect) {
+							chunk.push(field.customSelect(sql.identifier(field.name)), sql` as ${sql.identifier(field.name)}`);
+						} else {
+							chunk.push(sql.identifier(field.name));
+						}
 					} else {
-						chunk.push(sql`${sql.identifier(tableName)}.${sql.identifier(columnName)}`);
+						if (isCustomColumn(field) && field.customSelect) {
+							chunk.push(field, sql` as ${sql.identifier(field.name)}`);
+						} else {
+							chunk.push(sql`${sql.identifier(tableName)}.${sql.identifier(columnName)}`);
+						}
 					}
 				}
 
@@ -783,3 +794,20 @@ export class SQLiteAsyncDialect extends SQLiteDialect {
 		});
 	}
 }
+
+// Had to reuse the constructor logic from `is` to avoid circular dependencies
+const isCustomColumn = (c: Column): c is AnySQLiteCustomColumn => {
+	let cls = c.constructor;
+	if (cls) {
+		// Traverse the prototype chain to find the entityKind
+		while (cls) {
+			if (entityKind in cls && cls[entityKind] === 'SQLiteCustomColumn') {
+				return true;
+			}
+
+			cls = Object.getPrototypeOf(cls);
+		}
+	}
+
+	return false;
+};

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -19,7 +19,7 @@ import {
 import type { Name } from '~/sql/index.ts';
 import { and, eq } from '~/sql/index.ts';
 import { Param, type QueryWithTypings, SQL, sql, type SQLChunk } from '~/sql/sql.ts';
-import { type AnySQLiteCustomColumn, SQLiteColumn } from '~/sqlite-core/columns/index.ts';
+import { SQLiteColumn, SQLiteCustomColumn } from '~/sqlite-core/columns/index.ts';
 import type { SQLiteDeleteConfig, SQLiteInsertConfig, SQLiteUpdateConfig } from '~/sqlite-core/query-builders/index.ts';
 import { SQLiteTable } from '~/sqlite-core/table.ts';
 import { Subquery, SubqueryConfig } from '~/subquery.ts';
@@ -119,7 +119,7 @@ export abstract class SQLiteDialect {
 							new SQL(
 								query.queryChunks.map((c) => {
 									if (is(c, Column)) {
-										if (isCustomColumn(c) && c.customSelect) {
+										if (is(c, SQLiteCustomColumn) && c.customSelect) {
 											return c.customSelect(sql.identifier(c.name));
 										}
 										return sql.identifier(c.name);
@@ -139,13 +139,13 @@ export abstract class SQLiteDialect {
 					const tableName = field.table[Table.Symbol.Name];
 					const columnName = field.name;
 					if (isSingleTable) {
-						if (isCustomColumn(field) && field.customSelect) {
+						if (is(field, SQLiteCustomColumn) && field.customSelect) {
 							chunk.push(field.customSelect(sql.identifier(field.name)), sql` as ${sql.identifier(field.name)}`);
 						} else {
 							chunk.push(sql.identifier(field.name));
 						}
 					} else {
-						if (isCustomColumn(field) && field.customSelect) {
+						if (is(field, SQLiteCustomColumn) && field.customSelect) {
 							chunk.push(field, sql` as ${sql.identifier(field.name)}`);
 						} else {
 							chunk.push(sql`${sql.identifier(tableName)}.${sql.identifier(columnName)}`);
@@ -794,20 +794,3 @@ export class SQLiteAsyncDialect extends SQLiteDialect {
 		});
 	}
 }
-
-// Had to reuse the constructor logic from `is` to avoid circular dependencies
-const isCustomColumn = (c: Column): c is AnySQLiteCustomColumn => {
-	let cls = c.constructor;
-	if (cls) {
-		// Traverse the prototype chain to find the entityKind
-		while (cls) {
-			if (entityKind in cls && cls[entityKind] === 'SQLiteCustomColumn') {
-				return true;
-			}
-
-			cls = Object.getPrototypeOf(cls);
-		}
-	}
-
-	return false;
-};

--- a/drizzle-orm/type-tests/mysql/tables.ts
+++ b/drizzle-orm/type-tests/mysql/tables.ts
@@ -405,6 +405,38 @@ Expect<
 }
 
 {
+	const customText = customType<{ data: string }>({
+		dataType() {
+			return 'text';
+		},
+		customSelect(value) {
+			return sql`lower(${value})`;
+		},
+	});
+
+	const t = customText('name').notNull();
+	Expect<
+		Equal<
+			{
+				brand: 'Column';
+				name: 'name';
+				tableName: 'table';
+				dataType: 'custom';
+				columnType: 'MySqlCustomColumn';
+				data: string;
+				driverParam: unknown;
+				notNull: true;
+				hasDefault: false;
+				enumValues: undefined;
+				baseColumn: never;
+				dialect: 'mysql';
+			},
+			Simplify<BuildColumn<'table', typeof t, 'mysql'>['_']>
+		>
+	>;
+}
+
+{
 	mysqlTable('test', {
 		bigint: bigint('bigint', { mode: 'bigint' }),
 		number: bigint('number', { mode: 'number' }),

--- a/integration-tests/tests/libsql.test.ts
+++ b/integration-tests/tests/libsql.test.ts
@@ -2467,12 +2467,14 @@ test.serial('select custom field with custom select', async (t) => {
 	const { db } = t.context;
 
 	await db.insert(anotherUsersTable).values([
-		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john' },
-		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
-		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+		{ id: 1, name: 'John', lowerName: 'JOHN', greetings: 'JOHN' },
+		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
+		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
+  const query = db.select().from(anotherUsersTable);
+  console.log(query.toSQL())
 
-	const res = await db.select().from(anotherUsersTable);
+	const res = await query
 
 	t.deepEqual(res, [
 		{ id: 1, name: 'John', lowerName: 'john', greetings: 'hello john', related: null },
@@ -2485,17 +2487,19 @@ test.serial('select custom field with custom select in a join', async (t) => {
 	const { db } = t.context;
 
 	await db.insert(anotherUsersTable).values([
-		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', related: 'Jane' },
-		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
-		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+		{ id: 1, name: 'John', lowerName: 'JOHN', greetings: 'JOHN', related: 'Jane' },
+		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
+		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
 	const aliased = alias(anotherUsersTable, 'us');
-
-	const res = await db.select({
+  const query = db.select({
 		name: anotherUsersTable.name,
 		related: aliased.name,
 		greetings: aliased.greetings,
 	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
+  console.log(query.toSQL())
+
+	const res = await query
 
 	t.deepEqual(res, [
 		{ name: 'John', related: null, greetings: null },
@@ -2508,18 +2512,20 @@ test.serial('select custom field with custom select + sql', async (t) => {
 	const { db } = t.context;
 
 	await db.insert(anotherUsersTable).values([
-		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john' },
-		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
-		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+		{ id: 1, name: 'John', lowerName: 'JOHN', greetings: 'JOHN' },
+		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
+		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
 
-	const res = await db.select({
+  const query = db.select({
 		id: anotherUsersTable.id,
 		name: anotherUsersTable.name,
 		lowerName: sql`${anotherUsersTable.lowerName}`, // It ignores the column alias but uses the custom select
 		greetings: sql`${anotherUsersTable.greetings}`.as('col3'),
 		greetings2: sql`${anotherUsersTable.greetings}`.mapWith((val) => `${val} and bye`).as('col4'),
 	}).from(anotherUsersTable);
+  console.log(query.toSQL());
+	const res = await query
 
 	t.deepEqual(res, [
 		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', greetings2: 'john and bye' },
@@ -2532,21 +2538,24 @@ test.serial('select custom field with custom select in a join and sql', async (t
 	const { db } = t.context;
 
 	await db.insert(anotherUsersTable).values([
-		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', related: 'Jane' },
-		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
-		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+		{ id: 1, name: 'John', lowerName: 'JOHN', greetings: 'JOHN', related: 'Jane' },
+		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
+		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
 	const aliased = alias(anotherUsersTable, 'us');
 
-	const res = await db.select({
+  const query = db.select({
 		name: sql`${anotherUsersTable.name}`,
 		related: sql`${aliased.name}`,
 		greetings: aliased.greetings,
 	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
+  console.log(query.toSQL());
+
+	const res = await query
 
 	t.deepEqual(res, [
 		{ name: 'John', related: null, greetings: null },
 		{ name: 'Jane', related: 'John', greetings: 'hello john' },
 		{ name: 'Joe', related: null, greetings: null },
-	]);
+  ]);
 });

--- a/integration-tests/tests/libsql.test.ts
+++ b/integration-tests/tests/libsql.test.ts
@@ -2471,10 +2471,8 @@ test.serial('select custom field with custom select', async (t) => {
 		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
 		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
-  const query = db.select().from(anotherUsersTable);
-  console.log(query.toSQL())
 
-	const res = await query
+	const res = await db.select().from(anotherUsersTable);
 
 	t.deepEqual(res, [
 		{ id: 1, name: 'John', lowerName: 'john', greetings: 'hello john', related: null },
@@ -2492,14 +2490,12 @@ test.serial('select custom field with custom select in a join', async (t) => {
 		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
 	const aliased = alias(anotherUsersTable, 'us');
-  const query = db.select({
+
+	const res = await db.select({
 		name: anotherUsersTable.name,
 		related: aliased.name,
 		greetings: aliased.greetings,
 	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
-  console.log(query.toSQL())
-
-	const res = await query
 
 	t.deepEqual(res, [
 		{ name: 'John', related: null, greetings: null },
@@ -2517,15 +2513,13 @@ test.serial('select custom field with custom select + sql', async (t) => {
 		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
 
-  const query = db.select({
+	const res = await db.select({
 		id: anotherUsersTable.id,
 		name: anotherUsersTable.name,
 		lowerName: sql`${anotherUsersTable.lowerName}`, // It ignores the column alias but uses the custom select
 		greetings: sql`${anotherUsersTable.greetings}`.as('col3'),
 		greetings2: sql`${anotherUsersTable.greetings}`.mapWith((val) => `${val} and bye`).as('col4'),
 	}).from(anotherUsersTable);
-  console.log(query.toSQL());
-	const res = await query
 
 	t.deepEqual(res, [
 		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', greetings2: 'john and bye' },
@@ -2544,18 +2538,15 @@ test.serial('select custom field with custom select in a join and sql', async (t
 	]);
 	const aliased = alias(anotherUsersTable, 'us');
 
-  const query = db.select({
+	const res = await db.select({
 		name: sql`${anotherUsersTable.name}`,
 		related: sql`${aliased.name}`,
 		greetings: aliased.greetings,
 	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
-  console.log(query.toSQL());
-
-	const res = await query
 
 	t.deepEqual(res, [
 		{ name: 'John', related: null, greetings: null },
 		{ name: 'Jane', related: 'John', greetings: 'hello john' },
 		{ name: 'Joe', related: null, greetings: null },
-  ]);
+	]);
 });

--- a/integration-tests/tests/libsql.test.ts
+++ b/integration-tests/tests/libsql.test.ts
@@ -21,6 +21,7 @@ import { migrate } from 'drizzle-orm/libsql/migrator';
 import {
 	alias,
 	blob,
+	customType,
 	except,
 	foreignKey,
 	getTableConfig,
@@ -47,12 +48,39 @@ interface Context {
 
 const test = anyTest as TestFn<Context>;
 
+const customLowerText = customType<{ data: string }>({
+	dataType() {
+		return 'text';
+	},
+	customSelect(value) {
+		return sql`lower(${value})`;
+	},
+});
+
+const customPrefixedText = customType<{ data: string }>({
+	dataType() {
+		return 'text';
+	},
+	customSelect(value) {
+		return sql`lower(${value})`;
+	},
+	fromDriver: (k) => `hello ${k}`,
+});
+
 const usersTable = sqliteTable('users', {
 	id: integer('id').primaryKey(),
 	name: text('name').notNull(),
 	verified: integer('verified', { mode: 'boolean' }).notNull().default(false),
 	json: blob('json', { mode: 'json' }).$type<string[]>(),
 	createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`strftime('%s', 'now')`),
+});
+
+const anotherUsersTable = sqliteTable('another_users', {
+	id: integer('id').primaryKey(),
+	name: text('name').notNull(),
+	lowerName: customLowerText('lower_name').default(sql`(name)`),
+	greetings: customPrefixedText('greetings').default(sql`(name)`),
+	related: text('related'),
 });
 
 const users2Table = sqliteTable('users2', {
@@ -155,6 +183,7 @@ test.beforeEach(async (t) => {
 	await ctx.db.run(sql`drop table if exists ${orders}`);
 	await ctx.db.run(sql`drop table if exists ${bigIntExample}`);
 	await ctx.db.run(sql`drop table if exists ${pkExampleTable}`);
+	await ctx.db.run(sql`drop table if exists ${anotherUsersTable}`);
 
 	await ctx.db.run(sql`
 		create table ${usersTable} (
@@ -215,6 +244,16 @@ test.beforeEach(async (t) => {
 		  id integer primary key,
 		  name text not null,
 		  big_int blob not null
+		)
+	`);
+
+	await ctx.db.run(sql`
+		create table ${anotherUsersTable} (
+			id integer primary key,
+			name text not null,
+			lower_name text,
+			greetings text,
+			related text
 		)
 	`);
 });
@@ -2422,4 +2461,92 @@ test.serial('set operations (mixed all) as function with subquery', async (t) =>
 				.from(citiesTable).where(gt(citiesTable.id, 1)),
 		).orderBy(asc(sql`id`));
 	});
+});
+
+test.serial('select custom field with custom select', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(anotherUsersTable).values([
+		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john' },
+		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
+		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+	]);
+
+	const res = await db.select().from(anotherUsersTable);
+
+	t.deepEqual(res, [
+		{ id: 1, name: 'John', lowerName: 'john', greetings: 'hello john', related: null },
+		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'hello jane', related: null },
+		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'hello joe', related: null },
+	]);
+});
+
+test.serial('select custom field with custom select in a join', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(anotherUsersTable).values([
+		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', related: 'Jane' },
+		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
+		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+	]);
+	const aliased = alias(anotherUsersTable, 'us');
+
+	const res = await db.select({
+		name: anotherUsersTable.name,
+		related: aliased.name,
+		greetings: aliased.greetings,
+	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
+
+	t.deepEqual(res, [
+		{ name: 'John', related: null, greetings: null },
+		{ name: 'Jane', related: 'John', greetings: 'hello john' },
+		{ name: 'Joe', related: null, greetings: null },
+	]);
+});
+
+test.serial('select custom field with custom select + sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(anotherUsersTable).values([
+		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john' },
+		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
+		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+	]);
+
+	const res = await db.select({
+		id: anotherUsersTable.id,
+		name: anotherUsersTable.name,
+		lowerName: sql`${anotherUsersTable.lowerName}`, // It ignores the column alias but uses the custom select
+		greetings: sql`${anotherUsersTable.greetings}`.as('col3'),
+		greetings2: sql`${anotherUsersTable.greetings}`.mapWith((val) => `${val} and bye`).as('col4'),
+	}).from(anotherUsersTable);
+
+	t.deepEqual(res, [
+		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', greetings2: 'john and bye' },
+		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane', greetings2: 'jane and bye' },
+		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe', greetings2: 'joe and bye' },
+	]);
+});
+
+test.serial('select custom field with custom select in a join and sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(anotherUsersTable).values([
+		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', related: 'Jane' },
+		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
+		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+	]);
+	const aliased = alias(anotherUsersTable, 'us');
+
+	const res = await db.select({
+		name: sql`${anotherUsersTable.name}`,
+		related: sql`${aliased.name}`,
+		greetings: aliased.greetings,
+	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
+
+	t.deepEqual(res, [
+		{ name: 'John', related: null, greetings: null },
+		{ name: 'Jane', related: 'John', greetings: 'hello john' },
+		{ name: 'Joe', related: null, greetings: null },
+	]);
 });

--- a/integration-tests/tests/mysql.custom.test.ts
+++ b/integration-tests/tests/mysql.custom.test.ts
@@ -140,8 +140,8 @@ const usersMigratorTable = mysqlTable('users12', {
 const anotherUsersTable = mysqlTable('another_users', {
 	id: customSerial('id').primaryKey(),
 	name: text('name').notNull(),
-	lowerName: customLowerText('lower_name').default(sql`(\`name\`)`),
-	greetings: customPrefixedText('greetings').default(sql`(\`name\`)`),
+	lowerName: customLowerText('lower_name').default(sql`(upper(\`name\`))`),
+	greetings: customPrefixedText('greetings').default(sql`(upper(\`name\`))`),
 	related: text('related'),
 });
 

--- a/integration-tests/tests/mysql.custom.test.ts
+++ b/integration-tests/tests/mysql.custom.test.ts
@@ -89,6 +89,25 @@ const customBinary = customType<{ data: string; driverData: Buffer; config: { le
 	},
 });
 
+const customLowerText = customType<{ data: string }>({
+	dataType() {
+		return 'text';
+	},
+	customSelect(value) {
+		return sql`lower(${value})`;
+	},
+});
+
+const customPrefixedText = customType<{ data: string }>({
+	dataType() {
+		return 'text';
+	},
+	customSelect(value) {
+		return sql`lower(${value})`;
+	},
+	fromDriver: (k) => `hello ${k}`,
+});
+
 const usersTable = mysqlTable('userstest', {
 	id: customSerial('id').primaryKey(),
 	name: customText('name').notNull(),
@@ -116,6 +135,14 @@ const usersMigratorTable = mysqlTable('users12', {
 	id: serial('id').primaryKey(),
 	name: text('name').notNull(),
 	email: text('email').notNull(),
+});
+
+const anotherUsersTable = mysqlTable('another_users', {
+	id: customSerial('id').primaryKey(),
+	name: text('name').notNull(),
+	lowerName: customLowerText('lower_name').default(sql`(\`name\`)`),
+	greetings: customPrefixedText('greetings').default(sql`(\`name\`)`),
+	related: text('related'),
 });
 
 interface Context {
@@ -188,6 +215,7 @@ test.beforeEach(async (t) => {
 	await ctx.db.execute(sql`drop table if exists \`userstest\``);
 	await ctx.db.execute(sql`drop table if exists \`datestable\``);
 	await ctx.db.execute(sql`drop table if exists \`test_table\``);
+	await ctx.db.execute(sql`drop table if exists \`another_users\``);
 	// await ctx.db.execute(sql`create schema public`);
 	await ctx.db.execute(
 		sql`
@@ -221,6 +249,18 @@ test.beforeEach(async (t) => {
 				\`sql_id\` binary(16),
 				\`raw_id\` varchar(64)
 			)
+		`,
+	);
+
+	await ctx.db.execute(
+		sql`
+			create table \`another_users\` (
+			\`id\` serial primary key,
+			\`name\` text not null,
+			\`lower_name\` text default (\`name\`),
+			\`greetings\` text default (\`name\`),
+			\`related\` text
+						)
 		`,
 	);
 });
@@ -849,4 +889,92 @@ test.after.always(async (t) => {
 	const ctx = t.context;
 	await ctx.client?.end().catch(console.error);
 	await ctx.mysqlContainer?.stop().catch(console.error);
+});
+
+test.serial('select custom field with custom select', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(anotherUsersTable).values([
+		{ id: 1, name: 'John' },
+		{ id: 2, name: 'Jane' },
+		{ id: 3, name: 'Joe' },
+	]);
+
+	const res = await db.select().from(anotherUsersTable);
+
+	t.deepEqual(res, [
+		{ id: 1, name: 'John', lowerName: 'john', greetings: 'hello john', related: null },
+		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'hello jane', related: null },
+		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'hello joe', related: null },
+	]);
+});
+
+test.serial('select custom field with custom select in a join', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(anotherUsersTable).values([
+		{ id: 1, name: 'John', related: 'Jane' },
+		{ id: 2, name: 'Jane' },
+		{ id: 3, name: 'Joe' },
+	]);
+	const aliased = alias(anotherUsersTable, 'us');
+
+	const res = await db.select({
+		name: anotherUsersTable.name,
+		related: aliased.name,
+		greetings: aliased.greetings,
+	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
+
+	t.deepEqual(res, [
+		{ name: 'John', related: null, greetings: null },
+		{ name: 'Jane', related: 'John', greetings: 'hello john' },
+		{ name: 'Joe', related: null, greetings: null },
+	]);
+});
+
+test.serial('select custom field with custom select + sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(anotherUsersTable).values([
+		{ id: 1, name: 'John' },
+		{ id: 2, name: 'Jane' },
+		{ id: 3, name: 'Joe' },
+	]);
+
+	const res = await db.select({
+		id: anotherUsersTable.id,
+		name: anotherUsersTable.name,
+		lowerName: sql`${anotherUsersTable.lowerName}`, // It ignores the column alias but uses the custom select
+		greetings: sql`${anotherUsersTable.greetings}`.as('col3'),
+		greetings2: sql`${anotherUsersTable.greetings}`.mapWith((val) => `${val} and bye`).as('col4'),
+	}).from(anotherUsersTable);
+
+	t.deepEqual(res, [
+		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', greetings2: 'john and bye' },
+		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane', greetings2: 'jane and bye' },
+		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe', greetings2: 'joe and bye' },
+	]);
+});
+
+test.serial('select custom field with custom select in a join and sql', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(anotherUsersTable).values([
+		{ id: 1, name: 'John', related: 'Jane' },
+		{ id: 2, name: 'Jane' },
+		{ id: 3, name: 'Joe' },
+	]);
+	const aliased = alias(anotherUsersTable, 'us');
+
+	const res = await db.select({
+		name: sql`${anotherUsersTable.name}`,
+		related: sql`${aliased.name}`,
+		greetings: aliased.greetings,
+	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
+
+	t.deepEqual(res, [
+		{ name: 'John', related: null, greetings: null },
+		{ name: 'Jane', related: 'John', greetings: 'hello john' },
+		{ name: 'Joe', related: null, greetings: null },
+	]);
 });

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -810,10 +810,8 @@ test.serial('select custom field with custom select', async (t) => {
 		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
 		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
-  const query = db.select().from(anotherUsersTable);
-  console.log(query.toSQL())
 
-	const res = await query
+	const res = await db.select().from(anotherUsersTable);
 
 	t.deepEqual(res, [
 		{ id: 1, name: 'John', lowerName: 'john', greetings: 'hello john', related: null },
@@ -831,14 +829,12 @@ test.serial('select custom field with custom select in a join', async (t) => {
 		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
 	const aliased = alias(anotherUsersTable, 'us');
-  const query = db.select({
+
+	const res = await db.select({
 		name: anotherUsersTable.name,
 		related: aliased.name,
 		greetings: aliased.greetings,
 	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
-  console.log(query.toSQL())
-
-	const res = await query
 
 	t.deepEqual(res, [
 		{ name: 'John', related: null, greetings: null },
@@ -855,16 +851,14 @@ test.serial('select custom field with custom select + sql', async (t) => {
 		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
 		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
-  const query = db.select({
+
+	const res = await db.select({
 		id: anotherUsersTable.id,
 		name: anotherUsersTable.name,
 		lowerName: sql`${anotherUsersTable.lowerName}`, // It ignores the column alias but uses the custom select
 		greetings: sql`${anotherUsersTable.greetings}`.as('col3'),
 		greetings2: sql`${anotherUsersTable.greetings}`.mapWith((val) => `${val} and bye`).as('col4'),
 	}).from(anotherUsersTable);
-  console.log(query.toSQL())
-
-	const res = await query
 
 	t.deepEqual(res, [
 		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', greetings2: 'john and bye' },
@@ -882,14 +876,12 @@ test.serial('select custom field with custom select in a join and sql', async (t
 		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
 	const aliased = alias(anotherUsersTable, 'us');
-  const query = db.select({
+
+	const res = await db.select({
 		name: sql`${anotherUsersTable.name}`,
 		related: sql`${aliased.name}`,
 		greetings: aliased.greetings,
 	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
-  console.log(query.toSQL())
-
-	const res = await query
 
 	t.deepEqual(res, [
 		{ name: 'John', related: null, greetings: null },

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -806,12 +806,14 @@ test.serial('select custom field with custom select', async (t) => {
 	const { db } = t.context;
 
 	await db.insert(anotherUsersTable).values([
-		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john' },
-		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
-		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+		{ id: 1, name: 'John', lowerName: 'JOHN', greetings: 'JOHN' },
+		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
+		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
+  const query = db.select().from(anotherUsersTable);
+  console.log(query.toSQL())
 
-	const res = await db.select().from(anotherUsersTable);
+	const res = await query
 
 	t.deepEqual(res, [
 		{ id: 1, name: 'John', lowerName: 'john', greetings: 'hello john', related: null },
@@ -824,17 +826,19 @@ test.serial('select custom field with custom select in a join', async (t) => {
 	const { db } = t.context;
 
 	await db.insert(anotherUsersTable).values([
-		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', related: 'Jane' },
-		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
-		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+		{ id: 1, name: 'John', lowerName: 'JOHN', greetings: 'JOHN', related: 'Jane' },
+		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
+		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
 	const aliased = alias(anotherUsersTable, 'us');
-
-	const res = await db.select({
+  const query = db.select({
 		name: anotherUsersTable.name,
 		related: aliased.name,
 		greetings: aliased.greetings,
 	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
+  console.log(query.toSQL())
+
+	const res = await query
 
 	t.deepEqual(res, [
 		{ name: 'John', related: null, greetings: null },
@@ -847,18 +851,20 @@ test.serial('select custom field with custom select + sql', async (t) => {
 	const { db } = t.context;
 
 	await db.insert(anotherUsersTable).values([
-		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john' },
-		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
-		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+		{ id: 1, name: 'John', lowerName: 'JOHN', greetings: 'JOHN' },
+		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
+		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
-
-	const res = await db.select({
+  const query = db.select({
 		id: anotherUsersTable.id,
 		name: anotherUsersTable.name,
 		lowerName: sql`${anotherUsersTable.lowerName}`, // It ignores the column alias but uses the custom select
 		greetings: sql`${anotherUsersTable.greetings}`.as('col3'),
 		greetings2: sql`${anotherUsersTable.greetings}`.mapWith((val) => `${val} and bye`).as('col4'),
 	}).from(anotherUsersTable);
+  console.log(query.toSQL())
+
+	const res = await query
 
 	t.deepEqual(res, [
 		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', greetings2: 'john and bye' },
@@ -871,17 +877,19 @@ test.serial('select custom field with custom select in a join and sql', async (t
 	const { db } = t.context;
 
 	await db.insert(anotherUsersTable).values([
-		{ id: 1, name: 'John', lowerName: 'john', greetings: 'john', related: 'Jane' },
-		{ id: 2, name: 'Jane', lowerName: 'jane', greetings: 'jane' },
-		{ id: 3, name: 'Joe', lowerName: 'joe', greetings: 'joe' },
+		{ id: 1, name: 'John', lowerName: 'JOHN', greetings: 'JOHN', related: 'Jane' },
+		{ id: 2, name: 'Jane', lowerName: 'JANE', greetings: 'JANE' },
+		{ id: 3, name: 'Joe', lowerName: 'JOE', greetings: 'JOE' },
 	]);
 	const aliased = alias(anotherUsersTable, 'us');
-
-	const res = await db.select({
+  const query = db.select({
 		name: sql`${anotherUsersTable.name}`,
 		related: sql`${aliased.name}`,
 		greetings: aliased.greetings,
 	}).from(anotherUsersTable).leftJoin(aliased, eq(anotherUsersTable.name, aliased.related));
+  console.log(query.toSQL())
+
+	const res = await query
 
 	t.deepEqual(res, [
 		{ name: 'John', related: null, greetings: null },


### PR DESCRIPTION
This PR will close #554 and will close #1083.

I have added a new API for customTypes that allows wrapping the column name with custom sql. The syntax is the following:
```ts
const getAsLower = customType<{
  data: string;
}>({
  dataType: () => "text",
  customSelect: (column) => sql`lower(${column})`
});
```
You can then use the customType as follows:
```ts
export const users = mysqlTable("users", {
  id: int("id").autoincrement().primaryKey(),
  name: text("name").notNull(),
  lowercase: getAsLower("lowercase").default(sql`(\`name\`)`),
  managerId: int("manager_id")
    .references((): AnyMySqlColumn => users.id)
    .$default(() => 1),
});
```
Then, a select like this:
```ts
const q = await db.select().from(users);
```
Will result in the following query:
```sql
select `id`, `name`, lower(`lowercase`) as `lowercase`, `manager_id` from `users`
```
Notice how as opposed to the suggestion in #1083 it's not necessary to define a `mapWith` or an alias.
By default, the column will be aliased to the column name, and the custom decoder can be defined the usual way with `fromDriver`.

/claim #554
/claim #1083