### PR TITLE
Fix: placeholder on insert update

### DIFF
--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -1,4 +1,5 @@
 import { entityKind, is } from '~/entity.ts';
+import type { SelectedFields } from '~/operations.ts';
 import { Relation } from '~/relations.ts';
 import { Subquery, SubqueryConfig } from '~/subquery.ts';
 import { tracer } from '~/tracing.ts';
@@ -6,7 +7,6 @@ import { ViewBaseConfig } from '~/view-common.ts';
 import type { AnyColumn } from '../column.ts';
 import { Column } from '../column.ts';
 import { Table } from '../table.ts';
-import type { SelectedFields } from '~/operations.ts';
 
 /**
  * This class is used to indicate a primitive param value that is used in `sql` tag.
@@ -199,7 +199,11 @@ export class SQL<T = unknown> implements SQLWrapper {
 			}
 
 			if (is(chunk, Param)) {
-				const mappedValue = (chunk.value === null) ? null : chunk.encoder.mapToDriverValue(chunk.value);
+				const mappedValue = (chunk.value === null)
+					? null
+					: is(chunk.value, Placeholder)
+					? chunk.value
+					: chunk.encoder.mapToDriverValue(chunk.value);
 
 				if (is(mappedValue, SQL)) {
 					return this.buildQueryFromSourceParams([mappedValue], config);

--- a/drizzle-typebox/package.json
+++ b/drizzle-typebox/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-valibot/package.json
+++ b/drizzle-valibot/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-zod/package.json
+++ b/drizzle-zod/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test:types": "tsc",
-    "test": "ava tests --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
     "test:rqb": "vitest run --no-threads",
     "test:esm": "node tests/imports.test.mjs && node tests/imports.test.cjs"
   },

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -1,10 +1,17 @@
+import 'dotenv/config';
 import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['tests/relational/**/*.test.ts', 'tests/libsql-batch.test.ts', 'tests/d1-batch.test.ts', 'tests/replicas/**/*', 'tests/imports/**/*'],
+		include: [
+			'tests/relational/**/*.test.ts',
+			'tests/libsql-batch.test.ts',
+			'tests/d1-batch.test.ts',
+			'tests/replicas/**/*',
+			'tests/imports/**/*',
+		],
 		exclude: [
 			...(process.env.SKIP_PLANETSCALE_TESTS ? ['tests/relational/mysql.planetscale.test.ts'] : []),
 			'tests/relational/vercel.test.ts',


### PR DESCRIPTION
fix #1113

- Handled the case when a placeholder on an insert is processed as Param. The sql parser attempts to run `mapToDriverValue` on a string and fails.
- Added tests
- Purposefully avoided add tests to postgres.js until [this PR](https://github.com/drizzle-team/drizzle-orm/pull/1659) with fixes for the Date handling is merged.