### PR TITLE
fix: move @typescript-eslint/utils to production dependencies

### DIFF
--- a/eslint-plugin-drizzle/package.json
+++ b/eslint-plugin-drizzle/package.json
@@ -21,11 +21,13 @@
     "url": "git+https://github.com/drizzle-team/drizzle-orm/tree/main/eslint-plugin-drizzle.git"
   },
   "license": "Apache-2.0",
+  "dependencies": {
+    "@typescript-eslint/utils": "^6.10.0"
+  },
   "devDependencies": {
     "@types/node": "^20.10.1",
     "@typescript-eslint/parser": "^6.10.0",
     "@typescript-eslint/rule-tester": "^6.10.0",
-    "@typescript-eslint/utils": "^6.10.0",
     "cpy-cli": "^5.0.0",
     "eslint": "^8.53.0",
     "typescript": "^5.2.2",


### PR DESCRIPTION
When this plugin is installed with a package manager that enforces isolated `node_modules`, which is the default behavior of [pnpm](https://pnpm.io/), the plugin fails with the following error:

```
Failed to load plugin 'drizzle' declared in '.eslintrc.yaml': Cannot find module '@typescript-eslint/utils'
```

This plugin has a production dependency on `@typescript-eslint/utils` [here](https://github.com/drizzle-team/drizzle-orm/blob/0da1cba84da08bc0407821c9ab55b3e780ff5e3f/eslint-plugin-drizzle/src/enforce-delete-with-where.ts#L1), so this change moves that package from `devDependencies` to `dependencies`. This change should ensure that all package managers treat this dependency as a production dependency, and makes this package usable with `pnpm`'s strict isolated `node_modules`.

This issue is likely masked when using `npm` or `yarn` because those package managers produce flat `node_modules` directories containing all transitive dependencies of the project.  It is highly likely that another ESLint plugin package in an end-user's project has specified `@typescript-eslint/utils` as a production dependency ([`eslint-plugin-jest`](https://github.com/jest-community/eslint-plugin-jest/blob/a5ca480b53369461f92ae9b54b8d13154dc00db1/package.json#L98) is one such example), resulting in this package being present in `node_modules` and `eslint-plugin-drizzle` being able to resolve it. 

The maintainer of `pnpm` has written about this scenario here: [pnpms strictness helps to avoid silly bugs](https://www.kochan.io/nodejs/pnpms-strictness-helps-to-avoid-silly-bugs.html). Without this fix, users of this plugin are effectively relying on a phantom dependency which could be removed by other packages at any time without notice.