### PR TITLE
[mysql2] Fix node mysql2 execute return type for raw queries

### DIFF
--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -110,7 +110,7 @@ jobs:
         if: steps.checks.outputs.has_new_release == 'true'
         env:
           PG_CONNECTION_STRING: postgres://postgres:postgres@localhost:5432/drizzle
-          MYSQL_CONNECTION_STRING: mysql://root:root@localhost:3306/drizzle
+          MYSQL_CONNECTION_STRING: mysql://root:root@localhost:3306/drizzle?multipleStatements=true
           PLANETSCALE_CONNECTION_STRING: ${{ secrets.PLANETSCALE_CONNECTION_STRING }}
           LIBSQL_URL: file:local.db
         run: |

--- a/drizzle-orm/src/mysql-core/db.ts
+++ b/drizzle-orm/src/mysql-core/db.ts
@@ -159,7 +159,7 @@ export class MySqlDatabase<
 		return new MySqlDeleteBase(table, this.session, this.dialect);
 	}
 
-	execute<T extends { [column: string]: any } = ResultSetHeader>(
+	execute<T extends { [column: string]: any } | { [column: string]: any }[] = ResultSetHeader>(
 		query: SQLWrapper,
 	): Promise<QueryResultKind<TQueryResult, T>> {
 		return this.session.execute(query.getSQL());

--- a/drizzle-orm/type-tests/mysql/raw-query.ts
+++ b/drizzle-orm/type-tests/mysql/raw-query.ts
@@ -1,0 +1,137 @@
+import { sql } from '~/sql/sql.ts';
+import type { Equal } from 'type-tests/utils.ts';
+import { Expect } from 'type-tests/utils.ts';
+import { db } from './db.ts';
+import { cities, users } from './tables.ts';
+import type { FieldPacket, ResultSetHeader } from 'mysql2/promise';
+
+const select = await db.execute<{ id: number, name: string, population: number | null }>(sql`
+  SELECT ${cities.id}, ${cities.name}, ${cities.population} from ${cities}
+`)
+Expect<
+    Equal<
+        [
+            {
+                id: number;
+                name: string;
+                population: number | null;
+            }[],
+            FieldPacket[]
+        ],
+        typeof select
+    >
+>;
+
+const insert = await db.execute(sql`
+  INSERT INTO ${cities} (${cities.name}) VALUES('Tokyo')
+`)
+Expect<
+    Equal<
+        [
+            ResultSetHeader,
+            FieldPacket[]
+        ],
+        typeof insert
+    >
+>;
+
+const update = await db.execute(sql`
+  UPDATE ${cities} SET ${cities.name}) = 'London' WHERE ${cities.id} = 1
+`)
+Expect<
+    Equal<
+        [
+            ResultSetHeader,
+            FieldPacket[]
+        ],
+        typeof update
+    >
+>;
+
+const insertSelect = await db.execute<[ResultSetHeader, { id: number, name: string, population: number | null }]>(sql`
+  INSERT INTO ${cities} (${cities.name}) VALUES('New York');
+  SELECT ${cities.id}, ${cities.name}, ${cities.population} from ${cities};
+`)
+Expect<
+    Equal<
+        [
+            [
+                ResultSetHeader,
+                {
+                    id: number;
+                    name: string;
+                    population: number | null;
+                }[]
+            ],
+            FieldPacket[]
+        ],
+        typeof insertSelect
+    >
+>;
+
+const selectInsert = await db.execute<[{ id: number, name: string, population: number | null }, ResultSetHeader]>(sql`
+  SELECT ${cities.id}, ${cities.name}, ${cities.population} from ${cities};   
+  INSERT INTO ${cities} (${cities.name}) VALUES('Osaka');
+`)
+Expect<
+    Equal<
+        [
+            [
+                {
+                    id: number;
+                    name: string;
+                    population: number | null;
+                }[],
+                ResultSetHeader
+            ],
+            FieldPacket[]
+        ],
+        typeof selectInsert
+    >
+>;
+
+const selectSelect = await db.execute<[
+    { id: number, name: string, population: number | null },
+    { id: number, class: 'A' | 'C', subClass: 'B' | 'D' | null }
+]>(sql`
+  SELECT ${cities.id}, ${cities.name}, ${cities.population} from ${cities};   
+  SELECT ${users.id}, ${users.class}, ${users.subClass} from ${users};
+`)
+Expect<
+    Equal<
+        [
+            [
+                {
+                    id: number;
+                    name: string;
+                    population: number | null;
+                }[],
+                {
+                    id: number;
+                    class: 'A' | 'C';
+                    subClass: 'B' | 'D' | null;
+                }[],
+            ],
+            FieldPacket[]
+        ],
+        typeof selectSelect
+    >
+>;
+
+const insertUpdate = await db.execute<[ResultSetHeader, ResultSetHeader]>(sql`
+
+  INSERT INTO ${cities} (${cities.name}) VALUES ('Oxfrod');
+  UPDATE ${cities} SET ${cities.name}) = 'Oxford' WHERE ${cities.name} = 'Oxfrod';
+`)
+Expect<
+    Equal<
+        [
+            [
+                ResultSetHeader,
+                ResultSetHeader
+            ],
+            FieldPacket[]
+        ],
+        typeof insertUpdate
+    >
+>;


### PR DESCRIPTION
This will close #661 

This PR will fix return type of mysql2 execute return type

###  USAGE 
```typescript

  const [result, fieldPackets] = await db.execute(
    sql`INSERT INTO users (name) VALUES ('Joe')`,
  );
  // result type is: ResultSetHeader

  const [result, fieldPackets] = await db.execute<{ id: number; name: string }>(sql`SELECT id,name FROM users`);
  // result type is: { id: number; name: string }[]

  // multiple statement
  const [result, fieldPackets] = await db.execute<[ResultSetHeader, { id: number; name: string }]>(
    sql`INSERT INTO users (name) VALUES ('Joe'); SELECT id,name FROM users;`,
  );
  // result type is: [ResultSetHeader, { id: number; name: string }[]]

  const [result, fieldPackets] = await db.execute<[{ id: number; name: string }, { id: number; age: number }]>(
    sql`SELECT id,name FROM users; SELECT id,age FROM profile;`,
  );
  // result type is: [{ id: number; name: string }[], { id: number; age: number }[]]
```