### PR TITLE
fix(Relational queries): support tables sharing the same name across schemas

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -1200,7 +1200,7 @@ export class PgDialect {
 				} of selectedRelations
 			) {
 				const normalizedRelation = normalizeRelation(schema, tableNamesMap, relation);
-				const relationTableName = relation.referencedTable[Table.Symbol.Name];
+        const relationTableName = relation.referencedTable[Table.Symbol.Schema] ? `${relation.referencedTable[Table.Symbol.Schema]}_${relation.referencedTable[Table.Symbol.Name]}` : relation.referencedTable[Table.Symbol.Name];
 				const relationTableTsName = tableNamesMap[relationTableName]!;
 				const relationTableAlias = `${tableAlias}_${selectedRelationTsKey}`;
 				const joinOn = and(

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -430,7 +430,7 @@ export function extractTablesRelationalConfig<
 	const tablesConfig: TablesRelationalConfig = {};
 	for (const [key, value] of Object.entries(schema)) {
 		if (isTable(value)) {
-			const dbName = value[Table.Symbol.Name];
+      const dbName = value[Table.Symbol.Schema] ? `${value[Table.Symbol.Schema]}_${value[Table.Symbol.Name]}` : value[Table.Symbol.Name];
 			const bufferedRelations = relationsBuffer[dbName];
 			tableNamesMap[dbName] = key;
 			tablesConfig[key] = {
@@ -462,7 +462,7 @@ export function extractTablesRelationalConfig<
 				}
 			}
 		} else if (is(value, Relations)) {
-			const dbName: string = value.table[Table.Symbol.Name];
+      const dbName: string = value.table[Table.Symbol.Schema] ? `${value.table[Table.Symbol.Schema]}_${value.table[Table.Symbol.Name]}` : value.table[Table.Symbol.Name];
 			const tableName = tableNamesMap[dbName];
 			const relations: Record<string, Relation> = value.config(
 				configHelpers(value.table),
@@ -561,10 +561,11 @@ export function normalizeRelation(
 		};
 	}
 
-	const referencedTableTsName = tableNamesMap[relation.referencedTable[Table.Symbol.Name]];
+	const referencedTableDbName = relation.referencedTable[Table.Symbol.Schema] ? `${relation.referencedTable[Table.Symbol.Schema]}_${relation.referencedTable[Table.Symbol.Name]}` : relation.referencedTable[Table.Symbol.Name];
+	const referencedTableTsName = tableNamesMap[referencedTableDbName];
 	if (!referencedTableTsName) {
 		throw new Error(
-			`Table "${relation.referencedTable[Table.Symbol.Name]}" not found in schema`,
+			`Table "${referencedTableDbName}" not found in schema`,
 		);
 	}
 
@@ -574,10 +575,11 @@ export function normalizeRelation(
 	}
 
 	const sourceTable = relation.sourceTable;
-	const sourceTableTsName = tableNamesMap[sourceTable[Table.Symbol.Name]];
+	const sourceTableDbName = sourceTable[Table.Symbol.Schema] ? `${sourceTable[Table.Symbol.Schema]}_${sourceTable[Table.Symbol.Name]}` : sourceTable[Table.Symbol.Name];
+	const sourceTableTsName = tableNamesMap[sourceTableDbName];
 	if (!sourceTableTsName) {
 		throw new Error(
-			`Table "${sourceTable[Table.Symbol.Name]}" not found in schema`,
+			`Table "${sourceTableDbName}" not found in schema`,
 		);
 	}
 
@@ -605,7 +607,7 @@ export function normalizeRelation(
 			)
 			: new Error(
 				`There are multiple relations between "${referencedTableTsName}" and "${
-					relation.sourceTable[Table.Symbol.Name]
+					sourceTableDbName
 				}". Please specify relation name`,
 			);
 	}


### PR DESCRIPTION
Fix #1964

This is modifying the  `extractTablesRelationalConfig` function to take database schemas into account.

The patch inside this PR is making the following example works:
```ts
import { relations } from 'drizzle-orm';
import { pgTable, pgSchema, uuid, text } from 'drizzle-orm/pg-core';

// PUBLIC SCHEMA
export const organisations = pgTable('organisations', {
  id: uuid('id').primaryKey().notNull(),
  name: text('name').notNull(),
});

export const users = pgTable('users', {
  id: uuid('id').primaryKey().notNull(),
  email: text('email').notNull(),
  organisation_id: uuid('organisation_id').references(() => organisations.id, {
    onDelete: 'cascade',
    onUpdate: 'restrict',
  }),
});

export const usersRelations = relations(users, ({ one }) => ({
  organisation: one(organisations, {
    fields: [users.organisation_id],
    references: [organisations.id],
  }),
}));

export const organisationsRelations = relations(organisations, ({ many }) => ({
  users: many(users),
}));

// SLACK_INTEGRATION SCHEMA
export const slack_integration = pgSchema('slack_integration');

export const slack_integration_users = slack_integration.table('users', {
  id: text('id').primaryKey().notNull(),
  email: text('email').notNull(),
  user_id: uuid('user_id')
    .notNull()
    .references(() => users.id, { onDelete: 'set null', onUpdate: 'set null' }),
});

const schema = {
  organisations,
  users,
  slack_integration_users, // this one is prefixed to avoid overwriting the public.users table
  usersRelations,
  organisationsRelations,
};

const db = drizzle(client, { schema });
```
