### PR TITLE
Fix `getTableConfig` not returning all the primary keys

### DIFF
--- a/drizzle-orm/src/mysql-core/utils.ts
+++ b/drizzle-orm/src/mysql-core/utils.ts
@@ -7,10 +7,9 @@ import type { ForeignKey } from './foreign-keys.ts';
 import { ForeignKeyBuilder } from './foreign-keys.ts';
 import type { Index } from './indexes.ts';
 import { IndexBuilder } from './indexes.ts';
-import type { PrimaryKey } from './primary-keys.ts';
-import { PrimaryKeyBuilder } from './primary-keys.ts';
+import { PrimaryKey, PrimaryKeyBuilder } from './primary-keys.ts';
 import { MySqlTable } from './table.ts';
-import { type UniqueConstraint, UniqueConstraintBuilder } from './unique-constraint.ts';
+import { UniqueConstraint, UniqueConstraintBuilder } from './unique-constraint.ts';
 import { MySqlViewConfig } from './view-common.ts';
 import type { MySqlView } from './view.ts';
 
@@ -24,6 +23,15 @@ export function getTableConfig(table: MySqlTable) {
 	const name = table[Table.Symbol.Name];
 	const schema = table[Table.Symbol.Schema];
 	const baseName = table[Table.Symbol.BaseName];
+
+	for (const column of columns) {
+		if (column.primary) {
+			primaryKeys.push(new PrimaryKey(table, [column]));
+		}
+		if (column.isUnique) {
+			uniqueConstraints.push(new UniqueConstraint(table, [column]));
+		}
+	}
 
 	const extraConfigBuilder = table[MySqlTable.Symbol.ExtraConfigBuilder];
 

--- a/drizzle-orm/src/pg-core/utils.ts
+++ b/drizzle-orm/src/pg-core/utils.ts
@@ -6,8 +6,8 @@ import { type Check, CheckBuilder } from './checks.ts';
 import type { AnyPgColumn } from './columns/index.ts';
 import { type ForeignKey, ForeignKeyBuilder } from './foreign-keys.ts';
 import { type Index, IndexBuilder } from './indexes.ts';
-import { type PrimaryKey, PrimaryKeyBuilder } from './primary-keys.ts';
-import { type UniqueConstraint, UniqueConstraintBuilder } from './unique-constraint.ts';
+import { PrimaryKey, PrimaryKeyBuilder } from './primary-keys.ts';
+import { UniqueConstraint, UniqueConstraintBuilder } from './unique-constraint.ts';
 import { PgViewConfig } from './view-common.ts';
 import { type PgMaterializedView, PgMaterializedViewConfig, type PgView } from './view.ts';
 
@@ -20,6 +20,17 @@ export function getTableConfig<TTable extends PgTable>(table: TTable) {
 	const uniqueConstraints: UniqueConstraint[] = [];
 	const name = table[Table.Symbol.Name];
 	const schema = table[Table.Symbol.Schema];
+
+	for (const column of columns) {
+		if (column.primary) {
+			primaryKeys.push(new PrimaryKey(table, [column]));
+		}
+		if (column.isUnique) {
+			uniqueConstraints.push(
+				new UniqueConstraint(table, [column], column.uniqueType === 'not distict', column.uniqueName),
+			);
+		}
+	}
 
 	const extraConfigBuilder = table[PgTable.Symbol.ExtraConfigBuilder];
 

--- a/drizzle-orm/src/sqlite-core/utils.ts
+++ b/drizzle-orm/src/sqlite-core/utils.ts
@@ -7,10 +7,9 @@ import type { ForeignKey } from './foreign-keys.ts';
 import { ForeignKeyBuilder } from './foreign-keys.ts';
 import type { Index } from './indexes.ts';
 import { IndexBuilder } from './indexes.ts';
-import type { PrimaryKey } from './primary-keys.ts';
-import { PrimaryKeyBuilder } from './primary-keys.ts';
+import { PrimaryKey, PrimaryKeyBuilder } from './primary-keys.ts';
 import { SQLiteTable } from './table.ts';
-import { type UniqueConstraint, UniqueConstraintBuilder } from './unique-constraint.ts';
+import { UniqueConstraint, UniqueConstraintBuilder } from './unique-constraint.ts';
 import { SQLiteViewConfig } from './view-common.ts';
 import type { SQLiteView } from './view.ts';
 
@@ -22,6 +21,15 @@ export function getTableConfig<TTable extends SQLiteTable>(table: TTable) {
 	const uniqueConstraints: UniqueConstraint[] = [];
 	const foreignKeys: ForeignKey[] = Object.values(table[SQLiteTable.Symbol.InlineForeignKeys]);
 	const name = table[Table.Symbol.Name];
+
+	for (const column of columns) {
+		if (column.primary) {
+			primaryKeys.push(new PrimaryKey(table, [column]));
+		}
+		if (column.isUnique) {
+			uniqueConstraints.push(new UniqueConstraint(table, [column]));
+		}
+	}
 
 	const extraConfigBuilder = table[SQLiteTable.Symbol.ExtraConfigBuilder];
 

--- a/integration-tests/tests/libsql.test.ts
+++ b/integration-tests/tests/libsql.test.ts
@@ -317,9 +317,21 @@ test.serial('table config: foreign keys name', async (t) => {
 	t.is(tableConfig.foreignKeys[1]!.getName(), 'custom_fk_deprecated');
 });
 
+test.serial('table config: primary key', async (t) => {
+	const table = sqliteTable('cities', {
+		id: int('id').primaryKey({ autoIncrement: true }),
+		name: text('name').notNull(),
+		state: text('state'),
+	});
+
+	const tableConfig = getTableConfig(table);
+
+	t.is(tableConfig.primaryKeys.length, 1);
+});
+
 test.serial('table config: primary keys name', async (t) => {
 	const table = sqliteTable('cities', {
-		id: int('id').primaryKey(),
+		id: int('id'),
 		name: text('name').notNull(),
 		state: text('state'),
 	}, (t) => ({

--- a/integration-tests/tests/mysql.test.ts
+++ b/integration-tests/tests/mysql.test.ts
@@ -376,9 +376,21 @@ test.serial('table config: foreign keys name', async (t) => {
 	t.is(tableConfig.foreignKeys[0]!.getName(), 'custom_fk');
 });
 
-test.serial('table config: primary keys name', async (t) => {
+test.serial('table config: primary key', async (t) => {
 	const table = mysqlTable('cities', {
 		id: serial('id').primaryKey(),
+		name: text('name').notNull(),
+		state: text('state'),
+	});
+
+	const tableConfig = getTableConfig(table);
+
+	t.is(tableConfig.primaryKeys.length, 1);
+});
+
+test.serial('table config: primary keys name', async (t) => {
+	const table = mysqlTable('cities', {
+		id: serial('id'),
 		name: text('name').notNull(),
 		state: text('state'),
 	}, (t) => ({

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -439,9 +439,21 @@ test.serial('table config: foreign keys name', async (t) => {
 	t.is(tableConfig.foreignKeys[0]!.getName(), 'custom_fk');
 });
 
-test.serial('table config: primary keys name', async (t) => {
+test.serial('table config: primary key', async (t) => {
 	const table = pgTable('cities', {
 		id: serial('id').primaryKey(),
+		name: text('name').notNull(),
+		state: text('state'),
+	});
+
+	const tableConfig = getTableConfig(table);
+
+	t.is(tableConfig.primaryKeys.length, 1);
+});
+
+test.serial('table config: primary keys name', async (t) => {
+	const table = pgTable('cities', {
+		id: serial('id'),
 		name: text('name').notNull(),
 		state: text('state'),
 	}, (t) => ({


### PR DESCRIPTION
close #1285

- Added a loop through all columns looking for primary keys to add it to the primary key array.
- I also added the unique constraints found in the columns to the list of constraints.
- Added integration tests.

It seems like the `.primarykey()` method on the column builders was not really doing anything, unless drizzle-kit was getting the primary key directly from the `column.config.primaryKey`.