### PR TITLE
fixing example typo in cloudflare-d1/README.md file

### DIFF
--- a/examples/cloudflare-d1/README.md
+++ b/examples/cloudflare-d1/README.md
@@ -40,7 +40,7 @@ npm install drizzle-kit
 ## package.json
 {
   ...
-  scripts: {
+  "scripts": {
     "generate": "drizzle-kit generate:sqlite --schema=src/schema.ts",
     "up": "drizzle-kit up:sqlite --schema=src/schema.ts"
   }


### PR DESCRIPTION
Have to surround "scripts" text with double quotes, because it's json file example