### PR TITLE
fix: Added correct handling of file extension when inlining type imports

### DIFF
--- a/drizzle-orm/scripts/fix-imports.ts
+++ b/drizzle-orm/scripts/fix-imports.ts
@@ -52,6 +52,8 @@ await Promise.all(cjsFiles.map(async (file) => {
 		},
 		visitTSImportType(path) {
 			path.value.argument.value = resolvePathAlias(path.value.argument.value, file);
+			path.value.argument.value = fixImportPath(path.value.argument.value, file, '.d.cts');
+
 			this.traverse(path);
 		},
 	});


### PR DESCRIPTION
close #1488 

As found by @Caesarovich, in [his comment](https://github.com/drizzle-team/drizzle-orm/issues/1488#issuecomment-1808749879), drizzle-orm's build scripts weren't properly handling inline imports of types. In this case in particular, the file `./sql/expressions/conditions.ts` doesn't exist in the final bundle. In the case of commonjs, the correct filename should be `./sql/expressions/conditions.d.cts`.

We haven't detected this in our test suite because our tests only use the modules implementation. This could only be detected by using the commonjs implementation and following the issue's reproduction steps.
