### PR TITLE
Implement skipSchemaCreation option

### DIFF
--- a/drizzle-orm/src/migrator.ts
+++ b/drizzle-orm/src/migrator.ts
@@ -11,6 +11,8 @@ export interface MigrationConfig {
 	migrationsFolder: string;
 	migrationsTable?: string;
 	migrationsSchema?: string;
+
+	skipSchemaCreation?: boolean;
 }
 
 export interface MigrationMeta {

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -69,7 +69,13 @@ export class PgDialect {
 				created_at bigint
 			)
 		`;
-		await session.execute(sql`CREATE SCHEMA IF NOT EXISTS ${sql.identifier(migrationsSchema)}`);
+
+		const skipSchemaCreation = typeof config === 'string' ? false : config.skipSchemaCreation ?? false;
+
+		if (!skipSchemaCreation) {
+			await session.execute(sql`CREATE SCHEMA IF NOT EXISTS ${sql.identifier(migrationsSchema)}`);
+		}
+
 		await session.execute(migrationTableCreate);
 
 		const dbMigrations = await session.all<{ id: number; hash: string; created_at: string }>(


### PR DESCRIPTION
### Case

In some postgres databases there may be no permissions to execute statement
```sql
CREATE SCHEMA IF NOT EXISTS "public"
```
which causes `migrate` function to fail with "permission denied for database ...".