### PR TITLE
Allow mapResultRow to handle keyed object rows to make sqlite-proxy implementation easier

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -13,11 +13,12 @@ import { ViewBaseConfig } from './view-common.ts';
 /** @internal */
 export function mapResultRow<TResult>(
 	columns: SelectedFieldsOrdered<AnyColumn>,
-	row: unknown[],
+	row: unknown[] | Record<string, unknown>,
 	joinsNotNullableMap: Record<string, boolean> | undefined,
 ): TResult {
 	// Key -> nested object key, value -> table name if all fields in the nested object are from the same table, false otherwise
 	const nullifyMap: Record<string, string | false> = {};
+	const rowIsArray = Array.isArray(row);
 
 	const result = columns.reduce<Record<string, any>>(
 		(result, { path, field }, columnIndex) => {
@@ -37,7 +38,7 @@ export function mapResultRow<TResult>(
 					}
 					node = node[pathChunk];
 				} else {
-					const rawValue = row[columnIndex]!;
+					const rawValue = rowIsArray ? row[columnIndex] : row[pathChunk];
 					const value = node[pathChunk] = rawValue === null ? null : decoder.mapFromDriverValue(rawValue);
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {


### PR DESCRIPTION
Many sqlite bindings will return the db responses as objects with column/value key pairs.

Though where drizzle automatically handles this in the official integrations for better-sqlite, and bun:sqlite, there is no way (just using the supplied sqlite-proxy interface) to map the response object keys to their correct order in the response array to give back to drizzle-orm.

However passing the selected columns as a new fields to `AsyncRemoteCallback`, I felt would be the wrong approach - essentially requiring that drizzle internals be documented just to do a simple row transformation (and forcing each user to write that out!).

As a result, I felt it better to allow `mapResultRow` to handle the case where a row is an object - which should be fully transparent as prior it assumed each row was an array of values in selected column order, thus it should be only more helpful when implementing a custom proxy as I'd argue it is expected that drizzle would receive an array of row objects given how many bindings go with this approach.