### PR TITLE
[SQLite]:  Add support for `blob` SQL type in relational queries

### DIFF
--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -4,6 +4,7 @@ import { entityKind } from '~/entity.ts';
 import type { SQL } from '~/sql/sql.ts';
 import type { AnySQLiteTable } from '~/sqlite-core/table.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
+import { hexStringToBuffer } from '../utils.ts';
 import { SQLiteColumn, SQLiteColumnBuilder } from './common.ts';
 
 export type ConvertCustomConfig<TName extends string, T extends Partial<CustomTypeValues>> =
@@ -79,6 +80,9 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
+		if (typeof value === 'string' && this.getSQLType() === 'blob') {
+			value = hexStringToBuffer(value);
+		}
 		return typeof this.mapFrom === 'function' ? this.mapFrom(value) : value as T['data'];
 	}
 

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -711,7 +711,9 @@ export abstract class SQLiteDialect {
 				sql.join(
 					selection.map(({ field }) =>
 						is(field, SQLiteColumn)
-							? sql.identifier(this.casing.getColumnCasing(field))
+							? field.getSQLType() === 'blob'
+								? sql.raw(`hex("${field.name}")`)
+								: sql.identifier(this.casing.getColumnCasing(field))
 							: is(field, SQL.Aliased)
 							? field.sql
 							: field

--- a/drizzle-orm/src/sqlite-core/utils.ts
+++ b/drizzle-orm/src/sqlite-core/utils.ts
@@ -63,3 +63,14 @@ export function getViewConfig<
 		// ...view[SQLiteViewConfig],
 	};
 }
+
+export function hexStringToBuffer(hexString: string): Buffer {
+	const numChunks = Math.ceil(hexString.length / 2);
+	const chunks = Array.from<number>({ length: numChunks });
+
+	for (let i = 0; i < numChunks; ++i) {
+		chunks[i] = Number.parseInt(hexString.slice(2 * i, 2 * i + 2), 16);
+	}
+
+	return Buffer.from(chunks);
+}


### PR DESCRIPTION
SQLite does not support selecting a blob type column in `json_array()` and this function is used in relational queries. Solve this by wrapping blob type columns in 'hex()' function to cast the blob to a hex string that we can parse back into a blob later. Later meaning, the `mapFromDriverValue` step where inside this function we turn the hex string back into a buffer before passing it along.

Closes #2171 

TODO:
- [ ] Tests