### PR TITLE
Fix timestamp precision bug

### DIFF
--- a/drizzle-orm/src/pg-core/columns/timestamp.ts
+++ b/drizzle-orm/src/pg-core/columns/timestamp.ts
@@ -54,7 +54,7 @@ export class PgTimestamp<T extends ColumnBaseConfig<'date', 'PgTimestamp'>> exte
 	}
 
 	getSQLType(): string {
-		const precision = this.precision === undefined ? '' : ` (${this.precision})`;
+		const precision = this.precision === undefined ? '' : `(${this.precision})`;
 		return `timestamp${precision}${this.withTimezone ? ' with time zone' : ''}`;
 	}
 


### PR DESCRIPTION
Timestamp precision is treated differently depending on whether "mode" is set to date or string - namely when set to date there is an extra space added before the precision. When changing between the modes drizzle incorrectly detects a column change and truncates all data