### PR TITLE
[Pg] Add targetWhere to onConflictDoUpdate

### DIFF
--- a/drizzle-orm/src/pg-core/query-builders/insert.ts
+++ b/drizzle-orm/src/pg-core/query-builders/insert.ts
@@ -97,6 +97,7 @@ export type PgInsertReturningAll<T extends AnyPgInsert, TDynamic extends boolean
 
 export interface PgInsertOnConflictDoUpdateConfig<T extends AnyPgInsert> {
 	target: IndexColumn | IndexColumn[];
+	targetWhere?: SQL;
 	where?: SQL;
 	set: PgUpdateSetSource<T['_']['table']>;
 }
@@ -200,7 +201,8 @@ export class PgInsertBase<
 		targetColumn = Array.isArray(config.target)
 			? config.target.map((it) => this.dialect.escapeName(it.name)).join(',')
 			: this.dialect.escapeName(config.target.name);
-		this.config.onConflict = sql`(${sql.raw(targetColumn)}) do update set ${setSql}${whereSql}`;
+		const targetWhereSql = config.targetWhere ? sql` where ${config.targetWhere}` : undefined;
+		this.config.onConflict = sql`(${sql.raw(targetColumn)})${targetWhereSql} do update set ${setSql}${whereSql}`;
 		return this as any;
 	}
 


### PR DESCRIPTION
Add support for where clauses on the conflict target to help match with partial indexes when upserting. This where clause can be used in addition to the existing where clause which goes after the "DO UPDATE SET". 

This is useful for cases where you have a partial unique index and want to upsert on that partial index. I think this is not currently possible with drizzle without raw sql.