### PR TITLE
Fix nested partial select which returns null on left join if first column value is null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -42,12 +42,10 @@ export function mapResultRow<TResult>(
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;
-						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
-						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+						if (!(objectName in nullifyMap) || 
+							(typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] === getTableName(field.table))
 						) {
-							nullifyMap[objectName] = false;
+							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						}
 					}
 				}


### PR DESCRIPTION
Fixes
- #1603 

/claim #1603

The issue was with the `nullifyMap` in the `mapResultRow` method, which was not updating an object with multiple columns once the first value was null and leading to the whole object being nullified (see culprit [code](https://github.com/drizzle-team/drizzle-orm/blob/d20bd54cfbc7a8ead2b14eb24af7b73c752b80e2/drizzle-orm/src/utils.ts#L45C7-L51C8)).

Tests were added which verify that both an object with first as well as last column value null do not nullify the whole object.