### PR TITLE
Upgrade valibot to 0.31.0

### DIFF
--- a/drizzle-valibot/package.json
+++ b/drizzle-valibot/package.json
@@ -68,7 +68,7 @@
 	"license": "Apache-2.0",
 	"peerDependencies": {
 		"drizzle-orm": ">=0.23.13",
-		"valibot": ">=0.20"
+		"valibot": ">=0.31"
 	},
 	"devDependencies": {
 		"@rollup/plugin-terser": "^0.4.1",
@@ -80,7 +80,7 @@
 		"rimraf": "^5.0.0",
 		"rollup": "^3.20.7",
 		"tsx": "^3.12.2",
-		"valibot": "^0.30.0",
+		"valibot": "^0.31.0",
 		"zx": "^7.2.2"
 	}
 }

--- a/drizzle-valibot/src/index.ts
+++ b/drizzle-valibot/src/index.ts
@@ -18,13 +18,13 @@ import {
 	type AnySchema,
 	array,
 	type ArraySchema,
-	type GenericSchema,
 	bigint,
 	type BigintSchema,
 	boolean,
 	type BooleanSchema,
 	date,
 	type DateSchema,
+	type GenericSchema,
 	maxLength,
 	null_,
 	nullable,
@@ -37,12 +37,12 @@ import {
 	type OptionalSchema,
 	picklist,
 	type PicklistSchema,
+	pipe,
 	record,
 	string,
 	type StringSchema,
 	union,
 	uuid,
-    pipe,
 } from 'valibot';
 
 const literalSchema = union([string(), number(), boolean(), null_()]);
@@ -85,7 +85,8 @@ type GetValibotType<TColumn extends Column> = TColumn['_']['dataType'] extends i
 		? Equal<TColumn['enumValues'], [string, ...string[]]> extends true ? StringSchema<undefined>
 		: PicklistSchema<Readonly<TColumn['enumValues']>, undefined>
 	: TDataType extends 'array'
-		? TColumn['_']['baseColumn'] extends Column ? ArraySchema<GetValibotType<TColumn['_']['baseColumn']>, undefined> : never
+		? TColumn['_']['baseColumn'] extends Column ? ArraySchema<GetValibotType<TColumn['_']['baseColumn']>, undefined>
+		: never
 	: TDataType extends 'bigint' ? BigintSchema<undefined>
 	: TDataType extends 'number' ? NumberSchema<undefined>
 	: TDataType extends 'string' ? StringSchema<undefined>
@@ -163,7 +164,7 @@ export function createInsertSchema<
 		TTable,
 		Equal<TRefine, Refine<TTable, 'insert'>> extends true ? {} : TRefine
 	>,
-    undefined
+	undefined
 > {
 	const columns = getTableColumns(table);
 	const columnEntries = Object.entries(columns);
@@ -228,7 +229,7 @@ export function createSelectSchema<
 		TTable,
 		Equal<TRefine, Refine<TTable, 'select'>> extends true ? {} : TRefine
 	>,
-    undefined
+	undefined
 > {
 	const columns = getTableColumns(table);
 	const columnEntries = Object.entries(columns);
@@ -285,7 +286,7 @@ function mapColumnToSchema(column: Column): GenericSchema {
 
 	if (isWithEnum(column)) {
 		type = column.enumValues?.length
-			? picklist(column.enumValues )
+			? picklist(column.enumValues)
 			: string();
 	}
 

--- a/drizzle-valibot/src/index.ts
+++ b/drizzle-valibot/src/index.ts
@@ -54,14 +54,14 @@ export const jsonSchema = union([literalSchema, array(any()), record(any(), any(
 type MapInsertColumnToValibot<
 	TColumn extends Column,
 	TType extends GenericSchema,
-> = TColumn['_']['notNull'] extends false ? OptionalSchema<NullableSchema<TType, undefined>, undefined>
-	: TColumn['_']['hasDefault'] extends true ? OptionalSchema<TType, undefined>
+> = TColumn['_']['notNull'] extends false ? OptionalSchema<NullableSchema<TType, never>, never>
+	: TColumn['_']['hasDefault'] extends true ? OptionalSchema<TType, never>
 	: TType;
 
 type MapSelectColumnToValibot<
 	TColumn extends Column,
 	TType extends GenericSchema,
-> = TColumn['_']['notNull'] extends false ? NullableSchema<TType, undefined> : TType;
+> = TColumn['_']['notNull'] extends false ? NullableSchema<TType, never> : TType;
 
 type MapColumnToValibot<
 	TColumn extends Column,
@@ -83,7 +83,7 @@ type GetValibotType<TColumn extends Column> = TColumn['_']['dataType'] extends i
 	: TDataType extends 'json' ? Json
 	: TColumn extends { enumValues: [string, ...string[]] }
 		? Equal<TColumn['enumValues'], [string, ...string[]]> extends true ? StringSchema<undefined>
-		: PicklistSchema<TColumn['enumValues'], undefined>
+		: PicklistSchema<Readonly<TColumn['enumValues']>, undefined>
 	: TDataType extends 'array'
 		? TColumn['_']['baseColumn'] extends Column ? ArraySchema<GetValibotType<TColumn['_']['baseColumn']>, undefined> : never
 	: TDataType extends 'bigint' ? BigintSchema<undefined>
@@ -115,7 +115,7 @@ export type BuildInsertSchema<
 	string,
 	Column<any>
 > ? {
-		[K in keyof TColumns & string]: MaybeOptional<
+		readonly [K in keyof TColumns & string]: MaybeOptional<
 			TColumns[K],
 			K extends keyof TRefine ? Assume<UnwrapValueOrUpdater<TRefine[K]>, GenericSchema>
 				: GetValibotType<TColumns[K]>,
@@ -131,7 +131,7 @@ export type BuildSelectSchema<
 	TNoOptional extends boolean = false,
 > = Simplify<
 	{
-		[K in keyof TTable['_']['columns']]: MaybeOptional<
+		readonly [K in keyof TTable['_']['columns']]: MaybeOptional<
 			TTable['_']['columns'][K],
 			K extends keyof TRefine ? Assume<UnwrapValueOrUpdater<TRefine[K]>, GenericSchema>
 				: GetValibotType<TTable['_']['columns'][K]>,

--- a/drizzle-valibot/tests/mysql.test.ts
+++ b/drizzle-valibot/tests/mysql.test.ts
@@ -42,8 +42,8 @@ import {
 	optional,
 	parse,
 	picklist,
+	pipe,
 	string,
-    pipe,
 } from 'valibot';
 import { createInsertSchema, createSelectSchema, jsonSchema } from '../src';
 import { expectSchemaShape } from './utils';

--- a/drizzle-valibot/tests/mysql.test.ts
+++ b/drizzle-valibot/tests/mysql.test.ts
@@ -43,6 +43,7 @@ import {
 	parse,
 	picklist,
 	string,
+    pipe,
 } from 'valibot';
 import { createInsertSchema, createSelectSchema, jsonSchema } from '../src';
 import { expectSchemaShape } from './utils';
@@ -183,7 +184,7 @@ test('insert schema', (t) => {
 		bigintNumber: number(),
 		binary: string(),
 		boolean: valiboolean(),
-		char: string([minLength(4), maxLength(4)]),
+		char: pipe(string(), minLength(4), maxLength(4)),
 		charEnum: picklist([
 			'a',
 			'b',
@@ -236,8 +237,8 @@ test('insert schema', (t) => {
 		timestamp: valiDate(),
 		timestampString: string(),
 		tinyint: number(),
-		varbinary: string([maxLength(200)]),
-		varchar: string([maxLength(200)]),
+		varbinary: pipe(string(), maxLength(200)),
+		varchar: pipe(string(), maxLength(200)),
 		varcharEnum: picklist([
 			'a',
 			'b',
@@ -258,7 +259,7 @@ test('select schema', (t) => {
 		bigintNumber: number(),
 		binary: string(),
 		boolean: valiboolean(),
-		char: string([minLength(4), maxLength(4)]),
+		char: pipe(string(), minLength(4), maxLength(4)),
 		charEnum: picklist([
 			'a',
 			'b',
@@ -312,8 +313,8 @@ test('select schema', (t) => {
 		timestamp: valiDate(),
 		timestampString: string(),
 		tinyint: number(),
-		varbinary: string([maxLength(200)]),
-		varchar: string([maxLength(200)]),
+		varbinary: pipe(string(), maxLength(200)),
+		varchar: pipe(string(), maxLength(200)),
 		varcharEnum: picklist([
 			'a',
 			'b',
@@ -328,15 +329,15 @@ test('select schema', (t) => {
 
 test('select schema w/ refine', (t) => {
 	const actual = createSelectSchema(testTable, {
-		bigint: (_) => valibigint([minValue(0n)]),
+		bigint: (_) => pipe(valibigint(), minValue(0n)),
 	});
 
 	const expected = object({
-		bigint: valibigint([minValue(0n)]),
+		bigint: pipe(valibigint(), minValue(0n)),
 		bigintNumber: number(),
 		binary: string(),
 		boolean: valiboolean(),
-		char: string([minLength(5), maxLength(5)]),
+		char: pipe(string(), minLength(5), maxLength(5)),
 		charEnum: picklist([
 			'a',
 			'b',
@@ -389,8 +390,8 @@ test('select schema w/ refine', (t) => {
 		timestamp: valiDate(),
 		timestampString: string(),
 		tinyint: number(),
-		varbinary: string([maxLength(200)]),
-		varchar: string([maxLength(200)]),
+		varbinary: pipe(string(), maxLength(200)),
+		varchar: pipe(string(), maxLength(200)),
 		varcharEnum: picklist([
 			'a',
 			'b',

--- a/drizzle-valibot/tests/pg.test.ts
+++ b/drizzle-valibot/tests/pg.test.ts
@@ -14,6 +14,7 @@ import {
 	parse,
 	picklist,
 	string,
+    pipe,
 } from 'valibot';
 import { createInsertSchema, createSelectSchema } from '../src';
 import { expectSchemaShape } from './utils';
@@ -79,8 +80,8 @@ test('users insert invalid char', (t) => {
 
 test('users insert schema', (t) => {
 	const actual = createInsertSchema(users, {
-		id: () => number([minValue(0)]),
-		email: () => string([email()]),
+		id: () => pipe(number(), minValue(0)),
+		email: () => pipe(string(), email()),
 		roleText: picklist(['user', 'manager', 'admin']),
 	});
 
@@ -102,7 +103,7 @@ test('users insert schema', (t) => {
 
 	const expected = object({
 		a: optional(nullable(array(number()))),
-		id: optional(number([minValue(0)])),
+		id: optional(pipe(number(), minValue(0))),
 		name: optional(nullable(string())),
 		email: string(),
 		birthdayString: string(),
@@ -111,8 +112,8 @@ test('users insert schema', (t) => {
 		role: picklist(['admin', 'user']),
 		roleText: picklist(['user', 'manager', 'admin']),
 		roleText2: optional(picklist(['admin', 'user'])),
-		profession: string([maxLength(20), minLength(1)]),
-		initials: string([maxLength(2), minLength(1)]),
+		profession: pipe(string(), maxLength(20), minLength(1)),
+		initials: pipe(string(), maxLength(2), minLength(1)),
 	});
 
 	expectSchemaShape(t, expected).from(actual);
@@ -132,8 +133,8 @@ test('users insert schema w/ defaults', (t) => {
 		role: picklist(['admin', 'user']),
 		roleText: picklist(['admin', 'user']),
 		roleText2: optional(picklist(['admin', 'user'])),
-		profession: string([maxLength(20), minLength(1)]),
-		initials: string([maxLength(2), minLength(1)]),
+		profession: pipe(string(), maxLength(20), minLength(1)),
+		initials: pipe(string(), maxLength(2), minLength(1)),
 	});
 
 	expectSchemaShape(t, expected).from(actual);
@@ -141,14 +142,14 @@ test('users insert schema w/ defaults', (t) => {
 
 test('users select schema', (t) => {
 	const actual = createSelectSchema(users, {
-		id: () => number([minValue(0)]),
+		id: () => pipe(number(), minValue(0)),
 		email: () => string(),
 		roleText: picklist(['user', 'manager', 'admin']),
 	});
 
 	const expected = object({
 		a: nullable(array(number())),
-		id: number([minValue(0)]),
+		id: pipe(number(), minValue(0)),
 		name: nullable(string()),
 		email: string(),
 		birthdayString: string(),
@@ -157,8 +158,8 @@ test('users select schema', (t) => {
 		role: picklist(['admin', 'user']),
 		roleText: picklist(['user', 'manager', 'admin']),
 		roleText2: picklist(['admin', 'user']),
-		profession: string([maxLength(20), minLength(1)]),
-		initials: string([maxLength(2), minLength(1)]),
+		profession: pipe(string(), maxLength(20), minLength(1)),
+		initials: pipe(string(), maxLength(2), minLength(1)),
 	});
 
 	expectSchemaShape(t, expected).from(actual);
@@ -178,8 +179,8 @@ test('users select schema w/ defaults', (t) => {
 		role: picklist(['admin', 'user']),
 		roleText: picklist(['admin', 'user']),
 		roleText2: picklist(['admin', 'user']),
-		profession: string([maxLength(20), minLength(1)]),
-		initials: string([maxLength(2), minLength(1)]),
+		profession: pipe(string(), maxLength(20), minLength(1)),
+		initials: pipe(string(), maxLength(2), minLength(1)),
 	});
 
 	expectSchemaShape(t, expected).from(actual);

--- a/drizzle-valibot/tests/pg.test.ts
+++ b/drizzle-valibot/tests/pg.test.ts
@@ -13,8 +13,8 @@ import {
 	optional,
 	parse,
 	picklist,
+	pipe,
 	string,
-    pipe,
 } from 'valibot';
 import { createInsertSchema, createSelectSchema } from '../src';
 import { expectSchemaShape } from './utils';

--- a/drizzle-valibot/tests/sqlite.test.ts
+++ b/drizzle-valibot/tests/sqlite.test.ts
@@ -9,10 +9,11 @@ import {
 	number,
 	object,
 	optional,
-	type Output,
+	type InferOutput,
 	parse,
 	picklist,
 	string,
+    pipe,
 } from 'valibot';
 import { createInsertSchema, createSelectSchema, jsonSchema } from '../src';
 import { expectSchemaShape } from './utils';
@@ -24,7 +25,7 @@ const blobJsonSchema = object({
 const users = sqliteTable('users', {
 	id: integer('id').primaryKey(),
 	blobJson: blob('blob', { mode: 'json' })
-		.$type<Output<typeof blobJsonSchema>>()
+		.$type<InferOutput<typeof blobJsonSchema>>()
 		.notNull(),
 	blobBigInt: blob('blob', { mode: 'bigint' }).notNull(),
 	numeric: numeric('numeric').notNull(),
@@ -67,7 +68,7 @@ test('users insert invalid text length', (t) => {
 
 test('users insert schema', (t) => {
 	const actual = createInsertSchema(users, {
-		id: () => number([minValue(0)]),
+		id: () => pipe(number(), minValue(0)),
 		blobJson: blobJsonSchema,
 		role: picklist(['admin', 'user', 'manager']),
 	});
@@ -89,7 +90,7 @@ test('users insert schema', (t) => {
 	});
 
 	const expected = object({
-		id: optional(number([minValue(0)])),
+		id: optional(pipe(number(), minValue(0))),
 		blobJson: blobJsonSchema,
 		blobBigInt: valibigint(),
 		numeric: string(),

--- a/drizzle-valibot/tests/sqlite.test.ts
+++ b/drizzle-valibot/tests/sqlite.test.ts
@@ -4,16 +4,16 @@ import {
 	bigint as valibigint,
 	boolean,
 	date as valiDate,
+	type InferOutput,
 	minValue,
 	nullable,
 	number,
 	object,
 	optional,
-	type InferOutput,
 	parse,
 	picklist,
+	pipe,
 	string,
-    pipe,
 } from 'valibot';
 import { createInsertSchema, createSelectSchema, jsonSchema } from '../src';
 import { expectSchemaShape } from './utils';

--- a/drizzle-valibot/tests/utils.ts
+++ b/drizzle-valibot/tests/utils.ts
@@ -1,7 +1,7 @@
 import type { ExecutionContext } from 'ava';
-import type { BaseSchema } from 'valibot';
+import type { GenericSchema } from 'valibot';
 
-export function expectSchemaShape<T extends BaseSchema<any, any>>(t: ExecutionContext, expected: T) {
+export function expectSchemaShape<T extends GenericSchema>(t: ExecutionContext, expected: T) {
 	return {
 		from(actual: T) {
 			t.deepEqual(Object.keys(actual), Object.keys(expected));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,8 +260,8 @@ importers:
         specifier: ^3.12.2
         version: 3.12.7
       valibot:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.31.0
+        version: 0.31.0
       zx:
         specifier: ^7.2.2
         version: 7.2.2
@@ -7657,8 +7657,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  valibot@0.30.0:
-    resolution: {integrity: sha512-5POBdbSkM+3nvJ6ZlyQHsggisfRtyT4tVTo1EIIShs6qCdXJnyWU5TJ68vr8iTg5zpOLjXLRiBqNx+9zwZz/rA==}
+  valibot@0.31.0:
+    resolution: {integrity: sha512-bleS8aVFpRGTUgbMoXzsRJhpxJGiZ3MG1nuNSORuDvio+sI1EyT1+lQHg+77Pfnlxz+25Uj5HiwdaklcDcYdiQ==}
 
   valid-url@1.0.9:
     resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
@@ -10629,7 +10629,7 @@ snapshots:
   '@libsql/isomorphic-ws@0.1.5':
     dependencies:
       '@types/ws': 8.5.4
-      ws: 8.14.2
+      ws: 8.14.2(bufferutil@4.0.7)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17152,7 +17152,7 @@ snapshots:
       kleur: 4.1.5
       sade: 1.8.1
 
-  valibot@0.30.0: {}
+  valibot@0.31.0: {}
 
   valid-url@1.0.9: {}
 
@@ -17459,9 +17459,6 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.7
       utf-8-validate: 6.0.3
-
-  ws@8.14.2:
-    optional: true
 
   ws@8.14.2(bufferutil@4.0.7)(utf-8-validate@6.0.3):
     optionalDependencies:


### PR DESCRIPTION
[Valibot 0.31.0](https://valibot.dev/blog/valibot-v0.31.0-is-finally-available/) introduced some breaking changes like the new pipe operator among other things.

```tsx
// With the previous API
const BirthdaySchema = v.brand(
  v.transform(v.string([v.isoDate()]), (input) => new Date(input)),
  'birthday'
);

// With the brand new API
const BirthdaySchema = v.pipe(
  v.string(),
  v.isoDate(),
  v.transform((input) => new Date(input)),
  v.brand('birthday')
);
```

So far tests are passing but types are broken. Any help will be appreciated.