### PR TITLE
Fix comment in "lt" and "lte" functions to clarify example usage

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -228,7 +228,7 @@ export const gte: BinaryOperator = (left: SQLWrapper, right: unknown): SQL => {
  *   .where(lt(cars.year, 2000))
  * ```
  *
- * @see lte for greater-than-or-equal
+ * @see lte for less-than-or-equal
  */
 export const lt: BinaryOperator = (left: SQLWrapper, right: unknown): SQL => {
 	return sql`${left} < ${bindIfParam(right, left)}`;
@@ -241,7 +241,7 @@ export const lt: BinaryOperator = (left: SQLWrapper, right: unknown): SQL => {
  * ## Examples
  *
  * ```ts
- * // Select cars made before 2000.
+ * // Select cars made on or before 2000.
  * db.select().from(cars)
  *   .where(lte(cars.year, 2000))
  * ```


### PR DESCRIPTION
Fixed the comment in the `lt` and `lte` functions to accurately describe the example usage.

| Before | After |
| --- | --- |
| <img width="284" alt="Screenshot 2024-04-08 at 23 54 50" src="https://github.com/drizzle-team/drizzle-orm/assets/7074983/b45c935f-cd09-488f-bbb6-c0ab7855541e">  |  <img width="282" alt="Screenshot 2024-04-08 at 23 55 18" src="https://github.com/drizzle-team/drizzle-orm/assets/7074983/b4534fa7-e375-456a-88db-82d7df21cefd"> |



