### PR TITLE
Replace Buffer with Uint8Array in libsql session

### DIFF
--- a/drizzle-orm/src/libsql/session.ts
+++ b/drizzle-orm/src/libsql/session.ts
@@ -264,16 +264,7 @@ function normalizeRow(obj: any) {
 
 function normalizeFieldValue(value: unknown) {
 	if (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) { // eslint-disable-line no-instanceof/no-instanceof
-		if (typeof Buffer !== 'undefined') {
-			if (!(value instanceof Buffer)) { // eslint-disable-line no-instanceof/no-instanceof
-				return Buffer.from(value);
-			}
-			return value;
-		}
-		if (typeof TextDecoder !== 'undefined') {
-			return new TextDecoder().decode(value);
-		}
-		throw new Error('TextDecoder is not available. Please provide either Buffer or TextDecoder polyfill.');
+		return new Uint8Array(value)
 	}
 	return value;
 }


### PR DESCRIPTION
I believe Buffer is not necessary here, [see article](https://sindresorhus.com/blog/goodbye-nodejs-buffer). Ideally, Buffer should be removed from drizzle completely cc @dankochetov .
TextDecoder causes https://github.com/drizzle-team/drizzle-orm/issues/1926
