### PR TITLE
Fix: allow enums (and any other column) to accept placeholders on update

### DIFF
--- a/drizzle-orm/src/mysql-core/query-builders/update.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/update.ts
@@ -12,7 +12,7 @@ import type {
 } from '~/mysql-core/session.ts';
 import type { MySqlTable } from '~/mysql-core/table.ts';
 import { QueryPromise } from '~/query-promise.ts';
-import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
+import type { Placeholder, Query, SQL, SQLWrapper } from '~/sql/sql.ts';
 import { mapUpdateSet, type UpdateSet } from '~/utils.ts';
 import type { SelectedFieldsOrdered } from './select.types.ts';
 
@@ -27,7 +27,8 @@ export type MySqlUpdateSetSource<TTable extends MySqlTable> =
 	& {
 		[Key in keyof TTable['_']['columns']]?:
 			| GetColumnData<TTable['_']['columns'][Key], 'query'>
-			| SQL;
+			| SQL
+			| Placeholder;
 	}
 	& {};
 
@@ -133,16 +134,16 @@ export class MySqlUpdateBase<
 
 	/**
 	 * Adds a 'where' clause to the query.
-	 * 
+	 *
 	 * Calling this method will update only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update}
-	 * 
+	 *
 	 * @param where the 'where' clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be updated.
-	 * 
+	 *
 	 * ```ts
 	 * // Update all cars with green color
 	 * db.update(cars).set({ color: 'red' })
@@ -151,14 +152,14 @@ export class MySqlUpdateBase<
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Update all BMW cars with a green color
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Update all cars with the green or blue color
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));

--- a/drizzle-orm/src/pg-core/query-builders/update.ts
+++ b/drizzle-orm/src/pg-core/query-builders/update.ts
@@ -11,11 +11,11 @@ import type {
 import type { PgTable } from '~/pg-core/table.ts';
 import type { SelectResultFields } from '~/query-builders/select.types.ts';
 import { QueryPromise } from '~/query-promise.ts';
-import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
+import type { Placeholder, Query, SQL, SQLWrapper } from '~/sql/sql.ts';
 import { Table } from '~/table.ts';
 import { mapUpdateSet, orderSelectedFields, type UpdateSet } from '~/utils.ts';
-import type { SelectedFields, SelectedFieldsOrdered } from './select.types.ts';
 import type { PgColumn } from '../columns/common.ts';
+import type { SelectedFields, SelectedFieldsOrdered } from './select.types.ts';
 
 export interface PgUpdateConfig {
 	where?: SQL | undefined;
@@ -28,7 +28,8 @@ export type PgUpdateSetSource<TTable extends PgTable> =
 	& {
 		[Key in keyof TTable['_']['columns']]?:
 			| GetColumnData<TTable['_']['columns'][Key]>
-			| SQL;
+			| SQL
+			| Placeholder;
 	}
 	& {};
 
@@ -162,16 +163,16 @@ export class PgUpdateBase<
 
 	/**
 	 * Adds a 'where' clause to the query.
-	 * 
+	 *
 	 * Calling this method will update only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update}
-	 * 
+	 *
 	 * @param where the 'where' clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be updated.
-	 * 
+	 *
 	 * ```ts
 	 * // Update all cars with green color
 	 * await db.update(cars).set({ color: 'red' })
@@ -180,14 +181,14 @@ export class PgUpdateBase<
 	 * await db.update(cars).set({ color: 'red' })
 	 *   .where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Update all BMW cars with a green color
 	 * await db.update(cars).set({ color: 'red' })
 	 *   .where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Update all cars with the green or blue color
 	 * await db.update(cars).set({ color: 'red' })
 	 *   .where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
@@ -200,11 +201,11 @@ export class PgUpdateBase<
 
 	/**
 	 * Adds a `returning` clause to the query.
-	 * 
+	 *
 	 * Calling this method will return the specified fields of the updated rows. If no fields are specified, all fields will be returned.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update#update-with-returning}
-	 * 
+	 *
 	 * @example
 	 * ```ts
 	 * // Update all cars with the green color and return all fields
@@ -212,7 +213,7 @@ export class PgUpdateBase<
 	 *   .set({ color: 'red' })
 	 *   .where(eq(cars.color, 'green'))
 	 *   .returning();
-	 * 
+	 *
 	 * // Update all cars with the green color and return only their id and brand fields
 	 * const updatedCarsIdsAndBrands: { id: number, brand: string }[] = await db.update(cars)
 	 *   .set({ color: 'red' })

--- a/drizzle-orm/src/sqlite-core/query-builders/update.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/update.ts
@@ -3,13 +3,13 @@ import { entityKind } from '~/entity.ts';
 import type { SelectResultFields } from '~/query-builders/select.types.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
-import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
+import type { Placeholder, Query, SQL, SQLWrapper } from '~/sql/sql.ts';
 import type { SQLiteDialect } from '~/sqlite-core/dialect.ts';
 import type { SQLitePreparedQuery, SQLiteSession } from '~/sqlite-core/session.ts';
 import { SQLiteTable } from '~/sqlite-core/table.ts';
 import { type DrizzleTypeError, mapUpdateSet, orderSelectedFields, type UpdateSet } from '~/utils.ts';
-import type { SelectedFields, SelectedFieldsOrdered } from './select.types.ts';
 import type { SQLiteColumn } from '../columns/common.ts';
+import type { SelectedFields, SelectedFieldsOrdered } from './select.types.ts';
 
 export interface SQLiteUpdateConfig {
 	where?: SQL | undefined;
@@ -22,7 +22,8 @@ export type SQLiteUpdateSetSource<TTable extends SQLiteTable> =
 	& {
 		[Key in keyof TTable['_']['columns']]?:
 			| GetColumnData<TTable['_']['columns'][Key], 'query'>
-			| SQL;
+			| SQL
+			| Placeholder;
 	}
 	& {};
 
@@ -177,16 +178,16 @@ export class SQLiteUpdateBase<
 
 	/**
 	 * Adds a 'where' clause to the query.
-	 * 
+	 *
 	 * Calling this method will update only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update}
-	 * 
+	 *
 	 * @param where the 'where' clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be updated.
-	 * 
+	 *
 	 * ```ts
 	 * // Update all cars with green color
 	 * db.update(cars).set({ color: 'red' })
@@ -195,14 +196,14 @@ export class SQLiteUpdateBase<
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Update all BMW cars with a green color
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Update all cars with the green or blue color
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
@@ -215,11 +216,11 @@ export class SQLiteUpdateBase<
 
 	/**
 	 * Adds a `returning` clause to the query.
-	 * 
+	 *
 	 * Calling this method will return the specified fields of the updated rows. If no fields are specified, all fields will be returned.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update#update-with-returning}
-	 * 
+	 *
 	 * @example
 	 * ```ts
 	 * // Update all cars with the green color and return all fields
@@ -227,7 +228,7 @@ export class SQLiteUpdateBase<
 	 *   .set({ color: 'red' })
 	 *   .where(eq(cars.color, 'green'))
 	 *   .returning();
-	 * 
+	 *
 	 * // Update all cars with the green color and return only their id and brand fields
 	 * const updatedCarsIdsAndBrands: { id: number, brand: string }[] = await db.update(cars)
 	 *   .set({ color: 'red' })

--- a/drizzle-typebox/package.json
+++ b/drizzle-typebox/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-valibot/package.json
+++ b/drizzle-valibot/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-zod/package.json
+++ b/drizzle-zod/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test:types": "tsc",
-    "test": "ava tests --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
     "test:rqb": "vitest run --no-threads",
     "test:esm": "node tests/imports.test.mjs && node tests/imports.test.cjs"
   },

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -9,25 +9,25 @@ import {
 	arrayContains,
 	arrayOverlaps,
 	asc,
+	avg,
+	avgDistinct,
+	count,
+	countDistinct,
 	eq,
 	gt,
 	gte,
 	inArray,
 	lt,
+	max,
+	min,
 	name,
 	placeholder,
 	type SQL,
 	sql,
 	type SQLWrapper,
-	TransactionRollbackError,
-	count,
-	countDistinct,
-	avg,
-	avgDistinct,
 	sum,
 	sumDistinct,
-	max,
-	min,
+	TransactionRollbackError,
 } from 'drizzle-orm';
 import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
@@ -50,6 +50,7 @@ import {
 	macaddr,
 	macaddr8,
 	type PgColumn,
+	pgEnum,
 	pgMaterializedView,
 	pgTable,
 	pgTableCreator,
@@ -64,7 +65,6 @@ import {
 	uniqueKeyName,
 	uuid as pgUuid,
 	varchar,
-	pgEnum,
 } from 'drizzle-orm/pg-core';
 import getPort from 'get-port';
 import pg from 'pg';
@@ -149,7 +149,7 @@ const aggregateTable = pgTable('aggregate_table', {
 	a: integer('a'),
 	b: integer('b'),
 	c: integer('c'),
-	nullOnly: integer('null_only')
+	nullOnly: integer('null_only'),
 });
 
 interface Context {
@@ -523,7 +523,7 @@ test.serial('select distinct', async (t) => {
 	const usersDistinctTable = pgTable('users_distinct', {
 		id: integer('id').notNull(),
 		name: text('name').notNull(),
-		age: integer('age').notNull()
+		age: integer('age').notNull(),
 	});
 
 	await db.execute(sql`drop table if exists ${usersDistinctTable}`);
@@ -534,7 +534,7 @@ test.serial('select distinct', async (t) => {
 		{ id: 1, name: 'John', age: 24 },
 		{ id: 2, name: 'John', age: 25 },
 		{ id: 1, name: 'Jane', age: 24 },
-		{ id: 1, name: 'Jane', age: 26 }
+		{ id: 1, name: 'Jane', age: 26 },
 	]);
 	const users1 = await db.selectDistinct().from(usersDistinctTable).orderBy(
 		usersDistinctTable.id,
@@ -547,8 +547,8 @@ test.serial('select distinct', async (t) => {
 		usersDistinctTable,
 	).orderBy(usersDistinctTable.name);
 	const users4 = await db.selectDistinctOn([usersDistinctTable.id, usersDistinctTable.age]).from(
-		usersDistinctTable
-	).orderBy(usersDistinctTable.id, usersDistinctTable.age)
+		usersDistinctTable,
+	).orderBy(usersDistinctTable.id, usersDistinctTable.age);
 
 	await db.execute(sql`drop table ${usersDistinctTable}`);
 
@@ -556,7 +556,7 @@ test.serial('select distinct', async (t) => {
 		{ id: 1, name: 'Jane', age: 24 },
 		{ id: 1, name: 'Jane', age: 26 },
 		{ id: 1, name: 'John', age: 24 },
-		{ id: 2, name: 'John', age: 25 }
+		{ id: 2, name: 'John', age: 25 },
 	]);
 
 	t.deepEqual(users2.length, 2);
@@ -570,7 +570,7 @@ test.serial('select distinct', async (t) => {
 	t.deepEqual(users4, [
 		{ id: 1, name: 'John', age: 24 },
 		{ id: 1, name: 'Jane', age: 26 },
-		{ id: 2, name: 'John', age: 25 }
+		{ id: 2, name: 'John', age: 25 },
 	]);
 });
 
@@ -1116,6 +1116,44 @@ test.serial('prepared statement with placeholder in .offset', async (t) => {
 	const result = await stmt.execute({ offset: 1 });
 
 	t.deepEqual(result, [{ id: 2, name: 'John1' }]);
+});
+
+test.serial('prepared statement in update', async (t) => {
+	const { db } = t.context;
+
+	const enumValues = ['a', 'b', 'c'] as const;
+
+	const anEnum = pgEnum('an_enum', enumValues);
+
+	const testTable = pgTable('prepared_test_table', {
+		id: serial('id').primaryKey(),
+		name: text('name').notNull(),
+		anEnum: anEnum('enum_column').notNull().default('a'),
+	});
+
+	await db.execute(sql`create type ${sql.identifier(anEnum.enumName)} as enum ('a', 'b', 'c')`);
+
+	await db.execute(sql`
+		create table ${testTable} (
+			id serial primary key,
+			name text not null,
+			enum_column ${sql.identifier(anEnum.enumName)} not null default 'a'
+		)
+	`);
+
+	await db.insert(testTable).values({ name: 'John', anEnum: 'c' });
+
+	const preparedUpdate = db.update(testTable).set({ anEnum: sql.placeholder('anEnum') }).where(eq(testTable.id, 1))
+		.prepare('preparedUpdate');
+
+	await preparedUpdate.execute({ anEnum: 'b' });
+
+	const result = await db.select().from(testTable);
+
+	t.deepEqual(result, [{ id: 1, name: 'John', anEnum: 'b' }]);
+
+	db.execute(sql`drop table ${testTable}`);
+	await db.execute(sql`drop type ${sql.identifier(anEnum.enumName)}`);
 });
 
 // TODO change tests to new structure

--- a/integration-tests/tests/postgres.js.test.ts
+++ b/integration-tests/tests/postgres.js.test.ts
@@ -757,6 +757,44 @@ test.serial('prepared statement with placeholder in .where', async (t) => {
 	t.deepEqual(result, [{ id: 1, name: 'John' }]);
 });
 
+test.serial('prepared statement in update', async (t) => {
+	const { db } = t.context;
+
+	const enumValues = ['a', 'b', 'c'] as const;
+
+	const anEnum = pgEnum('an_enum', enumValues);
+
+	const testTable = pgTable('prepared_test_table', {
+		id: serial('id').primaryKey(),
+		name: text('name').notNull(),
+		anEnum: anEnum('enum_column').notNull().default('a'),
+	});
+
+	await db.execute(sql`create type ${sql.identifier(anEnum.enumName)} as enum ('a', 'b', 'c')`);
+
+	await db.execute(sql`
+		create table ${testTable} (
+			id serial primary key,
+			name text not null,
+			enum_column ${sql.identifier(anEnum.enumName)} not null default 'a'
+		)
+	`);
+
+	await db.insert(testTable).values({ name: 'John', anEnum: 'c' });
+
+	const preparedUpdate = db.update(testTable).set({ anEnum: sql.placeholder('anEnum') }).where(eq(testTable.id, 1))
+		.prepare('preparedUpdate');
+
+	await preparedUpdate.execute({ anEnum: 'b' });
+
+	const result = await db.select().from(testTable);
+
+	t.deepEqual(result, [{ id: 1, name: 'John', anEnum: 'b' }]);
+
+	db.execute(sql`drop table ${testTable}`);
+	await db.execute(sql`drop type ${sql.identifier(anEnum.enumName)}`);
+});
+
 // TODO change tests to new structure
 test.serial('migrator', async (t) => {
 	const { db } = t.context;

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -1,10 +1,17 @@
+import 'dotenv/config';
 import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['tests/relational/**/*.test.ts', 'tests/libsql-batch.test.ts', 'tests/d1-batch.test.ts', 'tests/replicas/**/*', 'tests/imports/**/*'],
+		include: [
+			'tests/relational/**/*.test.ts',
+			'tests/libsql-batch.test.ts',
+			'tests/d1-batch.test.ts',
+			'tests/replicas/**/*',
+			'tests/imports/**/*',
+		],
 		exclude: [
 			...(process.env.SKIP_PLANETSCALE_TESTS ? ['tests/relational/mysql.planetscale.test.ts'] : []),
 			'tests/relational/vercel.test.ts',


### PR DESCRIPTION
close #1608 

 - [All] Added placeholder to the accepted types of the values of the update
 - [All] Added tests

Please note that this is only a type change, nothing is done on runtime to prevent the user from inserting values different than the intended type until #519 if implemented.