### PR TITLE
fix: numeric types being used as strings

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/decimal.ts
+++ b/drizzle-orm/src/mysql-core/columns/decimal.ts
@@ -6,20 +6,20 @@ import { MySqlColumnBuilderWithAutoIncrement, MySqlColumnWithAutoIncrement } fro
 
 export type MySqlDecimalBuilderInitial<TName extends string> = MySqlDecimalBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'number';
 	columnType: 'MySqlDecimal';
-	data: string;
-	driverParam: string;
+	data: number;
+	driverParam: number | string;
 	enumValues: undefined;
 }>;
 
 export class MySqlDecimalBuilder<
-	T extends ColumnBuilderBaseConfig<'string', 'MySqlDecimal'>,
+	T extends ColumnBuilderBaseConfig<'number', 'MySqlDecimal'>,
 > extends MySqlColumnBuilderWithAutoIncrement<T, MySqlDecimalConfig> {
 	static readonly [entityKind]: string = 'MySqlDecimalBuilder';
 
 	constructor(name: T['name'], precision?: number, scale?: number) {
-		super(name, 'string', 'MySqlDecimal');
+		super(name, 'number', 'MySqlDecimal');
 		this.config.precision = precision;
 		this.config.scale = scale;
 	}
@@ -35,7 +35,7 @@ export class MySqlDecimalBuilder<
 	}
 }
 
-export class MySqlDecimal<T extends ColumnBaseConfig<'string', 'MySqlDecimal'>>
+export class MySqlDecimal<T extends ColumnBaseConfig<'number', 'MySqlDecimal'>>
 	extends MySqlColumnWithAutoIncrement<T, MySqlDecimalConfig>
 {
 	static readonly [entityKind]: string = 'MySqlDecimal';

--- a/drizzle-orm/src/pg-core/columns/numeric.ts
+++ b/drizzle-orm/src/pg-core/columns/numeric.ts
@@ -6,14 +6,14 @@ import { PgColumn, PgColumnBuilder } from './common.ts';
 
 export type PgNumericBuilderInitial<TName extends string> = PgNumericBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'number';
 	columnType: 'PgNumeric';
-	data: string;
-	driverParam: string;
+	data: number;
+	driverParam: string | number;
 	enumValues: undefined;
 }>;
 
-export class PgNumericBuilder<T extends ColumnBuilderBaseConfig<'string', 'PgNumeric'>> extends PgColumnBuilder<
+export class PgNumericBuilder<T extends ColumnBuilderBaseConfig<'number', 'PgNumeric'>> extends PgColumnBuilder<
 	T,
 	{
 		precision: number | undefined;
@@ -23,7 +23,7 @@ export class PgNumericBuilder<T extends ColumnBuilderBaseConfig<'string', 'PgNum
 	static readonly [entityKind]: string = 'PgNumericBuilder';
 
 	constructor(name: string, precision?: number, scale?: number) {
-		super(name, 'string', 'PgNumeric');
+		super(name, 'number', 'PgNumeric');
 		this.config.precision = precision;
 		this.config.scale = scale;
 	}
@@ -36,7 +36,7 @@ export class PgNumericBuilder<T extends ColumnBuilderBaseConfig<'string', 'PgNum
 	}
 }
 
-export class PgNumeric<T extends ColumnBaseConfig<'string', 'PgNumeric'>> extends PgColumn<T> {
+export class PgNumeric<T extends ColumnBaseConfig<'number', 'PgNumeric'>> extends PgColumn<T> {
 	static readonly [entityKind]: string = 'PgNumeric';
 
 	readonly precision: number | undefined;

--- a/drizzle-orm/src/sqlite-core/columns/numeric.ts
+++ b/drizzle-orm/src/sqlite-core/columns/numeric.ts
@@ -6,20 +6,20 @@ import { SQLiteColumn, SQLiteColumnBuilder } from './common.ts';
 
 export type SQLiteNumericBuilderInitial<TName extends string> = SQLiteNumericBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'number';
 	columnType: 'SQLiteNumeric';
-	data: string;
-	driverParam: string;
+	data: number;
+	driverParam: number;
 	enumValues: undefined;
 }>;
 
-export class SQLiteNumericBuilder<T extends ColumnBuilderBaseConfig<'string', 'SQLiteNumeric'>>
+export class SQLiteNumericBuilder<T extends ColumnBuilderBaseConfig<'number', 'SQLiteNumeric'>>
 	extends SQLiteColumnBuilder<T>
 {
 	static readonly [entityKind]: string = 'SQLiteNumericBuilder';
 
 	constructor(name: T['name']) {
-		super(name, 'string', 'SQLiteNumeric');
+		super(name, 'number', 'SQLiteNumeric');
 	}
 
 	/** @internal */
@@ -33,7 +33,7 @@ export class SQLiteNumericBuilder<T extends ColumnBuilderBaseConfig<'string', 'S
 	}
 }
 
-export class SQLiteNumeric<T extends ColumnBaseConfig<'string', 'SQLiteNumeric'>> extends SQLiteColumn<T> {
+export class SQLiteNumeric<T extends ColumnBaseConfig<'number', 'SQLiteNumeric'>> extends SQLiteColumn<T> {
 	static readonly [entityKind]: string = 'SQLiteNumeric';
 
 	getSQLType(): string {


### PR DESCRIPTION
The numeric/decimal types are wrong in all implementations.

With this fix it will be possible to use the default numeric/decimal value, which is now not possible without a workaround

Fix: https://github.com/drizzle-team/drizzle-orm/issues/1950