### PR TITLE
fix(docs): can't appear a sponsers image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,4 @@ And we have a [**Drizzle Studio**](https://orm.drizzle.team/drizzle-studio/overv
 Check out the full documentation on [the website](https://orm.drizzle.team/docs/overview)
 
 ### Our sponsors ❤️
-<p align="center">
-<a href="https://drizzle.team" target="_blank">
-<img src='https://api.drizzle.team/v2/sponsors/svg'/>
-</a>
-</p>
+[![sponsors](https://api.drizzle.team/v2/sponsors/svg?raw=true)](https://drizzle.team)


### PR DESCRIPTION
# Summary
Show the sponsers image using github syntax instead of HTML

## Before
![スクリーンショット 2024-05-09 113449](https://github.com/drizzle-team/drizzle-orm/assets/146040408/ae3f72fe-06c2-4517-9ffc-99256d0c1c18)

## After
![スクリーンショット 2024-05-09 113422](https://github.com/drizzle-team/drizzle-orm/assets/146040408/8640c5a3-cf9b-4eba-b8a4-adb54551e6e8)
