### PR TITLE
Feat: allow empty arrays to passed to `inArray` and `notInArray`

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -289,7 +289,7 @@ export function inArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			throw new Error('inArray requires at least one value');
+			return sql`false`;
 		}
 		return sql`${column} in ${values.map((v) => bindIfParam(v, column))}`;
 	}
@@ -335,7 +335,7 @@ export function notInArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			throw new Error('notInArray requires at least one value');
+			return sql`true`;
 		}
 		return sql`${column} not in ${values.map((v) => bindIfParam(v, column))}`;
 	}

--- a/integration-tests/tests/libsql.test.ts
+++ b/integration-tests/tests/libsql.test.ts
@@ -20,6 +20,7 @@ import {
 	min,
 	Name,
 	name,
+	notInArray,
 	placeholder,
 	sql,
 	sum,
@@ -954,6 +955,28 @@ test.serial('select with group by complex query', async (t) => {
 		.all();
 
 	t.deepEqual(result, [{ name: 'Jane' }]);
+});
+
+test.serial('select with empty array in inArray', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.where(inArray(usersTable.id, []));
+
+	t.deepEqual(result, []);
+});
+
+test.serial('select with empty array in notInArray', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.where(notInArray(usersTable.id, []));
+
+	t.deepEqual(result, [{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
 });
 
 test.serial('build query', async (t) => {

--- a/integration-tests/tests/mysql.test.ts
+++ b/integration-tests/tests/mysql.test.ts
@@ -20,6 +20,7 @@ import {
 	max,
 	min,
 	Name,
+	notInArray,
 	placeholder,
 	sql,
 	sum,
@@ -756,6 +757,28 @@ test.serial('select with group by as column + sql', async (t) => {
 
 	const result = await db.select({ name: usersTable.name }).from(usersTable)
 		.groupBy(usersTable.id, sql`${usersTable.name}`);
+
+	t.deepEqual(result, [{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+});
+
+test.serial('select with empty array in inArray', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.where(inArray(usersTable.id, []));
+
+	t.deepEqual(result, []);
+});
+
+test.serial('select with empty array in notInArray', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.where(notInArray(usersTable.id, []));
 
 	t.deepEqual(result, [{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
 });

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -22,6 +22,7 @@ import {
 	max,
 	min,
 	name,
+	notInArray,
 	placeholder,
 	type SQL,
 	sql,
@@ -1726,6 +1727,28 @@ test.serial('array types', async (t) => {
 	const res = await db.select().from(salEmp);
 
 	t.deepEqual(res, values);
+});
+
+test.serial('select with empty array in inArray', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.where(inArray(usersTable.id, []));
+
+	t.deepEqual(result, []);
+});
+
+test.serial('select with empty array in notInArray', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.where(notInArray(usersTable.id, []));
+
+	t.deepEqual(result, [{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
 });
 
 test.serial('select for ...', (t) => {

--- a/integration-tests/tests/postgres.js.test.ts
+++ b/integration-tests/tests/postgres.js.test.ts
@@ -17,6 +17,7 @@ import {
 	lt,
 	Name,
 	name,
+	notInArray,
 	placeholder,
 	type SQL,
 	sql,
@@ -1316,6 +1317,28 @@ test.serial('select count w/ custom mapper', async (t) => {
 	const res = await db.select({ count: count(sql`*`) }).from(usersTable);
 
 	t.deepEqual(res, [{ count: 2 }]);
+});
+
+test.serial('select with empty array in inArray', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.where(inArray(usersTable.id, []));
+
+	t.deepEqual(result, []);
+});
+
+test.serial('select with empty array in notInArray', async (t) => {
+	const { db } = t.context;
+
+	await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+
+	const result = await db.select({ name: usersTable.name }).from(usersTable)
+		.where(notInArray(usersTable.id, []));
+
+	t.deepEqual(result, [{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
 });
 
 test.serial('select for ...', (t) => {


### PR DESCRIPTION
close #1295 

- When passed an empty array inArray now returns false and notInArray now return true instead of throwing.
- Added tests to all dialects.

Please see [this comment](https://github.com/drizzle-team/drizzle-orm/issues/1295#issuecomment-1858204805) for a compelling argument for this change.