### PR TITLE
[Pg] Add tests for Postgres ->> and -> operators

### DIFF
--- a/integration-tests/tests/neon-http.test.ts
+++ b/integration-tests/tests/neon-http.test.ts
@@ -47,6 +47,7 @@ import {
 	timestamp,
 	uuid as pgUuid,
 	varchar,
+	json,
 } from 'drizzle-orm/pg-core';
 import getPort from 'get-port';
 import pg from 'pg';
@@ -111,6 +112,12 @@ const salEmp = pgTable('sal_emp', {
 
 const _tictactoe = pgTable('tictactoe', {
 	squares: integer('squares').array(3).array(3),
+});
+
+const jsonTestTable = pgTable('jsontest', {
+	id: serial('id').primaryKey(),
+	json: json('json').$type<{ string: string, number: number }>(),
+	jsonb: jsonb('jsonb').$type<{ string: string, number: number }>(),
 });
 
 const usersMigratorTable = pgTable('users12', {
@@ -289,6 +296,15 @@ test.beforeEach(async (t) => {
 			)
 		`,
 	);
+	await ctx.db.execute(
+		sql`
+			create table jsontest (
+				id serial primary key,
+				json json,
+				jsonb jsonb
+			)
+		`
+	)
 });
 
 test.serial('select all fields', async (t) => {
@@ -2329,6 +2345,118 @@ test.serial('set null to jsonb field', async (t) => {
 
 	await db.execute(sql`drop table ${users}`);
 });
+
+test.serial('set json/jsonb fields with objects and retrieve with the ->> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: obj,
+		jsonb: obj
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->>'string'`,
+		jsonNumberField: sql<string>`${jsonTestTable.json}->>'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->>'string'`,
+		jsonbNumberField: sql<string>`${jsonTestTable.jsonb}->>'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: String(testNumber),
+		jsonbStringField: testString,
+		jsonbNumberField: String(testNumber)
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
+
+test.serial('set json/jsonb fields with strings and retrieve with the ->> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: sql`${JSON.stringify(obj)}`,
+		jsonb: sql`${JSON.stringify(obj)}`
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->>'string'`,
+		jsonNumberField: sql<string>`${jsonTestTable.json}->>'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->>'string'`,
+		jsonbNumberField: sql<string>`${jsonTestTable.jsonb}->>'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: String(testNumber),
+		jsonbStringField: testString,
+		jsonbNumberField: String(testNumber)
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
+
+test.serial('set json/jsonb fields with objects and retrieve with the -> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: obj,
+		jsonb: obj
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->'string'`,
+		jsonNumberField: sql<number>`${jsonTestTable.json}->'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->'string'`,
+		jsonbNumberField: sql<number>`${jsonTestTable.jsonb}->'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: testNumber,
+		jsonbStringField: testString,
+		jsonbNumberField: testNumber
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
+
+test.serial('set json/jsonb fields with strings and retrieve with the -> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: sql`${JSON.stringify(obj)}`,
+		jsonb: sql`${JSON.stringify(obj)}`
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->'string'`,
+		jsonNumberField: sql<number>`${jsonTestTable.json}->'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->'string'`,
+		jsonbNumberField: sql<number>`${jsonTestTable.jsonb}->'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: testNumber,
+		jsonbStringField: testString,
+		jsonbNumberField: testNumber
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
 
 test.serial('insert undefined', async (t) => {
 	const { db } = t.context;

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -57,6 +57,7 @@ import {
 	uuid as pgUuid,
 	varchar,
 	pgEnum,
+	json,
 } from 'drizzle-orm/pg-core';
 import getPort from 'get-port';
 import pg from 'pg';
@@ -126,6 +127,12 @@ const salEmp = pgTable('sal_emp', {
 
 const _tictactoe = pgTable('tictactoe', {
 	squares: integer('squares').array(3).array(3),
+});
+
+const jsonTestTable = pgTable('jsontest', {
+	id: serial('id').primaryKey(),
+	json: json('json').$type<{ string: string, number: number }>(),
+	jsonb: jsonb('jsonb').$type<{ string: string, number: number }>(),
 });
 
 const usersMigratorTable = pgTable('users12', {
@@ -292,6 +299,15 @@ test.beforeEach(async (t) => {
 			)
 		`,
 	);
+	await ctx.db.execute(
+		sql`
+			create table jsontest (
+				id serial primary key,
+				json json,
+				jsonb jsonb
+			)
+		`
+	)
 });
 
 async function setupSetOperationTest(db: NodePgDatabase) {
@@ -2553,6 +2569,118 @@ test.serial('set null to jsonb field', async (t) => {
 
 	await db.execute(sql`drop table ${users}`);
 });
+
+test.serial('set json/jsonb fields with objects and retrieve with the ->> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: obj,
+		jsonb: obj
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->>'string'`,
+		jsonNumberField: sql<string>`${jsonTestTable.json}->>'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->>'string'`,
+		jsonbNumberField: sql<string>`${jsonTestTable.jsonb}->>'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: String(testNumber),
+		jsonbStringField: testString,
+		jsonbNumberField: String(testNumber)
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
+
+test.serial('set json/jsonb fields with strings and retrieve with the ->> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: sql`${JSON.stringify(obj)}`,
+		jsonb: sql`${JSON.stringify(obj)}`
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->>'string'`,
+		jsonNumberField: sql<string>`${jsonTestTable.json}->>'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->>'string'`,
+		jsonbNumberField: sql<string>`${jsonTestTable.jsonb}->>'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: String(testNumber),
+		jsonbStringField: testString,
+		jsonbNumberField: String(testNumber)
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
+
+test.serial('set json/jsonb fields with objects and retrieve with the -> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: obj,
+		jsonb: obj
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->'string'`,
+		jsonNumberField: sql<number>`${jsonTestTable.json}->'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->'string'`,
+		jsonbNumberField: sql<number>`${jsonTestTable.jsonb}->'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: testNumber,
+		jsonbStringField: testString,
+		jsonbNumberField: testNumber
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
+
+test.serial('set json/jsonb fields with strings and retrieve with the -> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: sql`${JSON.stringify(obj)}`,
+		jsonb: sql`${JSON.stringify(obj)}`
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->'string'`,
+		jsonNumberField: sql<number>`${jsonTestTable.json}->'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->'string'`,
+		jsonbNumberField: sql<number>`${jsonTestTable.jsonb}->'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: testNumber,
+		jsonbStringField: testString,
+		jsonbNumberField: testNumber
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
 
 test.serial('insert undefined', async (t) => {
 	const { db } = t.context;

--- a/integration-tests/tests/postgres.js.test.ts
+++ b/integration-tests/tests/postgres.js.test.ts
@@ -433,7 +433,7 @@ test.serial('json insert', async (t) => {
 	t.deepEqual(result, [{ id: 1, name: 'John', jsonb: ['foo', 'bar'] }]);
 });
 
-test.serial.failing('set json/jsonb fields with objects and retrieve with the ->> operator', async (t) => {
+test.serial('set json/jsonb fields with objects and retrieve with the ->> operator', async (t) => {
 	const { db } = t.context;
 
 	const obj = { string: 'test', number: 123 }

--- a/integration-tests/tests/vercel-pg.test.ts
+++ b/integration-tests/tests/vercel-pg.test.ts
@@ -45,6 +45,7 @@ import {
 	timestamp,
 	uuid as pgUuid,
 	varchar,
+	json,
 } from 'drizzle-orm/pg-core';
 import { drizzle, type VercelPgDatabase } from 'drizzle-orm/vercel-postgres';
 import { migrate } from 'drizzle-orm/vercel-postgres/migrator';
@@ -109,6 +110,13 @@ const salEmp = pgTable('sal_emp', {
 const _tictactoe = pgTable('tictactoe', {
 	squares: integer('squares').array(3).array(3),
 });
+
+const jsonTestTable = pgTable('jsontest', {
+	id: serial('id').primaryKey(),
+	json: json('json').$type<{ string: string, number: number }>(),
+	jsonb: jsonb('jsonb').$type<{ string: string, number: number }>(),
+});
+
 
 const usersMigratorTable = pgTable('users12', {
 	id: serial('id').primaryKey(),
@@ -274,6 +282,15 @@ test.beforeEach(async (t) => {
 			)
 		`,
 	);
+	await ctx.db.execute(
+		sql`
+			create table jsontest (
+				id serial primary key,
+				json json,
+				jsonb jsonb
+			)
+		`
+	)
 });
 
 test.serial('select all fields', async (t) => {
@@ -2307,6 +2324,118 @@ test.serial('set null to jsonb field', async (t) => {
 
 	await db.execute(sql`drop table ${users}`);
 });
+
+test.serial('set json/jsonb fields with objects and retrieve with the ->> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: obj,
+		jsonb: obj
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->>'string'`,
+		jsonNumberField: sql<string>`${jsonTestTable.json}->>'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->>'string'`,
+		jsonbNumberField: sql<string>`${jsonTestTable.jsonb}->>'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: String(testNumber),
+		jsonbStringField: testString,
+		jsonbNumberField: String(testNumber)
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
+
+test.serial('set json/jsonb fields with strings and retrieve with the ->> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: sql`${JSON.stringify(obj)}`,
+		jsonb: sql`${JSON.stringify(obj)}`
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->>'string'`,
+		jsonNumberField: sql<string>`${jsonTestTable.json}->>'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->>'string'`,
+		jsonbNumberField: sql<string>`${jsonTestTable.jsonb}->>'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: String(testNumber),
+		jsonbStringField: testString,
+		jsonbNumberField: String(testNumber)
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
+
+test.serial('set json/jsonb fields with objects and retrieve with the -> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: obj,
+		jsonb: obj
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->'string'`,
+		jsonNumberField: sql<number>`${jsonTestTable.json}->'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->'string'`,
+		jsonbNumberField: sql<number>`${jsonTestTable.jsonb}->'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: testNumber,
+		jsonbStringField: testString,
+		jsonbNumberField: testNumber
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
+
+test.serial('set json/jsonb fields with strings and retrieve with the -> operator', async (t) => {
+	const { db } = t.context;
+
+	const obj = { string: 'test', number: 123 }
+	const { string: testString, number: testNumber } = obj
+
+	await db.insert(jsonTestTable).values({
+		json: sql`${JSON.stringify(obj)}`,
+		jsonb: sql`${JSON.stringify(obj)}`
+	})
+
+	const result = await db.select({
+		jsonStringField: sql<string>`${jsonTestTable.json}->'string'`,
+		jsonNumberField: sql<number>`${jsonTestTable.json}->'number'`,
+		jsonbStringField: sql<string>`${jsonTestTable.jsonb}->'string'`,
+		jsonbNumberField: sql<number>`${jsonTestTable.jsonb}->'number'`
+	}).from(jsonTestTable)
+
+	t.deepEqual(result, [{
+		jsonStringField: testString,
+		jsonNumberField: testNumber,
+		jsonbStringField: testString,
+		jsonbNumberField: testNumber
+	}])
+
+	await db.execute(sql`drop table ${jsonTestTable}`);
+})
 
 test.serial('insert undefined', async (t) => {
 	const { db } = t.context;


### PR DESCRIPTION
This PR adds tests only, related to issue https://github.com/drizzle-team/drizzle-orm/issues/1511. The tests assert whether the `->` and `->>` operators work after inserting `json` or `jsonb` values into Postgres. 

The included tests include a [failing test](https://github.com/avajs/ava/blob/main/docs/01-writing-tests.md#skipping-tests) for the postgres.js integration, it seems it does not properly handle stringified objects as input to JSON/JSONB columns, I have prepared a demo of this behavior here: https://github.com/serdnam/postgres-js-json-behavior.

I tried my hand at solving it, but I do not know the codebase well enough to know how or where to make a change to fix this (or if the change has to be done on drizzle's side at all, it seems there is a related postgres.js issue https://github.com/porsager/postgres/pull/392)

