### PR TITLE
fix: make prisma packages optional

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -149,6 +149,12 @@
 		},
 		"@tidbcloud/serverless": {
 			"optional": true
+		},
+		"prisma": {
+			"optional": true
+		},
+		"@prisma/client": {
+			"optional": true
 		}
 	},
 	"devDependencies": {


### PR DESCRIPTION
Similar to https://github.com/drizzle-team/drizzle-orm/pull/1714, https://github.com/drizzle-team/drizzle-orm/pull/2478 added a Prisma driver, but didn't mark the dependencies as optional, resulting in both `prisma` and `@prisma/client` being installed with every `drizzle-orm` install now.

This results in unnecessary inflation of `node_modules` in projects that do not use prisma.