### PR TITLE
Fix: relations across schemas

### DIFF
--- a/drizzle-orm/src/column-builder.ts
+++ b/drizzle-orm/src/column-builder.ts
@@ -31,9 +31,11 @@ export interface ColumnBuilderBaseConfig<TDataType extends ColumnDataType, TColu
 export type MakeColumnConfig<
 	T extends ColumnBuilderBaseConfig<ColumnDataType, string>,
 	TTableName extends string,
+	TSchemaName extends string | undefined = undefined,
 > = {
 	name: T['name'];
 	tableName: TTableName;
+	schemaName: TSchemaName;
 	dataType: T['dataType'];
 	columnType: T['columnType'];
 	data: T extends { $type: infer U } ? U : T['data'];
@@ -41,7 +43,8 @@ export type MakeColumnConfig<
 	notNull: T extends { notNull: true } ? true : false;
 	hasDefault: T extends { hasDefault: true } ? true : false;
 	enumValues: T['enumValues'];
-	baseColumn: T extends { baseBuilder: infer U extends ColumnBuilderBase } ? BuildColumn<TTableName, U, 'common'>
+	baseColumn: T extends { baseBuilder: infer U extends ColumnBuilderBase }
+		? BuildColumn<TTableName, U, 'common', TSchemaName>
 		: never;
 } & {};
 
@@ -208,19 +211,21 @@ export type BuildColumn<
 	TTableName extends string,
 	TBuilder extends ColumnBuilderBase,
 	TDialect extends Dialect,
-> = TDialect extends 'pg' ? PgColumn<MakeColumnConfig<TBuilder['_'], TTableName>>
-	: TDialect extends 'mysql' ? MySqlColumn<MakeColumnConfig<TBuilder['_'], TTableName>>
-	: TDialect extends 'sqlite' ? SQLiteColumn<MakeColumnConfig<TBuilder['_'], TTableName>>
-	: TDialect extends 'common' ? Column<MakeColumnConfig<TBuilder['_'], TTableName>>
+	TSchemaName extends string | undefined = undefined,
+> = TDialect extends 'pg' ? PgColumn<MakeColumnConfig<TBuilder['_'], TTableName, TSchemaName>>
+	: TDialect extends 'mysql' ? MySqlColumn<MakeColumnConfig<TBuilder['_'], TTableName, TSchemaName>>
+	: TDialect extends 'sqlite' ? SQLiteColumn<MakeColumnConfig<TBuilder['_'], TTableName, TSchemaName>>
+	: TDialect extends 'common' ? Column<MakeColumnConfig<TBuilder['_'], TTableName, TSchemaName>>
 	: never;
 
 export type BuildColumns<
 	TTableName extends string,
 	TConfigMap extends Record<string, ColumnBuilderBase>,
 	TDialect extends Dialect,
+	TSchemaName extends string | undefined = undefined,
 > =
 	& {
-		[Key in keyof TConfigMap]: BuildColumn<TTableName, TConfigMap[Key], TDialect>;
+		[Key in keyof TConfigMap]: BuildColumn<TTableName, TConfigMap[Key], TDialect, TSchemaName>;
 	}
 	& {};
 

--- a/drizzle-orm/src/mysql-core/db.ts
+++ b/drizzle-orm/src/mysql-core/db.ts
@@ -71,7 +71,7 @@ export class MySqlDatabase<
 						dialect,
 						session,
 						this.mode,
-					);
+					) as any;
 			}
 		}
 	}

--- a/drizzle-orm/src/mysql-core/table.ts
+++ b/drizzle-orm/src/mysql-core/table.ts
@@ -61,19 +61,21 @@ export function mysqlTableWithSchema<
 >(
 	name: TTableName,
 	columns: TColumnsMap,
-	extraConfig: ((self: BuildColumns<TTableName, TColumnsMap, 'mysql'>) => MySqlTableExtraConfig) | undefined,
+	extraConfig:
+		| ((self: BuildColumns<TTableName, TColumnsMap, 'mysql', TSchemaName>) => MySqlTableExtraConfig)
+		| undefined,
 	schema: TSchemaName,
 	baseName = name,
 ): MySqlTableWithColumns<{
 	name: TTableName;
 	schema: TSchemaName;
-	columns: BuildColumns<TTableName, TColumnsMap, 'mysql'>;
+	columns: BuildColumns<TTableName, TColumnsMap, 'mysql', TSchemaName>;
 	dialect: 'mysql';
 }> {
 	const rawTable = new MySqlTable<{
 		name: TTableName;
 		schema: TSchemaName;
-		columns: BuildColumns<TTableName, TColumnsMap, 'mysql'>;
+		columns: BuildColumns<TTableName, TColumnsMap, 'mysql', TSchemaName>;
 		dialect: 'mysql';
 	}>(name, schema, baseName);
 
@@ -84,7 +86,7 @@ export function mysqlTableWithSchema<
 			rawTable[InlineForeignKeys].push(...colBuilder.buildForeignKeys(column, rawTable));
 			return [name, column];
 		}),
-	) as unknown as BuildColumns<TTableName, TColumnsMap, 'mysql'>;
+	) as unknown as BuildColumns<TTableName, TColumnsMap, 'mysql', TSchemaName>;
 
 	const table = Object.assign(rawTable, builtColumns);
 
@@ -106,11 +108,11 @@ export interface MySqlTableFn<TSchemaName extends string | undefined = undefined
 	>(
 		name: TTableName,
 		columns: TColumnsMap,
-		extraConfig?: (self: BuildColumns<TTableName, TColumnsMap, 'mysql'>) => MySqlTableExtraConfig,
+		extraConfig?: (self: BuildColumns<TTableName, TColumnsMap, 'mysql', TSchemaName>) => MySqlTableExtraConfig,
 	): MySqlTableWithColumns<{
 		name: TTableName;
 		schema: TSchemaName;
-		columns: BuildColumns<TTableName, TColumnsMap, 'mysql'>;
+		columns: BuildColumns<TTableName, TColumnsMap, 'mysql', TSchemaName>;
 		dialect: 'mysql';
 	}>;
 }

--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -67,7 +67,7 @@ export class PgDatabase<
 					columns,
 					dialect,
 					session,
-				);
+				) as any;
 			}
 		}
 	}

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -24,6 +24,7 @@ import {
 	type TableRelationalConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
+import { and, eq, View } from '~/sql/index.ts';
 import {
 	type DriverValueEncoder,
 	type Name,
@@ -39,9 +40,8 @@ import { getTableName, Table } from '~/table.ts';
 import { orderSelectedFields, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type { PgSession } from './session.ts';
-import type { PgMaterializedView } from './view.ts';
-import { View, and, eq } from '~/sql/index.ts';
 import { PgViewBase } from './view-base.ts';
+import type { PgMaterializedView } from './view.ts';
 
 export class PgDialect {
 	static readonly [entityKind]: string = 'PgDialect';
@@ -1183,7 +1183,10 @@ export class PgDialect {
 				} of selectedRelations
 			) {
 				const normalizedRelation = normalizeRelation(schema, tableNamesMap, relation);
-				const relationTableName = relation.referencedTable[Table.Symbol.Name];
+				const relationTableName = relation.referencedTable[Table.Symbol.Schema]
+					? `${relation.referencedTable[Table.Symbol.Schema]}.${relation.referencedTable[Table.Symbol.Name]}`
+					: relation.referencedTable[Table.Symbol.Name];
+
 				const relationTableTsName = tableNamesMap[relationTableName]!;
 				const relationTableAlias = `${tableAlias}_${selectedRelationTsKey}`;
 				const joinOn = and(

--- a/drizzle-orm/src/pg-core/table.ts
+++ b/drizzle-orm/src/pg-core/table.ts
@@ -60,13 +60,13 @@ export function pgTableWithSchema<
 ): PgTableWithColumns<{
 	name: TTableName;
 	schema: TSchemaName;
-	columns: BuildColumns<TTableName, TColumnsMap, 'pg'>;
+	columns: BuildColumns<TTableName, TColumnsMap, 'pg', TSchemaName>;
 	dialect: 'pg';
 }> {
 	const rawTable = new PgTable<{
 		name: TTableName;
 		schema: TSchemaName;
-		columns: BuildColumns<TTableName, TColumnsMap, 'pg'>;
+		columns: BuildColumns<TTableName, TColumnsMap, 'pg', TSchemaName>;
 		dialect: 'pg';
 	}>(name, schema, baseName);
 
@@ -77,7 +77,7 @@ export function pgTableWithSchema<
 			rawTable[InlineForeignKeys].push(...colBuilder.buildForeignKeys(column, rawTable));
 			return [name, column];
 		}),
-	) as unknown as BuildColumns<TTableName, TColumnsMap, 'pg'>;
+	) as unknown as BuildColumns<TTableName, TColumnsMap, 'pg', TSchemaName>;
 
 	const table = Object.assign(rawTable, builtColumns);
 
@@ -101,7 +101,7 @@ export interface PgTableFn<TSchema extends string | undefined = undefined> {
 	): PgTableWithColumns<{
 		name: TTableName;
 		schema: TSchema;
-		columns: BuildColumns<TTableName, TColumnsMap, 'pg'>;
+		columns: BuildColumns<TTableName, TColumnsMap, 'pg', TSchema>;
 		dialect: 'pg';
 	}>;
 }

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -16,9 +16,9 @@ import {
 	type TableRelationalConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
+import type { Name } from '~/sql/index.ts';
+import { and, eq } from '~/sql/index.ts';
 import { Param, type QueryWithTypings, SQL, sql, type SQLChunk } from '~/sql/sql.ts';
-import type { Name} from '~/sql/index.ts';
-import { and, eq } from '~/sql/index.ts'
 import { SQLiteColumn } from '~/sqlite-core/columns/index.ts';
 import type { SQLiteDeleteConfig, SQLiteInsertConfig, SQLiteUpdateConfig } from '~/sqlite-core/query-builders/index.ts';
 import { SQLiteTable } from '~/sqlite-core/table.ts';
@@ -567,7 +567,10 @@ export abstract class SQLiteDialect {
 				} of selectedRelations
 			) {
 				const normalizedRelation = normalizeRelation(schema, tableNamesMap, relation);
-				const relationTableName = relation.referencedTable[Table.Symbol.Name];
+				const relationTableName = relation.referencedTable[Table.Symbol.Schema]
+					? `${relation.referencedTable[Table.Symbol.Schema]}.${relation.referencedTable[Table.Symbol.Name]}`
+					: relation.referencedTable[Table.Symbol.Name];
+
 				const relationTableTsName = tableNamesMap[relationTableName]!;
 				const relationTableAlias = `${tableAlias}_${selectedRelationTsKey}`;
 				// const relationTable = schema[relationTableTsName]!;

--- a/drizzle-orm/src/sqlite-core/table.ts
+++ b/drizzle-orm/src/sqlite-core/table.ts
@@ -59,11 +59,11 @@ export interface SQLiteTableFn<TSchema extends string | undefined = undefined> {
 	>(
 		name: TTableName,
 		columns: TColumnsMap,
-		extraConfig?: (self: BuildColumns<TTableName, TColumnsMap, 'sqlite'>) => SQLiteTableExtraConfig,
+		extraConfig?: (self: BuildColumns<TTableName, TColumnsMap, 'sqlite', TSchema>) => SQLiteTableExtraConfig,
 	): SQLiteTableWithColumns<{
 		name: TTableName;
 		schema: TSchema;
-		columns: BuildColumns<TTableName, TColumnsMap, 'sqlite'>;
+		columns: BuildColumns<TTableName, TColumnsMap, 'sqlite', TSchema>;
 		dialect: 'sqlite';
 	}>;
 }
@@ -75,19 +75,19 @@ function sqliteTableBase<
 >(
 	name: TTableName,
 	columns: TColumnsMap,
-	extraConfig?: (self: BuildColumns<TTableName, TColumnsMap, 'sqlite'>) => SQLiteTableExtraConfig,
+	extraConfig?: (self: BuildColumns<TTableName, TColumnsMap, 'sqlite', TSchema>) => SQLiteTableExtraConfig,
 	schema?: TSchema,
 	baseName = name,
 ): SQLiteTableWithColumns<{
 	name: TTableName;
 	schema: TSchema;
-	columns: BuildColumns<TTableName, TColumnsMap, 'sqlite'>;
+	columns: BuildColumns<TTableName, TColumnsMap, 'sqlite', TSchema>;
 	dialect: 'sqlite';
 }> {
 	const rawTable = new SQLiteTable<{
 		name: TTableName;
 		schema: TSchema;
-		columns: BuildColumns<TTableName, TColumnsMap, 'sqlite'>;
+		columns: BuildColumns<TTableName, TColumnsMap, 'sqlite', TSchema>;
 		dialect: 'sqlite';
 	}>(name, schema, baseName);
 
@@ -98,7 +98,7 @@ function sqliteTableBase<
 			rawTable[InlineForeignKeys].push(...colBuilder.buildForeignKeys(column, rawTable));
 			return [name, column];
 		}),
-	) as unknown as BuildColumns<TTableName, TColumnsMap, 'sqlite'>;
+	) as unknown as BuildColumns<TTableName, TColumnsMap, 'sqlite', TSchema>;
 
 	const table = Object.assign(rawTable, builtColumns);
 

--- a/drizzle-orm/type-tests/mysql/tables.ts
+++ b/drizzle-orm/type-tests/mysql/tables.ts
@@ -91,7 +91,8 @@ export const citiesCustom = customSchema.table('cities_table', {
 	citiesNameIdx: index('citiesNameIdx').on(cities.id),
 }));
 
-Expect<Equal<typeof cities._.columns, typeof citiesCustom._.columns>>;
+// This test is not valid anymore because the schema is now part of the column type
+// Expect<Equal<typeof cities._.columns, typeof citiesCustom._.columns>>;
 
 export const classes = mysqlTable('classes_table', {
 	id: serial('id').primaryKey(),
@@ -126,28 +127,30 @@ Expect<
 		MySqlViewWithSelection<'new_yorkers', false, {
 			userId: MySqlColumn<{
 				name: 'id';
+				tableName: 'new_yorkers';
+				schemaName: undefined;
 				dataType: 'number';
 				columnType: 'MySqlSerial';
 				data: number;
 				driverParam: number;
 				notNull: true;
 				hasDefault: true;
-				tableName: 'new_yorkers';
 				enumValues: undefined;
 				baseColumn: never;
-			}>;
+			}, object>;
 			cityId: MySqlColumn<{
 				name: 'id';
+				tableName: 'new_yorkers';
+				schemaName: undefined;
 				dataType: 'number';
 				columnType: 'MySqlSerial';
 				data: number;
 				driverParam: number;
 				notNull: false;
 				hasDefault: true;
-				tableName: 'new_yorkers';
 				enumValues: undefined;
 				baseColumn: never;
-			}>;
+			}, object>;
 		}>,
 		typeof newYorkers
 	>
@@ -175,28 +178,30 @@ Expect<
 			MySqlViewWithSelection<'new_yorkers', false, {
 				userId: MySqlColumn<{
 					name: 'id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlSerial';
 					data: number;
 					driverParam: number;
 					notNull: true;
 					hasDefault: true;
-					tableName: 'new_yorkers';
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 				cityId: MySqlColumn<{
 					name: 'id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlSerial';
 					data: number;
 					driverParam: number;
 					notNull: false;
 					hasDefault: true;
-					tableName: 'new_yorkers';
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 			}>,
 			typeof newYorkers
 		>
@@ -222,28 +227,30 @@ Expect<
 			MySqlViewWithSelection<'new_yorkers', false, {
 				userId: MySqlColumn<{
 					name: 'user_id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlInt';
 					data: number;
 					driverParam: string | number;
-					hasDefault: false;
 					notNull: true;
-					tableName: 'new_yorkers';
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 				cityId: MySqlColumn<{
 					name: 'city_id';
-					notNull: false;
-					hasDefault: false;
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlInt';
 					data: number;
 					driverParam: string | number;
-					tableName: 'new_yorkers';
+					notNull: false;
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 			}>,
 			typeof newYorkers
 		>
@@ -269,28 +276,30 @@ Expect<
 			MySqlViewWithSelection<'new_yorkers', false, {
 				userId: MySqlColumn<{
 					name: 'user_id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlInt';
 					data: number;
 					driverParam: string | number;
-					hasDefault: false;
 					notNull: true;
-					tableName: 'new_yorkers';
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 				cityId: MySqlColumn<{
 					name: 'city_id';
-					notNull: false;
-					hasDefault: false;
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlInt';
 					data: number;
 					driverParam: string | number;
-					tableName: 'new_yorkers';
+					notNull: false;
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 			}>,
 			typeof newYorkers
 		>
@@ -308,28 +317,30 @@ Expect<
 			MySqlViewWithSelection<'new_yorkers', true, {
 				userId: MySqlColumn<{
 					name: 'user_id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlInt';
 					data: number;
 					driverParam: string | number;
-					hasDefault: false;
 					notNull: true;
-					tableName: 'new_yorkers';
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 				cityId: MySqlColumn<{
 					name: 'city_id';
-					notNull: false;
-					hasDefault: false;
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlInt';
 					data: number;
 					driverParam: string | number;
-					tableName: 'new_yorkers';
+					notNull: false;
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 			}>,
 			typeof newYorkers
 		>
@@ -347,28 +358,30 @@ Expect<
 			MySqlViewWithSelection<'new_yorkers', true, {
 				userId: MySqlColumn<{
 					name: 'user_id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlInt';
 					data: number;
 					driverParam: string | number;
-					hasDefault: false;
 					notNull: true;
-					tableName: 'new_yorkers';
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 				cityId: MySqlColumn<{
 					name: 'city_id';
-					notNull: false;
-					hasDefault: false;
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'MySqlInt';
 					data: number;
 					driverParam: string | number;
-					tableName: 'new_yorkers';
+					notNull: false;
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 			}>,
 			typeof newYorkers
 		>
@@ -389,6 +402,7 @@ Expect<
 				brand: 'Column';
 				name: 'name';
 				tableName: 'table';
+				schemaName: undefined;
 				dataType: 'custom';
 				columnType: 'MySqlCustomColumn';
 				data: string;

--- a/drizzle-orm/type-tests/pg/array.ts
+++ b/drizzle-orm/type-tests/pg/array.ts
@@ -12,6 +12,7 @@ import { integer, pgTable } from '~/pg-core/index.ts';
 				{
 					name: 'a';
 					tableName: 'table';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'PgInteger';
 					data: number;

--- a/drizzle-orm/type-tests/pg/tables.ts
+++ b/drizzle-orm/type-tests/pg/tables.ts
@@ -168,30 +168,40 @@ export const newYorkers = pgView('new_yorkers')
 Expect<
 	Equal<
 		PgViewWithSelection<'new_yorkers', false, {
-			userId: PgColumn<{
-				tableName: 'new_yorkers';
-				name: 'id';
-				dataType: 'number';
-				columnType: 'PgSerial';
-				data: number;
-				driverParam: number;
-				notNull: true;
-				hasDefault: true;
-				enumValues: undefined;
-				baseColumn: never;
-			}>;
-			cityId: PgColumn<{
-				tableName: 'new_yorkers';
-				name: 'id';
-				dataType: 'number';
-				columnType: 'PgSerial';
-				data: number;
-				driverParam: number;
-				notNull: false;
-				hasDefault: true;
-				enumValues: undefined;
-				baseColumn: never;
-			}>;
+			userId: PgColumn<
+				{
+					name: 'id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
+					dataType: 'number';
+					columnType: 'PgSerial';
+					data: number;
+					driverParam: number;
+					notNull: true;
+					hasDefault: true;
+					enumValues: undefined;
+					baseColumn: never;
+				},
+				{},
+				{}
+			>;
+			cityId: PgColumn<
+				{
+					name: 'id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
+					dataType: 'number';
+					columnType: 'PgSerial';
+					data: number;
+					driverParam: number;
+					notNull: false;
+					hasDefault: true;
+					enumValues: undefined;
+					baseColumn: never;
+				},
+				{},
+				{}
+			>;
 		}>,
 		typeof newYorkers
 	>
@@ -219,30 +229,40 @@ Expect<
 	Expect<
 		Equal<
 			PgViewWithSelection<'new_yorkers', false, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'id';
-					dataType: 'number';
-					columnType: 'PgSerial';
-					data: number;
-					driverParam: number;
-					notNull: true;
-					hasDefault: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'id';
-					dataType: 'number';
-					columnType: 'PgSerial';
-					data: number;
-					driverParam: number;
-					notNull: false;
-					hasDefault: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgSerial';
+						data: number;
+						driverParam: number;
+						notNull: true;
+						hasDefault: true;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgSerial';
+						data: number;
+						driverParam: number;
+						notNull: false;
+						hasDefault: true;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers
 		>
@@ -268,30 +288,40 @@ Expect<
 	Expect<
 		Equal<
 			PgViewWithSelection<'new_yorkers', false, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'user_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					data: number;
-					driverParam: string | number;
-					hasDefault: false;
-					notNull: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'city_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					notNull: false;
-					hasDefault: false;
-					data: number;
-					driverParam: string | number;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'user_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: true;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'city_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: false;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers
 		>
@@ -317,30 +347,40 @@ Expect<
 	Expect<
 		Equal<
 			PgViewWithSelection<'new_yorkers', false, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'user_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					data: number;
-					driverParam: string | number;
-					hasDefault: false;
-					notNull: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'city_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					notNull: false;
-					hasDefault: false;
-					data: number;
-					driverParam: string | number;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'user_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: true;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'city_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: false;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers
 		>
@@ -356,30 +396,40 @@ Expect<
 	Expect<
 		Equal<
 			PgViewWithSelection<'new_yorkers', true, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'user_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					data: number;
-					driverParam: string | number;
-					hasDefault: false;
-					notNull: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'city_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					notNull: false;
-					hasDefault: false;
-					data: number;
-					driverParam: string | number;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'user_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: true;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'city_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: false;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers
 		>
@@ -395,30 +445,40 @@ Expect<
 	Expect<
 		Equal<
 			PgViewWithSelection<'new_yorkers', true, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'user_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					data: number;
-					driverParam: string | number;
-					hasDefault: false;
-					notNull: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'city_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					notNull: false;
-					hasDefault: false;
-					data: number;
-					driverParam: string | number;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'user_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: true;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'city_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: false;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers
 		>
@@ -449,30 +509,40 @@ export const newYorkers2 = pgMaterializedView('new_yorkers')
 Expect<
 	Equal<
 		PgMaterializedViewWithSelection<'new_yorkers', false, {
-			userId: PgColumn<{
-				tableName: 'new_yorkers';
-				name: 'id';
-				dataType: 'number';
-				columnType: 'PgSerial';
-				data: number;
-				driverParam: number;
-				notNull: true;
-				hasDefault: true;
-				enumValues: undefined;
-				baseColumn: never;
-			}>;
-			cityId: PgColumn<{
-				tableName: 'new_yorkers';
-				name: 'id';
-				dataType: 'number';
-				columnType: 'PgSerial';
-				data: number;
-				driverParam: number;
-				notNull: false;
-				hasDefault: true;
-				enumValues: undefined;
-				baseColumn: never;
-			}>;
+			userId: PgColumn<
+				{
+					name: 'id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
+					dataType: 'number';
+					columnType: 'PgSerial';
+					data: number;
+					driverParam: number;
+					notNull: true;
+					hasDefault: true;
+					enumValues: undefined;
+					baseColumn: never;
+				},
+				{},
+				{}
+			>;
+			cityId: PgColumn<
+				{
+					name: 'id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
+					dataType: 'number';
+					columnType: 'PgSerial';
+					data: number;
+					driverParam: number;
+					notNull: false;
+					hasDefault: true;
+					enumValues: undefined;
+					baseColumn: never;
+				},
+				{},
+				{}
+			>;
 		}>,
 		typeof newYorkers2
 	>
@@ -503,30 +573,40 @@ Expect<
 	Expect<
 		Equal<
 			PgMaterializedViewWithSelection<'new_yorkers', false, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'id';
-					dataType: 'number';
-					columnType: 'PgSerial';
-					data: number;
-					driverParam: number;
-					notNull: true;
-					hasDefault: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'id';
-					dataType: 'number';
-					columnType: 'PgSerial';
-					data: number;
-					driverParam: number;
-					notNull: false;
-					hasDefault: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgSerial';
+						data: number;
+						driverParam: number;
+						notNull: true;
+						hasDefault: true;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgSerial';
+						data: number;
+						driverParam: number;
+						notNull: false;
+						hasDefault: true;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers2
 		>
@@ -555,30 +635,40 @@ Expect<
 	Expect<
 		Equal<
 			PgMaterializedViewWithSelection<'new_yorkers', false, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'user_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					data: number;
-					driverParam: string | number;
-					hasDefault: false;
-					notNull: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'city_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					notNull: false;
-					hasDefault: false;
-					data: number;
-					driverParam: string | number;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'user_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: true;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'city_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: false;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers2
 		>
@@ -607,30 +697,40 @@ Expect<
 	Expect<
 		Equal<
 			PgMaterializedViewWithSelection<'new_yorkers', false, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'user_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					data: number;
-					driverParam: string | number;
-					hasDefault: false;
-					notNull: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'city_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					notNull: false;
-					hasDefault: false;
-					data: number;
-					driverParam: string | number;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'user_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: true;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'city_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: false;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers2
 		>
@@ -646,30 +746,40 @@ Expect<
 	Expect<
 		Equal<
 			PgMaterializedViewWithSelection<'new_yorkers', true, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'user_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					data: number;
-					driverParam: string | number;
-					hasDefault: false;
-					notNull: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'city_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					notNull: false;
-					hasDefault: false;
-					data: number;
-					driverParam: string | number;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'user_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: true;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'city_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: false;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers2
 		>
@@ -685,30 +795,40 @@ Expect<
 	Expect<
 		Equal<
 			PgMaterializedViewWithSelection<'new_yorkers', true, {
-				userId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'user_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					data: number;
-					driverParam: string | number;
-					hasDefault: false;
-					notNull: true;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
-				cityId: PgColumn<{
-					tableName: 'new_yorkers';
-					name: 'city_id';
-					dataType: 'number';
-					columnType: 'PgInteger';
-					notNull: false;
-					hasDefault: false;
-					data: number;
-					driverParam: string | number;
-					enumValues: undefined;
-					baseColumn: never;
-				}>;
+				userId: PgColumn<
+					{
+						name: 'user_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: true;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
+				cityId: PgColumn<
+					{
+						name: 'city_id';
+						tableName: 'new_yorkers';
+						schemaName: undefined;
+						dataType: 'number';
+						columnType: 'PgInteger';
+						data: number;
+						driverParam: string | number;
+						notNull: false;
+						hasDefault: false;
+						enumValues: undefined;
+						baseColumn: never;
+					},
+					{},
+					{}
+				>;
 			}>,
 			typeof newYorkers2
 		>
@@ -799,54 +919,74 @@ await db.refreshMaterializedView(newYorkers2).withNoData().concurrently();
 				schema: undefined;
 				dialect: 'pg';
 				columns: {
-					id: PgColumn<{
-						tableName: 'cities_table';
-						name: 'id';
-						dataType: 'number';
-						columnType: 'PgSerial';
-						data: number;
-						driverParam: number;
-						hasDefault: true;
-						notNull: true;
-						enumValues: undefined;
-						baseColumn: never;
-					}>;
-					name: PgColumn<{
-						tableName: 'cities_table';
-						name: 'name';
-						dataType: 'string';
-						columnType: 'PgText';
-						data: string;
-						driverParam: string;
-						hasDefault: false;
-						enumValues: [string, ...string[]];
-						notNull: true;
-						baseColumn: never;
-					}>;
-					role: PgColumn<{
-						tableName: 'cities_table';
-						name: 'role';
-						dataType: 'string';
-						columnType: 'PgText';
-						data: 'admin' | 'user';
-						driverParam: string;
-						hasDefault: true;
-						enumValues: ['admin', 'user'];
-						notNull: true;
-						baseColumn: never;
-					}>;
-					population: PgColumn<{
-						tableName: 'cities_table';
-						name: 'population';
-						dataType: 'number';
-						columnType: 'PgInteger';
-						data: number;
-						driverParam: string | number;
-						notNull: false;
-						hasDefault: true;
-						enumValues: undefined;
-						baseColumn: never;
-					}>;
+					id: PgColumn<
+						{
+							name: 'id';
+							tableName: 'cities_table';
+							schemaName: undefined;
+							dataType: 'number';
+							columnType: 'PgSerial';
+							data: number;
+							driverParam: number;
+							notNull: true;
+							hasDefault: true;
+							enumValues: undefined;
+							baseColumn: never;
+						},
+						{},
+						{}
+					>;
+					name: PgColumn<
+						{
+							name: 'name';
+							tableName: 'cities_table';
+							schemaName: undefined;
+							dataType: 'string';
+							columnType: 'PgText';
+							data: string;
+							driverParam: string;
+							notNull: true;
+							hasDefault: false;
+							enumValues: [string, ...string[]];
+							baseColumn: never;
+						},
+						{},
+						{}
+					>;
+					role: PgColumn<
+						{
+							name: 'role';
+							tableName: 'cities_table';
+							schemaName: undefined;
+							dataType: 'string';
+							columnType: 'PgText';
+							data: 'admin' | 'user';
+							driverParam: string;
+							notNull: true;
+							hasDefault: true;
+							enumValues: ['admin', 'user'];
+							baseColumn: never;
+						},
+						{},
+						{}
+					>;
+					population: PgColumn<
+						{
+							name: 'population';
+							tableName: 'cities_table';
+							schemaName: undefined;
+							dataType: 'number';
+							columnType: 'PgInteger';
+							data: number;
+							driverParam: string | number;
+							notNull: false;
+							hasDefault: true;
+							enumValues: undefined;
+							baseColumn: never;
+						},
+						{},
+						{}
+					>;
 				};
 			}>,
 			typeof cities

--- a/drizzle-orm/type-tests/sqlite/tables.ts
+++ b/drizzle-orm/type-tests/sqlite/tables.ts
@@ -157,28 +157,30 @@ Expect<
 		SQLiteViewWithSelection<'new_yorkers', false, {
 			userId: SQLiteColumn<{
 				name: 'id';
+				tableName: 'new_yorkers';
+				schemaName: undefined;
 				dataType: 'number';
 				columnType: 'SQLiteInteger';
 				data: number;
 				driverParam: number;
 				notNull: true;
 				hasDefault: true;
-				tableName: 'new_yorkers';
 				enumValues: undefined;
 				baseColumn: never;
-			}>;
+			}, object>;
 			cityId: SQLiteColumn<{
 				name: 'id';
+				tableName: 'new_yorkers';
+				schemaName: undefined;
 				dataType: 'number';
 				columnType: 'SQLiteInteger';
 				data: number;
 				driverParam: number;
 				notNull: false;
 				hasDefault: true;
-				tableName: 'new_yorkers';
 				enumValues: undefined;
 				baseColumn: never;
-			}>;
+			}, object>;
 		}>,
 		typeof newYorkers
 	>
@@ -200,28 +202,30 @@ Expect<
 			SQLiteViewWithSelection<'new_yorkers', false, {
 				userId: SQLiteColumn<{
 					name: 'user_id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'SQLiteInteger';
 					data: number;
 					driverParam: number;
-					hasDefault: false;
 					notNull: true;
-					tableName: 'new_yorkers';
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 				cityId: SQLiteColumn<{
 					name: 'city_id';
-					notNull: false;
-					hasDefault: false;
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'SQLiteInteger';
 					data: number;
 					driverParam: number;
-					tableName: 'new_yorkers';
+					notNull: false;
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 			}>,
 			typeof newYorkers
 		>
@@ -239,28 +243,30 @@ Expect<
 			SQLiteViewWithSelection<'new_yorkers', true, {
 				userId: SQLiteColumn<{
 					name: 'user_id';
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'SQLiteInteger';
 					data: number;
 					driverParam: number;
-					hasDefault: false;
 					notNull: true;
-					tableName: 'new_yorkers';
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 				cityId: SQLiteColumn<{
 					name: 'city_id';
-					notNull: false;
-					hasDefault: false;
+					tableName: 'new_yorkers';
+					schemaName: undefined;
 					dataType: 'number';
 					columnType: 'SQLiteInteger';
 					data: number;
 					driverParam: number;
-					tableName: 'new_yorkers';
+					notNull: false;
+					hasDefault: false;
 					enumValues: undefined;
 					baseColumn: never;
-				}>;
+				}, object>;
 			}>,
 			typeof newYorkers
 		>

--- a/integration-tests/tests/relational/accross-schemas/mysql.relation-schema.test.ts
+++ b/integration-tests/tests/relational/accross-schemas/mysql.relation-schema.test.ts
@@ -1,0 +1,293 @@
+import 'dotenv/config';
+import Docker from 'dockerode';
+import { sql } from 'drizzle-orm';
+import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2';
+import getPort from 'get-port';
+import * as mysql from 'mysql2/promise';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, beforeEach, expect, expectTypeOf, test } from 'vitest';
+import * as schema from './mysql.schema.ts';
+
+const { usersTable, citiesTable, publicUsersTable, parentTable1, childTable1 } = schema;
+
+const ENABLE_LOGGING = false;
+
+/*
+	Test cases:
+	- querying nested relation without PK with additional fields
+*/
+
+declare module 'vitest' {
+	export interface TestContext {
+		docker: Docker;
+		mysqlContainer: Docker.Container;
+		mysqlRelationsSchemaDb: MySql2Database<typeof schema>;
+		mysqlClient: mysql.Connection;
+	}
+}
+
+let globalDocker: Docker;
+let mysqlContainer: Docker.Container;
+let db: MySql2Database<typeof schema>;
+let client: mysql.Connection;
+
+async function createDockerDB(): Promise<string> {
+	const docker = (globalDocker = new Docker());
+	const port = await getPort({ port: 3306 });
+	const image = 'mysql:8';
+
+	const pullStream = await docker.pull(image);
+	await new Promise((resolve, reject) =>
+		docker.modem.followProgress(pullStream, (err) => (err ? reject(err) : resolve(err)))
+	);
+
+	mysqlContainer = await docker.createContainer({
+		Image: image,
+		Env: ['MYSQL_ROOT_PASSWORD=mysql', 'MYSQL_DATABASE=drizzle'],
+		name: `drizzle-integration-tests-${uuid()}`,
+		HostConfig: {
+			AutoRemove: true,
+			PortBindings: {
+				'3306/tcp': [{ HostPort: `${port}` }],
+			},
+		},
+	});
+
+	await mysqlContainer.start();
+
+	return `mysql://root:mysql@127.0.0.1:${port}/drizzle`;
+}
+
+beforeAll(async () => {
+	const connectionString = process.env['MYSQL_CONNECTION_STRING'] ?? await createDockerDB();
+
+	const sleep = 1000;
+	let timeLeft = 30000;
+	let connected = false;
+	let lastError: unknown | undefined;
+	do {
+		try {
+			client = await mysql.createConnection(connectionString);
+			await client.connect();
+			connected = true;
+			break;
+		} catch (e) {
+			lastError = e;
+			await new Promise((resolve) => setTimeout(resolve, sleep));
+			timeLeft -= sleep;
+		}
+	} while (timeLeft > 0);
+	if (!connected) {
+		console.error('Cannot connect to MySQL');
+		await client?.end().catch(console.error);
+		await mysqlContainer?.stop().catch(console.error);
+		throw lastError;
+	}
+	db = drizzle(client, { schema, logger: ENABLE_LOGGING, mode: 'default' });
+});
+
+afterAll(async () => {
+	await client?.end().catch(console.error);
+	await mysqlContainer?.stop().catch(console.error);
+});
+
+beforeEach(async (ctx) => {
+	ctx.mysqlRelationsSchemaDb = db;
+	ctx.mysqlClient = client;
+	ctx.docker = globalDocker;
+	ctx.mysqlContainer = mysqlContainer;
+
+	await ctx.mysqlRelationsSchemaDb.execute(sql`drop schema if exists public`);
+	await ctx.mysqlRelationsSchemaDb.execute(sql`drop schema if exists \`private\``);
+	await ctx.mysqlRelationsSchemaDb.execute(sql`drop schema if exists \`Test\``);
+	await ctx.mysqlRelationsSchemaDb.execute(sql`drop schema if exists \`Schema2\``);
+	await ctx.mysqlRelationsSchemaDb.execute(sql`drop table if exists \`publicUsers\``);
+	await ctx.mysqlRelationsSchemaDb.execute(sql`create schema public`);
+	await ctx.mysqlRelationsSchemaDb.execute(sql`create schema \`Test\``);
+	await ctx.mysqlRelationsSchemaDb.execute(sql`create schema \`Schema2\``);
+	await ctx.mysqlRelationsSchemaDb.execute(sql`create schema \`private\``);
+	await ctx.mysqlRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE \`private\`.\`users\` (
+				\`id\` integer PRIMARY KEY NOT NULL,
+				\`password\` text NOT NULL
+			);
+		`,
+	);
+	await ctx.mysqlRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE IF NOT EXISTS \`private\`.\`cities\` (
+				\`id\` serial PRIMARY KEY NOT NULL,
+				\`name\` text NOT NULL,
+				\`state\` char(2)
+			);
+		`,
+	);
+	await ctx.mysqlRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE if not exists \`publicUsers\` (
+				\`id\` serial PRIMARY KEY NOT NULL,
+				\`name\` text NOT NULL,
+				\`verified\` boolean DEFAULT false NOT NULL,
+				\`city_id\` int NOT NULL
+			);
+		`,
+	);
+	await ctx.mysqlRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE \`Test\`.\`ParentTable\` (
+			  \`Id\` serial PRIMARY KEY NOT NULL,
+			  \`Name\` text NOT NULL
+			)
+		`,
+	);
+	await ctx.mysqlRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE \`Test\`.\`ChildTable\` (
+			  \`Id\` serial PRIMARY KEY NOT NULL,
+			  \`ParentId\` int NOT NULL,
+			  \`Name\` text NOT NULL
+			)
+		`,
+	);
+	await ctx.mysqlRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE \`Schema2\`.\`ParentTable\` (
+			  \`Id\` serial PRIMARY KEY NOT NULL,
+			  \`Name\` text NOT NULL
+			)
+		`,
+	);
+	await ctx.mysqlRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE \`Schema2\`.\`ChildTable\` (
+			  \`Id\` serial PRIMARY KEY NOT NULL,
+			  \`ParentId\` int NOT NULL,
+			  \`Name\` text NOT NULL
+			)
+		`,
+	);
+});
+
+test('[Find Many] users with private password', async (t) => {
+	const { mysqlRelationsSchemaDb: db } = t;
+
+	await db.insert(citiesTable).values([
+		{ id: 1, name: 'Tampa', state: 'FL' },
+		{ id: 2, name: 'Philadelphia', state: 'PA' },
+	]);
+
+	await db.insert(publicUsersTable).values([
+		{ id: 1, name: 'Dan', cityId: 1 },
+		{ id: 2, name: 'Andrew', cityId: 2 },
+		{ id: 3, name: 'Alex', cityId: 1 },
+	]);
+
+	await db.insert(usersTable).values([
+		{ id: 1, password: 'secret' },
+		{ id: 2, password: 'secret' },
+		{ id: 3, password: 'secret' },
+	]);
+
+	const userWithEverything = await db.query.publicUsersTable.findMany({
+		with: {
+			city: true,
+			private: true,
+		},
+	});
+
+	expectTypeOf(userWithEverything).toEqualTypeOf<{
+		id: number;
+		name: string;
+		verified: boolean;
+		cityId: number | null;
+		private: {
+			id: number;
+			password: string;
+		};
+		city: {
+			id: number;
+			name: string;
+			state: string | null;
+		} | null;
+	}[]>();
+
+	expect(userWithEverything.length).eq(3);
+
+	expect(userWithEverything).toEqual(
+		[
+			{
+				id: 1,
+				name: 'Dan',
+				verified: false,
+				cityId: 1,
+				city: { id: 1, name: 'Tampa', state: 'FL' },
+				private: { id: 1, password: 'secret' },
+			},
+			{
+				id: 2,
+				name: 'Andrew',
+				verified: false,
+				cityId: 2,
+				city: { id: 2, name: 'Philadelphia', state: 'PA' },
+				private: { id: 2, password: 'secret' },
+			},
+			{
+				id: 3,
+				name: 'Alex',
+				verified: false,
+				cityId: 1,
+				city: { id: 1, name: 'Tampa', state: 'FL' },
+				private: { id: 3, password: 'secret' },
+			},
+		],
+	);
+});
+
+test('[Find Many] parent table with children, repeated names', async (t) => {
+	const { mysqlRelationsSchemaDb: db } = t;
+
+	await db.insert(parentTable1).values([
+		{ id: 1, name: 'parent1' },
+		{ id: 2, name: 'parent2' },
+	]);
+
+	await db.insert(childTable1).values([
+		{ id: 1, name: 'child1', parentId: 1 },
+		{ id: 2, name: 'child2', parentId: 2 },
+		{ id: 3, name: 'child3', parentId: 2 },
+	]);
+
+	const parentWithChildren = await db.query.parentTable1.findMany({
+		with: {
+			children: true,
+		},
+	});
+
+	expectTypeOf(parentWithChildren).toEqualTypeOf<{
+		id: number;
+		name: string;
+		children: {
+			id: number;
+			name: string;
+			parentId: number;
+		}[];
+	}[]>();
+
+	expect(parentWithChildren.length).eq(2);
+
+	expect(parentWithChildren).toEqual(
+		[
+			{
+				id: 1,
+				name: 'parent1',
+				children: [{ id: 1, name: 'child1', parentId: 1 }],
+			},
+			{
+				id: 2,
+				name: 'parent2',
+				children: [{ id: 2, name: 'child2', parentId: 2 }, { id: 3, name: 'child3', parentId: 2 }],
+			},
+		],
+	);
+});

--- a/integration-tests/tests/relational/accross-schemas/mysql.schema.ts
+++ b/integration-tests/tests/relational/accross-schemas/mysql.schema.ts
@@ -1,0 +1,92 @@
+import { boolean, char, int, type MySqlColumn, mysqlSchema, mysqlTable, serial, text } from 'drizzle-orm/mysql-core';
+
+import { relations } from 'drizzle-orm';
+
+export const mySchema = mysqlSchema('private');
+
+export const usersTable = mySchema.table('users', {
+	id: int('id').notNull().primaryKey().references((): MySqlColumn => publicUsersTable.id),
+	password: text('password').notNull(),
+});
+
+export const usersRelations = relations(usersTable, ({ one }) => ({
+	main: one(publicUsersTable, {
+		fields: [usersTable.id],
+		references: [publicUsersTable.id],
+	}),
+}));
+
+export const citiesTable = mySchema.table('cities', {
+	id: serial('id').primaryKey(),
+	name: text('name').notNull(),
+	state: char('state', { length: 2 }),
+});
+
+export const citiesRelations = relations(citiesTable, ({ many }) => ({
+	users: many(publicUsersTable),
+}));
+
+export const publicUsersTable = mysqlTable('publicUsers', {
+	id: serial('id').primaryKey(),
+	name: text('name').notNull(),
+	verified: boolean('verified').notNull().default(false),
+	cityId: int('city_id').references(() => citiesTable.id),
+});
+
+export const publicUsersRelations = relations(publicUsersTable, ({ one }) => ({
+	private: one(usersTable, {
+		fields: [publicUsersTable.id],
+		references: [usersTable.id],
+	}),
+	city: one(citiesTable, {
+		fields: [publicUsersTable.cityId],
+		references: [citiesTable.id],
+	}),
+}));
+
+export const schema1 = mysqlSchema('Test');
+
+export const parentTable1 = schema1.table('ParentTable', {
+	id: int('Id').primaryKey().notNull(),
+	name: text('Name').notNull(),
+});
+
+export const childTable1 = schema1.table('ChildTable', {
+	id: int('Id').primaryKey().notNull(),
+	parentId: int('ParentId').notNull(),
+	name: text('Name').notNull(),
+});
+
+export const parentTableRelations1 = relations(parentTable1, ({ many }) => ({
+	children: many(childTable1),
+}));
+
+export const childTableRelations1 = relations(childTable1, ({ one }) => ({
+	parent: one(parentTable1, {
+		fields: [childTable1.parentId],
+		references: [parentTable1.id],
+	}),
+}));
+
+export const schema2 = mysqlSchema('Schema2');
+export const parentTable2 = schema2.table('ParentTable', {
+	id: int('Id').notNull(),
+	name: text('Name').notNull(),
+});
+
+export const parentTableRelations2 = relations(parentTable2, ({ many }) => ({
+	children: many(childTable2),
+}));
+
+export const childTable2 = schema2.table('ChildTable', {
+	id: int('Id').notNull(),
+	parentId: int('ParentId').notNull(),
+	name: text('Name').notNull(),
+});
+
+export const childTableRelations2 = relations(childTable2, ({ one }) => ({
+	parent: one(parentTable2, {
+		fields: [childTable2.parentId],
+		references: [parentTable2.id],
+	}),
+}));

--- a/integration-tests/tests/relational/accross-schemas/pg.relation-schema.test.ts
+++ b/integration-tests/tests/relational/accross-schemas/pg.relation-schema.test.ts
@@ -1,0 +1,300 @@
+import 'dotenv/config';
+import Docker from 'dockerode';
+import { sql } from 'drizzle-orm';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import getPort from 'get-port';
+import pg from 'pg';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, beforeEach, expect, expectTypeOf, test } from 'vitest';
+import * as schema from './pg.schema.ts';
+
+const { Client } = pg;
+
+const { usersTable, citiesTable, publicUsersTable, parentTable1, childTable1 } = schema;
+
+const ENABLE_LOGGING = false;
+
+/*
+	Test cases:
+	- querying nested relation without PK with additional fields
+*/
+
+declare module 'vitest' {
+	export interface TestContext {
+		docker: Docker;
+		pgContainer: Docker.Container;
+		pgRelationsSchemaDb: NodePgDatabase<typeof schema>;
+		pgClient: pg.Client;
+	}
+}
+
+let globalDocker: Docker;
+let pgContainer: Docker.Container;
+let db: NodePgDatabase<typeof schema>;
+let client: pg.Client;
+
+async function createDockerDB(): Promise<string> {
+	const docker = (globalDocker = new Docker());
+	const port = await getPort({ port: 5432 });
+	const image = 'postgres:14';
+
+	const pullStream = await docker.pull(image);
+	await new Promise((resolve, reject) =>
+		docker.modem.followProgress(pullStream, (err) => err ? reject(err) : resolve(err))
+	);
+
+	pgContainer = await docker.createContainer({
+		Image: image,
+		Env: [
+			'POSTGRES_PASSWORD=postgres',
+			'POSTGRES_USER=postgres',
+			'POSTGRES_DB=postgres',
+		],
+		name: `drizzle-integration-tests-${uuid()}`,
+		HostConfig: {
+			AutoRemove: true,
+			PortBindings: {
+				'5432/tcp': [{ HostPort: `${port}` }],
+			},
+		},
+	});
+
+	await pgContainer.start();
+
+	return `postgres://postgres:postgres@localhost:${port}/postgres`;
+}
+
+beforeAll(async () => {
+	const connectionString = process.env['PG_CONNECTION_STRING'] ?? (await createDockerDB());
+
+	const sleep = 250;
+	let timeLeft = 5000;
+	let connected = false;
+	let lastError: unknown | undefined;
+	do {
+		try {
+			client = new Client(connectionString);
+			await client.connect();
+			connected = true;
+			break;
+		} catch (e) {
+			lastError = e;
+			await new Promise((resolve) => setTimeout(resolve, sleep));
+			timeLeft -= sleep;
+		}
+	} while (timeLeft > 0);
+	if (!connected) {
+		console.error('Cannot connect to Postgres');
+		await client?.end().catch(console.error);
+		await pgContainer?.stop().catch(console.error);
+		throw lastError;
+	}
+	db = drizzle(client, { schema, logger: ENABLE_LOGGING });
+});
+
+afterAll(async () => {
+	await client?.end().catch(console.error);
+	await pgContainer?.stop().catch(console.error);
+});
+
+beforeEach(async (ctx) => {
+	ctx.pgRelationsSchemaDb = db;
+	ctx.pgClient = client;
+	ctx.docker = globalDocker;
+	ctx.pgContainer = pgContainer;
+
+	await ctx.pgRelationsSchemaDb.execute(sql`drop schema if exists public cascade`);
+	await ctx.pgRelationsSchemaDb.execute(sql`drop schema if exists "private" cascade`);
+	await ctx.pgRelationsSchemaDb.execute(sql`drop schema if exists "Test" cascade`);
+	await ctx.pgRelationsSchemaDb.execute(sql`drop schema if exists "Schema2" cascade`);
+	await ctx.pgRelationsSchemaDb.execute(sql`create schema public`);
+	await ctx.pgRelationsSchemaDb.execute(sql`create schema "Test"`);
+	await ctx.pgRelationsSchemaDb.execute(sql`create schema "Schema2"`);
+	await ctx.pgRelationsSchemaDb.execute(
+		sql`create schema "private"`,
+	);
+	await ctx.pgRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE "private"."users" (
+				"id" integer PRIMARY KEY NOT NULL,
+				"password" text NOT NULL
+			);
+		`,
+	);
+	await ctx.pgRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE IF NOT EXISTS "private"."cities" (
+				"id" serial PRIMARY KEY NOT NULL,
+				"name" text NOT NULL,
+				"state" char(2)
+			);
+		`,
+	);
+	await ctx.pgRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE "public"."users" (
+				"id" serial PRIMARY KEY NOT NULL,
+				"name" text NOT NULL,
+				"verified" boolean DEFAULT false NOT NULL,
+				"city_id" integer NOT NULL
+			);
+		`,
+	);
+	await ctx.pgRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE "Test"."ParentTable" (
+			  "Id" serial PRIMARY KEY NOT NULL,
+			  "Name" text NOT NULL
+			)
+		`,
+	);
+	await ctx.pgRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE "Test"."ChildTable" (
+			  "Id" serial PRIMARY KEY NOT NULL,
+			  "ParentId" integer NOT NULL,
+			  "Name" text NOT NULL
+			)
+		`,
+	);
+	await ctx.pgRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE "Schema2"."ParentTable" (
+			  "Id" serial PRIMARY KEY NOT NULL,
+			  "Name" text NOT NULL
+			)
+		`,
+	);
+	await ctx.pgRelationsSchemaDb.execute(
+		sql`
+			CREATE TABLE "Schema2"."ChildTable" (
+			  "Id" serial PRIMARY KEY NOT NULL,
+			  "ParentId" integer NOT NULL,
+			  "Name" text NOT NULL
+			)
+		`,
+	);
+});
+
+test('[Find Many] users with private password', async (t) => {
+	const { pgRelationsSchemaDb: db } = t;
+
+	await db.insert(citiesTable).values([
+		{ id: 1, name: 'Tampa', state: 'FL' },
+		{ id: 2, name: 'Philadelphia', state: 'PA' },
+	]);
+
+	await db.insert(publicUsersTable).values([
+		{ id: 1, name: 'Dan', cityId: 1 },
+		{ id: 2, name: 'Andrew', cityId: 2 },
+		{ id: 3, name: 'Alex', cityId: 1 },
+	]);
+
+	await db.insert(usersTable).values([
+		{ id: 1, password: 'secret' },
+		{ id: 2, password: 'secret' },
+		{ id: 3, password: 'secret' },
+	]);
+
+	const userWithEverything = await db.query.publicUsersTable.findMany({
+		with: {
+			city: true,
+			private: true,
+		},
+	});
+
+	expectTypeOf(userWithEverything).toEqualTypeOf<{
+		id: number;
+		name: string;
+		verified: boolean;
+		cityId: number | null;
+		private: {
+			id: number;
+			password: string;
+		};
+		city: {
+			id: number;
+			name: string;
+			state: string | null;
+		} | null;
+	}[]>();
+
+	expect(userWithEverything.length).eq(3);
+
+	expect(userWithEverything).toEqual(
+		[
+			{
+				id: 1,
+				name: 'Dan',
+				verified: false,
+				cityId: 1,
+				city: { id: 1, name: 'Tampa', state: 'FL' },
+				private: { id: 1, password: 'secret' },
+			},
+			{
+				id: 2,
+				name: 'Andrew',
+				verified: false,
+				cityId: 2,
+				city: { id: 2, name: 'Philadelphia', state: 'PA' },
+				private: { id: 2, password: 'secret' },
+			},
+			{
+				id: 3,
+				name: 'Alex',
+				verified: false,
+				cityId: 1,
+				city: { id: 1, name: 'Tampa', state: 'FL' },
+				private: { id: 3, password: 'secret' },
+			},
+		],
+	);
+});
+
+test('[Find Many] parent table with children, repeated names', async (t) => {
+	const { pgRelationsSchemaDb: db } = t;
+
+	await db.insert(parentTable1).values([
+		{ id: 1, name: 'parent1' },
+		{ id: 2, name: 'parent2' },
+	]);
+
+	await db.insert(childTable1).values([
+		{ id: 1, name: 'child1', parentId: 1 },
+		{ id: 2, name: 'child2', parentId: 2 },
+		{ id: 3, name: 'child3', parentId: 2 },
+	]);
+
+	const parentWithChildren = await db.query.parentTable1.findMany({
+		with: {
+			children: true,
+		},
+	});
+
+	expectTypeOf(parentWithChildren).toEqualTypeOf<{
+		id: number;
+		name: string;
+		children: {
+			id: number;
+			name: string;
+			parentId: number;
+		}[];
+	}[]>();
+
+	expect(parentWithChildren.length).eq(2);
+
+	expect(parentWithChildren).toEqual(
+		[
+			{
+				id: 1,
+				name: 'parent1',
+				children: [{ id: 1, name: 'child1', parentId: 1 }],
+			},
+			{
+				id: 2,
+				name: 'parent2',
+				children: [{ id: 2, name: 'child2', parentId: 2 }, { id: 3, name: 'child3', parentId: 2 }],
+			},
+		],
+	);
+});

--- a/integration-tests/tests/relational/accross-schemas/pg.schema.ts
+++ b/integration-tests/tests/relational/accross-schemas/pg.schema.ts
@@ -1,0 +1,92 @@
+import { boolean, char, integer, type PgColumn, pgSchema, pgTable, serial, text } from 'drizzle-orm/pg-core';
+
+import { relations } from 'drizzle-orm';
+
+export const mySchema = pgSchema('private');
+
+export const usersTable = mySchema.table('users', {
+	id: integer('id').notNull().primaryKey().references((): PgColumn => publicUsersTable.id),
+	password: text('password').notNull(),
+});
+
+export const usersRelations = relations(usersTable, ({ one }) => ({
+	main: one(publicUsersTable, {
+		fields: [usersTable.id],
+		references: [publicUsersTable.id],
+	}),
+}));
+
+export const citiesTable = mySchema.table('cities', {
+	id: serial('id').primaryKey(),
+	name: text('name').notNull(),
+	state: char('state', { length: 2 }),
+});
+
+export const citiesRelations = relations(citiesTable, ({ many }) => ({
+	users: many(publicUsersTable),
+}));
+
+export const publicUsersTable = pgTable('users', {
+	id: serial('id').primaryKey(),
+	name: text('name').notNull(),
+	verified: boolean('verified').notNull().default(false),
+	cityId: integer('city_id').references(() => citiesTable.id),
+});
+
+export const publicUsersRelations = relations(publicUsersTable, ({ one }) => ({
+	private: one(usersTable, {
+		fields: [publicUsersTable.id],
+		references: [usersTable.id],
+	}),
+	city: one(citiesTable, {
+		fields: [publicUsersTable.cityId],
+		references: [citiesTable.id],
+	}),
+}));
+
+export const schema1 = pgSchema('Test');
+
+export const parentTable1 = schema1.table('ParentTable', {
+	id: integer('Id').primaryKey().notNull(),
+	name: text('Name').notNull(),
+});
+
+export const childTable1 = schema1.table('ChildTable', {
+	id: integer('Id').primaryKey().notNull(),
+	parentId: integer('ParentId').notNull(),
+	name: text('Name').notNull(),
+});
+
+export const parentTableRelations1 = relations(parentTable1, ({ many }) => ({
+	children: many(childTable1),
+}));
+
+export const childTableRelations1 = relations(childTable1, ({ one }) => ({
+	parent: one(parentTable1, {
+		fields: [childTable1.parentId],
+		references: [parentTable1.id],
+	}),
+}));
+
+export const schema2 = pgSchema('Schema2');
+export const parentTable2 = schema2.table('ParentTable', {
+	id: integer('Id').notNull(),
+	name: text('Name').notNull(),
+});
+
+export const parentTableRelations2 = relations(parentTable2, ({ many }) => ({
+	children: many(childTable2),
+}));
+
+export const childTable2 = schema2.table('ChildTable', {
+	id: integer('Id').notNull(),
+	parentId: integer('ParentId').notNull(),
+	name: text('Name').notNull(),
+});
+
+export const childTableRelations2 = relations(childTable2, ({ one }) => ({
+	parent: one(parentTable2, {
+		fields: [childTable2.parentId],
+		references: [parentTable2.id],
+	}),
+}));


### PR DESCRIPTION
close #830 but applies to mysql as well.

 - Added the schema information to the types and runtime to all the relation objects and columns
 - Added correct handling of schemas to the dialects when using RQB and the columns. Types and runtime
 - Fixed type tests to add the schema information to the columns
 - Added integration tests with same table names across schemas

It was necessary to add the schema information to the columns to be able to correctly restrict the columns that can be passed during the relation definition. This might not actually be needed and can be removed.

The relations now carry the information of the schema, to be able to infer the types properly across schemas, even with tables with the same name. It was also necessary to add the schema name to the `tableNamesMap` created to map the each relation to its corresponding table names.