### PR TITLE
[MySql] Optimization: Avoid using window function in related tables if orderBy and limit is added

### DIFF
--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -18,7 +18,7 @@ import { Param, type QueryWithTypings, SQL, sql, type SQLChunk, View } from '~/s
 import { Subquery, SubqueryConfig } from '~/subquery.ts';
 import { getTableName, Table } from '~/table.ts';
 import { orderSelectedFields, type UpdateSet } from '~/utils.ts';
-import { DrizzleError, type Name, ViewBaseConfig, and, eq } from '../index.ts';
+import { and, DrizzleError, eq, type Name, ViewBaseConfig } from '../index.ts';
 import { MySqlColumn } from './columns/common.ts';
 import type { MySqlDeleteConfig } from './query-builders/delete.ts';
 import type { MySqlInsertConfig } from './query-builders/insert.ts';
@@ -681,7 +681,7 @@ export class MySqlDialect {
 							path: [],
 							field: sql.raw('*'),
 						},
-						...(((orderBy?.length ?? 0) > 0)
+						...(((orderBy?.length ?? 0) > 0 && !limit)
 							? [{
 								path: [],
 								field: sql`row_number() over (order by ${sql.join(orderBy!, sql`, `)})`,
@@ -690,6 +690,7 @@ export class MySqlDialect {
 					],
 					where,
 					limit,
+					orderBy: (orderBy?.length ?? 0) > 0 && !limit ? undefined : orderBy,
 					offset,
 					setOperators: [],
 				});
@@ -974,7 +975,7 @@ export class MySqlDialect {
 							path: [],
 							field: sql.raw('*'),
 						},
-						...(orderBy.length > 0)
+						...(orderBy.length > 0 && !limit)
 							? [{
 								path: [],
 								field: sql`row_number() over (order by ${sql.join(orderBy, sql`, `)})`,
@@ -983,6 +984,7 @@ export class MySqlDialect {
 					],
 					where,
 					limit,
+					orderBy: orderBy.length > 0 && !limit ? undefined : orderBy,
 					offset,
 					setOperators: [],
 				});

--- a/integration-tests/tests/relational/mysql.planetscale.test.ts
+++ b/integration-tests/tests/relational/mysql.planetscale.test.ts
@@ -6080,6 +6080,58 @@ test('Get groups with users + custom', async () => {
 	});
 });
 
+test('Make sure RQB is not using window function if not necessary', async () => {
+	const query1 = db.query.usersTable.findMany({
+		orderBy: (users, { desc }) => [desc(users.id)],
+		limit: 2,
+		with: {
+			usersToGroups: {
+				limit: 1,
+				orderBy: [desc(usersToGroupsTable.groupId)],
+				columns: {},
+				with: {
+					group: true,
+				},
+			},
+		},
+	});
+
+	// No use of window function if the query has groupBy and limit (mysql will order the query properly)
+	expect(query1.toSQL().sql.search('row_number')).toEqual(-1);
+
+	const query2 = db.query.usersTable.findMany({
+		limit: 2,
+		with: {
+			usersToGroups: {
+				limit: 1,
+				columns: {},
+				with: {
+					group: true,
+				},
+			},
+		},
+	});
+
+	// No use of window function if the query doesn't have an orderBy
+	expect(query2.toSQL().sql.search('row_number')).toEqual(-1);
+
+	const query3 = db.query.usersTable.findMany({
+		orderBy: (users, { desc }) => [desc(users.id)],
+		with: {
+			usersToGroups: {
+				orderBy: [desc(usersToGroupsTable.groupId)],
+				columns: {},
+				with: {
+					group: true,
+				},
+			},
+		},
+	});
+
+	// the window function is necessary when the query has orderBy but no limit
+	expect(query3.toSQL().sql.search('row_number')).toBeGreaterThan(0);
+});
+
 test('.toSQL()', () => {
 	const query = db.query.usersTable.findFirst().toSQL();
 


### PR DESCRIPTION
close #1653 

The explanation for this change is very clear from the opened issue about it.
The problem is that a windows function is necessary to order the rows inside the aggregated tables, because the mysql planner will optimize away the `order by`. Please see this [SO answer](https://stackoverflow.com/a/60572518) and [this](https://stackoverflow.com/a/70680949), and the [documentation here](https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_json-arrayagg) where it states that the order is undefined.
In any case, as discovered by @titong0 and the planetscale support, the window function makes the query ignore the indexes created for performance.
Upon some investigation, I also discovered that the window function is necessary to order the array only if no limit is defined. So if a user uses `order by` along with `limit`, he will benefit from this PR and no window function will be used.

An example of this being used is in [this query from the integration tests](https://github.com/drizzle-team/drizzle-orm/blob/d20bd54cfbc7a8ead2b14eb24af7b73c752b80e2/integration-tests/tests/relational/mysql.planetscale.test.ts#L5710), where before the optimization the resulting query was:
```sql
select
  `id`,
  `name`,
  `verified`,
  `invited_by`,
  coalesce(
    (
      select json_arrayagg(
        json_array(
          (
            select json_array(
              `id`,
              `name`,
              `description`
            )
            from (
              select * from `groups` `usersTable_usersToGroups_group`
              where `usersTable_usersToGroups_group`.`id` = `usersTable_usersToGroups`.`group_id`
              limit 1
            ) `usersTable_usersToGroups_group`
          )
        )
      )
    from (
      select
        *,
        row_number()  -- This is now being avoided
        over (
          order by `usersTable_usersToGroups`.`group_id` desc
        )
        from `users_to_groups` `usersTable_usersToGroups`
        where `usersTable_usersToGroups`.`user_id` = `usersTable`.`id`
        limit 1
      ) `usersTable_usersToGroups`
    ),
    json_array()
  ) as `usersToGroups`
from `users` `usersTable`
order by `usersTable`.`id` desc
limit 2;
```

But now the resulting query will be like this:
```sql
select
  `id`,
  `name`,
  `verified`,
  `invited_by`,
  coalesce(
    (
      select json_arrayagg(
        json_array(
          (
            select json_array(
              `id`,
              `name`,
              `description`
            )
            from (
              select *
              from `groups` `usersTable_usersToGroups_group`
              where `usersTable_usersToGroups_group`.`id` = `usersTable_usersToGroups`.`group_id`
              limit 1
            ) `usersTable_usersToGroups_group`
          )
        )
      )
    from (
      select *
      from `users_to_groups` `usersTable_usersToGroups`
      where `usersTable_usersToGroups`.`user_id` = `usersTable`.`id`
      order by `usersTable_usersToGroups`.`group_id` desc
      limit 1
    ) `usersTable_usersToGroups`
  ),
  json_array()
) as `usersToGroups`
from `users` `usersTable`
order by `usersTable`.`id` desc
limit 2;
```

Testing the new behavior is tricky, I attempted to use `explain analyze` and even though I found that the query planner was using the index properly, I didn't think a test for the query planner was appropriate for this. I only included a test that verifies that no window function was used, and the existing test for the RQB confirm that the result is correct.