### PR TITLE
Added Skip Option on useLiveQuery

### DIFF
--- a/drizzle-orm/src/expo-sqlite/query.ts
+++ b/drizzle-orm/src/expo-sqlite/query.ts
@@ -7,6 +7,11 @@ import { SQLiteRelationalQuery } from '~/sqlite-core/query-builders/query.ts';
 
 export const useLiveQuery = <T extends Pick<AnySQLiteSelect, '_' | 'then'> | SQLiteRelationalQuery<'sync', unknown>>(
 	query: T,
+	{
+		skip = false
+	}: {
+		skip: boolean
+	}
 ) => {
 	const [data, setData] = useState<Awaited<T>>(
 		(is(query, SQLiteRelationalQuery) && query.mode === 'first' ? undefined : []) as Awaited<T>,
@@ -15,6 +20,10 @@ export const useLiveQuery = <T extends Pick<AnySQLiteSelect, '_' | 'then'> | SQL
 	const [updatedAt, setUpdatedAt] = useState<Date>();
 
 	useEffect(() => {
+		if (skip) {
+			return ;
+		}
+
 		const entity = is(query, SQLiteRelationalQuery) ? query.table : (query as AnySQLiteSelect).config.table;
 
 		if (is(entity, Subquery) || is(entity, SQL)) {
@@ -43,7 +52,7 @@ export const useLiveQuery = <T extends Pick<AnySQLiteSelect, '_' | 'then'> | SQL
 		return () => {
 			listener?.remove();
 		};
-	}, []);
+	}, [skip]);
 
 	return {
 		data,


### PR DESCRIPTION
Sometimes, You want to wait for some condition before running a query, this PR adds a skip option,

Example

```ts
const [canSeeOrders, setCanSeeOrders] = useState(false);

const { data: orders } = useLiveQuery(
  database.query.orders.findMany(), {
    skip: canSeeOrders
  }
);

```

Query should not return value until canSeeOrders is set to true;

