### PR TITLE
fix: make expo peer dependencies optional

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -123,6 +123,15 @@
     },
     "@opentelemetry/api": {
       "optional": true
+    },
+    "expo-sqlite": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "@types/react": {
+      "optional": true
     }
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/drizzle-team/drizzle-orm/pull/1678 introduced an expo driver, but did not make these peer dependencies optional.

This results in unnecessary inflation of `node_modules` in other projects, with `react` (appears to solely be used for https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-orm/src/expo-sqlite/migrator.ts), and then the main `expo-sqlite` dependency.