### PR TITLE
[sqllite] Prevent error if json column is empty

### DIFF
--- a/drizzle-orm/src/sqlite-core/columns/text.ts
+++ b/drizzle-orm/src/sqlite-core/columns/text.ts
@@ -94,7 +94,7 @@ export class SQLiteTextJson<T extends ColumnBaseConfig<'json', 'SQLiteTextJson'>
 	}
 
 	override mapFromDriverValue(value: string): T['data'] {
-		return JSON.parse(value);
+		return value ? JSON.parse(value) : value;
 	}
 
 	override mapToDriverValue(value: T['data']): string {


### PR DESCRIPTION
When reading from an empty text json column in sqlite it throws an error if the column is empty