### PR TITLE
feat: supports dates as string coming from a json payload to the driver

### DIFF
--- a/drizzle-orm/src/pg-core/columns/timestamp.ts
+++ b/drizzle-orm/src/pg-core/columns/timestamp.ts
@@ -64,7 +64,7 @@ export class PgTimestamp<T extends ColumnBaseConfig<'date', 'PgTimestamp'>> exte
 	};
 
 	override mapToDriverValue = (value: Date): string => {
-		return value.toISOString();
+		return value instanceof Date ? value.toISOString() : value;
 	};
 }
 


### PR DESCRIPTION
When a date coming from a json payload is a string, it breaks before inserting it into the database because the value.toISOString does not exist.

To get around this in my code, I ended up creating a custom type, but we can't use cool timestamp things like defaultNow.

So this suggestion for improvement.