### PR TITLE
[feat] inArray and notInArray accept empty list 

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -289,7 +289,7 @@ export function inArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			throw new Error('inArray requires at least one value');
+			return sql`false`;
 		}
 		return sql`${column} in ${values.map((v) => bindIfParam(v, column))}`;
 	}
@@ -335,7 +335,7 @@ export function notInArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			throw new Error('notInArray requires at least one value');
+			return sql`true`;
 		}
 		return sql`${column} not in ${values.map((v) => bindIfParam(v, column))}`;
 	}

--- a/integration-tests/tests/mysql/mysql-common.ts
+++ b/integration-tests/tests/mysql/mysql-common.ts
@@ -18,6 +18,7 @@ import {
 	max,
 	min,
 	Name,
+	notInArray,
 	placeholder,
 	sql,
 	sum,
@@ -532,6 +533,34 @@ export function tests(driver?: string) {
 			}).from(usersTable);
 
 			expect(users).toEqual([{ name: 'JOHN' }]);
+		});
+
+		test('select with empty array in inArray', async (ctx) => {
+			const { db } = ctx.mysql;
+
+			await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+			const result = await db
+				.select({
+					name: sql`upper(${usersTable.name})`,
+				})
+				.from(usersTable)
+				.where(inArray(usersTable.id, []));
+
+			expect(result).toEqual([]);
+		});
+
+		test('select with empty array in notInArray', async (ctx) => {
+			const { db } = ctx.mysql;
+
+			await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+			const result = await db
+				.select({
+					name: sql`upper(${usersTable.name})`,
+				})
+				.from(usersTable)
+				.where(notInArray(usersTable.id, []));
+
+			expect(result).toEqual([{ name: 'JOHN' }, { name: 'JANE' }, { name: 'JANE' }]);
 		});
 
 		test('select distinct', async (ctx) => {

--- a/integration-tests/tests/pg/awsdatapi.test.ts
+++ b/integration-tests/tests/pg/awsdatapi.test.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 
 import { RDSDataClient } from '@aws-sdk/client-rds-data';
 import * as dotenv from 'dotenv';
-import { asc, eq, sql, TransactionRollbackError } from 'drizzle-orm';
+import { asc, eq, inArray, notInArray, sql, TransactionRollbackError } from 'drizzle-orm';
 import type { AwsDataApiPgDatabase } from 'drizzle-orm/aws-data-api/pg';
 import { drizzle } from 'drizzle-orm/aws-data-api/pg';
 import { migrate } from 'drizzle-orm/aws-data-api/pg/migrator';
@@ -103,6 +103,32 @@ test('select sql', async () => {
 	}).from(usersTable);
 
 	expect(users).toEqual([{ name: 'JOHN' }]);
+});
+
+test('select with empty array in inArray', async () => {
+	await db.insert(usersTable).values([
+		{ name: 'John' },
+		{ name: 'Jane' },
+		{ name: 'Jane' },
+	]);
+	const users = await db.select({
+		name: sql`upper(${usersTable.name})`,
+	}).from(usersTable).where(inArray(usersTable.id, []));
+
+	expect(users).toEqual([]);
+});
+
+test('select with empty array in notInArray', async () => {
+	await db.insert(usersTable).values([
+		{ name: 'John' },
+		{ name: 'Jane' },
+		{ name: 'Jane' },
+	]);
+	const result = await db.select({
+		name: sql`upper(${usersTable.name})`,
+	}).from(usersTable).where(notInArray(usersTable.id, []));
+
+	expect(result).toEqual([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
 });
 
 test('select typed sql', async () => {

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -21,6 +21,7 @@ import {
 	lt,
 	max,
 	min,
+	notInArray,
 	or,
 	SQL,
 	sql,
@@ -537,6 +538,34 @@ export function tests() {
 			}).from(usersTable);
 
 			expect(users).toEqual([{ name: 'JOHN' }]);
+		});
+
+		test('select with empty array in inArray', async (ctx) => {
+			const { db } = ctx.pg;
+
+			await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+			const result = await db
+				.select({
+					name: sql`upper(${usersTable.name})`,
+				})
+				.from(usersTable)
+				.where(inArray(usersTable.id, []));
+
+			expect(result).toEqual([]);
+		});
+
+		test('select with empty array in notInArray', async (ctx) => {
+			const { db } = ctx.pg;
+
+			await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+			const result = await db
+				.select({
+					name: sql`upper(${usersTable.name})`,
+				})
+				.from(usersTable)
+				.where(notInArray(usersTable.id, []));
+
+			expect(result).toEqual([{ name: 'JOHN' }, { name: 'JANE' }, { name: 'JANE' }]);
 		});
 
 		test('$default function', async (ctx) => {

--- a/integration-tests/tests/sqlite/sqlite-common.ts
+++ b/integration-tests/tests/sqlite/sqlite-common.ts
@@ -15,6 +15,7 @@ import {
 	max,
 	min,
 	Name,
+	notInArray,
 	sql,
 	sum,
 	sumDistinct,
@@ -369,6 +370,34 @@ export function tests() {
 			}).from(usersTable).all();
 
 			expect(users).toEqual([{ name: 'JOHN' }]);
+		});
+
+		test('select with empty array in inArray', async (ctx) => {
+			const { db } = ctx.sqlite;
+
+			await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+			const result = await db
+				.select({
+					name: sql`upper(${usersTable.name})`,
+				})
+				.from(usersTable)
+				.where(inArray(usersTable.id, []));
+
+			expect(result).toEqual([]);
+		});
+
+		test('select with empty array in notInArray', async (ctx) => {
+			const { db } = ctx.sqlite;
+
+			await db.insert(usersTable).values([{ name: 'John' }, { name: 'Jane' }, { name: 'Jane' }]);
+			const result = await db
+				.select({
+					name: sql`upper(${usersTable.name})`,
+				})
+				.from(usersTable)
+				.where(notInArray(usersTable.id, []));
+
+			expect(result).toEqual([{ name: 'JOHN' }, { name: 'JANE' }, { name: 'JANE' }]);
 		});
 
 		test('select distinct', async (ctx) => {


### PR DESCRIPTION
close https://github.com/drizzle-team/drizzle-orm/issues/1295

Make inArray and notInArray methods accept an empty list as their second parameter instead of throwing an error :
- inArray returns false when called with an empty list
- notInArray returns true when called with an empty list

the [comment referencing](https://github.com/drizzle-team/drizzle-orm/issues/1295#issuecomment-1858204805) the choice of implementation in the thread

