### PR TITLE
[All] Fix: mapWith in extras not being applied

### DIFF
--- a/drizzle-orm/src/alias.ts
+++ b/drizzle-orm/src/alias.ts
@@ -2,7 +2,7 @@ import type { AnyColumn } from './column.ts';
 import { Column } from './column.ts';
 import { entityKind, is } from './entity.ts';
 import type { Relation } from './relations.ts';
-import type { View} from './sql/sql.ts';
+import type { View } from './sql/sql.ts';
 import { SQL, sql } from './sql/sql.ts';
 import { Table } from './table.ts';
 import { ViewBaseConfig } from './view-common.ts';
@@ -108,7 +108,7 @@ export function mapColumnsInAliasedSQLToAlias(query: SQL.Aliased, alias: string)
 }
 
 export function mapColumnsInSQLToAlias(query: SQL, alias: string): SQL {
-	return sql.join(query.queryChunks.map((c) => {
+	const newSql = sql.join(query.queryChunks.map((c) => {
 		if (is(c, Column)) {
 			return aliasedTableColumn(c, alias);
 		}
@@ -120,4 +120,6 @@ export function mapColumnsInSQLToAlias(query: SQL, alias: string): SQL {
 		}
 		return c;
 	}));
+	newSql.decoder = query.decoder;
+	return newSql;
 }

--- a/drizzle-typebox/package.json
+++ b/drizzle-typebox/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-valibot/package.json
+++ b/drizzle-valibot/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/drizzle-zod/package.json
+++ b/drizzle-zod/package.json
@@ -9,7 +9,7 @@
     "test:types": "cd tests && tsc",
     "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
     "publish": "npm publish package.tgz",
-    "test": "ava tests"
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava"
   },
   "exports": {
     ".": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test:types": "tsc",
-    "test": "ava tests --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
+    "test": "NODE_OPTIONS='--loader=tsx --no-warnings' ava --timeout=60s --serial && pnpm test:esm && pnpm test:rqb",
     "test:rqb": "vitest run --no-threads",
     "test:esm": "node tests/imports.test.mjs && node tests/imports.test.cjs"
   },

--- a/integration-tests/tests/relational/bettersqlite.test.ts
+++ b/integration-tests/tests/relational/bettersqlite.test.ts
@@ -963,6 +963,63 @@ test('[Find Many] Get only custom fields', () => {
 	});
 });
 
+test('[Find Many] Get custom fields with mapWith', async () => {
+	await db.insert(usersTable).values([
+		{ id: 1, name: 'Dan' },
+		{ id: 2, name: 'Andrew' },
+		{ id: 3, name: 'Alex' },
+	]);
+
+	await db.insert(postsTable).values([
+		{ id: 1, ownerId: 1, content: 'Post1' },
+		{ id: 2, ownerId: 1, content: 'Post1.2' },
+		{ id: 4, ownerId: 2, content: 'Post2' },
+	]);
+
+	const usersWithPosts = await db.query.usersTable.findMany({
+		columns: {},
+		with: {
+			posts: {
+				columns: {},
+				extras: ({ content }) => ({
+					lowerName: sql<string>`lower(${content})`.mapWith((val: unknown) => `${val}-extra`).as('content_lower'),
+				}),
+			},
+		},
+		extras: ({ name }) => ({
+			lowerName: sql<string>`lower(${name})`.mapWith((val: unknown) => `${val}-user`).as('name_lower'),
+		}),
+	});
+
+	expectTypeOf(usersWithPosts).toEqualTypeOf<{
+		lowerName: string;
+		posts: {
+			lowerName: string;
+		}[];
+	}[]>();
+
+	expect(usersWithPosts.length).toEqual(3);
+	expect(usersWithPosts[0]?.posts.length).toEqual(2);
+	expect(usersWithPosts[1]?.posts.length).toEqual(1);
+	expect(usersWithPosts[2]?.posts.length).toEqual(0);
+
+	expect(usersWithPosts[0]?.lowerName).toEqual('dan-user');
+	expect(usersWithPosts[1]?.lowerName).toEqual('andrew-user');
+	expect(usersWithPosts[2]?.lowerName).toEqual('alex-user');
+
+	expect(usersWithPosts[0]?.posts).toContainEqual({
+		lowerName: 'post1-extra',
+	});
+
+	expect(usersWithPosts[0]?.posts).toContainEqual({
+		lowerName: 'post1.2-extra',
+	});
+
+	expect(usersWithPosts[1]?.posts).toContainEqual({
+		lowerName: 'post2-extra',
+	});
+});
+
 test('[Find Many] Get only custom fields + where', () => {
 	db.insert(usersTable).values([
 		{ id: 1, name: 'Dan' },

--- a/integration-tests/tests/relational/mysql.planetscale.test.ts
+++ b/integration-tests/tests/relational/mysql.planetscale.test.ts
@@ -984,6 +984,63 @@ test('[Find Many] Get only custom fields', async () => {
 	});
 });
 
+test('[Find Many] Get custom fields with mapWith', async () => {
+	await db.insert(usersTable).values([
+		{ id: 1, name: 'Dan' },
+		{ id: 2, name: 'Andrew' },
+		{ id: 3, name: 'Alex' },
+	]);
+
+	await db.insert(postsTable).values([
+		{ id: 1, ownerId: 1, content: 'Post1' },
+		{ id: 2, ownerId: 1, content: 'Post1.2' },
+		{ id: 4, ownerId: 2, content: 'Post2' },
+	]);
+
+	const usersWithPosts = await db.query.usersTable.findMany({
+		columns: {},
+		with: {
+			posts: {
+				columns: {},
+				extras: ({ content }) => ({
+					lowerName: sql<string>`lower(${content})`.mapWith((val: unknown) => `${val}-extra`).as('content_lower'),
+				}),
+			},
+		},
+		extras: ({ name }) => ({
+			lowerName: sql<string>`lower(${name})`.mapWith((val: unknown) => `${val}-user`).as('name_lower'),
+		}),
+	});
+
+	expectTypeOf(usersWithPosts).toEqualTypeOf<{
+		lowerName: string;
+		posts: {
+			lowerName: string;
+		}[];
+	}[]>();
+
+	expect(usersWithPosts.length).toEqual(3);
+	expect(usersWithPosts[0]?.posts.length).toEqual(2);
+	expect(usersWithPosts[1]?.posts.length).toEqual(1);
+	expect(usersWithPosts[2]?.posts.length).toEqual(0);
+
+	expect(usersWithPosts[0]?.lowerName).toEqual('dan-user');
+	expect(usersWithPosts[1]?.lowerName).toEqual('andrew-user');
+	expect(usersWithPosts[2]?.lowerName).toEqual('alex-user');
+
+	expect(usersWithPosts[0]?.posts).toContainEqual({
+		lowerName: 'post1-extra',
+	});
+
+	expect(usersWithPosts[0]?.posts).toContainEqual({
+		lowerName: 'post1.2-extra',
+	});
+
+	expect(usersWithPosts[1]?.posts).toContainEqual({
+		lowerName: 'post2-extra',
+	});
+});
+
 test('[Find Many] Get only custom fields + where', async () => {
 	await db.insert(usersTable).values([
 		{ id: 1, name: 'Dan' },

--- a/integration-tests/tests/relational/mysql.test.ts
+++ b/integration-tests/tests/relational/mysql.test.ts
@@ -1063,6 +1063,63 @@ test('[Find Many] Get only custom fields', async () => {
 	});
 });
 
+test('[Find Many] Get custom fields with mapWith', async () => {
+	await db.insert(usersTable).values([
+		{ id: 1, name: 'Dan' },
+		{ id: 2, name: 'Andrew' },
+		{ id: 3, name: 'Alex' },
+	]);
+
+	await db.insert(postsTable).values([
+		{ id: 1, ownerId: 1, content: 'Post1' },
+		{ id: 2, ownerId: 1, content: 'Post1.2' },
+		{ id: 4, ownerId: 2, content: 'Post2' },
+	]);
+
+	const usersWithPosts = await db.query.usersTable.findMany({
+		columns: {},
+		with: {
+			posts: {
+				columns: {},
+				extras: ({ content }) => ({
+					lowerName: sql<string>`lower(${content})`.mapWith((val: unknown) => `${val}-extra`).as('content_lower'),
+				}),
+			},
+		},
+		extras: ({ name }) => ({
+			lowerName: sql<string>`lower(${name})`.mapWith((val: unknown) => `${val}-user`).as('name_lower'),
+		}),
+	});
+
+	expectTypeOf(usersWithPosts).toEqualTypeOf<{
+		lowerName: string;
+		posts: {
+			lowerName: string;
+		}[];
+	}[]>();
+
+	expect(usersWithPosts.length).toEqual(3);
+	expect(usersWithPosts[0]?.posts.length).toEqual(2);
+	expect(usersWithPosts[1]?.posts.length).toEqual(1);
+	expect(usersWithPosts[2]?.posts.length).toEqual(0);
+
+	expect(usersWithPosts[0]?.lowerName).toEqual('dan-user');
+	expect(usersWithPosts[1]?.lowerName).toEqual('andrew-user');
+	expect(usersWithPosts[2]?.lowerName).toEqual('alex-user');
+
+	expect(usersWithPosts[0]?.posts).toContainEqual({
+		lowerName: 'post1-extra',
+	});
+
+	expect(usersWithPosts[0]?.posts).toContainEqual({
+		lowerName: 'post1.2-extra',
+	});
+
+	expect(usersWithPosts[1]?.posts).toContainEqual({
+		lowerName: 'post2-extra',
+	});
+});
+
 test('[Find Many] Get only custom fields + where', async (t) => {
 	const { mysqlDb: db } = t;
 

--- a/integration-tests/tests/relational/pg.test.ts
+++ b/integration-tests/tests/relational/pg.test.ts
@@ -1053,6 +1053,63 @@ test('[Find Many] Get only custom fields', async (t) => {
 	});
 });
 
+test('[Find Many] Get custom fields with mapWith', async () => {
+	await db.insert(usersTable).values([
+		{ id: 1, name: 'Dan' },
+		{ id: 2, name: 'Andrew' },
+		{ id: 3, name: 'Alex' },
+	]);
+
+	await db.insert(postsTable).values([
+		{ id: 1, ownerId: 1, content: 'Post1' },
+		{ id: 2, ownerId: 1, content: 'Post1.2' },
+		{ id: 4, ownerId: 2, content: 'Post2' },
+	]);
+
+	const usersWithPosts = await db.query.usersTable.findMany({
+		columns: {},
+		with: {
+			posts: {
+				columns: {},
+				extras: ({ content }) => ({
+					lowerName: sql<string>`lower(${content})`.mapWith((val: unknown) => `${val}-extra`).as('content_lower'),
+				}),
+			},
+		},
+		extras: ({ name }) => ({
+			lowerName: sql<string>`lower(${name})`.mapWith((val: unknown) => `${val}-user`).as('name_lower'),
+		}),
+	});
+
+	expectTypeOf(usersWithPosts).toEqualTypeOf<{
+		lowerName: string;
+		posts: {
+			lowerName: string;
+		}[];
+	}[]>();
+
+	expect(usersWithPosts.length).toEqual(3);
+	expect(usersWithPosts[0]?.posts.length).toEqual(2);
+	expect(usersWithPosts[1]?.posts.length).toEqual(1);
+	expect(usersWithPosts[2]?.posts.length).toEqual(0);
+
+	expect(usersWithPosts[0]?.lowerName).toEqual('dan-user');
+	expect(usersWithPosts[1]?.lowerName).toEqual('andrew-user');
+	expect(usersWithPosts[2]?.lowerName).toEqual('alex-user');
+
+	expect(usersWithPosts[0]?.posts).toContainEqual({
+		lowerName: 'post1-extra',
+	});
+
+	expect(usersWithPosts[0]?.posts).toContainEqual({
+		lowerName: 'post1.2-extra',
+	});
+
+	expect(usersWithPosts[1]?.posts).toContainEqual({
+		lowerName: 'post2-extra',
+	});
+});
+
 test('[Find Many] Get only custom fields + where', async (t) => {
 	const { pgDb: db } = t;
 

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -1,10 +1,17 @@
+import 'dotenv/config';
 import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['tests/relational/**/*.test.ts', 'tests/libsql-batch.test.ts', 'tests/d1-batch.test.ts', 'tests/replicas/**/*', 'tests/imports/**/*'],
+		include: [
+			'tests/relational/**/*.test.ts',
+			'tests/libsql-batch.test.ts',
+			'tests/d1-batch.test.ts',
+			'tests/replicas/**/*',
+			'tests/imports/**/*',
+		],
 		exclude: [
 			...(process.env.SKIP_PLANETSCALE_TESTS ? ['tests/relational/mysql.planetscale.test.ts'] : []),
 			'tests/relational/vercel.test.ts',


### PR DESCRIPTION
close #1157 

This will also help workaround #820 but more work will be needed to fully fix.

- Used the decoder passed to SQL columns defined in extras to the correct location when defining the correct alias for the column.
- Added integration tests.

To fix #820, using this PR, the user will have to manually cast the decimal value to `char`, similar to the implemented fix in #1688.