### PR TITLE
Fix Bun Sqlite JSONb parsing

### DIFF
--- a/drizzle-orm/src/bun-sqlite/session.ts
+++ b/drizzle-orm/src/bun-sqlite/session.ts
@@ -137,7 +137,12 @@ export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> 
 			return customResultMapper(rows) as T['all'];
 		}
 
-		return rows.map((row) => mapResultRow(fields!, row, joinsNotNullableMap));
+		return rows.map((row) => {
+		    return mapResultRow(fields!, row.map(item => {
+			if(ArrayBuffer.isView(item)) return Buffer.from(item)
+		        return item
+		    }), joinsNotNullableMap)
+		});
 	}
 
 	get(placeholderValues?: Record<string, unknown>): T['get'] {


### PR DESCRIPTION
I am not sure if this is the correct place to have this fix. 

Better-sqlite3 adapter returns a "Buffer" for jsonb fields in the all function.

Bun sqlite is returning an U8IntArray.

This breaks json parsing in drizzle when querying for jsonb records.

The fix I did, just converts the u8intarrays to buffers which drizzle is expecting, now I can query and return json with bun correctly. 