### PR TITLE
[Pg] Fix issue with inserting of string timestamps not working in data api

### DIFF
--- a/drizzle-orm/src/aws-data-api/pg/driver.ts
+++ b/drizzle-orm/src/aws-data-api/pg/driver.ts
@@ -1,4 +1,4 @@
-import { entityKind } from '~/entity.ts';
+import { entityKind, is } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { PgDatabase } from '~/pg-core/db.ts';
@@ -9,9 +9,11 @@ import {
 	type RelationalSchemaConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
-import type { DrizzleConfig } from '~/utils.ts';
+import type { DrizzleConfig, UpdateSet } from '~/utils.ts';
 import type { AwsDataApiClient, AwsDataApiPgQueryResultHKT } from './session.ts';
 import { AwsDataApiSession } from './session.ts';
+import { PgColumn, PgInsertConfig, PgTable, PgTimestampString, TableConfig } from '~/pg-core/index.ts';
+import { Param, SQL, Table, sql } from '~/index.ts';
 
 export interface PgDriverOptions {
 	logger?: Logger;
@@ -37,6 +39,34 @@ export class AwsPgDialect extends PgDialect {
 
 	override escapeParam(num: number): string {
 		return `:${num + 1}`;
+	}
+
+	override buildInsertQuery({ table, values, onConflict, returning }: PgInsertConfig<PgTable<TableConfig>>): SQL<unknown> {
+		const columns: Record<string, PgColumn> = table[Table.Symbol.Columns];
+		const colEntries: [string, PgColumn][] = Object.entries(columns);
+		for (let value of values) {
+			for (const [fieldName, col] of colEntries) {
+				const colValue = value[fieldName];
+				if (is(colValue, Param) && colValue.value !== undefined && is(colValue.encoder, PgTimestampString)) {
+					value[fieldName] = sql`cast(${col.mapToDriverValue(colValue.value)} as timestamp)`
+				}
+			}
+		}
+
+		return super.buildInsertQuery({table, values, onConflict, returning})
+	}
+
+	override buildUpdateSet(table: PgTable<TableConfig>, set: UpdateSet): SQL<unknown> {
+		const columns: Record<string, PgColumn> = table[Table.Symbol.Columns];
+		
+		Object.entries(set)
+			.forEach(([colName, colValue]) => {
+				const currentColumn = columns[colName];
+				if (currentColumn && is(colValue, Param) && colValue.value !== undefined && is(colValue.encoder, PgTimestampString)) {
+					set[colName] = sql`cast(${currentColumn?.mapToDriverValue(colValue.value)} as timestamp)`
+				}
+			})
+		return super.buildUpdateSet(table, set)
 	}
 }
 


### PR DESCRIPTION
Previously if you want to insert or update a record with a timestamp (mode:string)
You got an error which suggested that data api was recognizing it as a string not a timestamp

This pr casts it to be a timestamp so there will never be such an issue again.