### PR TITLE
Feat: infer type helpers for relations

### DIFF
--- a/drizzle-orm/src/mysql-core/db.ts
+++ b/drizzle-orm/src/mysql-core/db.ts
@@ -51,7 +51,7 @@ export class MySqlDatabase<
 		: {
 			[K in keyof TSchema]: RelationalQueryBuilder<TPreparedQueryHKT, TSchema, TSchema[K]> & {
 				$inferFindManyArgs: Simplify<DBQueryConfig<'many', true, TSchema, TSchema[K]>>;
-				$InferFindFirstArgs: Simplify<Omit<DBQueryConfig<'many', true, TSchema, TSchema[K]>, 'limit'>>;
+				$inferFindFirstArgs: Simplify<Omit<DBQueryConfig<'many', true, TSchema, TSchema[K]>, 'limit'>>;
 			};
 		};
 

--- a/drizzle-orm/src/mysql-core/db.ts
+++ b/drizzle-orm/src/mysql-core/db.ts
@@ -1,11 +1,16 @@
 import type { ResultSetHeader } from 'mysql2/promise';
 import { entityKind } from '~/entity.ts';
 import type { TypedQueryBuilder } from '~/query-builders/query-builder.ts';
-import type { ExtractTablesWithRelations, RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
+import type {
+	DBQueryConfig,
+	ExtractTablesWithRelations,
+	RelationalSchemaConfig,
+	TablesRelationalConfig,
+} from '~/relations.ts';
 import { SelectionProxyHandler } from '~/selection-proxy.ts';
 import type { ColumnsSelection, SQLWrapper } from '~/sql/sql.ts';
 import { WithSubquery } from '~/subquery.ts';
-import type { DrizzleTypeError } from '~/utils.ts';
+import type { DrizzleTypeError, Simplify } from '~/utils.ts';
 import type { MySqlDialect } from './dialect.ts';
 import {
 	MySqlDeleteBase,
@@ -44,7 +49,10 @@ export class MySqlDatabase<
 	query: TFullSchema extends Record<string, never>
 		? DrizzleTypeError<'Seems like the schema generic is missing - did you forget to add it to your DB type?'>
 		: {
-			[K in keyof TSchema]: RelationalQueryBuilder<TPreparedQueryHKT, TSchema, TSchema[K]>;
+			[K in keyof TSchema]: RelationalQueryBuilder<TPreparedQueryHKT, TSchema, TSchema[K]> & {
+				$inferFindManyArgs: Simplify<DBQueryConfig<'many', true, TSchema, TSchema[K]>>;
+				$InferFindFirstArgs: Simplify<Omit<DBQueryConfig<'many', true, TSchema, TSchema[K]>, 'limit'>>;
+			};
 		};
 
 	constructor(
@@ -71,40 +79,40 @@ export class MySqlDatabase<
 						dialect,
 						session,
 						this.mode,
-					);
+					) as any;
 			}
 		}
 	}
 
 	/**
 	 * Creates a subquery that defines a temporary named result set as a CTE.
-	 * 
+	 *
 	 * It is useful for breaking down complex queries into simpler parts and for reusing the result set in subsequent parts of the query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#with-clause}
-	 * 
+	 *
 	 * @param alias The alias for the subquery.
-	 * 
+	 *
 	 * Failure to provide an alias will result in a DrizzleTypeError, preventing the subquery from being referenced in other queries.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Create a subquery with alias 'sq' and use it in the select query
 	 * const sq = db.$with('sq').as(db.select().from(users).where(eq(users.id, 42)));
-	 * 
+	 *
 	 * const result = await db.with(sq).select().from(sq);
 	 * ```
-	 * 
+	 *
 	 * To select arbitrary SQL values as fields in a CTE and reference them in other CTEs or in the main query, you need to add aliases to them:
-	 * 
+	 *
 	 * ```ts
 	 * // Select an arbitrary SQL value as a field in a CTE and reference it in the main query
 	 * const sq = db.$with('sq').as(db.select({
 	 *   name: sql<string>`upper(${users.name})`.as('name'),
 	 * })
 	 * .from(users));
-	 * 
+	 *
 	 * const result = await db.with(sq).select({ name: sq.name }).from(sq);
 	 * ```
 	 */
@@ -127,19 +135,19 @@ export class MySqlDatabase<
 
 	/**
 	 * Incorporates a previously defined CTE (using `$with`) into the main query.
-	 * 
+	 *
 	 * This method allows the main query to reference a temporary named result set.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#with-clause}
-	 * 
+	 *
 	 * @param queries The CTEs to incorporate into the main query.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Define a subquery 'sq' as a CTE using $with
 	 * const sq = db.$with('sq').as(db.select().from(users).where(eq(users.id, 42)));
-	 * 
+	 *
 	 * // Incorporate the CTE 'sq' into the main query and select from it
 	 * const result = await db.with(sq).select().from(sq);
 	 * ```
@@ -181,31 +189,31 @@ export class MySqlDatabase<
 
 	/**
 	 * Creates a select query.
-	 * 
+	 *
 	 * Calling this method with no arguments will select all columns from the table. Pass a selection object to specify the columns you want to select.
-	 * 
+	 *
 	 * Use `.from()` method to specify which table to select from.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select}
-	 * 
+	 *
 	 * @param fields The selection object.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all columns and all rows from the 'cars' table
 	 * const allCars: Car[] = await db.select().from(cars);
-	 * 
+	 *
 	 * // Select specific columns and all rows from the 'cars' table
-	 * const carsIdsAndBrands: { id: number; brand: string }[] = await db.select({ 
-	 *   id: cars.id, 
-	 *   brand: cars.brand 
+	 * const carsIdsAndBrands: { id: number; brand: string }[] = await db.select({
+	 *   id: cars.id,
+	 *   brand: cars.brand
 	 * })
 	 *   .from(cars);
 	 * ```
-	 * 
+	 *
 	 * Like in SQL, you can use arbitrary expressions as selection fields, not just table columns:
-	 * 
+	 *
 	 * ```ts
 	 * // Select specific columns along with expression and all rows from the 'cars' table
 	 * const carsIdsAndLowerNames: { id: number; lowerBrand: string }[] = await db.select({
@@ -223,22 +231,22 @@ export class MySqlDatabase<
 
 	/**
 	 * Adds `distinct` expression to the select query.
-	 * 
+	 *
 	 * Calling this method will return only unique values. When multiple columns are selected, it returns rows with unique combinations of values in these columns.
-	 * 
+	 *
 	 * Use `.from()` method to specify which table to select from.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#distinct}
-	 * 
+	 *
 	 * @param fields The selection object.
-	 * 
+	 *
 	 * @example
 	 * ```ts
 	 * // Select all unique rows from the 'cars' table
 	 * await db.selectDistinct()
 	 *   .from(cars)
 	 *   .orderBy(cars.id, cars.brand, cars.color);
-	 * 
+	 *
 	 * // Select all unique brands from the 'cars' table
 	 * await db.selectDistinct({ brand: cars.brand })
 	 *   .from(cars)
@@ -260,21 +268,21 @@ export class MySqlDatabase<
 
 	/**
 	 * Creates an update query.
-	 * 
+	 *
 	 * Calling this method without `.where()` clause will update all rows in a table. The `.where()` clause specifies which rows should be updated.
-	 * 
+	 *
 	 * Use `.set()` method to specify which values to update.
-	 * 
-	 * See docs: {@link https://orm.drizzle.team/docs/update} 
-	 * 
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/update}
+	 *
 	 * @param table The table to update.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Update all rows in the 'cars' table
 	 * await db.update(cars).set({ color: 'red' });
-	 * 
+	 *
 	 * // Update rows with filters and conditions
 	 * await db.update(cars).set({ color: 'red' }).where(eq(cars.brand, 'BMW'));
 	 * ```
@@ -285,19 +293,19 @@ export class MySqlDatabase<
 
 	/**
 	 * Creates an insert query.
-	 * 
+	 *
 	 * Calling this method will create new rows in a table. Use `.values()` method to specify which values to insert.
-	 * 
-	 * See docs: {@link https://orm.drizzle.team/docs/insert} 
-	 * 
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/insert}
+	 *
 	 * @param table The table to insert into.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Insert one row
 	 * await db.insert(cars).values({ brand: 'BMW' });
-	 * 
+	 *
 	 * // Insert multiple rows
 	 * await db.insert(cars).values([{ brand: 'BMW' }, { brand: 'Porsche' }]);
 	 * ```
@@ -308,19 +316,19 @@ export class MySqlDatabase<
 
 	/**
 	 * Creates a delete query.
-	 * 
-	 * Calling this method without `.where()` clause will delete all rows in a table. The `.where()` clause specifies which rows should be deleted. 
-	 * 
+	 *
+	 * Calling this method without `.where()` clause will delete all rows in a table. The `.where()` clause specifies which rows should be deleted.
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/delete}
-	 *  
+	 *
 	 * @param table The table to delete from.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Delete all rows in the 'cars' table
 	 * await db.delete(cars);
-	 * 
+	 *
 	 * // Delete rows with filters and conditions
 	 * await db.delete(cars).where(eq(cars.color, 'green'));
 	 * ```

--- a/drizzle-orm/src/mysql-core/query-builders/query.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/query.ts
@@ -32,6 +32,9 @@ export class RelationalQueryBuilder<
 		private mode: Mode,
 	) {}
 
+	declare $inferFindManyArgs: DBQueryConfig<'many', true, TSchema, TFields>;
+	declare $inferFindFirstArgs: Omit<DBQueryConfig<'many', true, TSchema, TFields>, 'limit'>;
+
 	findMany<TConfig extends DBQueryConfig<'many', true, TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', true, TSchema, TFields>>,
 	): MySqlRelationalQuery<TPreparedQueryHKT, BuildQueryResult<TSchema, TFields, TConfig>[]> {

--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -50,7 +50,7 @@ export class PgDatabase<
 		: {
 			[K in keyof TSchema]: RelationalQueryBuilder<TSchema, TSchema[K]> & {
 				$inferFindManyArgs: Simplify<DBQueryConfig<'many', true, TSchema, TSchema[K]>>;
-				$InferFindFirstArgs: Simplify<Omit<DBQueryConfig<'many', true, TSchema, TSchema[K]>, 'limit'>>;
+				$inferFindFirstArgs: Simplify<Omit<DBQueryConfig<'many', true, TSchema, TSchema[K]>, 'limit'>>;
 			};
 		};
 

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -24,6 +24,7 @@ import {
 	type TableRelationalConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
+import { and, eq, View } from '~/sql/index.ts';
 import {
 	type DriverValueEncoder,
 	type Name,
@@ -39,14 +40,13 @@ import { getTableName, Table } from '~/table.ts';
 import { orderSelectedFields, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type { PgSession } from './session.ts';
-import type { PgMaterializedView } from './view.ts';
-import { View, and, eq } from '~/sql/index.ts';
 import { PgViewBase } from './view-base.ts';
+import type { PgMaterializedView } from './view.ts';
 
 export class PgDialect {
 	static readonly [entityKind]: string = 'PgDialect';
 
-	async migrate(migrations: MigrationMeta[], session: PgSession): Promise<void> {
+	async migrate(migrations: MigrationMeta[], session: PgSession<any, any, any>): Promise<void> {
 		const migrationTableCreate = sql`
 			CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
 				id SERIAL PRIMARY KEY,

--- a/drizzle-orm/src/pg-core/query-builders/query.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query.ts
@@ -1,12 +1,12 @@
 import { entityKind } from '~/entity.ts';
 import { QueryPromise } from '~/query-promise.ts';
-import {
-	type BuildQueryResult,
-	type BuildRelationalQueryResult,
-	type DBQueryConfig,
-	mapRelationalRow,
-	type TableRelationalConfig,
-	type TablesRelationalConfig,
+import { mapRelationalRow } from '~/relations.ts';
+import type {
+	BuildQueryResult,
+	BuildRelationalQueryResult,
+	DBQueryConfig,
+	TableRelationalConfig,
+	TablesRelationalConfig,
 } from '~/relations.ts';
 import type { Query, QueryWithTypings, SQL } from '~/sql/sql.ts';
 import { tracer } from '~/tracing.ts';

--- a/drizzle-orm/src/pg-core/query-builders/query.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query.ts
@@ -28,6 +28,9 @@ export class RelationalQueryBuilder<TSchema extends TablesRelationalConfig, TFie
 		private session: PgSession,
 	) {}
 
+	declare $inferFindManyArgs: DBQueryConfig<'many', true, TSchema, TFields>;
+	declare $inferFindFirstArgs: Omit<DBQueryConfig<'many', true, TSchema, TFields>, 'limit'>;
+
 	findMany<TConfig extends DBQueryConfig<'many', true, TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', true, TSchema, TFields>>,
 	): PgRelationalQuery<BuildQueryResult<TSchema, TFields, TConfig>[]> {

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -716,3 +716,39 @@ export function mapRelationalRow(
 
 	return result;
 }
+
+export type InferRelationalResult<
+	TFullSchema extends Record<string, unknown>,
+	TTable extends keyof TSchema,
+	TConfig extends Simplify<DBQueryConfig<'many', true, TSchema, TFields>>,
+	TMode extends 'many' | 'first' = 'many',
+	TSchema extends TablesRelationalConfig = ExtractTablesWithRelations<TFullSchema>,
+	TFields extends TableRelationalConfig = TSchema[TTable],
+> = TMode extends 'many' ? BuildQueryResult<TSchema, TFields, TConfig>[]
+	: BuildQueryResult<TSchema, TFields, TConfig> | undefined;
+
+export type InferManyRelationalResult<
+	TFullSchema extends Record<string, unknown>,
+	TTable extends keyof ExtractTablesWithRelations<TFullSchema>,
+	TConfig extends Simplify<
+		DBQueryConfig<
+			'many',
+			true,
+			ExtractTablesWithRelations<TFullSchema>,
+			ExtractTablesWithRelations<TFullSchema>[TTable]
+		>
+	> = {},
+> = InferRelationalResult<TFullSchema, TTable, TConfig>;
+
+export type InferFirstRelationalResult<
+	TFullSchema extends Record<string, unknown>,
+	TTable extends keyof ExtractTablesWithRelations<TFullSchema>,
+	TConfig extends Simplify<
+		DBQueryConfig<
+			'many',
+			true,
+			ExtractTablesWithRelations<TFullSchema>,
+			ExtractTablesWithRelations<TFullSchema>[TTable]
+		>
+	> = {},
+> = InferRelationalResult<TFullSchema, TTable, TConfig, 'first'>;

--- a/drizzle-orm/src/sqlite-core/db.ts
+++ b/drizzle-orm/src/sqlite-core/db.ts
@@ -49,7 +49,7 @@ export class BaseSQLiteDatabase<
 		: {
 			[K in keyof TSchema]: RelationalQueryBuilder<TResultKind, TFullSchema, TSchema, TSchema[K]> & {
 				$inferFindManyArgs: Simplify<DBQueryConfig<'many', true, TSchema, TSchema[K]>>;
-				$InferFindFirstArgs: Simplify<Omit<DBQueryConfig<'many', true, TSchema, TSchema[K]>, 'limit'>>;
+				$inferFindFirstArgs: Simplify<Omit<DBQueryConfig<'many', true, TSchema, TSchema[K]>, 'limit'>>;
 			};
 		};
 

--- a/drizzle-orm/src/sqlite-core/db.ts
+++ b/drizzle-orm/src/sqlite-core/db.ts
@@ -1,6 +1,11 @@
 import { entityKind } from '~/entity.ts';
 import type { TypedQueryBuilder } from '~/query-builders/query-builder.ts';
-import type { ExtractTablesWithRelations, RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
+import type {
+	DBQueryConfig,
+	ExtractTablesWithRelations,
+	RelationalSchemaConfig,
+	TablesRelationalConfig,
+} from '~/relations.ts';
 import { SelectionProxyHandler } from '~/selection-proxy.ts';
 import type { ColumnsSelection, SQLWrapper } from '~/sql/sql.ts';
 import type { SQLiteAsyncDialect, SQLiteSyncDialect } from '~/sqlite-core/dialect.ts';
@@ -20,7 +25,7 @@ import type {
 } from '~/sqlite-core/session.ts';
 import type { SQLiteTable } from '~/sqlite-core/table.ts';
 import { WithSubquery } from '~/subquery.ts';
-import type { DrizzleTypeError } from '~/utils.ts';
+import type { DrizzleTypeError, Simplify } from '~/utils.ts';
 import { RelationalQueryBuilder } from './query-builders/query.ts';
 import { SQLiteRaw } from './query-builders/raw.ts';
 import type { SelectedFields } from './query-builders/select.types.ts';
@@ -42,7 +47,10 @@ export class BaseSQLiteDatabase<
 	query: TFullSchema extends Record<string, never>
 		? DrizzleTypeError<'Seems like the schema generic is missing - did you forget to add it to your DB type?'>
 		: {
-			[K in keyof TSchema]: RelationalQueryBuilder<TResultKind, TFullSchema, TSchema, TSchema[K]>;
+			[K in keyof TSchema]: RelationalQueryBuilder<TResultKind, TFullSchema, TSchema, TSchema[K]> & {
+				$inferFindManyArgs: Simplify<DBQueryConfig<'many', true, TSchema, TSchema[K]>>;
+				$InferFindFirstArgs: Simplify<Omit<DBQueryConfig<'many', true, TSchema, TSchema[K]>, 'limit'>>;
+			};
 		};
 
 	constructor(
@@ -75,33 +83,33 @@ export class BaseSQLiteDatabase<
 
 	/**
 	 * Creates a subquery that defines a temporary named result set as a CTE.
-	 * 
+	 *
 	 * It is useful for breaking down complex queries into simpler parts and for reusing the result set in subsequent parts of the query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#with-clause}
-	 * 
+	 *
 	 * @param alias The alias for the subquery.
-	 * 
+	 *
 	 * Failure to provide an alias will result in a DrizzleTypeError, preventing the subquery from being referenced in other queries.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Create a subquery with alias 'sq' and use it in the select query
 	 * const sq = db.$with('sq').as(db.select().from(users).where(eq(users.id, 42)));
-	 * 
+	 *
 	 * const result = await db.with(sq).select().from(sq);
 	 * ```
-	 * 
+	 *
 	 * To select arbitrary SQL values as fields in a CTE and reference them in other CTEs or in the main query, you need to add aliases to them:
-	 * 
+	 *
 	 * ```ts
 	 * // Select an arbitrary SQL value as a field in a CTE and reference it in the main query
 	 * const sq = db.$with('sq').as(db.select({
 	 *   name: sql<string>`upper(${users.name})`.as('name'),
 	 * })
 	 * .from(users));
-	 * 
+	 *
 	 * const result = await db.with(sq).select({ name: sq.name }).from(sq);
 	 * ```
 	 */
@@ -124,19 +132,19 @@ export class BaseSQLiteDatabase<
 
 	/**
 	 * Incorporates a previously defined CTE (using `$with`) into the main query.
-	 * 
+	 *
 	 * This method allows the main query to reference a temporary named result set.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#with-clause}
-	 * 
+	 *
 	 * @param queries The CTEs to incorporate into the main query.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Define a subquery 'sq' as a CTE using $with
 	 * const sq = db.$with('sq').as(db.select().from(users).where(eq(users.id, 42)));
-	 * 
+	 *
 	 * // Incorporate the CTE 'sq' into the main query and select from it
 	 * const result = await db.with(sq).select().from(sq);
 	 * ```
@@ -180,31 +188,31 @@ export class BaseSQLiteDatabase<
 
 	/**
 	 * Creates a select query.
-	 * 
+	 *
 	 * Calling this method with no arguments will select all columns from the table. Pass a selection object to specify the columns you want to select.
-	 * 
+	 *
 	 * Use `.from()` method to specify which table to select from.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select}
-	 * 
+	 *
 	 * @param fields The selection object.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all columns and all rows from the 'cars' table
 	 * const allCars: Car[] = await db.select().from(cars);
-	 * 
+	 *
 	 * // Select specific columns and all rows from the 'cars' table
-	 * const carsIdsAndBrands: { id: number; brand: string }[] = await db.select({ 
-	 *   id: cars.id, 
-	 *   brand: cars.brand 
+	 * const carsIdsAndBrands: { id: number; brand: string }[] = await db.select({
+	 *   id: cars.id,
+	 *   brand: cars.brand
 	 * })
 	 *   .from(cars);
 	 * ```
-	 * 
+	 *
 	 * Like in SQL, you can use arbitrary expressions as selection fields, not just table columns:
-	 * 
+	 *
 	 * ```ts
 	 * // Select specific columns along with expression and all rows from the 'cars' table
 	 * const carsIdsAndLowerNames: { id: number; lowerBrand: string }[] = await db.select({
@@ -224,23 +232,23 @@ export class BaseSQLiteDatabase<
 
 	/**
 	 * Adds `distinct` expression to the select query.
-	 * 
+	 *
 	 * Calling this method will return only unique values. When multiple columns are selected, it returns rows with unique combinations of values in these columns.
-	 * 
+	 *
 	 * Use `.from()` method to specify which table to select from.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#distinct}
-	 * 
+	 *
 	 * @param fields The selection object.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all unique rows from the 'cars' table
 	 * await db.selectDistinct()
 	 *   .from(cars)
 	 *   .orderBy(cars.id, cars.brand, cars.color);
-	 * 
+	 *
 	 * // Select all unique brands from the 'cars' table
 	 * await db.selectDistinct({ brand: cars.brand })
 	 *   .from(cars)
@@ -264,24 +272,24 @@ export class BaseSQLiteDatabase<
 
 	/**
 	 * Creates an update query.
-	 * 
+	 *
 	 * Calling this method without `.where()` clause will update all rows in a table. The `.where()` clause specifies which rows should be updated.
-	 * 
+	 *
 	 * Use `.set()` method to specify which values to update.
-	 * 
-	 * See docs: {@link https://orm.drizzle.team/docs/update} 
-	 * 
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/update}
+	 *
 	 * @param table The table to update.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Update all rows in the 'cars' table
 	 * await db.update(cars).set({ color: 'red' });
-	 * 
+	 *
 	 * // Update rows with filters and conditions
 	 * await db.update(cars).set({ color: 'red' }).where(eq(cars.brand, 'BMW'));
-	 * 
+	 *
 	 * // Update with returning clause
 	 * const updatedCar: Car[] = await db.update(cars)
 	 *   .set({ color: 'red' })
@@ -295,22 +303,22 @@ export class BaseSQLiteDatabase<
 
 	/**
 	 * Creates an insert query.
-	 * 
+	 *
 	 * Calling this method will create new rows in a table. Use `.values()` method to specify which values to insert.
-	 * 
-	 * See docs: {@link https://orm.drizzle.team/docs/insert} 
-	 * 
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/insert}
+	 *
 	 * @param table The table to insert into.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Insert one row
 	 * await db.insert(cars).values({ brand: 'BMW' });
-	 * 
+	 *
 	 * // Insert multiple rows
 	 * await db.insert(cars).values([{ brand: 'BMW' }, { brand: 'Porsche' }]);
-	 * 
+	 *
 	 * // Insert with returning clause
 	 * const insertedCar: Car[] = await db.insert(cars)
 	 *   .values({ brand: 'BMW' })
@@ -323,22 +331,22 @@ export class BaseSQLiteDatabase<
 
 	/**
 	 * Creates a delete query.
-	 * 
-	 * Calling this method without `.where()` clause will delete all rows in a table. The `.where()` clause specifies which rows should be deleted. 
-	 * 
+	 *
+	 * Calling this method without `.where()` clause will delete all rows in a table. The `.where()` clause specifies which rows should be deleted.
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/delete}
-	 *  
+	 *
 	 * @param table The table to delete from.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Delete all rows in the 'cars' table
 	 * await db.delete(cars);
-	 * 
+	 *
 	 * // Delete rows with filters and conditions
 	 * await db.delete(cars).where(eq(cars.color, 'green'));
-	 * 
+	 *
 	 * // Delete with returning clause
 	 * const deletedCar: Car[] = await db.delete(cars)
 	 *   .where(eq(cars.id, 1))

--- a/drizzle-orm/src/sqlite-core/db.ts
+++ b/drizzle-orm/src/sqlite-core/db.ts
@@ -1,11 +1,6 @@
 import { entityKind } from '~/entity.ts';
 import type { TypedQueryBuilder } from '~/query-builders/query-builder.ts';
-import type {
-	DBQueryConfig,
-	ExtractTablesWithRelations,
-	RelationalSchemaConfig,
-	TablesRelationalConfig,
-} from '~/relations.ts';
+import type { ExtractTablesWithRelations, RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
 import { SelectionProxyHandler } from '~/selection-proxy.ts';
 import type { ColumnsSelection, SQLWrapper } from '~/sql/sql.ts';
 import type { SQLiteAsyncDialect, SQLiteSyncDialect } from '~/sqlite-core/dialect.ts';
@@ -25,7 +20,7 @@ import type {
 } from '~/sqlite-core/session.ts';
 import type { SQLiteTable } from '~/sqlite-core/table.ts';
 import { WithSubquery } from '~/subquery.ts';
-import type { DrizzleTypeError, Simplify } from '~/utils.ts';
+import type { DrizzleTypeError } from '~/utils.ts';
 import { RelationalQueryBuilder } from './query-builders/query.ts';
 import { SQLiteRaw } from './query-builders/raw.ts';
 import type { SelectedFields } from './query-builders/select.types.ts';
@@ -47,10 +42,7 @@ export class BaseSQLiteDatabase<
 	query: TFullSchema extends Record<string, never>
 		? DrizzleTypeError<'Seems like the schema generic is missing - did you forget to add it to your DB type?'>
 		: {
-			[K in keyof TSchema]: RelationalQueryBuilder<TResultKind, TFullSchema, TSchema, TSchema[K]> & {
-				$inferFindManyArgs: Simplify<DBQueryConfig<'many', true, TSchema, TSchema[K]>>;
-				$inferFindFirstArgs: Simplify<Omit<DBQueryConfig<'many', true, TSchema, TSchema[K]>, 'limit'>>;
-			};
+			[K in keyof TSchema]: RelationalQueryBuilder<TResultKind, TFullSchema, TSchema, TSchema[K]>;
 		};
 
 	constructor(

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -16,9 +16,9 @@ import {
 	type TableRelationalConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
+import type { Name } from '~/sql/index.ts';
+import { and, eq } from '~/sql/index.ts';
 import { Param, type QueryWithTypings, SQL, sql, type SQLChunk } from '~/sql/sql.ts';
-import type { Name} from '~/sql/index.ts';
-import { and, eq } from '~/sql/index.ts'
 import { SQLiteColumn } from '~/sqlite-core/columns/index.ts';
 import type { SQLiteDeleteConfig, SQLiteInsertConfig, SQLiteUpdateConfig } from '~/sqlite-core/query-builders/index.ts';
 import { SQLiteTable } from '~/sqlite-core/table.ts';
@@ -709,7 +709,7 @@ export class SQLiteSyncDialect extends SQLiteDialect {
 
 	migrate(
 		migrations: MigrationMeta[],
-		session: SQLiteSession<'sync', unknown, Record<string, unknown>, TablesRelationalConfig>,
+		session: SQLiteSession<'sync', unknown, Record<string, unknown>, any>,
 	): void {
 		const migrationTableCreate = sql`
 			CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
@@ -752,7 +752,7 @@ export class SQLiteAsyncDialect extends SQLiteDialect {
 
 	async migrate(
 		migrations: MigrationMeta[],
-		session: SQLiteSession<'async', unknown, Record<string, unknown>, TablesRelationalConfig>,
+		session: SQLiteSession<'async', unknown, Record<string, unknown>, any>,
 	): Promise<void> {
 		const migrationTableCreate = sql`
 			CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (

--- a/drizzle-orm/src/sqlite-core/query-builders/query.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/query.ts
@@ -38,6 +38,9 @@ export class RelationalQueryBuilder<
 		protected session: SQLiteSession<'async', unknown, TFullSchema, TSchema>,
 	) {}
 
+	declare $inferFindManyArgs: DBQueryConfig<'many', true, TSchema, TFields>;
+	declare $inferFindFirstArgs: Omit<DBQueryConfig<'many', true, TSchema, TFields>, 'limit'>;
+
 	findMany<TConfig extends DBQueryConfig<'many', true, TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', true, TSchema, TFields>>,
 	): SQLiteRelationalQueryKind<TMode, BuildQueryResult<TSchema, TFields, TConfig>[]> {
@@ -116,7 +119,7 @@ export class SQLiteRelationalQuery<TType extends 'sync' | 'async', TResult> exte
 		private table: SQLiteTable,
 		private tableConfig: TableRelationalConfig,
 		private dialect: SQLiteDialect,
-		private session: SQLiteSession<'sync' | 'async', unknown, Record<string, unknown>, TablesRelationalConfig>,
+		private session: SQLiteSession<'sync' | 'async', unknown, Record<string, unknown>, any>,
 		private config: DBQueryConfig<'many', true> | true,
 		mode: 'many' | 'first',
 	) {

--- a/drizzle-orm/type-tests/mysql/db-rel.ts
+++ b/drizzle-orm/type-tests/mysql/db-rel.ts
@@ -1,7 +1,7 @@
 import * as mysql from 'mysql2';
 import { type Equal, Expect } from 'type-tests/utils.ts';
 import { drizzle } from '~/mysql2/index.ts';
-import { InferFirstRelationalResult, InferManyRelationalResult } from '~/relations.ts';
+import type { InferFirstRelationalResult, InferManyRelationalResult } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';
 import * as schema from './tables-rel.ts';
 

--- a/drizzle-orm/type-tests/pg/db-rel.ts
+++ b/drizzle-orm/type-tests/pg/db-rel.ts
@@ -1,7 +1,7 @@
 import pg from 'pg';
 import { type Equal, Expect } from 'type-tests/utils.ts';
 import { drizzle } from '~/node-postgres/index.ts';
-import { InferFirstRelationalResult, InferManyRelationalResult } from '~/relations.ts';
+import type { InferFirstRelationalResult, InferManyRelationalResult } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';
 import * as schema from './tables-rel.ts';
 

--- a/drizzle-orm/type-tests/sqlite/db-rel.ts
+++ b/drizzle-orm/type-tests/sqlite/db-rel.ts
@@ -1,14 +1,12 @@
-import pg from 'pg';
+import Database from 'better-sqlite3';
 import { type Equal, Expect } from 'type-tests/utils.ts';
-import { drizzle } from '~/node-postgres/index.ts';
+import { drizzle } from '~/better-sqlite3';
 import { InferFirstRelationalResult, InferManyRelationalResult } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';
 import * as schema from './tables-rel.ts';
 
-const { Pool } = pg;
-
-const pdb = new Pool({ connectionString: process.env['PG_CONNECTION_STRING'] });
-const db = drizzle(pdb, { schema });
+const sqlite = new Database('sqlite.db');
+const db = drizzle(sqlite, { schema });
 
 {
 	const result = await db.query.users.findMany({
@@ -21,7 +19,6 @@ const db = drizzle(pdb, { schema });
 				limit: sql.placeholder('l'),
 				columns: {
 					id: false,
-					title: undefined,
 				},
 				with: {
 					author: true,
@@ -33,9 +30,7 @@ const db = drizzle(pdb, { schema });
 						},
 						with: {
 							author: {
-								columns: {
-									id: undefined,
-								},
+								columns: {},
 								with: {
 									city: {
 										with: {

--- a/drizzle-orm/type-tests/sqlite/db-rel.ts
+++ b/drizzle-orm/type-tests/sqlite/db-rel.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import { type Equal, Expect } from 'type-tests/utils.ts';
 import { drizzle } from '~/better-sqlite3';
-import { InferFirstRelationalResult, InferManyRelationalResult } from '~/relations.ts';
+import type { InferFirstRelationalResult, InferManyRelationalResult } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';
 import * as schema from './tables-rel.ts';
 

--- a/drizzle-orm/type-tests/sqlite/tables-rel.ts
+++ b/drizzle-orm/type-tests/sqlite/tables-rel.ts
@@ -1,0 +1,79 @@
+import { relations } from '~/relations.ts';
+import { foreignKey, int, sqliteTable, text } from '~/sqlite-core/index.ts';
+
+export const users = sqliteTable('users', {
+	id: int('id').primaryKey({ autoIncrement: true }),
+	name: text('name').notNull(),
+	cityId: int('city_id').references(() => cities.id).notNull(),
+	homeCityId: int('home_city_id').references(() => cities.id),
+	createdAt: int('created_at', { mode: 'timestamp_ms' }).notNull(),
+});
+export const usersConfig = relations(users, ({ one, many }) => ({
+	city: one(cities, { relationName: 'UsersInCity', fields: [users.cityId], references: [cities.id] }),
+	homeCity: one(cities, { fields: [users.homeCityId], references: [cities.id] }),
+	posts: many(posts),
+	comments: many(comments),
+}));
+
+export const cities = sqliteTable('cities', {
+	id: int('id').primaryKey({ autoIncrement: true }),
+	name: text('name').notNull(),
+});
+export const citiesConfig = relations(cities, ({ many }) => ({
+	users: many(users, { relationName: 'UsersInCity' }),
+}));
+
+export const posts = sqliteTable('posts', {
+	id: int('id').primaryKey({ autoIncrement: true }),
+	title: text('title').notNull(),
+	authorId: int('author_id').references(() => users.id),
+});
+export const postsConfig = relations(posts, ({ one, many }) => ({
+	author: one(users, { fields: [posts.authorId], references: [users.id] }),
+	comments: many(comments),
+}));
+
+export const comments = sqliteTable('comments', {
+	id: int('id').primaryKey({ autoIncrement: true }),
+	postId: int('post_id').references(() => posts.id).notNull(),
+	authorId: int('author_id').references(() => users.id),
+	text: text('text').notNull(),
+});
+export const commentsConfig = relations(comments, ({ one }) => ({
+	post: one(posts, { fields: [comments.postId], references: [posts.id] }),
+	author: one(users, { fields: [comments.authorId], references: [users.id] }),
+}));
+
+export const books = sqliteTable('books', {
+	id: int('id').primaryKey({ autoIncrement: true }),
+	name: text('name').notNull(),
+});
+export const booksConfig = relations(books, ({ many }) => ({
+	authors: many(bookAuthors),
+}));
+
+export const bookAuthors = sqliteTable('book_authors', {
+	bookId: int('book_id').references(() => books.id).notNull(),
+	authorId: int('author_id').references(() => users.id).notNull(),
+	role: text('role').notNull(),
+});
+export const bookAuthorsConfig = relations(bookAuthors, ({ one }) => ({
+	book: one(books, { fields: [bookAuthors.bookId], references: [books.id] }),
+	author: one(users, { fields: [bookAuthors.authorId], references: [users.id] }),
+}));
+
+export const node = sqliteTable('node', {
+	id: int('id').primaryKey({ autoIncrement: true }),
+	parentId: int('parent_id'),
+	leftId: int('left_id'),
+	rightId: int('right_id'),
+}, (node) => ({
+	fk1: foreignKey({ columns: [node.parentId], foreignColumns: [node.id] }),
+	fk2: foreignKey({ columns: [node.leftId], foreignColumns: [node.id] }),
+	fk3: foreignKey({ columns: [node.rightId], foreignColumns: [node.id] }),
+}));
+export const nodeRelations = relations(node, ({ one }) => ({
+	parent: one(node, { fields: [node.parentId], references: [node.id] }),
+	left: one(node, { fields: [node.leftId], references: [node.id] }),
+	right: one(node, { fields: [node.rightId], references: [node.id] }),
+}));

--- a/drizzle-typebox/package.json
+++ b/drizzle-typebox/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-valibot/package.json
+++ b/drizzle-valibot/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-zod/package.json
+++ b/drizzle-zod/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test:types": "tsc",
-    "test": "ava tests --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
     "test:rqb": "vitest run --no-threads",
     "test:esm": "node tests/imports.test.mjs && node tests/imports.test.cjs"
   },

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -1,10 +1,17 @@
+import 'dotenv/config';
 import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['tests/relational/**/*.test.ts', 'tests/libsql-batch.test.ts', 'tests/d1-batch.test.ts', 'tests/replicas/**/*', 'tests/imports/**/*'],
+		include: [
+			'tests/relational/**/*.test.ts',
+			'tests/libsql-batch.test.ts',
+			'tests/d1-batch.test.ts',
+			'tests/replicas/**/*',
+			'tests/imports/**/*',
+		],
 		exclude: [
 			...(process.env.SKIP_PLANETSCALE_TESTS ? ['tests/relational/mysql.planetscale.test.ts'] : []),
 			'tests/relational/vercel.test.ts',


### PR DESCRIPTION
close #695 

 - Added `InferManyRelationalResult` and `InferFirstRelationalResult` generic types to infer the resulting object shape.
 - Added `db.query.<tableName>.$inferFindManyArgs` and `db.query.<tableName>.$inferFindFirstArgs` to infer the parameter of `findMany` and `findFirst` respectively.
 - Added type tests

Assuming you have the following schema:
```ts
export const posts = sqliteTable("posts", {
  id: integer("id").primaryKey({ autoIncrement: true }),
  content: text("content").notNull(),
  authorId: integer("author_id").notNull(),
  json: text("json", { mode: "json" })
    .notNull()
    .$type<{ hola: string; hey: number }>(),
});

export const postsRelations = relations(posts, ({ one }) => ({
  author: one(users, { fields: [posts.authorId], references: [users.id] }),
}));

export const users = sqliteTable("users", {
  id: integer("id").primaryKey({ autoIncrement: true }),
  name: text("name").notNull(),
  managerId: integer("manager_id").references((): AnySQLiteColumn => users.id),
});

export const usersRelations = relations(users, ({ many, one }) => ({
  posts: many(posts),
  manager: one(users, { fields: [users.managerId], references: [users.id] }),
}));

export const db = drizzle(sqlite, {
  schema: { posts, users, usersRelations, postsRelations },
});
```

This is how you could use the new type helpers:
```ts
type UsersWithPosts = InferManyRelationalResult<
  typeof schema,
  'users',
  { with: { posts: true } }
>;

/* Resulting type */
type UserWithPosts = {
  id: number;
  name: string;
  managerId: number;
  posts: {
    id: number;
    content: string;
    authorId: number | null;
    json: { hola: string, hey: number };
  }[];
}[]

type UsersManyArgument = typeof db.query.users.$inferFindManyArgs;

/* Resulting type */
type UsersManyArgument = {
    columns?: {
        id?: boolean | undefined;
        name?: boolean | undefined;
        managerId?: boolean | undefined;
    } | undefined;
    with?: <Super Long Type> | undefined;
    extras?: Record<string, SQL.Aliased<unknown>> | ((fields: <Long Type>, operators: {
        sql: typeof sql;
    }) => Record<string, SQL.Aliased<unknown>>) | undefined;
    where?: SQL<unknown> | ((fields: <Long Type>, operators: <Long Type>) => SQL<unknown> | undefined) | undefined;
    orderBy?: ValueOrArray<SQL<unknown> | AnyColumn> | ((fields: <Long Type>, operators: {
        sql: typeof sql;
        asc: (column: SQLWrapper | AnyColumn) => SQL<unknown>;
        desc: (column: SQLWrapper | AnyColumn) => SQL<unknown>;
    }) => ValueOrArray<SQL<unknown> | AnyColumn>) | undefined;
    limit?: number | Placeholder<string, any> | undefined;
    offset?: number | Placeholder<string, any> | undefined;
}
```

The `InferManyRelationalResult` and `InferFirstRelationalResult` are also very helpful because after the first type parameter (`typeof schema`), the table name has intelisense and the arguments have intelisense as well.