### PR TITLE
Add kysely type helpers

### DIFF
--- a/drizzle-orm/src/kysely/README.md
+++ b/drizzle-orm/src/kysely/README.md
@@ -9,7 +9,7 @@ You can define you DB schema using Drizzle and use Kysely as the query builder. 
 ```ts
 import { Kysely, PostgresDialect } from 'kysely';
 import { Pool } from 'pg';
-import { Kyselify } from 'drizzle-orm/kysely';
+import { Kyselify, KyselifySchema } from 'drizzle-orm/kysely';
 import { pgTable, serial, text } from 'drizzle-orm/pg-core';
 
 const test = pgTable('test', {
@@ -20,6 +20,10 @@ const test = pgTable('test', {
 interface Database {
   test: Kyselify<typeof test>;
 }
+
+// OR
+import { schema } from './schema';
+type KyselyDatabase = KyselifySchema<typeof schema>;
 
 const db = new Kysely<Database>({
   dialect: new PostgresDialect({

--- a/drizzle-orm/src/kysely/index.ts
+++ b/drizzle-orm/src/kysely/index.ts
@@ -22,3 +22,17 @@ export type Kyselify<T extends Table> = Simplify<
 		>;
 	}
 >;
+
+// test
+
+export type KyselifyTableName<Schema, K extends keyof Schema> = Schema[K] extends Table
+  ? Schema[K]['_']['schema'] extends string
+    ? `${Schema[K]['_']['schema']}.${Schema[K]['_']['name']}`
+    : K
+  : never;
+
+export type KyselifySchema<Schema> = {
+  [K in keyof Schema as KyselifyTableName<Schema, K>]: Schema[K] extends Table
+    ? Kyselify<Schema[K]>
+    : never;
+};


### PR DESCRIPTION
Infer all  Kysely tables from drizzle schema.

- Adds a type helper : `KyselifySchema`, a generic that takes schema and maps all the tables in the schema to their corresponding Kysely tables.
- Handles multi schema naming as per [Kysely specs](https://kysely.dev/docs/recipes/schemas).

Closes : #2208 