### PR TITLE
Validate integer types on zod schema for Postgres `integer` columns

### DIFF
--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -208,10 +208,10 @@ function mapColumnToSchema(column: Column): z.ZodTypeAny {
 			type = jsonSchema;
 		} else if (column.dataType === 'array') {
 			type = z.array(mapColumnToSchema((column as PgArray<any, any>).baseColumn));
-		} else if (column.dataType === 'number') {
-			type = z.number();
 		} else if (is(column, PgInteger)) {
 			type = z.number().int();
+		} else if (column.dataType === 'number') {
+			type = z.number();
 		} else if (column.dataType === 'bigint') {
 			type = z.bigint();
 		} else if (column.dataType === 'boolean') {

--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -210,6 +210,10 @@ function mapColumnToSchema(column: Column): z.ZodTypeAny {
 			type = z.array(mapColumnToSchema((column as PgArray<any, any>).baseColumn));
 		} else if (column.dataType === 'number') {
 			type = z.number();
+		} else if (column.dataType === 'real') {
+			type = z.number();
+		} else if (column.dataType === 'integer') {
+			type = z.number().int();
 		} else if (column.dataType === 'bigint') {
 			type = z.bigint();
 		} else if (column.dataType === 'boolean') {

--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -9,7 +9,7 @@ import {
 	type Table,
 } from 'drizzle-orm';
 import { MySqlChar, MySqlVarBinary, MySqlVarChar } from 'drizzle-orm/mysql-core';
-import { type PgArray, PgChar, PgUUID, PgVarchar } from 'drizzle-orm/pg-core';
+import {type PgArray, PgChar, PgInteger, PgUUID, PgVarchar} from 'drizzle-orm/pg-core';
 import { SQLiteText } from 'drizzle-orm/sqlite-core';
 import { z } from 'zod';
 
@@ -210,9 +210,7 @@ function mapColumnToSchema(column: Column): z.ZodTypeAny {
 			type = z.array(mapColumnToSchema((column as PgArray<any, any>).baseColumn));
 		} else if (column.dataType === 'number') {
 			type = z.number();
-		} else if (column.dataType === 'real') {
-			type = z.number();
-		} else if (column.dataType === 'integer') {
+		} else if (is(column, PgInteger)) {
 			type = z.number().int();
 		} else if (column.dataType === 'bigint') {
 			type = z.bigint();

--- a/drizzle-zod/tests/pg.test.ts
+++ b/drizzle-zod/tests/pg.test.ts
@@ -19,6 +19,7 @@ const users = pgTable('users', {
 	roleText2: text('role2', { enum: ['admin', 'user'] }).notNull().default('user'),
 	profession: varchar('profession', { length: 20 }).notNull(),
 	initials: char('initials', { length: 2 }).notNull(),
+	numberOfDogs :integer('number_of_dogs').notNull(),
 });
 
 const testUser = {
@@ -34,6 +35,7 @@ const testUser = {
 	roleText2: 'admin',
 	profession: 'Software Engineer',
 	initials: 'JD',
+	numberOfDogs: 4,
 };
 
 test('users insert valid user', (t) => {
@@ -52,6 +54,12 @@ test('users insert invalid char', (t) => {
 	const schema = createInsertSchema(users);
 
 	t.is(schema.safeParse({ ...testUser, initials: 'JoDo' }).success, false);
+});
+
+test('users insert invalid number type', (t) => {
+	const schema = createInsertSchema(users);
+
+	t.is(schema.safeParse({ ...testUser, numberOfDogs: 7.31 }).success, false);
 });
 
 test('users insert schema', (t) => {
@@ -90,6 +98,7 @@ test('users insert schema', (t) => {
 		roleText2: z.enum(['admin', 'user']).optional(),
 		profession: z.string().max(20).min(1),
 		initials: z.string().max(2).min(1),
+		numberOfDogs: z.number().int(),
 	});
 
 	expectSchemaShape(t, expected).from(actual);
@@ -111,6 +120,7 @@ test('users insert schema w/ defaults', (t) => {
 		roleText2: z.enum(['admin', 'user']).optional(),
 		profession: z.string().max(20).min(1),
 		initials: z.string().max(2).min(1),
+		numberOfDogs: z.number().int(),
 	});
 
 	expectSchemaShape(t, expected).from(actual);
@@ -136,6 +146,7 @@ test('users select schema', (t) => {
 		roleText2: z.enum(['admin', 'user']),
 		profession: z.string().max(20).min(1),
 		initials: z.string().max(2).min(1),
+		numberOfDogs: z.number().int(),
 	});
 
 	expectSchemaShape(t, expected).from(actual);
@@ -157,6 +168,7 @@ test('users select schema w/ defaults', (t) => {
 		roleText2: z.enum(['admin', 'user']),
 		profession: z.string().max(20).min(1),
 		initials: z.string().max(2).min(1),
+		numberOfDogs: z.number().int(),
 	});
 
 	expectSchemaShape(t, expected).from(actual);


### PR DESCRIPTION
Appears related to #2220 