### PR TITLE
Add missing `drizzel` import on PostgreSQL migration document's example code

### DIFF
--- a/drizzle-orm/src/postgres-js/README.md
+++ b/drizzle-orm/src/postgres-js/README.md
@@ -35,6 +35,7 @@ In order to run the migrations, [you need to use `max: 1` in the postgres.js con
 ```typescript
 import postgres from 'postgres';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import { drizzle } from "drizzle-orm/postgres-js";
 
 const migrationsClient = postgres(connectionString, {
   max: 1,


### PR DESCRIPTION
## Why

Because the `drizzel` function used here

https://github.com/drizzle-team/drizzle-orm/blob/18983a09b56ea5aea8f3b630c4e9849a55a96fa0/drizzle-orm/src/postgres-js/README.md#L43

are not imported in this sample. To onboard the PostgreSQL users who want to migrate, I think it is better to add it and make the example complete.