### PR TITLE
Add comment support for query builders

### DIFF
--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -79,14 +79,15 @@ export class MySqlDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
-	buildDeleteQuery({ table, where, returning }: MySqlDeleteConfig): SQL {
+	buildDeleteQuery({ table, where, returning, comment }: MySqlDeleteConfig): SQL {
 		const returningSql = returning
 			? sql` returning ${this.buildSelection(returning, { isSingleTable: true })}`
 			: undefined;
 
 		const whereSql = where ? sql` where ${where}` : undefined;
+		const commentSql = this.buildSqlComment(comment);
 
-		return sql`delete from ${table}${whereSql}${returningSql}`;
+		return sql`${commentSql}delete from ${table}${whereSql}${returningSql}`;
 	}
 
 	buildUpdateSet(table: MySqlTable, set: UpdateSet): SQL {

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -403,7 +403,7 @@ export class MySqlDialect {
 		return sql`${leftChunk}${operatorChunk}${rightChunk}${orderBySql}${limitSql}${offsetSql}`;
 	}
 
-	buildInsertQuery({ table, values, ignore, onConflict }: MySqlInsertConfig): SQL {
+	buildInsertQuery({ table, values, ignore, onConflict, comment }: MySqlInsertConfig): SQL {
 		// const isSingleValue = values.length === 1;
 		const valuesSqlList: ((SQLChunk | SQL)[] | SQL)[] = [];
 		const columns: Record<string, MySqlColumn> = table[Table.Symbol.Columns];
@@ -440,7 +440,9 @@ export class MySqlDialect {
 
 		const onConflictSql = onConflict ? sql` on duplicate key ${onConflict}` : undefined;
 
-		return sql`insert${ignoreSql} into ${table} ${insertOrder} values ${valuesSql}${onConflictSql}`;
+		const commentSql = this.buildSqlComment(comment);
+
+		return sql`${commentSql}insert${ignoreSql} into ${table} ${insertOrder} values ${valuesSql}${onConflictSql}`;
 	}
 
 	sqlToQuery(sql: SQL): QueryWithTypings {

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -476,7 +476,7 @@ export class MySqlDialect {
 		joinOn?: SQL;
 	}): BuildRelationalQueryResult<MySqlTable, MySqlColumn> {
 		let selection: BuildRelationalQueryResult<MySqlTable, MySqlColumn>['selection'] = [];
-		let limit, offset, orderBy: MySqlSelectConfig['orderBy'], where;
+		let limit, offset, orderBy: MySqlSelectConfig['orderBy'], where, comment;
 		const joins: MySqlSelectJoinConfig[] = [];
 
 		if (config === true) {
@@ -564,6 +564,10 @@ export class MySqlDialect {
 						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
 					});
 				}
+			}
+
+			if (config.comment) {
+				comment = config.comment;
 			}
 
 			// Transform `fieldsSelection` into `selection`
@@ -726,6 +730,7 @@ export class MySqlDialect {
 				limit,
 				offset,
 				orderBy,
+				comment,
 				setOperators: [],
 			});
 		} else {
@@ -741,6 +746,7 @@ export class MySqlDialect {
 				limit,
 				offset,
 				orderBy,
+				comment,
 				setOperators: [],
 			});
 		}

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -780,7 +780,7 @@ export class MySqlDialect {
 		joinOn?: SQL;
 	}): BuildRelationalQueryResult<MySqlTable, MySqlColumn> {
 		let selection: BuildRelationalQueryResult<MySqlTable, MySqlColumn>['selection'] = [];
-		let limit, offset, orderBy: MySqlSelectConfig['orderBy'] = [], where;
+		let limit, offset, orderBy: MySqlSelectConfig['orderBy'] = [], where, comment;
 
 		if (config === true) {
 			const selectionEntries = Object.entries(tableConfig.columns);
@@ -867,6 +867,10 @@ export class MySqlDialect {
 						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
 					});
 				}
+			}
+
+			if (config.comment) {
+				comment = config.comment;
 			}
 
 			// Transform `fieldsSelection` into `selection`
@@ -1024,6 +1028,7 @@ export class MySqlDialect {
 				limit,
 				offset,
 				orderBy,
+				comment,
 				setOperators: [],
 			});
 		} else {
@@ -1038,6 +1043,7 @@ export class MySqlDialect {
 				limit,
 				offset,
 				orderBy,
+				comment,
 				setOperators: [],
 			});
 		}

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -107,7 +107,7 @@ export class MySqlDialect {
 		);
 	}
 
-	buildUpdateQuery({ table, set, where, returning }: MySqlUpdateConfig): SQL {
+	buildUpdateQuery({ table, set, where, returning, comment }: MySqlUpdateConfig): SQL {
 		const setSql = this.buildUpdateSet(table, set);
 
 		const returningSql = returning
@@ -115,8 +115,9 @@ export class MySqlDialect {
 			: undefined;
 
 		const whereSql = where ? sql` where ${where}` : undefined;
+		const commentSql = this.buildSqlComment(comment);
 
-		return sql`update ${table} set ${setSql}${whereSql}${returningSql}`;
+		return sql`${commentSql}update ${table} set ${setSql}${whereSql}${returningSql}`;
 	}
 
 	// Builds a SQL comment and removess /* and */ occurences

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -120,7 +120,7 @@ export class MySqlDialect {
 		return sql`${commentSql}update ${table} set ${setSql}${whereSql}${returningSql}`;
 	}
 
-	// Builds a SQL comment and removess /* and */ occurences
+	// Builds a SQL comment and removes /* and */ occurences
 	private buildSqlComment(comment?: string) {
 		return comment ? sql.raw(`/* ${comment.replace(/\/\*|\*\//g, '')} */`) : undefined;
 	}

--- a/drizzle-orm/src/mysql-core/query-builders/delete.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/delete.ts
@@ -132,6 +132,27 @@ export class MySqlDeleteBase<
 		return this as any;
 	}
 
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/update#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=delete-car"
+	 * await db.delete(cars).where(eq(cars.color, 'green')).comment("action=delete-car");
+	 * ```
+	 */
+	comment(comment: string): MySqlDeleteWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
+		return this as any;
+	}
+
 	/** @internal */
 	getSQL(): SQL {
 		return this.dialect.buildDeleteQuery(this.config);

--- a/drizzle-orm/src/mysql-core/query-builders/delete.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/delete.ts
@@ -137,7 +137,7 @@ export class MySqlDeleteBase<
 	 *
 	 * Calling this method will add a comment to the query.
 	 *
-	 * See docs: {@link https://orm.drizzle.team/docs/update#comment}
+	 * See docs: {@link https://orm.drizzle.team/docs/delete#comment}
 	 *
 	 * @param comment the `comment` to be added.
 	 *

--- a/drizzle-orm/src/mysql-core/query-builders/delete.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/delete.ts
@@ -40,6 +40,7 @@ export interface MySqlDeleteConfig {
 	where?: SQL | undefined;
 	table: MySqlTable;
 	returning?: SelectedFieldsOrdered;
+	comment?: string;
 }
 
 export type MySqlDeletePrepare<T extends AnyMySqlDeleteBase> = PreparedQueryKind<
@@ -97,35 +98,35 @@ export class MySqlDeleteBase<
 		this.config = { table };
 	}
 
-	/** 
+	/**
 	 * Adds a `where` clause to the query.
-	 * 
+	 *
 	 * Calling this method will delete only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/delete}
-	 * 
+	 *
 	 * @param where the `where` clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be deleted.
-	 * 
+	 *
 	 * ```ts
 	 * // Delete all cars with green color
 	 * db.delete(cars).where(eq(cars.color, 'green'));
 	 * // or
 	 * db.delete(cars).where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Delete all BMW cars with a green color
 	 * db.delete(cars).where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Delete all cars with the green or blue color
 	 * db.delete(cars).where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
 	 * ```
-	*/
+	 */
 	where(where: SQL | undefined): MySqlDeleteWithout<this, TDynamic, 'where'> {
 		this.config.where = where;
 		return this as any;

--- a/drizzle-orm/src/mysql-core/query-builders/insert.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/insert.ts
@@ -22,6 +22,7 @@ export interface MySqlInsertConfig<TTable extends MySqlTable = MySqlTable> {
 	values: Record<string, Param | SQL>[];
 	ignore: boolean;
 	onConflict?: SQL;
+	comment?: string;
 }
 
 export type AnyMySqlInsertConfig = MySqlInsertConfig<MySqlTable>;
@@ -160,25 +161,25 @@ export class MySqlInsertBase<
 
 	/**
 	 * Adds an `on duplicate key update` clause to the query.
-	 * 
+	 *
 	 * Calling this method will update update the row if any unique index conflicts. MySQL will automatically determine the conflict target based on the primary key and unique indexes.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/insert#on-duplicate-key-update}
-	 * 
+	 *
 	 * @param config The `set` clause
-	 * 
+	 *
 	 * @example
 	 * ```ts
 	 * await db.insert(cars)
 	 *   .values({ id: 1, brand: 'BMW'})
 	 *   .onDuplicateKeyUpdate({ set: { brand: 'Porsche' }});
 	 * ```
-	 * 
+	 *
 	 * While MySQL does not directly support doing nothing on conflict, you can perform a no-op by setting any column's value to itself and achieve the same effect:
-	 * 
+	 *
 	 * ```ts
 	 * import { sql } from 'drizzle-orm';
-	 * 
+	 *
 	 * await db.insert(cars)
 	 *   .values({ id: 1, brand: 'BMW' })
 	 *   .onDuplicateKeyUpdate({ set: { id: sql`id` } });
@@ -189,6 +190,27 @@ export class MySqlInsertBase<
 	): MySqlInsertWithout<this, TDynamic, 'onDuplicateKeyUpdate'> {
 		const setSql = this.dialect.buildUpdateSet(this.config.table, mapUpdateSet(this.config.table, config.set));
 		this.config.onConflict = sql`update ${setSql}`;
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/insert#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=insert-car"
+	 * await db.insert(cars).values({ id: 1, brand: 'BMW' }).comment("action=insert-car");
+	 * ```
+	 */
+	comment(comment: string): MySqlInsertWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
 		return this as any;
 	}
 

--- a/drizzle-orm/src/mysql-core/query-builders/select.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.ts
@@ -263,22 +263,22 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Executes a `left join` operation by adding another table to the current query.
-	 * 
+	 *
 	 * Calling this method associates each row of the table with the corresponding row from the joined table, if a match is found. If no matching row exists, it sets all columns of the joined table to null.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#left-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User; pets: Pet | null }[] = await db.select()
 	 *   .from(users)
 	 *   .leftJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number; petId: number | null }[] = await db.select({
 	 *   userId: users.id,
@@ -289,25 +289,25 @@ export abstract class MySqlSelectQueryBuilderBase<
 	 * ```
 	 */
 	leftJoin = this.createJoin('left');
-	
+
 	/**
 	 * Executes a `right join` operation by adding another table to the current query.
-	 * 
+	 *
 	 * Calling this method associates each row of the joined table with the corresponding row from the main table, if a match is found. If no matching row exists, it sets all columns of the main table to null.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#right-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User | null; pets: Pet }[] = await db.select()
 	 *   .from(users)
 	 *   .rightJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number | null; petId: number }[] = await db.select({
 	 *   userId: users.id,
@@ -321,22 +321,22 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Executes an `inner join` operation, creating a new table by combining rows from two tables that have matching values.
-	 * 
+	 *
 	 * Calling this method retrieves rows that have corresponding entries in both joined tables. Rows without matching entries in either table are excluded, resulting in a table that includes only matching pairs.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#inner-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User; pets: Pet }[] = await db.select()
 	 *   .from(users)
 	 *   .innerJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number; petId: number }[] = await db.select({
 	 *   userId: users.id,
@@ -347,25 +347,25 @@ export abstract class MySqlSelectQueryBuilderBase<
 	 * ```
 	 */
 	innerJoin = this.createJoin('inner');
-	
+
 	/**
 	 * Executes a `full join` operation by combining rows from two tables into a new table.
-	 * 
+	 *
 	 * Calling this method retrieves all rows from both main and joined tables, merging rows with matching values and filling in `null` for non-matching columns.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#full-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User | null; pets: Pet | null }[] = await db.select()
 	 *   .from(users)
 	 *   .fullJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number | null; petId: number | null }[] = await db.select({
 	 *   userId: users.id,
@@ -411,13 +411,13 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds `union` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will combine the result sets of the `select` statements and remove any duplicate rows that appear across them.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#union}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all unique names from customers and users tables
 	 * await db.select({ name: users.name })
@@ -427,9 +427,9 @@ export abstract class MySqlSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { union } from 'drizzle-orm/mysql-core'
-	 * 
+	 *
 	 * await union(
-	 *   db.select({ name: users.name }).from(users), 
+	 *   db.select({ name: users.name }).from(users),
 	 *   db.select({ name: customers.name }).from(customers)
 	 * );
 	 * ```
@@ -438,13 +438,13 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds `union all` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will combine the result-set of the `select` statements and keep all duplicate rows that appear across them.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#union-all}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all transaction ids from both online and in-store sales
 	 * await db.select({ transaction: onlineSales.transactionId })
@@ -454,7 +454,7 @@ export abstract class MySqlSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { unionAll } from 'drizzle-orm/mysql-core'
-	 * 
+	 *
 	 * await unionAll(
 	 *   db.select({ transaction: onlineSales.transactionId }).from(onlineSales),
 	 *   db.select({ transaction: inStoreSales.transactionId }).from(inStoreSales)
@@ -465,13 +465,13 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds `intersect` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retain only the rows that are present in both result sets and eliminate duplicates.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select course names that are offered in both departments A and B
 	 * await db.select({ courseName: depA.courseName })
@@ -481,7 +481,7 @@ export abstract class MySqlSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { intersect } from 'drizzle-orm/mysql-core'
-	 * 
+	 *
 	 * await intersect(
 	 *   db.select({ courseName: depA.courseName }).from(depA),
 	 *   db.select({ courseName: depB.courseName }).from(depB)
@@ -492,30 +492,30 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds `intersect all` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retain only the rows that are present in both result sets including all duplicates.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect-all}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all products and quantities that are ordered by both regular and VIP customers
-	 * await db.select({ 
-	 *   productId: regularCustomerOrders.productId, 
+	 * await db.select({
+	 *   productId: regularCustomerOrders.productId,
 	 *   quantityOrdered: regularCustomerOrders.quantityOrdered
 	 * })
 	 * .from(regularCustomerOrders)
 	 * .intersectAll(
-	 *   db.select({ 
-	 *     productId: vipCustomerOrders.productId, 
-	 *     quantityOrdered: vipCustomerOrders.quantityOrdered 
+	 *   db.select({
+	 *     productId: vipCustomerOrders.productId,
+	 *     quantityOrdered: vipCustomerOrders.quantityOrdered
 	 *   })
 	 *   .from(vipCustomerOrders)
 	 * );
 	 * // or
 	 * import { intersectAll } from 'drizzle-orm/mysql-core'
-	 * 
+	 *
 	 * await intersectAll(
 	 *   db.select({
 	 *     productId: regularCustomerOrders.productId,
@@ -534,13 +534,13 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds `except` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retrieve all unique rows from the left query, except for the rows that are present in the result set of the right query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#except}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all courses offered in department A but not in department B
 	 * await db.select({ courseName: depA.courseName })
@@ -550,7 +550,7 @@ export abstract class MySqlSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { except } from 'drizzle-orm/mysql-core'
-	 * 
+	 *
 	 * await except(
 	 *   db.select({ courseName: depA.courseName }).from(depA),
 	 *   db.select({ courseName: depB.courseName }).from(depB)
@@ -561,13 +561,13 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds `except all` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retrieve all rows from the left query, except for the rows that are present in the result set of the right query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#except-all}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all products that are ordered by regular customers but not by VIP customers
 	 * await db.select({
@@ -584,7 +584,7 @@ export abstract class MySqlSelectQueryBuilderBase<
 	 * );
 	 * // or
 	 * import { exceptAll } from 'drizzle-orm/mysql-core'
-	 * 
+	 *
 	 * await exceptAll(
 	 *   db.select({
 	 *     productId: regularCustomerOrders.productId,
@@ -612,35 +612,35 @@ export abstract class MySqlSelectQueryBuilderBase<
 		return this as any;
 	}
 
-	/** 
+	/**
 	 * Adds a `where` clause to the query.
-	 * 
+	 *
 	 * Calling this method will select only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#filtering}
-	 * 
+	 *
 	 * @param where the `where` clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be selected.
-	 * 
+	 *
 	 * ```ts
 	 * // Select all cars with green color
 	 * await db.select().from(cars).where(eq(cars.color, 'green'));
 	 * // or
 	 * await db.select().from(cars).where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Select all BMW cars with a green color
 	 * await db.select().from(cars).where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Select all cars with the green or blue color
 	 * await db.select().from(cars).where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
 	 * ```
-	*/
+	 */
 	where(
 		where: ((aliases: this['_']['selection']) => SQL | undefined) | SQL | undefined,
 	): MySqlSelectWithout<this, TDynamic, 'where'> {
@@ -658,15 +658,15 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `having` clause to the query.
-	 * 
+	 *
 	 * Calling this method will select only those rows that fulfill a specified condition. It is typically used with aggregate functions to filter the aggregated data based on a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#aggregations}
-	 * 
+	 *
 	 * @param having the `having` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all brands with more than one car
 	 * await db.select({
@@ -695,13 +695,13 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `group by` clause to the query.
-	 * 
+	 *
 	 * Calling this method will group rows that have the same values into summary rows, often used for aggregation purposes.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#aggregations}
 	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Group and count people by their last names
 	 * await db.select({
@@ -737,9 +737,9 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds an `order by` clause to the query.
-	 * 
+	 *
 	 * Calling this method will sort the result-set in ascending or descending order. By default, the sort order is ascending.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#order-by}
 	 *
 	 * @example
@@ -748,13 +748,13 @@ export abstract class MySqlSelectQueryBuilderBase<
 	 * // Select cars ordered by year
 	 * await db.select().from(cars).orderBy(cars.year);
 	 * ```
-	 * 
+	 *
 	 * You can specify whether results are in ascending or descending order with the `asc()` and `desc()` operators.
-	 * 
+	 *
 	 * ```ts
 	 * // Select cars ordered by year in descending order
 	 * await db.select().from(cars).orderBy(desc(cars.year));
-	 * 
+	 *
 	 * // Select cars ordered by year and price
 	 * await db.select().from(cars).orderBy(asc(cars.year), desc(cars.price));
 	 * ```
@@ -797,13 +797,13 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `limit` clause to the query.
-	 * 
+	 *
 	 * Calling this method will set the maximum number of rows that will be returned by this query.
 	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#limit--offset}
-	 * 
+	 *
 	 * @param limit the `limit` clause.
-	 * 
+	 *
 	 * @example
 	 *
 	 * ```ts
@@ -822,13 +822,13 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds an `offset` clause to the query.
-	 * 
+	 *
 	 * Calling this method will skip a number of rows when returning results from this query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#limit--offset}
-	 * 
+	 *
 	 * @param offset the `offset` clause.
-	 * 
+	 *
 	 * @example
 	 *
 	 * ```ts
@@ -847,16 +847,37 @@ export abstract class MySqlSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `for` clause to the query.
-	 * 
+	 *
 	 * Calling this method will specify a lock strength for this query that controls how strictly it acquires exclusive access to the rows being queried.
-	 * 
+	 *
 	 * See docs: {@link https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html}
-	 * 
+	 *
 	 * @param strength the lock strength.
 	 * @param config the lock configuration.
 	 */
 	for(strength: LockStrength, config: LockConfig = {}): MySqlSelectWithout<this, TDynamic, 'for'> {
 		this.config.lockingClause = { strength, config };
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/select#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=people-select"
+	 * await db.select().from(people).comment("action=people-select");
+	 * ```
+	 */
+	comment(comment: string): MySqlSelectWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
 		return this as any;
 	}
 
@@ -1004,19 +1025,19 @@ const getMySqlSetOperators = () => ({
 
 /**
  * Adds `union` set operator to the query.
- * 
+ *
  * Calling this method will combine the result sets of the `select` statements and remove any duplicate rows that appear across them.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#union}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all unique names from customers and users tables
  * import { union } from 'drizzle-orm/mysql-core'
- * 
+ *
  * await union(
- *   db.select({ name: users.name }).from(users), 
+ *   db.select({ name: users.name }).from(users),
  *   db.select({ name: customers.name }).from(customers)
  * );
  * // or
@@ -1031,17 +1052,17 @@ export const union = createSetOperator('union', false);
 
 /**
  * Adds `union all` set operator to the query.
- * 
+ *
  * Calling this method will combine the result-set of the `select` statements and keep all duplicate rows that appear across them.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#union-all}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all transaction ids from both online and in-store sales
  * import { unionAll } from 'drizzle-orm/mysql-core'
- * 
+ *
  * await unionAll(
  *   db.select({ transaction: onlineSales.transactionId }).from(onlineSales),
  *   db.select({ transaction: inStoreSales.transactionId }).from(inStoreSales)
@@ -1058,17 +1079,17 @@ export const unionAll = createSetOperator('union', true);
 
 /**
  * Adds `intersect` set operator to the query.
- * 
+ *
  * Calling this method will retain only the rows that are present in both result sets and eliminate duplicates.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select course names that are offered in both departments A and B
  * import { intersect } from 'drizzle-orm/mysql-core'
- * 
+ *
  * await intersect(
  *   db.select({ courseName: depA.courseName }).from(depA),
  *   db.select({ courseName: depB.courseName }).from(depB)
@@ -1085,17 +1106,17 @@ export const intersect = createSetOperator('intersect', false);
 
 /**
  * Adds `intersect all` set operator to the query.
- * 
+ *
  * Calling this method will retain only the rows that are present in both result sets including all duplicates.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect-all}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all products and quantities that are ordered by both regular and VIP customers
  * import { intersectAll } from 'drizzle-orm/mysql-core'
- * 
+ *
  * await intersectAll(
  *   db.select({
  *     productId: regularCustomerOrders.productId,
@@ -1109,15 +1130,15 @@ export const intersect = createSetOperator('intersect', false);
  *   .from(vipCustomerOrders)
  * );
  * // or
- * await db.select({ 
- *   productId: regularCustomerOrders.productId, 
+ * await db.select({
+ *   productId: regularCustomerOrders.productId,
  *   quantityOrdered: regularCustomerOrders.quantityOrdered
  * })
  * .from(regularCustomerOrders)
  * .intersectAll(
- *   db.select({ 
- *     productId: vipCustomerOrders.productId, 
- *     quantityOrdered: vipCustomerOrders.quantityOrdered 
+ *   db.select({
+ *     productId: vipCustomerOrders.productId,
+ *     quantityOrdered: vipCustomerOrders.quantityOrdered
  *   })
  *   .from(vipCustomerOrders)
  * );
@@ -1127,17 +1148,17 @@ export const intersectAll = createSetOperator('intersect', true);
 
 /**
  * Adds `except` set operator to the query.
- * 
+ *
  * Calling this method will retrieve all unique rows from the left query, except for the rows that are present in the result set of the right query.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#except}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all courses offered in department A but not in department B
  * import { except } from 'drizzle-orm/mysql-core'
- * 
+ *
  * await except(
  *   db.select({ courseName: depA.courseName }).from(depA),
  *   db.select({ courseName: depB.courseName }).from(depB)
@@ -1154,17 +1175,17 @@ export const except = createSetOperator('except', false);
 
 /**
  * Adds `except all` set operator to the query.
- * 
+ *
  * Calling this method will retrieve all rows from the left query, except for the rows that are present in the result set of the right query.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#except-all}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all products that are ordered by regular customers but not by VIP customers
  * import { exceptAll } from 'drizzle-orm/mysql-core'
- * 
+ *
  * await exceptAll(
  *   db.select({
  *     productId: regularCustomerOrders.productId,

--- a/drizzle-orm/src/mysql-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.types.ts
@@ -23,9 +23,9 @@ import type { Subquery } from '~/subquery.ts';
 import type { Table, UpdateTableConfig } from '~/table.ts';
 import type { Assume, ValidateShape } from '~/utils.ts';
 import type { PreparedQueryConfig, PreparedQueryHKTBase, PreparedQueryKind } from '../session.ts';
-import type { MySqlSelectBase, MySqlSelectQueryBuilderBase } from './select.ts';
 import type { MySqlViewBase } from '../view-base.ts';
 import type { MySqlViewWithSelection } from '../view.ts';
+import type { MySqlSelectBase, MySqlSelectQueryBuilderBase } from './select.ts';
 
 export interface MySqlSelectJoinConfig {
 	on: SQL | undefined;
@@ -66,6 +66,7 @@ export interface MySqlSelectConfig {
 		config: LockConfig;
 	};
 	distinct?: boolean;
+	comment?: string;
 	setOperators: {
 		rightSelect: TypedQueryBuilder<any, any>;
 		type: SetOperator;

--- a/drizzle-orm/src/mysql-core/query-builders/update.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/update.ts
@@ -21,6 +21,7 @@ export interface MySqlUpdateConfig {
 	set: UpdateSet;
 	table: MySqlTable;
 	returning?: SelectedFieldsOrdered;
+	comment?: string;
 }
 
 export type MySqlUpdateSetSource<TTable extends MySqlTable> =
@@ -133,16 +134,16 @@ export class MySqlUpdateBase<
 
 	/**
 	 * Adds a 'where' clause to the query.
-	 * 
+	 *
 	 * Calling this method will update only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update}
-	 * 
+	 *
 	 * @param where the 'where' clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be updated.
-	 * 
+	 *
 	 * ```ts
 	 * // Update all cars with green color
 	 * db.update(cars).set({ color: 'red' })
@@ -151,14 +152,14 @@ export class MySqlUpdateBase<
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Update all BMW cars with a green color
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Update all cars with the green or blue color
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
@@ -166,6 +167,27 @@ export class MySqlUpdateBase<
 	 */
 	where(where: SQL | undefined): MySqlUpdateWithout<this, TDynamic, 'where'> {
 		this.config.where = where;
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/update#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=update-car"
+	 * await db.update(cars).set({ color: 'red' }).where(eq(cars.color, 'green')).comment("action=update-car");
+	 * ```
+	 */
+	comment(comment: string): MySqlUpdateWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
 		return this as any;
 	}
 

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -194,7 +194,7 @@ export class PgDialect {
 		return sql.join(chunks);
 	}
 
-	// Builds a SQL comment and removess /* and */ occurences
+	// Builds a SQL comment and removes /* and */ occurences
 	private buildSqlComment(comment?: string) {
 		return comment ? sql.raw(`/* ${comment.replace(/\/\*|\*\//g, '')} */`) : undefined;
 	}

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -91,14 +91,15 @@ export class PgDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
-	buildDeleteQuery({ table, where, returning }: PgDeleteConfig): SQL {
+	buildDeleteQuery({ table, where, returning, comment }: PgDeleteConfig): SQL {
 		const returningSql = returning
 			? sql` returning ${this.buildSelection(returning, { isSingleTable: true })}`
 			: undefined;
 
 		const whereSql = where ? sql` where ${where}` : undefined;
+		const commentSql = this.buildSqlComment(comment);
 
-		return sql`delete from ${table}${whereSql}${returningSql}`;
+		return sql`${commentSql}delete from ${table}${whereSql}${returningSql}`;
 	}
 
 	buildUpdateSet(table: PgTable, set: UpdateSet): SQL {

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -332,7 +332,7 @@ export class PgDialect {
 
 		const offsetSql = offset ? sql` offset ${offset}` : undefined;
 
-		const commentSql = comment ? sql`${sql.raw(`/* ${comment.replace(/\*\//g, '')} */`)}` : undefined;
+		const commentSql = comment ? sql`${sql.raw(`/* ${comment.replace(/\/\*|\*\//g, '')} */`)}` : undefined;
 
 		const lockingClauseSql = sql.empty();
 		if (lockingClause) {
@@ -425,7 +425,7 @@ export class PgDialect {
 		return sql`${leftChunk}${operatorChunk}${rightChunk}${orderBySql}${limitSql}${offsetSql}`;
 	}
 
-	buildInsertQuery({ table, values, onConflict, returning }: PgInsertConfig): SQL {
+	buildInsertQuery({ table, values, onConflict, returning, comment }: PgInsertConfig): SQL {
 		const valuesSqlList: ((SQLChunk | SQL)[] | SQL)[] = [];
 		const columns: Record<string, PgColumn> = table[Table.Symbol.Columns];
 
@@ -465,7 +465,9 @@ export class PgDialect {
 
 		const onConflictSql = onConflict ? sql` on conflict ${onConflict}` : undefined;
 
-		return sql`insert into ${table} ${insertOrder} values ${valuesSql}${onConflictSql}${returningSql}`;
+		const commentSql = comment ? sql`${sql.raw(`/* ${comment.replace(/\/\*|\*\//g, '')} */`)}` : undefined;
+
+		return sql`${commentSql}insert into ${table} ${insertOrder} values ${valuesSql}${onConflictSql}${returningSql}`;
 	}
 
 	buildRefreshMaterializedViewQuery(

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -24,6 +24,7 @@ import {
 	type TableRelationalConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
+import { and, eq, View } from '~/sql/index.ts';
 import {
 	type DriverValueEncoder,
 	type Name,
@@ -39,9 +40,8 @@ import { getTableName, Table } from '~/table.ts';
 import { orderSelectedFields, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type { PgSession } from './session.ts';
-import type { PgMaterializedView } from './view.ts';
-import { View, and, eq } from '~/sql/index.ts';
 import { PgViewBase } from './view-base.ts';
+import type { PgMaterializedView } from './view.ts';
 
 export class PgDialect {
 	static readonly [entityKind]: string = 'PgDialect';
@@ -205,6 +205,7 @@ export class PgDialect {
 			groupBy,
 			limit,
 			offset,
+			comment,
 			lockingClause,
 			distinct,
 			setOperators,
@@ -331,6 +332,8 @@ export class PgDialect {
 
 		const offsetSql = offset ? sql` offset ${offset}` : undefined;
 
+		const commentSql = comment ? sql`${sql.raw(`/* ${comment.replace(/\*\//g, '')} */`)}` : undefined;
+
 		const lockingClauseSql = sql.empty();
 		if (lockingClause) {
 			const clauseSql = sql` for ${sql.raw(lockingClause.strength)}`;
@@ -352,7 +355,7 @@ export class PgDialect {
 			lockingClauseSql.append(clauseSql);
 		}
 		const finalQuery =
-			sql`${withSql}select${distinctSql} ${selection} from ${tableSql}${joinsSql}${whereSql}${groupBySql}${havingSql}${orderBySql}${limitSql}${offsetSql}${lockingClauseSql}`;
+			sql`${commentSql}${withSql}select${distinctSql} ${selection} from ${tableSql}${joinsSql}${whereSql}${groupBySql}${havingSql}${orderBySql}${limitSql}${offsetSql}${lockingClauseSql}`;
 
 		if (setOperators.length > 0) {
 			return this.buildSetOperations(finalQuery, setOperators);

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -1067,7 +1067,8 @@ export class PgDialect {
 		joinOn?: SQL;
 	}): BuildRelationalQueryResult<PgTable, PgColumn> {
 		let selection: BuildRelationalQueryResult<PgTable, PgColumn>['selection'] = [];
-		let limit, offset, orderBy: NonNullable<PgSelectConfig['orderBy']> = [], where;
+		let limit, offset, orderBy: NonNullable<PgSelectConfig['orderBy']> = [], where, comment;
+
 		const joins: PgSelectJoinConfig[] = [];
 
 		if (config === true) {
@@ -1155,6 +1156,10 @@ export class PgDialect {
 						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
 					});
 				}
+			}
+
+			if (config.comment) {
+				comment = config.comment;
 			}
 
 			// Transform `fieldsSelection` into `selection`
@@ -1313,6 +1318,7 @@ export class PgDialect {
 				limit,
 				offset,
 				orderBy,
+				comment,
 				setOperators: [],
 			});
 		} else {
@@ -1328,6 +1334,7 @@ export class PgDialect {
 				limit,
 				offset,
 				orderBy,
+				comment,
 				setOperators: [],
 			});
 		}

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -118,7 +118,7 @@ export class PgDialect {
 		);
 	}
 
-	buildUpdateQuery({ table, set, where, returning }: PgUpdateConfig): SQL {
+	buildUpdateQuery({ table, set, where, returning, comment }: PgUpdateConfig): SQL {
 		const setSql = this.buildUpdateSet(table, set);
 
 		const returningSql = returning
@@ -126,8 +126,9 @@ export class PgDialect {
 			: undefined;
 
 		const whereSql = where ? sql` where ${where}` : undefined;
+		const commentSql = this.buildSqlComment(comment);
 
-		return sql`update ${table} set ${setSql}${whereSql}${returningSql}`;
+		return sql`${commentSql}update ${table} set ${setSql}${whereSql}${returningSql}`;
 	}
 
 	/**
@@ -190,6 +191,11 @@ export class PgDialect {
 			});
 
 		return sql.join(chunks);
+	}
+
+	// Builds a SQL comment and removess /* and */ occurences
+	private buildSqlComment(comment?: string) {
+		return comment ? sql.raw(`/* ${comment.replace(/\/\*|\*\//g, '')} */`) : undefined;
 	}
 
 	buildSelectQuery(
@@ -332,7 +338,7 @@ export class PgDialect {
 
 		const offsetSql = offset ? sql` offset ${offset}` : undefined;
 
-		const commentSql = comment ? sql`${sql.raw(`/* ${comment.replace(/\/\*|\*\//g, '')} */`)}` : undefined;
+		const commentSql = this.buildSqlComment(comment);
 
 		const lockingClauseSql = sql.empty();
 		if (lockingClause) {
@@ -465,7 +471,7 @@ export class PgDialect {
 
 		const onConflictSql = onConflict ? sql` on conflict ${onConflict}` : undefined;
 
-		const commentSql = comment ? sql`${sql.raw(`/* ${comment.replace(/\/\*|\*\//g, '')} */`)}` : undefined;
+		const commentSql = this.buildSqlComment(comment);
 
 		return sql`${commentSql}insert into ${table} ${insertOrder} values ${valuesSql}${onConflictSql}${returningSql}`;
 	}

--- a/drizzle-orm/src/pg-core/query-builders/delete.ts
+++ b/drizzle-orm/src/pg-core/query-builders/delete.ts
@@ -14,8 +14,8 @@ import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
 import { Table } from '~/table.ts';
 import { tracer } from '~/tracing.ts';
 import { orderSelectedFields } from '~/utils.ts';
-import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
 import type { PgColumn } from '../columns/common.ts';
+import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
 
 export type PgDeleteWithout<
 	T extends AnyPgDeleteBase,
@@ -43,6 +43,7 @@ export interface PgDeleteConfig {
 	where?: SQL | undefined;
 	table: PgTable;
 	returning?: SelectedFieldsOrdered;
+	comment?: string;
 }
 
 export type PgDeleteReturningAll<
@@ -130,35 +131,35 @@ export class PgDeleteBase<
 		this.config = { table };
 	}
 
-	/** 
+	/**
 	 * Adds a `where` clause to the query.
-	 * 
+	 *
 	 * Calling this method will delete only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/delete}
-	 * 
+	 *
 	 * @param where the `where` clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be deleted.
-	 * 
+	 *
 	 * ```ts
 	 * // Delete all cars with green color
 	 * await db.delete(cars).where(eq(cars.color, 'green'));
 	 * // or
 	 * await db.delete(cars).where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Delete all BMW cars with a green color
 	 * await db.delete(cars).where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Delete all cars with the green or blue color
 	 * await db.delete(cars).where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
 	 * ```
-	*/
+	 */
 	where(where: SQL | undefined): PgDeleteWithout<this, TDynamic, 'where'> {
 		this.config.where = where;
 		return this as any;
@@ -166,18 +167,18 @@ export class PgDeleteBase<
 
 	/**
 	 * Adds a `returning` clause to the query.
-	 * 
+	 *
 	 * Calling this method will return the specified fields of the deleted rows. If no fields are specified, all fields will be returned.
-	 * 
-	 * See docs: {@link https://orm.drizzle.team/docs/delete#delete-with-return} 
-	 * 
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/delete#delete-with-return}
+	 *
 	 * @example
 	 * ```ts
 	 * // Delete all cars with the green color and return all fields
 	 * const deletedCars: Car[] = await db.delete(cars)
 	 *   .where(eq(cars.color, 'green'))
 	 *   .returning();
-	 * 
+	 *
 	 * // Delete all cars with the green color and return only their id and brand fields
 	 * const deletedCarsIdsAndBrands: { id: number, brand: string }[] = await db.delete(cars)
 	 *   .where(eq(cars.color, 'green'))
@@ -192,6 +193,27 @@ export class PgDeleteBase<
 		fields: SelectedFieldsFlat = this.config.table[Table.Symbol.Columns],
 	): PgDeleteReturning<this, TDynamic, any> {
 		this.config.returning = orderSelectedFields<PgColumn>(fields);
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/update#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=delete-car"
+	 * await db.delete(cars).where(eq(cars.color, 'green')).comment("action=delete-car");
+	 * ```
+	 */
+	comment(comment: string): PgDeleteWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
 		return this as any;
 	}
 

--- a/drizzle-orm/src/pg-core/query-builders/delete.ts
+++ b/drizzle-orm/src/pg-core/query-builders/delete.ts
@@ -201,7 +201,7 @@ export class PgDeleteBase<
 	 *
 	 * Calling this method will add a comment to the query.
 	 *
-	 * See docs: {@link https://orm.drizzle.team/docs/update#comment}
+	 * See docs: {@link https://orm.drizzle.team/docs/delete#comment}
 	 *
 	 * @param comment the `comment` to be added.
 	 *

--- a/drizzle-orm/src/pg-core/query-builders/insert.ts
+++ b/drizzle-orm/src/pg-core/query-builders/insert.ts
@@ -16,15 +16,16 @@ import { Param, SQL, sql } from '~/sql/sql.ts';
 import { Table } from '~/table.ts';
 import { tracer } from '~/tracing.ts';
 import { mapUpdateSet, orderSelectedFields } from '~/utils.ts';
+import type { PgColumn } from '../columns/common.ts';
 import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
 import type { PgUpdateSetSource } from './update.ts';
-import type { PgColumn } from '../columns/common.ts';
 
 export interface PgInsertConfig<TTable extends PgTable = PgTable> {
 	table: TTable;
 	values: Record<string, Param | SQL>[];
 	onConflict?: SQL;
 	returning?: SelectedFieldsOrdered;
+	comment?: string;
 }
 
 export type PgInsertValue<TTable extends PgTable> =
@@ -166,18 +167,18 @@ export class PgInsertBase<
 
 	/**
 	 * Adds a `returning` clause to the query.
-	 * 
+	 *
 	 * Calling this method will return the specified fields of the inserted rows. If no fields are specified, all fields will be returned.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/insert#insert-returning}
-	 * 
+	 *
 	 * @example
 	 * ```ts
 	 * // Insert one row and return all fields
 	 * const insertedCar: Car[] = await db.insert(cars)
 	 *   .values({ brand: 'BMW' })
 	 *   .returning();
-	 * 
+	 *
 	 * // Insert one row and return only the id
 	 * const insertedCarId: { id: number }[] = await db.insert(cars)
 	 *   .values({ brand: 'BMW' })
@@ -197,20 +198,20 @@ export class PgInsertBase<
 
 	/**
 	 * Adds an `on conflict do nothing` clause to the query.
-	 * 
+	 *
 	 * Calling this method simply avoids inserting a row as its alternative action.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/insert#on-conflict-do-nothing}
-	 * 
+	 *
 	 * @param config The `target` and `where` clauses.
-	 * 
+	 *
 	 * @example
 	 * ```ts
 	 * // Insert one row and cancel the insert if there's a conflict
 	 * await db.insert(cars)
 	 *   .values({ id: 1, brand: 'BMW' })
 	 *   .onConflictDoNothing();
-	 * 
+	 *
 	 * // Explicitly specify conflict target
 	 * await db.insert(cars)
 	 *   .values({ id: 1, brand: 'BMW' })
@@ -234,26 +235,25 @@ export class PgInsertBase<
 		return this as any;
 	}
 
-
 	/**
 	 * Adds an `on conflict do update` clause to the query.
-	 * 
+	 *
 	 * Calling this method will update the existing row that conflicts with the row proposed for insertion as its alternative action.
-	 * 
-	 * See docs: {@link https://orm.drizzle.team/docs/insert#upserts-and-conflicts} 
-	 * 
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/insert#upserts-and-conflicts}
+	 *
 	 * @param config The `target`, `set` and `where` clauses.
-	 * 
+	 *
 	 * @example
 	 * ```ts
 	 * // Update the row if there's a conflict
 	 * await db.insert(cars)
 	 *   .values({ id: 1, brand: 'BMW' })
-	 *   .onConflictDoUpdate({ 
-	 *     target: cars.id, 
-	 *     set: { brand: 'Porsche' } 
+	 *   .onConflictDoUpdate({
+	 *     target: cars.id,
+	 *     set: { brand: 'Porsche' }
 	 *   });
-	 * 
+	 *
 	 * // Upsert with 'where' clause
 	 * await db.insert(cars)
 	 *   .values({ id: 1, brand: 'BMW' })
@@ -274,6 +274,27 @@ export class PgInsertBase<
 			? config.target.map((it) => this.dialect.escapeName(it.name)).join(',')
 			: this.dialect.escapeName(config.target.name);
 		this.config.onConflict = sql`(${sql.raw(targetColumn)}) do update set ${setSql}${whereSql}`;
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/insert#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=insert-car"
+	 * await db.insert(cars).values({ id: 1, brand: 'BMW' }).comment("action=insert-car");
+	 * ```
+	 */
+	comment(comment: string): PgInsertWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
 		return this as any;
 	}
 

--- a/drizzle-orm/src/pg-core/query-builders/select.ts
+++ b/drizzle-orm/src/pg-core/query-builders/select.ts
@@ -883,11 +883,7 @@ export abstract class PgSelectQueryBuilderBase<
 	 * ```
 	 */
 	comment(comment: string): PgSelectWithout<this, TDynamic, 'comment'> {
-		if (this.config.setOperators.length > 0) {
-			this.config.setOperators.at(-1)!.comment = comment;
-		} else {
-			this.config.comment = comment;
-		}
+		this.config.comment = comment;
 		return this as any;
 	}
 

--- a/drizzle-orm/src/pg-core/query-builders/select.ts
+++ b/drizzle-orm/src/pg-core/query-builders/select.ts
@@ -269,22 +269,22 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Executes a `left join` operation by adding another table to the current query.
-	 * 
+	 *
 	 * Calling this method associates each row of the table with the corresponding row from the joined table, if a match is found. If no matching row exists, it sets all columns of the joined table to null.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#left-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User; pets: Pet | null }[] = await db.select()
 	 *   .from(users)
 	 *   .leftJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number; petId: number | null }[] = await db.select({
 	 *   userId: users.id,
@@ -298,22 +298,22 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Executes a `right join` operation by adding another table to the current query.
-	 * 
+	 *
 	 * Calling this method associates each row of the joined table with the corresponding row from the main table, if a match is found. If no matching row exists, it sets all columns of the main table to null.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#right-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User | null; pets: Pet }[] = await db.select()
 	 *   .from(users)
 	 *   .rightJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number | null; petId: number }[] = await db.select({
 	 *   userId: users.id,
@@ -327,22 +327,22 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Executes an `inner join` operation, creating a new table by combining rows from two tables that have matching values.
-	 * 
+	 *
 	 * Calling this method retrieves rows that have corresponding entries in both joined tables. Rows without matching entries in either table are excluded, resulting in a table that includes only matching pairs.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#inner-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User; pets: Pet }[] = await db.select()
 	 *   .from(users)
 	 *   .innerJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number; petId: number }[] = await db.select({
 	 *   userId: users.id,
@@ -356,22 +356,22 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Executes a `full join` operation by combining rows from two tables into a new table.
-	 * 
+	 *
 	 * Calling this method retrieves all rows from both main and joined tables, merging rows with matching values and filling in `null` for non-matching columns.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#full-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User | null; pets: Pet | null }[] = await db.select()
 	 *   .from(users)
 	 *   .fullJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number | null; petId: number | null }[] = await db.select({
 	 *   userId: users.id,
@@ -417,13 +417,13 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds `union` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will combine the result sets of the `select` statements and remove any duplicate rows that appear across them.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#union}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all unique names from customers and users tables
 	 * await db.select({ name: users.name })
@@ -433,9 +433,9 @@ export abstract class PgSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { union } from 'drizzle-orm/pg-core'
-	 * 
+	 *
 	 * await union(
-	 *   db.select({ name: users.name }).from(users), 
+	 *   db.select({ name: users.name }).from(users),
 	 *   db.select({ name: customers.name }).from(customers)
 	 * );
 	 * ```
@@ -444,13 +444,13 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds `union all` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will combine the result-set of the `select` statements and keep all duplicate rows that appear across them.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#union-all}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all transaction ids from both online and in-store sales
 	 * await db.select({ transaction: onlineSales.transactionId })
@@ -460,7 +460,7 @@ export abstract class PgSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { unionAll } from 'drizzle-orm/pg-core'
-	 * 
+	 *
 	 * await unionAll(
 	 *   db.select({ transaction: onlineSales.transactionId }).from(onlineSales),
 	 *   db.select({ transaction: inStoreSales.transactionId }).from(inStoreSales)
@@ -471,13 +471,13 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds `intersect` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retain only the rows that are present in both result sets and eliminate duplicates.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select course names that are offered in both departments A and B
 	 * await db.select({ courseName: depA.courseName })
@@ -487,7 +487,7 @@ export abstract class PgSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { intersect } from 'drizzle-orm/pg-core'
-	 * 
+	 *
 	 * await intersect(
 	 *   db.select({ courseName: depA.courseName }).from(depA),
 	 *   db.select({ courseName: depB.courseName }).from(depB)
@@ -495,33 +495,33 @@ export abstract class PgSelectQueryBuilderBase<
 	 * ```
 	 */
 	intersect = this.createSetOperator('intersect', false);
-	
+
 	/**
 	 * Adds `intersect all` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retain only the rows that are present in both result sets including all duplicates.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect-all}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all products and quantities that are ordered by both regular and VIP customers
-	 * await db.select({ 
-	 *   productId: regularCustomerOrders.productId, 
+	 * await db.select({
+	 *   productId: regularCustomerOrders.productId,
 	 *   quantityOrdered: regularCustomerOrders.quantityOrdered
 	 * })
 	 * .from(regularCustomerOrders)
 	 * .intersectAll(
-	 *   db.select({ 
-	 *     productId: vipCustomerOrders.productId, 
-	 *     quantityOrdered: vipCustomerOrders.quantityOrdered 
+	 *   db.select({
+	 *     productId: vipCustomerOrders.productId,
+	 *     quantityOrdered: vipCustomerOrders.quantityOrdered
 	 *   })
 	 *   .from(vipCustomerOrders)
 	 * );
 	 * // or
 	 * import { intersectAll } from 'drizzle-orm/pg-core'
-	 * 
+	 *
 	 * await intersectAll(
 	 *   db.select({
 	 *     productId: regularCustomerOrders.productId,
@@ -540,13 +540,13 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds `except` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retrieve all unique rows from the left query, except for the rows that are present in the result set of the right query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#except}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all courses offered in department A but not in department B
 	 * await db.select({ courseName: depA.courseName })
@@ -556,7 +556,7 @@ export abstract class PgSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { except } from 'drizzle-orm/pg-core'
-	 * 
+	 *
 	 * await except(
 	 *   db.select({ courseName: depA.courseName }).from(depA),
 	 *   db.select({ courseName: depB.courseName }).from(depB)
@@ -567,13 +567,13 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds `except all` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retrieve all rows from the left query, except for the rows that are present in the result set of the right query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#except-all}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all products that are ordered by regular customers but not by VIP customers
 	 * await db.select({
@@ -590,7 +590,7 @@ export abstract class PgSelectQueryBuilderBase<
 	 * );
 	 * // or
 	 * import { exceptAll } from 'drizzle-orm/pg-core'
-	 * 
+	 *
 	 * await exceptAll(
 	 *   db.select({
 	 *     productId: regularCustomerOrders.productId,
@@ -618,35 +618,35 @@ export abstract class PgSelectQueryBuilderBase<
 		return this as any;
 	}
 
-	/** 
+	/**
 	 * Adds a `where` clause to the query.
-	 * 
+	 *
 	 * Calling this method will select only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#filtering}
-	 * 
+	 *
 	 * @param where the `where` clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be selected.
-	 * 
+	 *
 	 * ```ts
 	 * // Select all cars with green color
 	 * await db.select().from(cars).where(eq(cars.color, 'green'));
 	 * // or
 	 * await db.select().from(cars).where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Select all BMW cars with a green color
 	 * await db.select().from(cars).where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Select all cars with the green or blue color
 	 * await db.select().from(cars).where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
 	 * ```
-	*/
+	 */
 	where(
 		where: ((aliases: this['_']['selection']) => SQL | undefined) | SQL | undefined,
 	): PgSelectWithout<this, TDynamic, 'where'> {
@@ -664,15 +664,15 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `having` clause to the query.
-	 * 
+	 *
 	 * Calling this method will select only those rows that fulfill a specified condition. It is typically used with aggregate functions to filter the aggregated data based on a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#aggregations}
-	 * 
+	 *
 	 * @param having the `having` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all brands with more than one car
 	 * await db.select({
@@ -701,13 +701,13 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `group by` clause to the query.
-	 * 
+	 *
 	 * Calling this method will group rows that have the same values into summary rows, often used for aggregation purposes.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#aggregations}
 	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Group and count people by their last names
 	 * await db.select({
@@ -743,9 +743,9 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds an `order by` clause to the query.
-	 * 
+	 *
 	 * Calling this method will sort the result-set in ascending or descending order. By default, the sort order is ascending.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#order-by}
 	 *
 	 * @example
@@ -754,13 +754,13 @@ export abstract class PgSelectQueryBuilderBase<
 	 * // Select cars ordered by year
 	 * await db.select().from(cars).orderBy(cars.year);
 	 * ```
-	 * 
+	 *
 	 * You can specify whether results are in ascending or descending order with the `asc()` and `desc()` operators.
-	 * 
+	 *
 	 * ```ts
 	 * // Select cars ordered by year in descending order
 	 * await db.select().from(cars).orderBy(desc(cars.year));
-	 * 
+	 *
 	 * // Select cars ordered by year and price
 	 * await db.select().from(cars).orderBy(asc(cars.year), desc(cars.price));
 	 * ```
@@ -803,13 +803,13 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `limit` clause to the query.
-	 * 
+	 *
 	 * Calling this method will set the maximum number of rows that will be returned by this query.
 	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#limit--offset}
-	 * 
+	 *
 	 * @param limit the `limit` clause.
-	 * 
+	 *
 	 * @example
 	 *
 	 * ```ts
@@ -828,13 +828,13 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds an `offset` clause to the query.
-	 * 
+	 *
 	 * Calling this method will skip a number of rows when returning results from this query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#limit--offset}
-	 * 
+	 *
 	 * @param offset the `offset` clause.
-	 * 
+	 *
 	 * @example
 	 *
 	 * ```ts
@@ -853,16 +853,41 @@ export abstract class PgSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `for` clause to the query.
-	 * 
+	 *
 	 * Calling this method will specify a lock strength for this query that controls how strictly it acquires exclusive access to the rows being queried.
-	 * 
+	 *
 	 * See docs: {@link https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE}
-	 * 
+	 *
 	 * @param strength the lock strength.
 	 * @param config the lock configuration.
 	 */
 	for(strength: LockStrength, config: LockConfig = {}): PgSelectWithout<this, TDynamic, 'for'> {
 		this.config.lockingClause = { strength, config };
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/select#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=user-select"
+	 * await db.select().from(user).comment("action=user-select");
+	 * ```
+	 */
+	comment(comment: string): PgSelectWithout<this, TDynamic, 'comment'> {
+		if (this.config.setOperators.length > 0) {
+			this.config.setOperators.at(-1)!.comment = comment;
+		} else {
+			this.config.comment = comment;
+		}
 		return this as any;
 	}
 
@@ -1012,19 +1037,19 @@ const getPgSetOperators = () => ({
 
 /**
  * Adds `union` set operator to the query.
- * 
+ *
  * Calling this method will combine the result sets of the `select` statements and remove any duplicate rows that appear across them.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#union}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all unique names from customers and users tables
  * import { union } from 'drizzle-orm/pg-core'
- * 
+ *
  * await union(
- *   db.select({ name: users.name }).from(users), 
+ *   db.select({ name: users.name }).from(users),
  *   db.select({ name: customers.name }).from(customers)
  * );
  * // or
@@ -1039,17 +1064,17 @@ export const union = createSetOperator('union', false);
 
 /**
  * Adds `union all` set operator to the query.
- * 
+ *
  * Calling this method will combine the result-set of the `select` statements and keep all duplicate rows that appear across them.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#union-all}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all transaction ids from both online and in-store sales
  * import { unionAll } from 'drizzle-orm/pg-core'
- * 
+ *
  * await unionAll(
  *   db.select({ transaction: onlineSales.transactionId }).from(onlineSales),
  *   db.select({ transaction: inStoreSales.transactionId }).from(inStoreSales)
@@ -1066,17 +1091,17 @@ export const unionAll = createSetOperator('union', true);
 
 /**
  * Adds `intersect` set operator to the query.
- * 
+ *
  * Calling this method will retain only the rows that are present in both result sets and eliminate duplicates.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select course names that are offered in both departments A and B
  * import { intersect } from 'drizzle-orm/pg-core'
- * 
+ *
  * await intersect(
  *   db.select({ courseName: depA.courseName }).from(depA),
  *   db.select({ courseName: depB.courseName }).from(depB)
@@ -1093,17 +1118,17 @@ export const intersect = createSetOperator('intersect', false);
 
 /**
  * Adds `intersect all` set operator to the query.
- * 
+ *
  * Calling this method will retain only the rows that are present in both result sets including all duplicates.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect-all}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all products and quantities that are ordered by both regular and VIP customers
  * import { intersectAll } from 'drizzle-orm/pg-core'
- * 
+ *
  * await intersectAll(
  *   db.select({
  *     productId: regularCustomerOrders.productId,
@@ -1117,15 +1142,15 @@ export const intersect = createSetOperator('intersect', false);
  *   .from(vipCustomerOrders)
  * );
  * // or
- * await db.select({ 
- *   productId: regularCustomerOrders.productId, 
+ * await db.select({
+ *   productId: regularCustomerOrders.productId,
  *   quantityOrdered: regularCustomerOrders.quantityOrdered
  * })
  * .from(regularCustomerOrders)
  * .intersectAll(
- *   db.select({ 
- *     productId: vipCustomerOrders.productId, 
- *     quantityOrdered: vipCustomerOrders.quantityOrdered 
+ *   db.select({
+ *     productId: vipCustomerOrders.productId,
+ *     quantityOrdered: vipCustomerOrders.quantityOrdered
  *   })
  *   .from(vipCustomerOrders)
  * );
@@ -1135,17 +1160,17 @@ export const intersectAll = createSetOperator('intersect', true);
 
 /**
  * Adds `except` set operator to the query.
- * 
+ *
  * Calling this method will retrieve all unique rows from the left query, except for the rows that are present in the result set of the right query.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#except}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all courses offered in department A but not in department B
  * import { except } from 'drizzle-orm/pg-core'
- * 
+ *
  * await except(
  *   db.select({ courseName: depA.courseName }).from(depA),
  *   db.select({ courseName: depB.courseName }).from(depB)
@@ -1162,17 +1187,17 @@ export const except = createSetOperator('except', false);
 
 /**
  * Adds `except all` set operator to the query.
- * 
+ *
  * Calling this method will retrieve all rows from the left query, except for the rows that are present in the result set of the right query.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#except-all}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all products that are ordered by regular customers but not by VIP customers
  * import { exceptAll } from 'drizzle-orm/pg-core'
- * 
+ *
  * await exceptAll(
  *   db.select({
  *     productId: regularCustomerOrders.productId,

--- a/drizzle-orm/src/pg-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/pg-core/query-builders/select.types.ts
@@ -77,7 +77,6 @@ export interface PgSelectConfig {
 		orderBy?: (PgColumn | SQL | SQL.Aliased)[];
 		limit?: number | Placeholder;
 		offset?: number | Placeholder;
-		comment?: string;
 	}[];
 }
 

--- a/drizzle-orm/src/pg-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/pg-core/query-builders/select.types.ts
@@ -59,6 +59,7 @@ export interface PgSelectConfig {
 	table: PgTable | Subquery | PgViewBase | SQL;
 	limit?: number | Placeholder;
 	offset?: number | Placeholder;
+	comment?: string;
 	joins?: PgSelectJoinConfig[];
 	orderBy?: (PgColumn | SQL | SQL.Aliased)[];
 	groupBy?: (PgColumn | SQL | SQL.Aliased)[];
@@ -76,6 +77,7 @@ export interface PgSelectConfig {
 		orderBy?: (PgColumn | SQL | SQL.Aliased)[];
 		limit?: number | Placeholder;
 		offset?: number | Placeholder;
+		comment?: string;
 	}[];
 }
 

--- a/drizzle-orm/src/pg-core/query-builders/update.ts
+++ b/drizzle-orm/src/pg-core/query-builders/update.ts
@@ -14,14 +14,15 @@ import { QueryPromise } from '~/query-promise.ts';
 import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
 import { Table } from '~/table.ts';
 import { mapUpdateSet, orderSelectedFields, type UpdateSet } from '~/utils.ts';
-import type { SelectedFields, SelectedFieldsOrdered } from './select.types.ts';
 import type { PgColumn } from '../columns/common.ts';
+import type { SelectedFields, SelectedFieldsOrdered } from './select.types.ts';
 
 export interface PgUpdateConfig {
 	where?: SQL | undefined;
 	set: UpdateSet;
 	table: PgTable;
 	returning?: SelectedFieldsOrdered;
+	comment?: string;
 }
 
 export type PgUpdateSetSource<TTable extends PgTable> =
@@ -162,16 +163,16 @@ export class PgUpdateBase<
 
 	/**
 	 * Adds a 'where' clause to the query.
-	 * 
+	 *
 	 * Calling this method will update only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update}
-	 * 
+	 *
 	 * @param where the 'where' clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be updated.
-	 * 
+	 *
 	 * ```ts
 	 * // Update all cars with green color
 	 * await db.update(cars).set({ color: 'red' })
@@ -180,14 +181,14 @@ export class PgUpdateBase<
 	 * await db.update(cars).set({ color: 'red' })
 	 *   .where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Update all BMW cars with a green color
 	 * await db.update(cars).set({ color: 'red' })
 	 *   .where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Update all cars with the green or blue color
 	 * await db.update(cars).set({ color: 'red' })
 	 *   .where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
@@ -200,11 +201,11 @@ export class PgUpdateBase<
 
 	/**
 	 * Adds a `returning` clause to the query.
-	 * 
+	 *
 	 * Calling this method will return the specified fields of the updated rows. If no fields are specified, all fields will be returned.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update#update-with-returning}
-	 * 
+	 *
 	 * @example
 	 * ```ts
 	 * // Update all cars with the green color and return all fields
@@ -212,7 +213,7 @@ export class PgUpdateBase<
 	 *   .set({ color: 'red' })
 	 *   .where(eq(cars.color, 'green'))
 	 *   .returning();
-	 * 
+	 *
 	 * // Update all cars with the green color and return only their id and brand fields
 	 * const updatedCarsIdsAndBrands: { id: number, brand: string }[] = await db.update(cars)
 	 *   .set({ color: 'red' })
@@ -228,6 +229,27 @@ export class PgUpdateBase<
 		fields: SelectedFields = this.config.table[Table.Symbol.Columns],
 	): PgUpdateWithout<AnyPgUpdate, TDynamic, 'returning'> {
 		this.config.returning = orderSelectedFields<PgColumn>(fields);
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/update#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=update-car"
+	 * await db.update(cars).set({ color: 'red' }).where(eq(cars.color, 'green')).comment("action=insert-car");
+	 * ```
+	 */
+	comment(comment: string): PgUpdateWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
 		return this as any;
 	}
 

--- a/drizzle-orm/src/pg-core/query-builders/update.ts
+++ b/drizzle-orm/src/pg-core/query-builders/update.ts
@@ -245,7 +245,7 @@ export class PgUpdateBase<
 	 *
 	 * ```ts
 	 * // add a comment "action=update-car"
-	 * await db.update(cars).set({ color: 'red' }).where(eq(cars.color, 'green')).comment("action=insert-car");
+	 * await db.update(cars).set({ color: 'red' }).where(eq(cars.color, 'green')).comment("action=update-car");
 	 * ```
 	 */
 	comment(comment: string): PgUpdateWithout<this, TDynamic, 'comment'> {

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -265,6 +265,7 @@ export type DBQueryConfig<
 			}
 			& (TIsRoot extends true ? {
 					offset?: number | Placeholder;
+					comment?: string;
 				}
 				: {})
 		: {});

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -370,7 +370,7 @@ export abstract class SQLiteDialect {
 		return sql`${leftChunk}${operatorChunk}${rightChunk}${orderBySql}${limitSql}${offsetSql}`;
 	}
 
-	buildInsertQuery({ table, values, onConflict, returning }: SQLiteInsertConfig): SQL {
+	buildInsertQuery({ table, values, onConflict, returning, comment }: SQLiteInsertConfig): SQL {
 		// const isSingleValue = values.length === 1;
 		const valuesSqlList: ((SQLChunk | SQL)[] | SQL)[] = [];
 		const columns: Record<string, SQLiteColumn> = table[Table.Symbol.Columns];
@@ -409,6 +409,7 @@ export abstract class SQLiteDialect {
 		const returningSql = returning
 			? sql` returning ${this.buildSelection(returning, { isSingleTable: true })}`
 			: undefined;
+		const commentSql = this.buildSqlComment(comment);
 
 		const onConflictSql = onConflict ? sql` on conflict ${onConflict}` : undefined;
 
@@ -416,7 +417,7 @@ export abstract class SQLiteDialect {
 		// 	return sql`insert into ${table} default values ${onConflictSql}${returningSql}`;
 		// }
 
-		return sql`insert into ${table} ${insertOrder} values ${valuesSql}${onConflictSql}${returningSql}`;
+		return sql`${commentSql}insert into ${table} ${insertOrder} values ${valuesSql}${onConflictSql}${returningSql}`;
 	}
 
 	sqlToQuery(sql: SQL): QueryWithTypings {

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -450,7 +450,7 @@ export abstract class SQLiteDialect {
 		joinOn?: SQL;
 	}): BuildRelationalQueryResult<SQLiteTable, SQLiteColumn> {
 		let selection: BuildRelationalQueryResult<SQLiteTable, SQLiteColumn>['selection'] = [];
-		let limit, offset, orderBy: SQLiteSelectConfig['orderBy'] = [], where;
+		let limit, offset, orderBy: SQLiteSelectConfig['orderBy'] = [], where, comment;
 		const joins: SQLiteSelectJoinConfig[] = [];
 
 		if (config === true) {
@@ -538,6 +538,10 @@ export abstract class SQLiteDialect {
 						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
 					});
 				}
+			}
+
+			if (config.comment) {
+				comment = config.comment;
 			}
 
 			// Transform `fieldsSelection` into `selection`
@@ -688,6 +692,7 @@ export abstract class SQLiteDialect {
 				limit,
 				offset,
 				orderBy,
+				comment,
 				setOperators: [],
 			});
 		} else {
@@ -703,6 +708,7 @@ export abstract class SQLiteDialect {
 				limit,
 				offset,
 				orderBy,
+				comment,
 				setOperators: [],
 			});
 		}

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -76,7 +76,7 @@ export abstract class SQLiteDialect {
 		);
 	}
 
-	buildUpdateQuery({ table, set, where, returning }: SQLiteUpdateConfig): SQL {
+	buildUpdateQuery({ table, set, where, returning, comment }: SQLiteUpdateConfig): SQL {
 		const setSql = this.buildUpdateSet(table, set);
 
 		const returningSql = returning
@@ -84,8 +84,9 @@ export abstract class SQLiteDialect {
 			: undefined;
 
 		const whereSql = where ? sql` where ${where}` : undefined;
+		const commentSql = this.buildSqlComment(comment);
 
-		return sql`update ${table} set ${setSql}${whereSql}${returningSql}`;
+		return sql`${commentSql}update ${table} set ${setSql}${whereSql}${returningSql}`;
 	}
 
 	// Builds a SQL comment and removess /* and */ occurences

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -90,7 +90,7 @@ export abstract class SQLiteDialect {
 		return sql`${commentSql}update ${table} set ${setSql}${whereSql}${returningSql}`;
 	}
 
-	// Builds a SQL comment and removess /* and */ occurences
+	// Builds a SQL comment and removes /* and */ occurences
 	private buildSqlComment(comment?: string) {
 		return comment ? sql.raw(`/* ${comment.replace(/\/\*|\*\//g, '')} */`) : undefined;
 	}

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -49,14 +49,15 @@ export abstract class SQLiteDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
-	buildDeleteQuery({ table, where, returning }: SQLiteDeleteConfig): SQL {
+	buildDeleteQuery({ table, where, returning, comment }: SQLiteDeleteConfig): SQL {
 		const returningSql = returning
 			? sql` returning ${this.buildSelection(returning, { isSingleTable: true })}`
 			: undefined;
 
 		const whereSql = where ? sql` where ${where}` : undefined;
+		const commentSql = this.buildSqlComment(comment);
 
-		return sql`delete from ${table}${whereSql}${returningSql}`;
+		return sql`${commentSql}delete from ${table}${whereSql}${returningSql}`;
 	}
 
 	buildUpdateSet(table: SQLiteTable, set: UpdateSet): SQL {

--- a/drizzle-orm/src/sqlite-core/query-builders/delete.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/delete.ts
@@ -7,8 +7,8 @@ import type { SQLiteDialect } from '~/sqlite-core/dialect.ts';
 import type { SQLitePreparedQuery, SQLiteSession } from '~/sqlite-core/session.ts';
 import { SQLiteTable } from '~/sqlite-core/table.ts';
 import { type DrizzleTypeError, orderSelectedFields } from '~/utils.ts';
-import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
 import type { SQLiteColumn } from '../columns/common.ts';
+import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
 
 export type SQLiteDeleteWithout<
 	T extends AnySQLiteDeleteBase,
@@ -38,6 +38,7 @@ export interface SQLiteDeleteConfig {
 	where?: SQL | undefined;
 	table: SQLiteTable;
 	returning?: SelectedFieldsOrdered;
+	comment?: string;
 }
 
 export type SQLiteDeleteReturningAll<
@@ -144,35 +145,35 @@ export class SQLiteDeleteBase<
 		this.config = { table };
 	}
 
-	/** 
+	/**
 	 * Adds a `where` clause to the query.
-	 * 
+	 *
 	 * Calling this method will delete only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/delete}
-	 * 
+	 *
 	 * @param where the `where` clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be deleted.
-	 * 
+	 *
 	 * ```ts
 	 * // Delete all cars with green color
 	 * db.delete(cars).where(eq(cars.color, 'green'));
 	 * // or
 	 * db.delete(cars).where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Delete all BMW cars with a green color
 	 * db.delete(cars).where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Delete all cars with the green or blue color
 	 * db.delete(cars).where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
 	 * ```
-	*/
+	 */
 	where(where: SQL | undefined): SQLiteDeleteWithout<this, TDynamic, 'where'> {
 		this.config.where = where;
 		return this as any;
@@ -180,18 +181,18 @@ export class SQLiteDeleteBase<
 
 	/**
 	 * Adds a `returning` clause to the query.
-	 * 
+	 *
 	 * Calling this method will return the specified fields of the deleted rows. If no fields are specified, all fields will be returned.
-	 * 
-	 * See docs: {@link https://orm.drizzle.team/docs/delete#delete-with-return} 
-	 * 
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/delete#delete-with-return}
+	 *
 	 * @example
 	 * ```ts
 	 * // Delete all cars with the green color and return all fields
 	 * const deletedCars: Car[] = await db.delete(cars)
 	 *   .where(eq(cars.color, 'green'))
 	 *   .returning();
-	 * 
+	 *
 	 * // Delete all cars with the green color and return only their id and brand fields
 	 * const deletedCarsIdsAndBrands: { id: number, brand: string }[] = await db.delete(cars)
 	 *   .where(eq(cars.color, 'green'))
@@ -206,6 +207,27 @@ export class SQLiteDeleteBase<
 		fields: SelectedFieldsFlat = this.table[SQLiteTable.Symbol.Columns],
 	): SQLiteDeleteReturning<this, TDynamic, any> {
 		this.config.returning = orderSelectedFields<SQLiteColumn>(fields);
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/update#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=delete-car"
+	 * await db.delete(cars).where(eq(cars.color, 'green')).comment("action=delete-car");
+	 * ```
+	 */
+	comment(comment: string): SQLiteDeleteWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
 		return this as any;
 	}
 

--- a/drizzle-orm/src/sqlite-core/query-builders/delete.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/delete.ts
@@ -215,7 +215,7 @@ export class SQLiteDeleteBase<
 	 *
 	 * Calling this method will add a comment to the query.
 	 *
-	 * See docs: {@link https://orm.drizzle.team/docs/update#comment}
+	 * See docs: {@link https://orm.drizzle.team/docs/delete#comment}
 	 *
 	 * @param comment the `comment` to be added.
 	 *

--- a/drizzle-orm/src/sqlite-core/query-builders/select.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/select.ts
@@ -12,6 +12,7 @@ import type {
 } from '~/query-builders/select.types.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
+import { SelectionProxyHandler } from '~/selection-proxy.ts';
 import { SQL, View } from '~/sql/sql.ts';
 import type { ColumnsSelection, Placeholder, Query } from '~/sql/sql.ts';
 import type { SQLiteColumn } from '~/sqlite-core/columns/index.ts';
@@ -19,6 +20,7 @@ import type { SQLiteDialect } from '~/sqlite-core/dialect.ts';
 import type { SQLiteSession } from '~/sqlite-core/session.ts';
 import type { SubqueryWithSelection } from '~/sqlite-core/subquery.ts';
 import type { SQLiteTable } from '~/sqlite-core/table.ts';
+import { Subquery, SubqueryConfig } from '~/subquery.ts';
 import { Table } from '~/table.ts';
 import {
 	applyMixins,
@@ -29,6 +31,7 @@ import {
 	type ValueOrArray,
 } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
+import { SQLiteViewBase } from '../view-base.ts';
 import type {
 	AnySQLiteSelect,
 	CreateSQLiteSelectFromBuilderMode,
@@ -47,9 +50,6 @@ import type {
 	SQLiteSetOperatorExcludedMethods,
 	SQLiteSetOperatorWithResult,
 } from './select.types.ts';
-import { Subquery, SubqueryConfig } from '~/subquery.ts';
-import { SQLiteViewBase } from '../view-base.ts';
-import { SelectionProxyHandler } from '~/selection-proxy.ts';
 
 export class SQLiteSelectBuilder<
 	TSelection extends SelectedFields | undefined,
@@ -269,22 +269,22 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Executes a `left join` operation by adding another table to the current query.
-	 * 
+	 *
 	 * Calling this method associates each row of the table with the corresponding row from the joined table, if a match is found. If no matching row exists, it sets all columns of the joined table to null.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#left-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User; pets: Pet | null }[] = await db.select()
 	 *   .from(users)
 	 *   .leftJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number; petId: number | null }[] = await db.select({
 	 *   userId: users.id,
@@ -295,25 +295,25 @@ export abstract class SQLiteSelectQueryBuilderBase<
 	 * ```
 	 */
 	leftJoin = this.createJoin('left');
-	
+
 	/**
 	 * Executes a `right join` operation by adding another table to the current query.
-	 * 
+	 *
 	 * Calling this method associates each row of the joined table with the corresponding row from the main table, if a match is found. If no matching row exists, it sets all columns of the main table to null.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#right-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User | null; pets: Pet }[] = await db.select()
 	 *   .from(users)
 	 *   .rightJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number | null; petId: number }[] = await db.select({
 	 *   userId: users.id,
@@ -327,22 +327,22 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Executes an `inner join` operation, creating a new table by combining rows from two tables that have matching values.
-	 * 
+	 *
 	 * Calling this method retrieves rows that have corresponding entries in both joined tables. Rows without matching entries in either table are excluded, resulting in a table that includes only matching pairs.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#inner-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User; pets: Pet }[] = await db.select()
 	 *   .from(users)
 	 *   .innerJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number; petId: number }[] = await db.select({
 	 *   userId: users.id,
@@ -356,22 +356,22 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Executes a `full join` operation by combining rows from two tables into a new table.
-	 * 
+	 *
 	 * Calling this method retrieves all rows from both main and joined tables, merging rows with matching values and filling in `null` for non-matching columns.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/joins#full-join}
-	 * 
+	 *
 	 * @param table the table to join.
 	 * @param on the `on` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all users and their pets
 	 * const usersWithPets: { user: User | null; pets: Pet | null }[] = await db.select()
 	 *   .from(users)
 	 *   .fullJoin(pets, eq(users.id, pets.ownerId))
-	 * 
+	 *
 	 * // Select userId and petId
 	 * const usersIdsAndPetIds: { userId: number | null; petId: number | null }[] = await db.select({
 	 *   userId: users.id,
@@ -417,13 +417,13 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Adds `union` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will combine the result sets of the `select` statements and remove any duplicate rows that appear across them.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#union}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all unique names from customers and users tables
 	 * await db.select({ name: users.name })
@@ -433,9 +433,9 @@ export abstract class SQLiteSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { union } from 'drizzle-orm/sqlite-core'
-	 * 
+	 *
 	 * await union(
-	 *   db.select({ name: users.name }).from(users), 
+	 *   db.select({ name: users.name }).from(users),
 	 *   db.select({ name: customers.name }).from(customers)
 	 * );
 	 * ```
@@ -444,13 +444,13 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Adds `union all` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will combine the result-set of the `select` statements and keep all duplicate rows that appear across them.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#union-all}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all transaction ids from both online and in-store sales
 	 * await db.select({ transaction: onlineSales.transactionId })
@@ -460,7 +460,7 @@ export abstract class SQLiteSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { unionAll } from 'drizzle-orm/sqlite-core'
-	 * 
+	 *
 	 * await unionAll(
 	 *   db.select({ transaction: onlineSales.transactionId }).from(onlineSales),
 	 *   db.select({ transaction: inStoreSales.transactionId }).from(inStoreSales)
@@ -471,13 +471,13 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Adds `intersect` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retain only the rows that are present in both result sets and eliminate duplicates.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select course names that are offered in both departments A and B
 	 * await db.select({ courseName: depA.courseName })
@@ -487,7 +487,7 @@ export abstract class SQLiteSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { intersect } from 'drizzle-orm/sqlite-core'
-	 * 
+	 *
 	 * await intersect(
 	 *   db.select({ courseName: depA.courseName }).from(depA),
 	 *   db.select({ courseName: depB.courseName }).from(depB)
@@ -498,13 +498,13 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Adds `except` set operator to the query.
-	 * 
+	 *
 	 * Calling this method will retrieve all unique rows from the left query, except for the rows that are present in the result set of the right query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/set-operations#except}
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all courses offered in department A but not in department B
 	 * await db.select({ courseName: depA.courseName })
@@ -514,7 +514,7 @@ export abstract class SQLiteSelectQueryBuilderBase<
 	 *   );
 	 * // or
 	 * import { except } from 'drizzle-orm/sqlite-core'
-	 * 
+	 *
 	 * await except(
 	 *   db.select({ courseName: depA.courseName }).from(depA),
 	 *   db.select({ courseName: depB.courseName }).from(depB)
@@ -534,35 +534,35 @@ export abstract class SQLiteSelectQueryBuilderBase<
 		return this as any;
 	}
 
-	/** 
+	/**
 	 * Adds a `where` clause to the query.
-	 * 
+	 *
 	 * Calling this method will select only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#filtering}
-	 * 
+	 *
 	 * @param where the `where` clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be selected.
-	 * 
+	 *
 	 * ```ts
 	 * // Select all cars with green color
 	 * await db.select().from(cars).where(eq(cars.color, 'green'));
 	 * // or
 	 * await db.select().from(cars).where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Select all BMW cars with a green color
 	 * await db.select().from(cars).where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Select all cars with the green or blue color
 	 * await db.select().from(cars).where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
 	 * ```
-	*/
+	 */
 	where(
 		where: ((aliases: TSelection) => SQL | undefined) | SQL | undefined,
 	): SQLiteSelectWithout<this, TDynamic, 'where'> {
@@ -580,15 +580,15 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `having` clause to the query.
-	 * 
+	 *
 	 * Calling this method will select only those rows that fulfill a specified condition. It is typically used with aggregate functions to filter the aggregated data based on a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#aggregations}
-	 * 
+	 *
 	 * @param having the `having` clause.
-	 * 
+	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Select all brands with more than one car
 	 * await db.select({
@@ -617,13 +617,13 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `group by` clause to the query.
-	 * 
+	 *
 	 * Calling this method will group rows that have the same values into summary rows, often used for aggregation purposes.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#aggregations}
 	 *
 	 * @example
-	 * 
+	 *
 	 * ```ts
 	 * // Group and count people by their last names
 	 * await db.select({
@@ -659,9 +659,9 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Adds an `order by` clause to the query.
-	 * 
+	 *
 	 * Calling this method will sort the result-set in ascending or descending order. By default, the sort order is ascending.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#order-by}
 	 *
 	 * @example
@@ -670,13 +670,13 @@ export abstract class SQLiteSelectQueryBuilderBase<
 	 * // Select cars ordered by year
 	 * await db.select().from(cars).orderBy(cars.year);
 	 * ```
-	 * 
+	 *
 	 * You can specify whether results are in ascending or descending order with the `asc()` and `desc()` operators.
-	 * 
+	 *
 	 * ```ts
 	 * // Select cars ordered by year in descending order
 	 * await db.select().from(cars).orderBy(desc(cars.year));
-	 * 
+	 *
 	 * // Select cars ordered by year and price
 	 * await db.select().from(cars).orderBy(asc(cars.year), desc(cars.price));
 	 * ```
@@ -719,13 +719,13 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Adds a `limit` clause to the query.
-	 * 
+	 *
 	 * Calling this method will set the maximum number of rows that will be returned by this query.
 	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#limit--offset}
-	 * 
+	 *
 	 * @param limit the `limit` clause.
-	 * 
+	 *
 	 * @example
 	 *
 	 * ```ts
@@ -744,13 +744,13 @@ export abstract class SQLiteSelectQueryBuilderBase<
 
 	/**
 	 * Adds an `offset` clause to the query.
-	 * 
+	 *
 	 * Calling this method will skip a number of rows when returning results from this query.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/select#limit--offset}
-	 * 
+	 *
 	 * @param offset the `offset` clause.
-	 * 
+	 *
 	 * @example
 	 *
 	 * ```ts
@@ -764,6 +764,27 @@ export abstract class SQLiteSelectQueryBuilderBase<
 		} else {
 			this.config.offset = offset;
 		}
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/select#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=people-select"
+	 * await db.select().from(people).comment("action=people-select");
+	 * ```
+	 */
+	comment(comment: string): SQLiteSelectWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
 		return this as any;
 	}
 
@@ -922,19 +943,19 @@ const getSQLiteSetOperators = () => ({
 
 /**
  * Adds `union` set operator to the query.
- * 
+ *
  * Calling this method will combine the result sets of the `select` statements and remove any duplicate rows that appear across them.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#union}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all unique names from customers and users tables
  * import { union } from 'drizzle-orm/sqlite-core'
- * 
+ *
  * await union(
- *   db.select({ name: users.name }).from(users), 
+ *   db.select({ name: users.name }).from(users),
  *   db.select({ name: customers.name }).from(customers)
  * );
  * // or
@@ -949,17 +970,17 @@ export const union = createSetOperator('union', false);
 
 /**
  * Adds `union all` set operator to the query.
- * 
+ *
  * Calling this method will combine the result-set of the `select` statements and keep all duplicate rows that appear across them.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#union-all}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all transaction ids from both online and in-store sales
  * import { unionAll } from 'drizzle-orm/sqlite-core'
- * 
+ *
  * await unionAll(
  *   db.select({ transaction: onlineSales.transactionId }).from(onlineSales),
  *   db.select({ transaction: inStoreSales.transactionId }).from(inStoreSales)
@@ -976,17 +997,17 @@ export const unionAll = createSetOperator('union', true);
 
 /**
  * Adds `intersect` set operator to the query.
- * 
+ *
  * Calling this method will retain only the rows that are present in both result sets and eliminate duplicates.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#intersect}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select course names that are offered in both departments A and B
  * import { intersect } from 'drizzle-orm/sqlite-core'
- * 
+ *
  * await intersect(
  *   db.select({ courseName: depA.courseName }).from(depA),
  *   db.select({ courseName: depB.courseName }).from(depB)
@@ -1003,17 +1024,17 @@ export const intersect = createSetOperator('intersect', false);
 
 /**
  * Adds `except` set operator to the query.
- * 
+ *
  * Calling this method will retrieve all unique rows from the left query, except for the rows that are present in the result set of the right query.
- * 
+ *
  * See docs: {@link https://orm.drizzle.team/docs/set-operations#except}
- * 
+ *
  * @example
- * 
+ *
  * ```ts
  * // Select all courses offered in department A but not in department B
  * import { except } from 'drizzle-orm/sqlite-core'
- * 
+ *
  * await except(
  *   db.select({ courseName: depA.courseName }).from(depA),
  *   db.select({ courseName: depB.courseName }).from(depB)

--- a/drizzle-orm/src/sqlite-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/select.types.ts
@@ -1,7 +1,7 @@
 import type { ColumnsSelection, Placeholder, SQL, View } from '~/sql/sql.ts';
-import type { Assume, ValidateShape } from '~/utils.ts';
 import type { SQLiteColumn } from '~/sqlite-core/columns/index.ts';
 import type { SQLiteTable, SQLiteTableWithColumns } from '~/sqlite-core/table.ts';
+import type { Assume, ValidateShape } from '~/utils.ts';
 
 import type {
 	SelectedFields as SelectFieldsBase,
@@ -24,9 +24,9 @@ import type {
 import type { Subquery } from '~/subquery.ts';
 import type { Table, UpdateTableConfig } from '~/table.ts';
 import type { SQLitePreparedQuery } from '../session.ts';
-import type { SQLiteSelectBase, SQLiteSelectQueryBuilderBase } from './select.ts';
 import type { SQLiteViewBase } from '../view-base.ts';
 import type { SQLiteViewWithSelection } from '../view.ts';
+import type { SQLiteSelectBase, SQLiteSelectQueryBuilderBase } from './select.ts';
 
 export interface SQLiteSelectJoinConfig {
 	on: SQL | undefined;
@@ -62,6 +62,7 @@ export interface SQLiteSelectConfig {
 	orderBy?: (SQLiteColumn | SQL | SQL.Aliased)[];
 	groupBy?: (SQLiteColumn | SQL | SQL.Aliased)[];
 	distinct?: boolean;
+	comment?: string;
 	setOperators: {
 		rightSelect: TypedQueryBuilder<any, any>;
 		type: SetOperator;

--- a/drizzle-orm/src/sqlite-core/query-builders/update.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/update.ts
@@ -8,14 +8,15 @@ import type { SQLiteDialect } from '~/sqlite-core/dialect.ts';
 import type { SQLitePreparedQuery, SQLiteSession } from '~/sqlite-core/session.ts';
 import { SQLiteTable } from '~/sqlite-core/table.ts';
 import { type DrizzleTypeError, mapUpdateSet, orderSelectedFields, type UpdateSet } from '~/utils.ts';
-import type { SelectedFields, SelectedFieldsOrdered } from './select.types.ts';
 import type { SQLiteColumn } from '../columns/common.ts';
+import type { SelectedFields, SelectedFieldsOrdered } from './select.types.ts';
 
 export interface SQLiteUpdateConfig {
 	where?: SQL | undefined;
 	set: UpdateSet;
 	table: SQLiteTable;
 	returning?: SelectedFieldsOrdered;
+	comment?: string;
 }
 
 export type SQLiteUpdateSetSource<TTable extends SQLiteTable> =
@@ -177,16 +178,16 @@ export class SQLiteUpdateBase<
 
 	/**
 	 * Adds a 'where' clause to the query.
-	 * 
+	 *
 	 * Calling this method will update only those rows that fulfill a specified condition.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update}
-	 * 
+	 *
 	 * @param where the 'where' clause.
-	 * 
+	 *
 	 * @example
 	 * You can use conditional operators and `sql function` to filter the rows to be updated.
-	 * 
+	 *
 	 * ```ts
 	 * // Update all cars with green color
 	 * db.update(cars).set({ color: 'red' })
@@ -195,14 +196,14 @@ export class SQLiteUpdateBase<
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(sql`${cars.color} = 'green'`)
 	 * ```
-	 * 
+	 *
 	 * You can logically combine conditional operators with `and()` and `or()` operators:
-	 * 
+	 *
 	 * ```ts
 	 * // Update all BMW cars with a green color
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(and(eq(cars.color, 'green'), eq(cars.brand, 'BMW')));
-	 * 
+	 *
 	 * // Update all cars with the green or blue color
 	 * db.update(cars).set({ color: 'red' })
 	 *   .where(or(eq(cars.color, 'green'), eq(cars.color, 'blue')));
@@ -215,11 +216,11 @@ export class SQLiteUpdateBase<
 
 	/**
 	 * Adds a `returning` clause to the query.
-	 * 
+	 *
 	 * Calling this method will return the specified fields of the updated rows. If no fields are specified, all fields will be returned.
-	 * 
+	 *
 	 * See docs: {@link https://orm.drizzle.team/docs/update#update-with-returning}
-	 * 
+	 *
 	 * @example
 	 * ```ts
 	 * // Update all cars with the green color and return all fields
@@ -227,7 +228,7 @@ export class SQLiteUpdateBase<
 	 *   .set({ color: 'red' })
 	 *   .where(eq(cars.color, 'green'))
 	 *   .returning();
-	 * 
+	 *
 	 * // Update all cars with the green color and return only their id and brand fields
 	 * const updatedCarsIdsAndBrands: { id: number, brand: string }[] = await db.update(cars)
 	 *   .set({ color: 'red' })
@@ -243,6 +244,27 @@ export class SQLiteUpdateBase<
 		fields: SelectedFields = this.config.table[SQLiteTable.Symbol.Columns],
 	): SQLiteUpdateWithout<AnySQLiteUpdate, TDynamic, 'returning'> {
 		this.config.returning = orderSelectedFields<SQLiteColumn>(fields);
+		return this as any;
+	}
+
+	/**
+	 * Adds a `comment` to the query.
+	 *
+	 * Calling this method will add a comment to the query.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/update#comment}
+	 *
+	 * @param comment the `comment` to be added.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // add a comment "action=update-car"
+	 * await db.update(cars).set({ color: 'red' }).where(eq(cars.color, 'green')).comment("action=update-car");
+	 * ```
+	 */
+	comment(comment: string): SQLiteUpdateWithout<this, TDynamic, 'comment'> {
+		this.config.comment = comment;
 		return this as any;
 	}
 

--- a/integration-tests/tests/awsdatapi.test.ts
+++ b/integration-tests/tests/awsdatapi.test.ts
@@ -865,3 +865,55 @@ test.after.always(async (t) => {
 	// await ctx.client?.end().catch(console.error);
 	// await ctx.pgContainer?.stop().catch(console.error);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update "users" set "name" = $1 where "users"."id" = $2',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from "users" where "users"."id" = $1',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/libsql.test.ts
+++ b/integration-tests/tests/libsql.test.ts
@@ -2547,3 +2547,55 @@ test.serial('aggregate function: min', async (t) => {
 	t.deepEqual(result1[0]?.value, 10);
 	t.deepEqual(result2[0]?.value, null);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "json", "created_at") values (null, ?, ?, null, strftime(\'%s\', \'now\'))',
+		params: ['John', 0],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update "users" set "name" = ? where "users"."id" = ?',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from "users" where "users"."id" = ?',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/mysql.custom.test.ts
+++ b/integration-tests/tests/mysql.custom.test.ts
@@ -850,3 +850,55 @@ test.after.always(async (t) => {
 	await ctx.client?.end().catch(console.error);
 	await ctx.mysqlContainer?.stop().catch(console.error);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select `id`, `name` from `userstest` group by `userstest`.`id`, `userstest`.`name`',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into `userstest` (`id`, `name`, `verified`, `jsonb`, `created_at`) values (default, ?, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update `userstest` set `name` = ? where `userstest`.`id` = ?',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from `userstest` where `userstest`.`id` = ?',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/mysql.prefixed.test.ts
+++ b/integration-tests/tests/mysql.prefixed.test.ts
@@ -1778,3 +1778,56 @@ test.serial('update undefined', async (t) => {
 
 	await db.execute(sql`drop table ${users}`);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */select `id`, `name` from `drizzle_tests_userstest` group by `drizzle_tests_userstest`.`id`, `drizzle_tests_userstest`.`name`',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into `drizzle_tests_userstest` (`id`, `name`, `verified`, `jsonb`, `created_at`) values (default, ?, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update `drizzle_tests_userstest` set `name` = ? where `drizzle_tests_userstest`.`id` = ?',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from `drizzle_tests_userstest` where `drizzle_tests_userstest`.`id` = ?',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/mysql.test.ts
+++ b/integration-tests/tests/mysql.test.ts
@@ -2778,3 +2778,55 @@ test.serial('aggregate function: min', async (t) => {
 	t.deepEqual(result1[0]?.value, 10);
 	t.deepEqual(result2[0]?.value, null);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select `id`, `name` from `userstest` group by `userstest`.`id`, `userstest`.`name`',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into `userstest` (`id`, `name`, `verified`, `jsonb`, `created_at`) values (default, ?, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update `userstest` set `name` = ? where `userstest`.`id` = ?',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from `userstest` where `userstest`.`id` = ?',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/neon-http.test.ts
+++ b/integration-tests/tests/neon-http.test.ts
@@ -2414,3 +2414,55 @@ test.serial('array operators', async (t) => {
 	t.deepEqual(overlaps, [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]);
 	t.deepEqual(withSubQuery, [{ id: 1 }, { id: 3 }, { id: 5 }]);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update "users" set "name" = $1 where "users"."id" = $2',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from "users" where "users"."id" = $1',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -467,6 +467,19 @@ test.serial('build update query with comment and replace /* and */ occurences', 
 	});
 });
 
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from "users" where "users"."id" = $1',
+		params: [1],
+	});
+});
+
 test.serial('partial join with alias', async (t) => {
 	const { db } = t.context;
 	const customerAlias = alias(usersTable, 'customer');

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -428,58 +428,6 @@ test.serial('build query', async (t) => {
 	});
 });
 
-test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
-	const { db } = t.context;
-
-	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
-		.comment('/*/*/**/test-*/comment')
-		.groupBy(usersTable.id, usersTable.name)
-		.toSQL();
-
-	t.deepEqual(query, {
-		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
-		params: [],
-	});
-});
-
-test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
-	const { db } = t.context;
-
-	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
-
-	t.deepEqual(query, {
-		sql:
-			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
-		params: ['John'],
-	});
-});
-
-test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
-	const { db } = t.context;
-
-	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
-		'/*/*/**/test-*/comment',
-	).toSQL();
-
-	t.deepEqual(query, {
-		sql: '/* test-comment */update "users" set "name" = $1 where "users"."id" = $2',
-		params: ['John', 1],
-	});
-});
-
-test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
-	const { db } = t.context;
-
-	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
-		'/*/*/**/test-*/comment',
-	).toSQL();
-
-	t.deepEqual(query, {
-		sql: '/* test-comment */delete from "users" where "users"."id" = $1',
-		params: [1],
-	});
-});
-
 test.serial('partial join with alias', async (t) => {
 	const { db } = t.context;
 	const customerAlias = alias(usersTable, 'customer');

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -428,6 +428,34 @@ test.serial('build query', async (t) => {
 	});
 });
 
+test.serial('build select query with comment', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.groupBy(usersTable.id, usersTable.name)
+		.comment('test-comment')
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('build select query with comment and replace */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('*/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
 test.serial('insert sql', async (t) => {
 	const { db } = t.context;
 

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -755,3 +755,55 @@ test.serial('insert with onConflict do nothing + target', async (t) => {
 
 	t.deepEqual(res, [{ id: 1, name: 'John' }]);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update "users" set "name" = $1 where "users"."id" = $2',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from "users" where "users"."id" = $1',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -442,11 +442,11 @@ test.serial('build select query with comment', async (t) => {
 	});
 });
 
-test.serial('build select query with comment and replace */ occurences', async (t) => {
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
 	const { db } = t.context;
 
 	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
-		.comment('*/test-*/comment')
+		.comment('/*/*/**/test-*/comment')
 		.groupBy(usersTable.id, usersTable.name)
 		.toSQL();
 
@@ -456,12 +456,28 @@ test.serial('build select query with comment and replace */ occurences', async (
 	});
 });
 
-test.serial('insert sql', async (t) => {
+test.serial('build insert query with comment', async (t) => {
 	const { db } = t.context;
 
-	await db.insert(usersTable).values({ name: sql`${'John'}` });
-	const result = await db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable);
-	t.deepEqual(result, [{ id: 1, name: 'John' }]);
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
+		params: ['John'],
+	});
 });
 
 test.serial('partial join with alias', async (t) => {

--- a/integration-tests/tests/pg.custom.test.ts
+++ b/integration-tests/tests/pg.custom.test.ts
@@ -428,20 +428,6 @@ test.serial('build query', async (t) => {
 	});
 });
 
-test.serial('build select query with comment', async (t) => {
-	const { db } = t.context;
-
-	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
-		.groupBy(usersTable.id, usersTable.name)
-		.comment('test-comment')
-		.toSQL();
-
-	t.deepEqual(query, {
-		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
-		params: [],
-	});
-});
-
 test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
 	const { db } = t.context;
 
@@ -456,7 +442,7 @@ test.serial('build select query with comment and replace /* and */ occurences', 
 	});
 });
 
-test.serial('build insert query with comment', async (t) => {
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
 	const { db } = t.context;
 
 	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
@@ -468,15 +454,16 @@ test.serial('build insert query with comment', async (t) => {
 	});
 });
 
-test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
 	const { db } = t.context;
 
-	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
 
 	t.deepEqual(query, {
-		sql:
-			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
-		params: ['John'],
+		sql: '/* test-comment */update "users" set "name" = $1 where "users"."id" = $2',
+		params: ['John', 1],
 	});
 });
 

--- a/integration-tests/tests/pg.test.ts
+++ b/integration-tests/tests/pg.test.ts
@@ -3328,3 +3328,55 @@ test.serial('array mapping and parsing', async (t) => {
 
 	await db.execute(sql`drop table ${arrays}`);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update "users" set "name" = $1 where "users"."id" = $2',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from "users" where "users"."id" = $1',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/postgres.js.test.ts
+++ b/integration-tests/tests/postgres.js.test.ts
@@ -2214,3 +2214,55 @@ test.serial('array mapping and parsing', async (t) => {
 
 	await db.execute(sql`drop table ${arrays}`);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update "users" set "name" = $1 where "users"."id" = $2',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from "users" where "users"."id" = $1',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/relational/bettersqlite.test.ts
+++ b/integration-tests/tests/relational/bettersqlite.test.ts
@@ -5923,6 +5923,36 @@ test('Get users with groups + custom', () => {
 	});
 });
 
+test('[Find One] build query with comment and replace /* and */ occurences', async (t) => {
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
+test('[Find Many] build query with comment and replace /* and */ occurences', async (t) => {
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
 test('Get groups with users + custom', () => {
 	db.insert(usersTable).values([
 		{ id: 1, name: 'Dan' },

--- a/integration-tests/tests/relational/mysql.planetscale.test.ts
+++ b/integration-tests/tests/relational/mysql.planetscale.test.ts
@@ -5754,6 +5754,36 @@ test('[Find One] Get users with groups + orderBy + limit', async () => {
 	});
 });
 
+test('[Find One] build query with comment and replace /* and */ occurences', () => {
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
+test('[Find Many] build query with comment and replace /* and */ occurences', () => {
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
 test('Get groups with users + orderBy + limit', async () => {
 	await db.insert(usersTable).values([
 		{ id: 1, name: 'Dan' },

--- a/integration-tests/tests/relational/mysql.test.ts
+++ b/integration-tests/tests/relational/mysql.test.ts
@@ -5948,6 +5948,36 @@ test('[Find One] Get users with groups + orderBy + limit', async (t) => {
 	});
 });
 
+test('[Find One] build query with comment and replace /* and */ occurences', () => {
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
+test('[Find Many] build query with comment and replace /* and */ occurences', () => {
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
 test('Get groups with users + orderBy + limit', async (t) => {
 	const { mysqlDb: db } = t;
 

--- a/integration-tests/tests/relational/pg.postgresjs.test.ts
+++ b/integration-tests/tests/relational/pg.postgresjs.test.ts
@@ -6012,6 +6012,40 @@ test('Get groups with users + orderBy + limit', async (t) => {
 	});
 });
 
+test('[Find One] build query with comment and replace /* and */ occurences', async (t) => {
+	const { pgjsDb: db } = t;
+
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
+test('[Find Many] build query with comment and replace /* and */ occurences', async (t) => {
+	const { pgjsDb: db } = t;
+
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
 test('Get users with groups + custom', async (t) => {
 	const { pgjsDb: db } = t;
 

--- a/integration-tests/tests/relational/pg.postgresjs.test.ts
+++ b/integration-tests/tests/relational/pg.postgresjs.test.ts
@@ -6012,7 +6012,7 @@ test('Get groups with users + orderBy + limit', async (t) => {
 	});
 });
 
-test('[Find One] build query with comment and replace /* and */ occurences', async (t) => {
+test('[Find One] build query with comment and replace /* and */ occurences', (t) => {
 	const { pgjsDb: db } = t;
 
 	const query = db.query.usersTable.findFirst({
@@ -6029,7 +6029,7 @@ test('[Find One] build query with comment and replace /* and */ occurences', asy
 	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
 });
 
-test('[Find Many] build query with comment and replace /* and */ occurences', async (t) => {
+test('[Find Many] build query with comment and replace /* and */ occurences', (t) => {
 	const { pgjsDb: db } = t;
 
 	const query = db.query.usersTable.findFirst({

--- a/integration-tests/tests/relational/pg.test.ts
+++ b/integration-tests/tests/relational/pg.test.ts
@@ -5924,6 +5924,40 @@ test('[Find One] Get users with groups + orderBy + limit', async (t) => {
 	});
 });
 
+test('[Find One] build query with comment and replace /* and */ occurences', async (t) => {
+	const { pgDb: db } = t;
+
+	const query = await db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
+test('[Find Many] build query with comment and replace /* and */ occurences', async (t) => {
+	const { pgDb: db } = t;
+
+	const query = await db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
 test('Get groups with users + orderBy + limit', async (t) => {
 	const { pgDb: db } = t;
 

--- a/integration-tests/tests/relational/pg.test.ts
+++ b/integration-tests/tests/relational/pg.test.ts
@@ -5924,10 +5924,10 @@ test('[Find One] Get users with groups + orderBy + limit', async (t) => {
 	});
 });
 
-test('[Find One] build query with comment and replace /* and */ occurences', async (t) => {
+test('[Find One] build query with comment and replace /* and */ occurences', (t) => {
 	const { pgDb: db } = t;
 
-	const query = await db.query.usersTable.findFirst({
+	const query = db.query.usersTable.findFirst({
 		columns: { name: true },
 		with: {
 			posts: {
@@ -5941,10 +5941,10 @@ test('[Find One] build query with comment and replace /* and */ occurences', asy
 	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
 });
 
-test('[Find Many] build query with comment and replace /* and */ occurences', async (t) => {
+test('[Find Many] build query with comment and replace /* and */ occurences', (t) => {
 	const { pgDb: db } = t;
 
-	const query = await db.query.usersTable.findFirst({
+	const query = db.query.usersTable.findFirst({
 		columns: { name: true },
 		with: {
 			posts: {

--- a/integration-tests/tests/relational/turso.test.ts
+++ b/integration-tests/tests/relational/turso.test.ts
@@ -5855,6 +5855,36 @@ test('Get users with groups + custom', async () => {
 	});
 });
 
+test('[Find One] build query with comment and replace /* and */ occurences', async (t) => {
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
+test('[Find Many] build query with comment and replace /* and */ occurences', async (t) => {
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
 test('Get groups with users + custom', async () => {
 	await db.insert(usersTable).values([
 		{ id: 1, name: 'Dan' },

--- a/integration-tests/tests/relational/turso.test.ts
+++ b/integration-tests/tests/relational/turso.test.ts
@@ -5855,7 +5855,7 @@ test('Get users with groups + custom', async () => {
 	});
 });
 
-test('[Find One] build query with comment and replace /* and */ occurences', async (t) => {
+test('[Find One] build query with comment and replace /* and */ occurences', () => {
 	const query = db.query.usersTable.findFirst({
 		columns: { name: true },
 		with: {
@@ -5870,7 +5870,7 @@ test('[Find One] build query with comment and replace /* and */ occurences', asy
 	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
 });
 
-test('[Find Many] build query with comment and replace /* and */ occurences', async (t) => {
+test('[Find Many] build query with comment and replace /* and */ occurences', () => {
 	const query = db.query.usersTable.findFirst({
 		columns: { name: true },
 		with: {

--- a/integration-tests/tests/relational/vercel.test.ts
+++ b/integration-tests/tests/relational/vercel.test.ts
@@ -5839,7 +5839,7 @@ test('[Find One] Get users with groups + orderBy + limit', async (t) => {
 	});
 });
 
-test('[Find One] build query with comment and replace /* and */ occurences', async (t) => {
+test('[Find One] build query with comment and replace /* and */ occurences', (t) => {
 	const { vpgDb: db } = t;
 
 	const query = db.query.usersTable.findFirst({
@@ -5856,7 +5856,7 @@ test('[Find One] build query with comment and replace /* and */ occurences', asy
 	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
 });
 
-test('[Find Many] build query with comment and replace /* and */ occurences', async (t) => {
+test('[Find Many] build query with comment and replace /* and */ occurences', (t) => {
 	const { vpgDb: db } = t;
 
 	const query = db.query.usersTable.findFirst({

--- a/integration-tests/tests/relational/vercel.test.ts
+++ b/integration-tests/tests/relational/vercel.test.ts
@@ -5839,6 +5839,40 @@ test('[Find One] Get users with groups + orderBy + limit', async (t) => {
 	});
 });
 
+test('[Find One] build query with comment and replace /* and */ occurences', async (t) => {
+	const { vpgDb: db } = t;
+
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
+test('[Find Many] build query with comment and replace /* and */ occurences', async (t) => {
+	const { vpgDb: db } = t;
+
+	const query = db.query.usersTable.findFirst({
+		columns: { name: true },
+		with: {
+			posts: {
+				columns: { content: true },
+			},
+		},
+		where: eq(usersTable.id, 1),
+		comment: '/*/*/**/test-*/comment',
+	}).toSQL();
+
+	expect(query.sql.startsWith('/* test-comment */')).toEqual(true);
+});
+
 test('Get groups with users + orderBy + limit', async (t) => {
 	const { vpgDb: db } = t;
 

--- a/integration-tests/tests/sqlite-proxy.test.ts
+++ b/integration-tests/tests/sqlite-proxy.test.ts
@@ -1112,3 +1112,55 @@ test.serial('select + .get() for empty result', async (t) => {
 
 	await db.run(sql`drop table ${users}`);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "json", "created_at") values (null, ?, ?, null, strftime(\'%s\', \'now\'))',
+		params: ['John', 0],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update "users" set "name" = ? where "users"."id" = ?',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from "users" where "users"."id" = ?',
+		params: [1],
+	});
+});

--- a/integration-tests/tests/vercel-pg.test.ts
+++ b/integration-tests/tests/vercel-pg.test.ts
@@ -2392,3 +2392,55 @@ test.serial('array operators', async (t) => {
 	t.deepEqual(overlaps, [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]);
 	t.deepEqual(withSubQuery, [{ id: 1 }, { id: 3 }, { id: 5 }]);
 });
+
+test.serial('build select query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.select({ id: usersTable.id, name: usersTable.name }).from(usersTable)
+		.comment('/*/*/**/test-*/comment')
+		.groupBy(usersTable.id, usersTable.name)
+		.toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */select "id", "name" from "users" group by "users"."id", "users"."name"',
+		params: [],
+	});
+});
+
+test.serial('build insert query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.insert(usersTable).values({ name: sql`${'John'}` }).comment('/*/*/**/test-*/comment').toSQL();
+
+	t.deepEqual(query, {
+		sql:
+			'/* test-comment */insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, default, default)',
+		params: ['John'],
+	});
+});
+
+test.serial('build update query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.update(usersTable).set({ name: 'John' }).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */update "users" set "name" = $1 where "users"."id" = $2',
+		params: ['John', 1],
+	});
+});
+
+test.serial('build delete query with comment and replace /* and */ occurences', async (t) => {
+	const { db } = t.context;
+
+	const query = db.delete(usersTable).where(eq(usersTable.id, 1)).comment(
+		'/*/*/**/test-*/comment',
+	).toSQL();
+
+	t.deepEqual(query, {
+		sql: '/* test-comment */delete from "users" where "users"."id" = $1',
+		params: [1],
+	});
+});


### PR DESCRIPTION

## Changes

This PR adds ```comment``` method to all query builders (relation, select, update, insert, delete) that appends a comment at the start of the generated sql query.

## Motivation
- Allows easy parsing of database queries from application logs
- Can be used by database APM tools for monitoring and analysing query performance

## Todos:
Add documentation in

https://orm.drizzle.team/docs/rqb#comment
https://orm.drizzle.team/docs/select#comment
https://orm.drizzle.team/docs/insert#comment
https://orm.drizzle.team/docs/update#comment
https://orm.drizzle.team/docs/delete#comment
