### PR TITLE
planetscale-serverless: allow Client as a valid type

### DIFF
--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -117,7 +117,7 @@ jobs:
           LIBSQL_URL: file:local.db
         run: |
           if [[ ${{ github.event_name }} != "push" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-            export SKIP_PLANETSCALE_TESTS=1
+            export SKIP_EXTERNAL_DB_TESTS=1
           fi
           if [[ "${{ matrix.package }}" == "drizzle-orm" ]]; then
             pnpm test --filter ${{ matrix.package }} --filter integration-tests

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -141,7 +141,7 @@
     "@neondatabase/serverless": "^0.4.24",
     "@opentelemetry/api": "^1.4.1",
     "@originjs/vite-plugin-commonjs": "^1.0.3",
-    "@planetscale/database": "^1.7.0",
+    "@planetscale/database": "^1.16.0",
     "@types/better-sqlite3": "^7.6.4",
     "@types/node": "^20.2.5",
     "@types/pg": "^8.10.1",

--- a/drizzle-orm/src/planetscale-serverless/driver.ts
+++ b/drizzle-orm/src/planetscale-serverless/driver.ts
@@ -1,4 +1,4 @@
-import type { Connection } from '@planetscale/database';
+import type { Connection, Client } from '@planetscale/database';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { MySqlDatabase } from '~/mysql-core/db.ts';
@@ -22,7 +22,7 @@ export type PlanetScaleDatabase<
 > = MySqlDatabase<PlanetscaleQueryResultHKT, PlanetScalePreparedQueryHKT, TSchema>;
 
 export function drizzle<TSchema extends Record<string, unknown> = Record<string, never>>(
-	client: Connection,
+	client: Connection | Client,
 	config: DrizzleConfig<TSchema> = {},
 ): PlanetScaleDatabase<TSchema> {
 	const dialect = new MySqlDialect();

--- a/drizzle-orm/src/planetscale-serverless/driver.ts
+++ b/drizzle-orm/src/planetscale-serverless/driver.ts
@@ -1,4 +1,6 @@
 import { Client } from '@planetscale/database';
+import { is } from '~/entity.ts';
+import { DrizzleError } from '~/errors.ts';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { MySqlDatabase } from '~/mysql-core/db.ts';
@@ -10,7 +12,6 @@ import {
 	type TablesRelationalConfig,
 } from '~/relations.ts';
 import type { DrizzleConfig } from '~/utils.ts';
-import { DrizzleError } from '../index.ts';
 import type { PlanetScalePreparedQueryHKT, PlanetscaleQueryResultHKT } from './session.ts';
 import { PlanetscaleSession } from './session.ts';
 
@@ -26,7 +27,7 @@ export function drizzle<TSchema extends Record<string, unknown> = Record<string,
 	client: Client,
 	config: DrizzleConfig<TSchema> = {},
 ): PlanetScaleDatabase<TSchema> {
-	if (!(client instanceof Client)) {
+	if (!is(client, Client)) {
 		throw new DrizzleError({
 			message: `You need to pass an instance of Client:
 

--- a/drizzle-orm/src/planetscale-serverless/driver.ts
+++ b/drizzle-orm/src/planetscale-serverless/driver.ts
@@ -1,5 +1,4 @@
 import { Client } from '@planetscale/database';
-import { is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
@@ -27,7 +26,9 @@ export function drizzle<TSchema extends Record<string, unknown> = Record<string,
 	client: Client,
 	config: DrizzleConfig<TSchema> = {},
 ): PlanetScaleDatabase<TSchema> {
-	if (!is(client, Client)) {
+	// Client is not Drizzle Object, so we can ignore this rule here
+	// eslint-disable-next-line no-instanceof/no-instanceof
+	if (client instanceof Client) {
 		throw new DrizzleError({
 			message: `You need to pass an instance of Client:
 

--- a/drizzle-orm/src/planetscale-serverless/driver.ts
+++ b/drizzle-orm/src/planetscale-serverless/driver.ts
@@ -10,6 +10,7 @@ import {
 	type TablesRelationalConfig,
 } from '~/relations.ts';
 import type { DrizzleConfig } from '~/utils.ts';
+import { DrizzleError } from '../index.ts';
 import type { PlanetScalePreparedQueryHKT, PlanetscaleQueryResultHKT } from './session.ts';
 import { PlanetscaleSession } from './session.ts';
 

--- a/drizzle-orm/src/planetscale-serverless/driver.ts
+++ b/drizzle-orm/src/planetscale-serverless/driver.ts
@@ -1,5 +1,5 @@
+import type { Connection } from '@planetscale/database';
 import { Client } from '@planetscale/database';
-import { DrizzleError } from '~/errors.ts';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { MySqlDatabase } from '~/mysql-core/db.ts';
@@ -23,14 +23,28 @@ export type PlanetScaleDatabase<
 > = MySqlDatabase<PlanetscaleQueryResultHKT, PlanetScalePreparedQueryHKT, TSchema>;
 
 export function drizzle<TSchema extends Record<string, unknown> = Record<string, never>>(
-	client: Client,
+	client: Client | Connection,
 	config: DrizzleConfig<TSchema> = {},
 ): PlanetScaleDatabase<TSchema> {
 	// Client is not Drizzle Object, so we can ignore this rule here
 	// eslint-disable-next-line no-instanceof/no-instanceof
-	if (client instanceof Client) {
-		throw new DrizzleError({
-			message: `You need to pass an instance of Client:
+	if (!(client instanceof Client)) {
+		// Should use error on 0.30.0 release
+		// 		throw new DrizzleError({
+		// 			message: `You need to pass an instance of Client:
+
+		// import { Client } from "@planetscale/database";
+
+		// const client = new Client({
+		//   host: process.env["DATABASE_HOST"],
+		//   username: process.env["DATABASE_USERNAME"],
+		//   password: process.env["DATABASE_PASSWORD"],
+		// });
+
+		// const db = drizzle(client);
+		// `,
+		// 		});
+		console.log(`Warning: You need to pass an instance of Client:
 
 import { Client } from "@planetscale/database";
 
@@ -41,8 +55,9 @@ const client = new Client({
 });
 
 const db = drizzle(client);
-`,
-		});
+		
+Starting from version 0.30.0, you will encounter an error if you attempt to use anything other than a Client instance.\nPlease make the necessary changes now to prevent any runtime errors in the future
+		`);
 	}
 
 	const dialect = new MySqlDialect();

--- a/drizzle-orm/src/planetscale-serverless/driver.ts
+++ b/drizzle-orm/src/planetscale-serverless/driver.ts
@@ -1,4 +1,4 @@
-import type { Connection, Client } from '@planetscale/database';
+import type { Client, Connection } from '@planetscale/database';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { MySqlDatabase } from '~/mysql-core/db.ts';
@@ -22,7 +22,7 @@ export type PlanetScaleDatabase<
 > = MySqlDatabase<PlanetscaleQueryResultHKT, PlanetScalePreparedQueryHKT, TSchema>;
 
 export function drizzle<TSchema extends Record<string, unknown> = Record<string, never>>(
-	client: Connection | Client,
+	client: Client | Connection,
 	config: DrizzleConfig<TSchema> = {},
 ): PlanetScaleDatabase<TSchema> {
 	const dialect = new MySqlDialect();

--- a/drizzle-orm/src/planetscale-serverless/driver.ts
+++ b/drizzle-orm/src/planetscale-serverless/driver.ts
@@ -1,4 +1,4 @@
-import type { Client, Connection } from '@planetscale/database';
+import type { Client } from '@planetscale/database';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { MySqlDatabase } from '~/mysql-core/db.ts';
@@ -22,9 +22,26 @@ export type PlanetScaleDatabase<
 > = MySqlDatabase<PlanetscaleQueryResultHKT, PlanetScalePreparedQueryHKT, TSchema>;
 
 export function drizzle<TSchema extends Record<string, unknown> = Record<string, never>>(
-	client: Client | Connection,
+	client: Client,
 	config: DrizzleConfig<TSchema> = {},
 ): PlanetScaleDatabase<TSchema> {
+	if (!(client instanceof Client)) {
+		throw new DrizzleError({
+			message: `You need to pass an instance of Client:
+
+import { Client } from "@planetscale/database";
+
+const client = new Client({
+  host: process.env["DATABASE_HOST"],
+  username: process.env["DATABASE_USERNAME"],
+  password: process.env["DATABASE_PASSWORD"],
+});
+
+const db = drizzle(client);
+`,
+		});
+	}
+
 	const dialect = new MySqlDialect();
 	let logger;
 	if (config.logger === true) {

--- a/drizzle-orm/src/planetscale-serverless/driver.ts
+++ b/drizzle-orm/src/planetscale-serverless/driver.ts
@@ -1,4 +1,4 @@
-import type { Client } from '@planetscale/database';
+import { Client } from '@planetscale/database';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { MySqlDatabase } from '~/mysql-core/db.ts';

--- a/drizzle-orm/src/planetscale-serverless/session.ts
+++ b/drizzle-orm/src/planetscale-serverless/session.ts
@@ -1,4 +1,4 @@
-import type { Connection, ExecutedQuery, Transaction } from '@planetscale/database';
+import type { Connection, Client, ExecutedQuery, Transaction } from '@planetscale/database';
 import { entityKind } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { NoopLogger } from '~/logger.ts';
@@ -16,7 +16,7 @@ import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations
 import { fillPlaceholders, type Query, type SQL, sql } from '~/sql/sql.ts';
 import { type Assume, mapResultRow } from '~/utils.ts';
 
-export type PlanetScaleConnection = Connection;
+export type PlanetScaleConnection = Connection | Client;
 
 export class PlanetScalePreparedQuery<T extends PreparedQueryConfig> extends PreparedQuery<T> {
 	static readonly [entityKind]: string = 'PlanetScalePreparedQuery';

--- a/drizzle-orm/src/planetscale-serverless/session.ts
+++ b/drizzle-orm/src/planetscale-serverless/session.ts
@@ -1,4 +1,4 @@
-import type { Connection, Client, ExecutedQuery, Transaction } from '@planetscale/database';
+import type { Client, Connection, ExecutedQuery, Transaction } from '@planetscale/database';
 import { entityKind } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { NoopLogger } from '~/logger.ts';
@@ -16,7 +16,7 @@ import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations
 import { fillPlaceholders, type Query, type SQL, sql } from '~/sql/sql.ts';
 import { type Assume, mapResultRow } from '~/utils.ts';
 
-export type PlanetScaleConnection = Connection | Client;
+export type PlanetScaleConnection = Connection;
 
 export class PlanetScalePreparedQuery<T extends PreparedQueryConfig> extends PreparedQuery<T> {
 	static readonly [entityKind]: string = 'PlanetScalePreparedQuery';
@@ -25,7 +25,7 @@ export class PlanetScalePreparedQuery<T extends PreparedQueryConfig> extends Pre
 	private query = { as: 'array' } as const;
 
 	constructor(
-		private client: PlanetScaleConnection | Transaction,
+		private client: Client | Connection | Transaction,
 		private queryString: string,
 		private params: unknown[],
 		private logger: Logger,
@@ -70,10 +70,10 @@ export class PlanetscaleSession<
 	static readonly [entityKind]: string = 'PlanetscaleSession';
 
 	private logger: Logger;
-	private client: PlanetScaleConnection | Transaction;
+	private client: Client | Connection | Transaction;
 
 	constructor(
-		private baseClient: PlanetScaleConnection,
+		private baseClient: Client | Connection,
 		dialect: MySqlDialect,
 		tx: Transaction | undefined,
 		private schema: RelationalSchemaConfig<TSchema> | undefined,

--- a/drizzle-orm/src/planetscale-serverless/session.ts
+++ b/drizzle-orm/src/planetscale-serverless/session.ts
@@ -1,4 +1,4 @@
-import type { Client, ExecutedQuery, Transaction } from '@planetscale/database';
+import type { Client, Connection, ExecutedQuery, Transaction } from '@planetscale/database';
 import { entityKind } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { NoopLogger } from '~/logger.ts';
@@ -23,7 +23,7 @@ export class PlanetScalePreparedQuery<T extends PreparedQueryConfig> extends Pre
 	private query = { as: 'array' } as const;
 
 	constructor(
-		private client: Client | Transaction,
+		private client: Client | Transaction | Connection,
 		private queryString: string,
 		private params: unknown[],
 		private logger: Logger,
@@ -68,10 +68,10 @@ export class PlanetscaleSession<
 	static readonly [entityKind]: string = 'PlanetscaleSession';
 
 	private logger: Logger;
-	private client: Client | Transaction;
+	private client: Client | Transaction | Connection;
 
 	constructor(
-		private baseClient: Client,
+		private baseClient: Client | Connection,
 		dialect: MySqlDialect,
 		tx: Transaction | undefined,
 		private schema: RelationalSchemaConfig<TSchema> | undefined,

--- a/drizzle-orm/src/planetscale-serverless/session.ts
+++ b/drizzle-orm/src/planetscale-serverless/session.ts
@@ -16,8 +16,6 @@ import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations
 import { fillPlaceholders, type Query, type SQL, sql } from '~/sql/sql.ts';
 import { type Assume, mapResultRow } from '~/utils.ts';
 
-export type PlanetScaleConnection = Connection;
-
 export class PlanetScalePreparedQuery<T extends PreparedQueryConfig> extends PreparedQuery<T> {
 	static readonly [entityKind]: string = 'PlanetScalePreparedQuery';
 
@@ -73,7 +71,7 @@ export class PlanetscaleSession<
 	private client: Client | Connection | Transaction;
 
 	constructor(
-		private baseClient: Client | Connection,
+		private baseClient: Client,
 		dialect: MySqlDialect,
 		tx: Transaction | undefined,
 		private schema: RelationalSchemaConfig<TSchema> | undefined,

--- a/drizzle-orm/src/planetscale-serverless/session.ts
+++ b/drizzle-orm/src/planetscale-serverless/session.ts
@@ -1,4 +1,4 @@
-import type { Client, Connection, ExecutedQuery, Transaction } from '@planetscale/database';
+import type { Client, ExecutedQuery, Transaction } from '@planetscale/database';
 import { entityKind } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { NoopLogger } from '~/logger.ts';
@@ -23,7 +23,7 @@ export class PlanetScalePreparedQuery<T extends PreparedQueryConfig> extends Pre
 	private query = { as: 'array' } as const;
 
 	constructor(
-		private client: Client | Connection | Transaction,
+		private client: Client | Transaction,
 		private queryString: string,
 		private params: unknown[],
 		private logger: Logger,
@@ -68,7 +68,7 @@ export class PlanetscaleSession<
 	static readonly [entityKind]: string = 'PlanetscaleSession';
 
 	private logger: Logger;
-	private client: Client | Connection | Transaction;
+	private client: Client | Transaction;
 
 	constructor(
 		private baseClient: Client,

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -62,7 +62,7 @@
     "@libsql/client": "^0.1.6",
     "@miniflare/d1": "^2.14.0",
     "@miniflare/shared": "^2.14.0",
-    "@planetscale/database": "^1.7.0",
+    "@planetscale/database": "^1.16.0",
     "@typescript/analyze-trace": "^0.10.0",
     "@vercel/postgres": "^0.3.0",
     "better-sqlite3": "^8.4.0",

--- a/integration-tests/tests/planetscale-serverless/mysql.test.ts
+++ b/integration-tests/tests/planetscale-serverless/mysql.test.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 
-import { connect } from '@planetscale/database';
+import { Client } from '@planetscale/database';
 import type { TestFn } from 'ava';
 import anyTest from 'ava';
 import { and, asc, eq, name, placeholder, sql, TransactionRollbackError } from 'drizzle-orm';
@@ -70,7 +70,7 @@ test.before(async (t) => {
 	const ctx = t.context;
 
 	ctx.db = drizzle(
-		connect({ url: process.env['PLANETSCALE_CONNECTION_STRING']! }),
+		new Client({ url: process.env['PLANETSCALE_CONNECTION_STRING']! }),
 		{ logger: ENABLE_LOGGING },
 	);
 });

--- a/integration-tests/tests/planetscale-serverless/mysql.test.ts
+++ b/integration-tests/tests/planetscale-serverless/mysql.test.ts
@@ -407,7 +407,7 @@ test.serial('build query insert with onDuplicate', async (t) => {
 	t.deepEqual(query, {
 		sql: `insert into \`${
 			getTableConfig(usersTable).name
-		}\` (\`name\`, \`jsonb\`) values (?, ?) on duplicate key update \`name\` = ?`,
+		}\` (\`id\`, \`name\`, \`verified\`, \`jsonb\`, \`created_at\`) values (default, ?, default, ?, default) on duplicate key update \`name\` = ?`,
 		params: ['John', '["foo","bar"]', 'John1'],
 	});
 });

--- a/integration-tests/tests/relational/mysql.planetscale.test.ts
+++ b/integration-tests/tests/relational/mysql.planetscale.test.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 
-import { connect } from '@planetscale/database';
+import { Client } from '@planetscale/database';
 import { desc, DrizzleError, eq, gt, gte, or, placeholder, sql, TransactionRollbackError } from 'drizzle-orm';
 import { drizzle, type PlanetScaleDatabase } from 'drizzle-orm/planetscale-serverless';
 import { beforeAll, beforeEach, expect, expectTypeOf, test } from 'vitest';
@@ -19,7 +19,7 @@ let db: PlanetScaleDatabase<typeof schema>;
 
 beforeAll(async () => {
 	db = drizzle(
-		connect({
+		new Client({
 			url: process.env['PLANETSCALE_CONNECTION_STRING']!,
 			// host: process.env['DATABASE_HOST']!,
 			// username: process.env['DATABASE_USERNAME']!,

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
 			'tests/imports/**/*',
 		],
 		exclude: [
-			...(process.env.SKIP_PLANETSCALE_TESTS ? ['tests/relational/mysql.planetscale.test.ts'] : []),
+			...(process.env.SKIP_EXTERNAL_DB_TESTS
+				? ['tests/relational/mysql.planetscale.test.ts', 'tests/neon-http-batch.test.ts']
+				: []),
 			'tests/relational/vercel.test.ts',
 		],
 		typecheck: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       '@planetscale/database':
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^1.16.0
+        version: 1.16.0
       '@types/better-sqlite3':
         specifier: ^7.6.4
         version: 7.6.4
@@ -171,10 +171,10 @@ importers:
         version: 3.12.7
       vite-tsconfig-paths:
         specifier: ^4.2.0
-        version: 4.2.0
+        version: 4.2.0(typescript@5.2.2)(vite@4.3.9)
       vitest:
         specifier: ^0.31.4
-        version: 0.31.4
+        version: 0.31.4(@vitest/ui@0.31.4)
       zod:
         specifier: ^3.20.2
         version: 3.21.4
@@ -338,8 +338,8 @@ importers:
         specifier: ^2.14.0
         version: 2.14.0
       '@planetscale/database':
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^1.16.0
+        version: 1.16.0
       '@typescript/analyze-trace':
         specifier: ^0.10.0
         version: 0.10.0
@@ -448,7 +448,7 @@ importers:
         version: 4.3.9(@types/node@20.2.5)
       vite-tsconfig-paths:
         specifier: ^4.2.0
-        version: 4.2.0(vite@4.3.9)
+        version: 4.2.0(typescript@5.2.2)(vite@4.3.9)
       zx:
         specifier: ^7.2.2
         version: 7.2.2
@@ -4244,8 +4244,8 @@ packages:
     dev: true
     optional: true
 
-  /@planetscale/database@1.7.0:
-    resolution: {integrity: sha512-lWR6biXChUyQnxsT4RT1CIeR3ZJvwTQXiQ+158MnY3VjLwjHEGakDzdH9kwUGPk6CHvu6UeqRXp1DgUOVHJFTw==}
+  /@planetscale/database@1.16.0:
+    resolution: {integrity: sha512-HNUrTqrd8aTRZYMDcsoZ62s36sIWkMMmKZBOehoCWR2WrfNPKq+Q1yQef5okl3pSVlldFnu2h/dbHjOsDTHXug==}
     engines: {node: '>=16'}
 
   /@polka/url@1.0.0-next.21:
@@ -8233,6 +8233,7 @@ packages:
 
   /glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
+    requiresBuild: true
     dependencies:
       inflight: 1.0.6
       inherits: 2.0.4
@@ -9821,6 +9822,7 @@ packages:
   /ncp@2.0.0:
     resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -11048,6 +11050,7 @@ packages:
   /rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
     hasBin: true
+    requiresBuild: true
     dependencies:
       glob: 6.0.4
     dev: true
@@ -11948,7 +11951,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /tsconfck@2.1.1:
+  /tsconfck@2.1.1(typescript@5.2.2):
     resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
     engines: {node: ^14.13.1 || ^16 || >=18}
     hasBin: true
@@ -11957,6 +11960,8 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+    dependencies:
+      typescript: 5.2.2(patch_hash=wmhs4olj6eveeldp6si4l46ssq)
     dev: true
 
   /tsconfig-paths@3.14.2:
@@ -12504,7 +12509,7 @@ packages:
       - terser
     dev: true
 
-  /vite-tsconfig-paths@4.2.0:
+  /vite-tsconfig-paths@4.2.0(typescript@5.2.2)(vite@4.3.9):
     resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
     peerDependencies:
       vite: '*'
@@ -12514,23 +12519,7 @@ packages:
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 2.1.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /vite-tsconfig-paths@4.2.0(vite@4.3.9):
-    resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-      globrex: 0.1.2
-      tsconfck: 2.1.1
+      tsconfck: 2.1.1(typescript@5.2.2)
       vite: 4.3.9(@types/node@20.2.5)
     transitivePeerDependencies:
       - supports-color
@@ -12634,71 +12623,6 @@ packages:
       rollup: 3.27.2
     optionalDependencies:
       fsevents: 2.3.3
-
-  /vitest@0.31.4:
-    resolution: {integrity: sha512-GoV0VQPmWrUFOZSg3RpQAPN+LPmHg2/gxlMNJlyxJihkz6qReHDV6b0pPDcqFLNEPya4tWJ1pgwUNP9MLmUfvQ==}
-    engines: {node: '>=v14.18.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.5
-      '@types/chai-subset': 1.3.3
-      '@types/node': 20.8.7
-      '@vitest/expect': 0.31.4
-      '@vitest/runner': 0.31.4
-      '@vitest/snapshot': 0.31.4
-      '@vitest/spy': 0.31.4
-      '@vitest/utils': 0.31.4
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      cac: 6.7.14
-      chai: 4.3.7
-      concordance: 5.0.4
-      debug: 4.3.4
-      local-pkg: 0.4.3
-      magic-string: 0.30.0
-      pathe: 1.1.1
-      picocolors: 1.0.0
-      std-env: 3.3.3
-      strip-literal: 1.0.1
-      tinybench: 2.5.0
-      tinypool: 0.5.0
-      vite: 4.3.9(@types/node@20.8.7)
-      vite-node: 0.31.4(@types/node@20.8.7)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
 
   /vitest@0.31.4(@vitest/ui@0.31.4):
     resolution: {integrity: sha512-GoV0VQPmWrUFOZSg3RpQAPN+LPmHg2/gxlMNJlyxJihkz6qReHDV6b0pPDcqFLNEPya4tWJ1pgwUNP9MLmUfvQ==}


### PR DESCRIPTION
I have no actually knowledge of TypeScript, but this should mitigate the issues in https://github.com/drizzle-team/drizzle-orm/issues/1743

Passing a `Client` instance to the drizzle constructor properly handles connection pooling and safely creating new connections when needed.

`Client` itself supports `execute()` and `transaction()` just like an individual `Connection`, just done in a more correct way.

Related: https://github.com/drizzle-team/drizzle-orm-docs/pull/210

As for documentation, currently for `mysql2`, it's documented both how to use a single connection and a connection pool, so this change is our version of a connection pool. So it might make sense to document both ways? But really, I'd personally believe should always use a `Client` rather than an explicit single `Connection` in all cases. Unlike a traditional MySQL connection, our `Connection` is essentially free and doesn't translate to a new TCP connection. It's just an object to store shared state.

Given my very limited knowledge of TypeScript, I'm not really sure how to verify this change works and passes the type checker, but I read through the code in this driver and it seems like this type union would satisfy all of the uses.

Example script I used to validate behavior:
https://gist.github.com/mattrobenolt/b33e965d285caa6ade5c2484c28d9194

<details>
<summary>Session logs</summary>

```
|INFO| ok method="Execute" query="select 2"              session_id="4Bbn0YabRmQ54TpY4PH2r" client_session=false
|INFO| ok method="Execute" query="select 1"              session_id="LM0chCw2uLqRaVvBH9mjI" client_session=false
|INFO| ok method="Execute" query="BEGIN"                 session_id="XK2sRh5KXx_kMXTMAKoZS" client_session=false
|INFO| ok method="Execute" query="select 1"              session_id="XK2sRh5KXx_kMXTMAKoZS" client_session=true
|INFO| ok method="Execute" query="savepoint sp1"         session_id="XK2sRh5KXx_kMXTMAKoZS" client_session=true
|INFO| ok method="Execute" query="select 2"              session_id="XK2sRh5KXx_kMXTMAKoZS" client_session=true
|INFO| ok method="Execute" query="release savepoint sp1" session_id="XK2sRh5KXx_kMXTMAKoZS" client_session=true
|INFO| ok method="Execute" query="COMMIT"                session_id="XK2sRh5KXx_kMXTMAKoZS" client_session=true
```

From these logs, each `session_id` represents a unique Connection. So we can see that the first two queries each used a new session with no `client_session`, meaning, the driver didn't send along an existing session. It was a new session entirely.

Then the subsequent BEGIN until COMMIT block shares the same `session_id` correctly, and after the first BEGIN, we can see `client_session=true` meaning, we are indeed sending along the existing client session for each query.
</details>