### PR TITLE
feat: Support generating v7 uuids in pg

### DIFF
--- a/drizzle-orm/src/pg-core/columns/uuid.ts
+++ b/drizzle-orm/src/pg-core/columns/uuid.ts
@@ -28,6 +28,13 @@ export class PgUUIDBuilder<T extends ColumnBuilderBaseConfig<'string', 'PgUUID'>
 		return this.default(sql`gen_random_uuid()`) as ReturnType<this['default']>;
 	}
 
+	/**
+	 * Adds `default uuidv7()` to the column definition.
+	 */
+	defaultV7(): ReturnType<this['default']> {
+		return this.default(sql`uuidv7()`) as ReturnType<this['default']>;
+	}
+
 	/** @internal */
 	override build<TTableName extends string>(
 		table: AnyPgTable<{ name: TTableName }>,


### PR DESCRIPTION
I _think_ this is relatively straightforward; just allows setting v7 uuids as well as v4