### PR TITLE
[Pg] Fix all datetime mappings

### DIFF
--- a/drizzle-orm/src/pg-core/columns/timestamp.ts
+++ b/drizzle-orm/src/pg-core/columns/timestamp.ts
@@ -58,12 +58,16 @@ export class PgTimestamp<T extends ColumnBaseConfig<'date', 'PgTimestamp'>> exte
 		return `timestamp${precision}${this.withTimezone ? ' with time zone' : ''}`;
 	}
 
-	override mapFromDriverValue = (value: string): Date => {
-		return new Date(this.withTimezone ? value : value + '+0000');
+	override mapFromDriverValue = (value: string | Date | null): Date | null => {
+		if (value === null) return null;
+		if (typeof value === 'string') {
+			return new Date(Date.parse(this.withTimezone ? value : value + 'Z'));
+		}
+		return value;
 	};
 
 	override mapToDriverValue = (value: Date): string => {
-		return this.withTimezone ? value.toUTCString() : value.toISOString();
+		return value.toISOString();
 	};
 }
 
@@ -121,6 +125,14 @@ export class PgTimestampString<T extends ColumnBaseConfig<'string', 'PgTimestamp
 		const precision = this.precision === undefined ? '' : `(${this.precision})`;
 		return `timestamp${precision}${this.withTimezone ? ' with time zone' : ''}`;
 	}
+
+	override mapFromDriverValue = (value: string | Date | null): string | null => {
+		// eslint-disable-next-line no-instanceof/no-instanceof
+		if (value instanceof Date) {
+			return value.toISOString();
+		}
+		return value;
+	};
 }
 
 export type Precision = 0 | 1 | 2 | 3 | 4 | 5 | 6;

--- a/drizzle-orm/src/postgres-js/driver.ts
+++ b/drizzle-orm/src/postgres-js/driver.ts
@@ -20,6 +20,14 @@ export function drizzle<TSchema extends Record<string, unknown> = Record<string,
 	client: Sql,
 	config: DrizzleConfig<TSchema> = {},
 ): PostgresJsDatabase<TSchema> {
+	const transparentParser = (val: any) => val;
+
+	// Override postgres.js default date parsers
+	client.options.parsers['1184'] = transparentParser;
+	client.options.parsers['1082'] = transparentParser;
+	client.options.parsers['1083'] = transparentParser;
+	client.options.parsers['1114'] = transparentParser;
+
 	const dialect = new PgDialect();
 	let logger;
 	if (config.logger === true) {

--- a/drizzle-typebox/package.json
+++ b/drizzle-typebox/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-valibot/package.json
+++ b/drizzle-valibot/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-zod/package.json
+++ b/drizzle-zod/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test:types": "tsc",
-    "test": "ava tests --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
     "test:rqb": "vitest run --no-threads",
     "test:esm": "node tests/imports.test.mjs && node tests/imports.test.cjs"
   },

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -21,6 +21,7 @@ import {
 	max,
 	min,
 	name,
+	or,
 	placeholder,
 	type SQL,
 	sql,
@@ -2226,11 +2227,16 @@ test.serial('timestamp and date in placeholders', async (t) => {
 		timestamp: date,
 	});
 
-	const prepared = db.select().from(datesTable).where(gte(datesTable.timestamp, sql.placeholder('timestamp'))).prepare(
+	const prepared = db.select().from(datesTable).where(
+		or(lt(datesTable.timestamp, sql.placeholder('timestamp')), gt(datesTable.timestamp, sql.placeholder('timestamp2'))),
+	).prepare(
 		'prepared',
 	);
 
-	const result = await prepared.execute({ timestamp: new Date() });
+	const result = await prepared.execute({
+		timestamp: new Date(date.valueOf() - 200),
+		timestamp2: new Date(date.valueOf() + 200),
+	});
 
 	t.deepEqual(result, [
 		{

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -1,10 +1,17 @@
+import 'dotenv/config';
 import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['tests/relational/**/*.test.ts', 'tests/libsql-batch.test.ts', 'tests/d1-batch.test.ts', 'tests/replicas/**/*', 'tests/imports/**/*'],
+		include: [
+			'tests/relational/**/*.test.ts',
+			'tests/libsql-batch.test.ts',
+			'tests/d1-batch.test.ts',
+			'tests/replicas/**/*',
+			'tests/imports/**/*',
+		],
 		exclude: [
 			...(process.env.SKIP_PLANETSCALE_TESTS ? ['tests/relational/mysql.planetscale.test.ts'] : []),
 			'tests/relational/vercel.test.ts',


### PR DESCRIPTION
This PR will close #806, close #971, close #1113, close #1176, close #1185, close #1407 and close #1587.
Most are the same. The problem is pastgres.js, it didn't have a clear way of replace the default parsing into a `Date` object after the client have been instantiates.
I spent some time researching and found a solution.
Although it looks like postgres.js is still trimming the microsecond precision, even after bypassing the parsing.

I'll look into it further and possibly submit a new PR.

Added tests on all/most drivers that use postgres.