### PR TITLE
fix: make expo-sqlite peer dep optional

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -106,6 +106,9 @@
     "bun-types": {
       "optional": true
     },
+    "expo-sqlite": {
+      "optional": true
+    },
     "@aws-sdk/client-rds-data": {
       "optional": true
     },


### PR DESCRIPTION
I noticed my db package started pulling in Expo and then I saw you had missed making the expo-sqlite dependency optional: 

![CleanShot 2023-12-30 at 13 30 21](https://github.com/drizzle-team/drizzle-orm/assets/51714798/7bc36842-929d-4a75-817a-57a05a24bb87)
