### PR TITLE
fix: Update how pg typings are calculated for typehints to support customType

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -582,9 +582,31 @@ export class PgDialect {
 			return 'date';
 		} else if (is(encoder, PgUUID)) {
 			return 'uuid';
-		} else {
-			return 'none';
+		} else if (is(encoder, PgColumn)) {
+			// Support custom types that extend PgColumn
+			const sqlType = encoder.getSQLType();
+
+			if (sqlType === 'json' || sqlType === 'jsonb') {
+				return 'json';
+			} else if (sqlType === 'uuid') {
+				return 'uuid';
+			} else if (sqlType === 'date') {
+				return 'date';
+			} else if (
+				/^numeric(\(\d+(,\s*\d+)?\))?$/.test(sqlType)
+			) {
+				return 'decimal';
+			} else if (
+				/^time(\s*\(\s*(\d+)\s*\))?(\s*(with|without)\s+time\s+zone)?$/.test(sqlType)
+			) {
+				return 'time';
+			} else if (
+				/^timestamp(\s*\(\s*(\d+)\s*\))?(\s*(with|without)\s+time\s+zone)?$/.test(sqlType)
+			) {
+				return 'timestamp';
+			}
 		}
+		return 'none';
 	}
 
 	sqlToQuery(sql: SQL, invokeSource?: 'indexes' | undefined): QueryWithTypings {


### PR DESCRIPTION
Fixes https://github.com/drizzle-team/drizzle-orm/issues/1997

- Had to make regexes since peoples custom types  could  define the data type in various waves that isn't to straight forward.
