### PR TITLE
[Pg] Fix Zod Schema Generation for Array Items

### DIFF
--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -42,10 +42,10 @@ type MaybeOptional<
 
 type GetZodType<TColumn extends Column> = TColumn['_']['dataType'] extends infer TDataType
 	? TDataType extends 'custom' ? z.ZodAny
+	: TDataType extends 'array' ? z.ZodArray<GetZodType<Assume<TColumn['_'], { baseColumn: Column }>['baseColumn']>>
 	: TDataType extends 'json' ? z.ZodType<Json>
 	: TColumn extends { enumValues: [string, ...string[]] }
 		? Equal<TColumn['enumValues'], [string, ...string[]]> extends true ? z.ZodString : z.ZodEnum<TColumn['enumValues']>
-	: TDataType extends 'array' ? z.ZodArray<GetZodType<Assume<TColumn['_'], { baseColumn: Column }>['baseColumn']>>
 	: TDataType extends 'bigint' ? z.ZodBigInt
 	: TDataType extends 'number' ? z.ZodNumber
 	: TDataType extends 'string' ? z.ZodString

--- a/drizzle-zod/tests/pg.test.ts
+++ b/drizzle-zod/tests/pg.test.ts
@@ -19,6 +19,7 @@ const users = pgTable('users', {
 	roleText2: text('role2', { enum: ['admin', 'user'] }).notNull().default('user'),
 	profession: varchar('profession', { length: 20 }).notNull(),
 	initials: char('initials', { length: 2 }).notNull(),
+	nicknames: varchar('nicknames', { length: 20 }).array().notNull()
 });
 
 const testUser = {
@@ -34,6 +35,7 @@ const testUser = {
 	roleText2: 'admin',
 	profession: 'Software Engineer',
 	initials: 'JD',
+	nicknames: ['John', 'JD']
 };
 
 test('users insert valid user', (t) => {
@@ -90,6 +92,7 @@ test('users insert schema', (t) => {
 		roleText2: z.enum(['admin', 'user']).optional(),
 		profession: z.string().max(20).min(1),
 		initials: z.string().max(2).min(1),
+		nicknames: z.array(z.string())
 	});
 
 	expectSchemaShape(t, expected).from(actual);
@@ -111,6 +114,7 @@ test('users insert schema w/ defaults', (t) => {
 		roleText2: z.enum(['admin', 'user']).optional(),
 		profession: z.string().max(20).min(1),
 		initials: z.string().max(2).min(1),
+		nicknames: z.array(z.string())
 	});
 
 	expectSchemaShape(t, expected).from(actual);
@@ -136,6 +140,7 @@ test('users select schema', (t) => {
 		roleText2: z.enum(['admin', 'user']),
 		profession: z.string().max(20).min(1),
 		initials: z.string().max(2).min(1),
+		nicknames: z.array(z.string())
 	});
 
 	expectSchemaShape(t, expected).from(actual);
@@ -157,6 +162,7 @@ test('users select schema w/ defaults', (t) => {
 		roleText2: z.enum(['admin', 'user']),
 		profession: z.string().max(20).min(1),
 		initials: z.string().max(2).min(1),
+		nicknames: z.array(z.string())
 	});
 
 	expectSchemaShape(t, expected).from(actual);


### PR DESCRIPTION
Not 100% sure, but I think this may solve https://github.com/drizzle-team/drizzle-orm/issues/1609 and https://github.com/drizzle-team/drizzle-orm/issues/1110

It seems like the bug might only be affecting the type inference and isn't a runtime bug. In a personal project I was able to remove the error by using `// @ts-ignore` to silence the warning, and it seemed to work normally.

In `src/index.ts`, this line is inferred as `true` for some reason: `Equal<TColumn['enumValues'], [string, ...string[]]> extends true`, so this could also be due to some other unrelated upstream issue. I fixed this by moving the type check `TDataType extends 'array'` check to be further up in the chain.