### PR TITLE
Add `drizzle-effect` package - an integration with @effect/schema

### DIFF
--- a/drizzle-effect/README.md
+++ b/drizzle-effect/README.md
@@ -1,0 +1,65 @@
+<div align='center'>
+<h1>drizzle-effect <a href=''><img alt='npm' src='https://img.shields.io/npm/v/drizzle-effect?label='></a></h1>
+<img alt='npm' src='https://img.shields.io/npm/dm/drizzle-effect'>
+<img alt='npm bundle size' src='https://img.shields.io/bundlephobia/min/drizzle-effect'>
+<a href='https://discord.gg/yfjTbVXMW4'><img alt='Discord' src='https://img.shields.io/discord/1043890932593987624'></a>
+<img alt='License' src='https://img.shields.io/npm/l/drizzle-effect'>
+<h6><i>If you know SQL, you know Drizzle ORM</i></h6>
+<hr />
+</div>
+
+`drizzle-effect` is a plugin for [Drizzle ORM](https://github.com/drizzle-team/drizzle-orm) that allows you to generate [Effect](https://effect.website/) schemas from Drizzle ORM schemas.
+
+| Database   | Insert schema | Select schema |
+| :--------- | :-----------: | :-----------: |
+| PostgreSQL |      ✅       |      ✅       |
+| MySQL      |      ✅       |      ✅       |
+| SQLite     |      ✅       |      ✅       |
+
+# Usage
+
+```ts
+import { pgEnum, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+import { createInsertSchema, createSelectSchema } from 'drizzle-effect';
+import { Schema } from '@effect/schema';
+
+const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull(),
+  role: text('role', { enum: ['admin', 'user'] }).notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+});
+
+// Schema for inserting a user - can be used to validate API requests
+const insertUserSchema = createInsertSchema(users);
+
+// Schema for selecting a user - can be used to validate API responses
+const selectUserSchema = createSelectSchema(users);
+
+// Overriding the fields
+const insertUserSchema = createInsertSchema(users, {
+  role: Schema.String,
+});
+
+const emailPattern = /[^ .@]+@[^ .@]+\.[^ .@]/;
+
+// Refining the fields - useful if you want to change the fields before they become nullable/optional in the final schema
+const insertUserSchema = createInsertSchema(users, {
+  id: (schema) => schema.id.pipe(Schema.positive()),
+  email: (schema) => schema.email.pipe(Schema.pattern(emailPattern)),
+  role: Schema.String,
+});
+
+// Usage
+
+const user = Schema.decodeSync(insertUserSchema)({
+  name: 'John Doe',
+  email: 'johndoe@test.com',
+  role: 'admin',
+});
+
+// Effect schema type is also inferred from the table schema, so you have full type safety.
+// Additionally it is created using `Schema.Struct`, so you can do:
+const requestSchema = insertUserSchema.pick('name', 'email');
+```

--- a/drizzle-effect/package.json
+++ b/drizzle-effect/package.json
@@ -67,7 +67,7 @@
   "license": "MIT",
   "peerDependencies": {
     "drizzle-orm": ">=0.23.13",
-    "@effect/schema": ">=0.68.26",
+    "@effect/schema": ">=0.69.1",
     "effect": ">=3.5.6"
   },
   "devDependencies": {
@@ -80,7 +80,7 @@
     "rollup": "^3.20.7",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.6.0",
-    "@effect/schema": "^0.68.26",
+    "@effect/schema": "^0.69.1",
     "effect": "^3.5.6",
     "zx": "^7.2.2"
   },

--- a/drizzle-effect/package.json
+++ b/drizzle-effect/package.json
@@ -1,0 +1,88 @@
+{
+  "name": "drizzle-effect",
+  "version": "0.0.1",
+  "description": "Generate `effect` schemas from Drizzle ORM schemas",
+  "type": "module",
+  "scripts": {
+    "build": "tsx scripts/build.ts",
+    "b": "pnpm build",
+    "test:types": "cd tests && tsc",
+    "pack": "(cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
+    "publish": "npm publish package.tgz",
+    "test": "vitest run"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.mts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./index.d.cjs",
+        "default": "./index.cjs"
+      },
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
+    }
+  },
+  "main": "./index.cjs",
+  "module": "./index.mjs",
+  "types": "./index.d.ts",
+  "publishConfig": {
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/drizzle-team/drizzle-orm.git"
+  },
+  "ava": {
+    "files": [
+      "tests/**/*.test.ts",
+      "!tests/bun/**/*"
+    ],
+    "extensions": {
+      "ts": "module"
+    }
+  },
+  "keywords": [
+    "effect",
+    "effect-ts",
+    "@effect/schema",
+    "validate",
+    "validation",
+    "schema",
+    "drizzle",
+    "orm",
+    "pg",
+    "mysql",
+    "postgresql",
+    "postgres",
+    "sqlite",
+    "database",
+    "sql",
+    "typescript",
+    "ts"
+  ],
+  "author": "Drizzle Team",
+  "license": "MIT",
+  "peerDependencies": {
+    "drizzle-orm": ">=0.23.13",
+    "@effect/schema": ">=0.68.26",
+    "effect": ">=3.5.6"
+  },
+  "devDependencies": {
+    "@rollup/plugin-terser": "^0.4.1",
+    "@rollup/plugin-typescript": "^11.1.0",
+    "@types/node": "^18.15.10",
+    "cpy": "^10.1.0",
+    "drizzle-orm": "link:../drizzle-orm/dist",
+    "rimraf": "^5.0.0",
+    "rollup": "^3.20.7",
+    "vite-tsconfig-paths": "^4.3.2",
+    "vitest": "^1.6.0",
+    "@effect/schema": "^0.68.26",
+    "effect": "^3.5.6",
+    "zx": "^7.2.2"
+  },
+  "dependencies": {}
+}

--- a/drizzle-effect/rollup.config.ts
+++ b/drizzle-effect/rollup.config.ts
@@ -1,0 +1,32 @@
+import terser from '@rollup/plugin-terser';
+import typescript from '@rollup/plugin-typescript';
+import { defineConfig } from 'rollup';
+
+export default defineConfig([
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        format: 'esm',
+        dir: 'dist',
+        entryFileNames: '[name].mjs',
+        chunkFileNames: '[name]-[hash].mjs',
+        sourcemap: true,
+      },
+      {
+        format: 'cjs',
+        dir: 'dist',
+        entryFileNames: '[name].cjs',
+        chunkFileNames: '[name]-[hash].cjs',
+        sourcemap: true,
+      },
+    ],
+    external: [/^drizzle-orm\/?/, '@effect/schema', 'effect'],
+    plugins: [
+      typescript({
+        tsconfig: 'tsconfig.build.json',
+      }),
+      terser(),
+    ],
+  },
+]);

--- a/drizzle-effect/scripts/build.ts
+++ b/drizzle-effect/scripts/build.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env -S pnpm tsx
+import 'zx/globals';
+import cpy from 'cpy';
+
+await fs.remove('dist');
+await $`rollup --config rollup.config.ts --configPlugin typescript`;
+await $`resolve-tspaths`;
+await fs.copy('README.md', 'dist/README.md');
+await cpy('dist/**/*.d.ts', 'dist', {
+	rename: (basename) => basename.replace(/\.d\.ts$/, '.d.mts'),
+});
+await cpy('dist/**/*.d.ts', 'dist', {
+	rename: (basename) => basename.replace(/\.d\.ts$/, '.d.cts'),
+});
+await fs.copy('package.json', 'dist/package.json');

--- a/drizzle-effect/src/index.ts
+++ b/drizzle-effect/src/index.ts
@@ -175,7 +175,7 @@ export const Json = Schema.suspend(
     Schema.Union(
       literalSchema,
       Schema.Array(Json),
-      Schema.Record(Schema.String, Json),
+      Schema.Record({ key: Schema.String, value: Json })
     ),
 );
 

--- a/drizzle-effect/src/index.ts
+++ b/drizzle-effect/src/index.ts
@@ -1,0 +1,520 @@
+import * as Schema from '@effect/schema/Schema';
+import * as Drizzle from 'drizzle-orm';
+import * as DrizzleMysql from 'drizzle-orm/mysql-core';
+import * as DrizzlePg from 'drizzle-orm/pg-core';
+import * as DrizzleSqlite from 'drizzle-orm/sqlite-core';
+
+type Columns<TTable extends Drizzle.Table> =
+  TTable['_']['columns'] extends infer TColumns extends Record<
+    string,
+    Drizzle.Column<any>
+  >
+    ? TColumns
+    : never;
+
+type PropertySignatureEncoded<T> = T extends Schema.PropertySignature<
+  any,
+  any,
+  any,
+  any,
+  infer From,
+  any,
+  any
+>
+  ? From
+  : never;
+
+type PropertySignatureType<T> = T extends Schema.PropertySignature<
+  any,
+  infer To,
+  any,
+  any,
+  any,
+  any,
+  any
+>
+  ? To
+  : never;
+
+type InsertRefineArg<
+  TTable extends Drizzle.Table,
+  Col extends keyof Columns<TTable>,
+> =
+  | Schema.Schema<any, any, any>
+  | ((s: {
+      [S in keyof InsertColumnPropertySignatures<TTable>]: InsertColumnPropertySignatures<TTable>[S] extends Schema.PropertySignature<
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any
+      >
+        ? Schema.Schema<
+            Exclude<
+              PropertySignatureEncoded<
+                InsertColumnPropertySignatures<TTable>[S]
+              >,
+              undefined | null
+            >,
+            Exclude<
+              PropertySignatureType<InsertColumnPropertySignatures<TTable>[S]>,
+              undefined | null
+            >
+          >
+        : InsertColumnPropertySignatures<TTable>[S];
+    }) => InsertColumnPropertySignatures<TTable>[Col] extends Schema.PropertySignature<
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >
+      ? Schema.Schema<
+          Exclude<
+            PropertySignatureEncoded<
+              InsertColumnPropertySignatures<TTable>[Col]
+            >,
+            undefined | null
+          >,
+          any
+        >
+      : Schema.Schema<
+          Exclude<
+            Schema.Schema.Encoded<InsertColumnPropertySignatures<TTable>[Col]>,
+            undefined | null
+          >,
+          any
+        >);
+
+type SelectRefineArg<
+  TTable extends Drizzle.Table,
+  Col extends keyof Columns<TTable>,
+> =
+  | Schema.Schema<any, any, any>
+  | ((s: {
+      [S in keyof InsertColumnPropertySignatures<TTable>]: InsertColumnPropertySignatures<TTable>[S] extends Schema.PropertySignature<
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any
+      >
+        ? Schema.Schema<
+            Exclude<
+              PropertySignatureEncoded<
+                InsertColumnPropertySignatures<TTable>[S]
+              >,
+              undefined | null
+            >,
+            Exclude<
+              PropertySignatureType<InsertColumnPropertySignatures<TTable>[S]>,
+              undefined | null
+            >
+          >
+        : InsertColumnPropertySignatures<TTable>[S];
+    }) => InsertColumnPropertySignatures<TTable>[Col] extends Schema.PropertySignature<
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >
+      ? Schema.Schema<
+          Exclude<
+            PropertySignatureEncoded<
+              InsertColumnPropertySignatures<TTable>[Col]
+            >,
+            undefined | null
+          >,
+          any
+        >
+      : Schema.Schema<
+          Exclude<
+            Schema.Schema.Encoded<InsertColumnPropertySignatures<TTable>[Col]>,
+            undefined | null
+          >,
+          any
+        >);
+
+type InsertRefine<TTable extends Drizzle.Table> = {
+  [K in keyof Columns<TTable>]?: InsertRefineArg<TTable, K>;
+};
+
+type SelectRefine<TTable extends Drizzle.Table> = {
+  [K in keyof Columns<TTable>]?: SelectRefineArg<TTable, K>;
+};
+
+const literalSchema = Schema.Union(
+  Schema.String,
+  Schema.Number,
+  Schema.Boolean,
+  Schema.Null,
+);
+
+type Json =
+  | string
+  | number
+  | boolean
+  | {
+      [key: string]: Json;
+    }
+  | Json[]
+  | readonly Json[]
+  | null;
+
+export const Json = Schema.suspend(
+  (): Schema.Schema<Json> =>
+    Schema.Union(
+      literalSchema,
+      Schema.Array(Json),
+      Schema.Record(Schema.String, Json),
+    ),
+);
+
+type GetSchemaForType<TColumn extends Drizzle.Column> =
+  TColumn['_']['dataType'] extends infer TDataType
+    ? TDataType extends 'custom'
+      ? Schema.Schema<any>
+      : TDataType extends 'json'
+      ? Schema.Schema<Json>
+      : TColumn extends { enumValues: [string, ...string[]] }
+      ? Drizzle.Equal<TColumn['enumValues'], [string, ...string[]]> extends true
+        ? Schema.Schema<string>
+        : Schema.Schema<TColumn['enumValues'][number]>
+      : TDataType extends 'array'
+      ? Schema.Schema<
+          | null
+          | readonly Drizzle.Assume<
+              TColumn['_'],
+              { baseColumn: Drizzle.Column }
+            >['baseColumn']['_']['data'][]
+        >
+      : TDataType extends 'bigint'
+      ? Schema.Schema<bigint>
+      : TDataType extends 'number'
+      ? Schema.Schema<number>
+      : TDataType extends 'string'
+      ? Schema.Schema<string>
+      : TDataType extends 'boolean'
+      ? Schema.Schema<boolean>
+      : TDataType extends 'date'
+      ? Schema.Schema<Date>
+      : Schema.Schema<any>
+    : never;
+
+type MapInsertColumnToPropertySignature<TColumn extends Drizzle.Column> =
+  TColumn['_']['notNull'] extends false
+    ? Schema.PropertySignature<
+        '?:',
+        Schema.Schema.Type<GetSchemaForType<TColumn>> | undefined | null,
+        TColumn['_']['name'],
+        '?:',
+        Schema.Schema.Encoded<GetSchemaForType<TColumn>> | undefined | null,
+        false,
+        never
+      >
+    : TColumn['_']['hasDefault'] extends true
+    ? Schema.PropertySignature<
+        '?:',
+        Schema.Schema.Type<GetSchemaForType<TColumn>> | undefined,
+        TColumn['_']['name'],
+        '?:',
+        Schema.Schema.Encoded<GetSchemaForType<TColumn>> | undefined,
+        true,
+        never
+      >
+    : GetSchemaForType<TColumn>;
+
+type MapSelectColumnToPropertySignature<TColumn extends Drizzle.Column> =
+  TColumn['_']['notNull'] extends false
+    ? Schema.Schema<Schema.Schema.Type<GetSchemaForType<TColumn>> | null>
+    : GetSchemaForType<TColumn>;
+
+type InsertColumnPropertySignatures<TTable extends Drizzle.Table> = {
+  [K in keyof Columns<TTable>]: MapInsertColumnToPropertySignature<
+    Columns<TTable>[K]
+  >;
+};
+
+type SelectColumnPropertySignatures<TTable extends Drizzle.Table> = {
+  [K in keyof Columns<TTable>]: MapSelectColumnToPropertySignature<
+    Columns<TTable>[K]
+  >;
+};
+
+type PropertySignatureReplaceType<S, ReplaceWith> =
+  S extends Schema.PropertySignature<
+    infer TokenType,
+    any,
+    infer Name,
+    infer TokenEncoded,
+    infer Encoded,
+    infer HasDefault,
+    infer R
+  >
+    ? Schema.PropertySignature<
+        TokenType,
+        ReplaceWith,
+        Name,
+        TokenEncoded,
+        Encoded,
+        HasDefault,
+        R
+      >
+    : never;
+
+type CarryOverNull<From, To> = null extends From ? To | null : To;
+type CarryOverUndefined<From, To> = undefined extends From
+  ? To | undefined
+  : To;
+
+type CarryOverOptionality<From, To> = CarryOverNull<
+  From,
+  CarryOverUndefined<From, To>
+>;
+
+type BuildInsertSchema<
+  TTable extends Drizzle.Table,
+  TRefine extends InsertRefine<TTable> | {} = {},
+> = Schema.Struct<
+  InsertColumnPropertySignatures<TTable> & {
+    [K in keyof TRefine &
+      string]: InsertColumnPropertySignatures<TTable>[K] extends Schema.PropertySignature<
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >
+      ? TRefine[K] extends Schema.Schema<any, any, any>
+        ? Schema.Schema<
+            CarryOverOptionality<
+              PropertySignatureType<InsertColumnPropertySignatures<TTable>[K]>,
+              Schema.Schema.Type<TRefine[K]>
+            >
+          >
+        : TRefine[K] extends (...a: any[]) => any
+        ? PropertySignatureReplaceType<
+            InsertColumnPropertySignatures<TTable>[K],
+            CarryOverOptionality<
+              PropertySignatureType<InsertColumnPropertySignatures<TTable>[K]>,
+              Schema.Schema.Type<ReturnType<TRefine[K]>>
+            >
+          >
+        : never
+      : TRefine[K];
+  }
+>;
+
+type BuildSelectSchema<
+  TTable extends Drizzle.Table,
+  TRefine extends InsertRefine<TTable> | {} = {},
+> = Schema.Struct<
+  {
+    [K in keyof SelectColumnPropertySignatures<TTable>]: SelectColumnPropertySignatures<TTable>[K];
+  } & {
+    [K in keyof TRefine &
+      string]: SelectColumnPropertySignatures<TTable>[K] extends Schema.PropertySignature<
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >
+      ? TRefine[K] extends Schema.Schema<any, any, any>
+        ? Schema.Schema<
+            CarryOverOptionality<
+              PropertySignatureType<SelectColumnPropertySignatures<TTable>[K]>,
+              Schema.Schema.Type<TRefine[K]>
+            >
+          >
+        : TRefine[K] extends (...a: any[]) => any
+        ? PropertySignatureReplaceType<
+            SelectColumnPropertySignatures<TTable>[K],
+            CarryOverOptionality<
+              PropertySignatureType<SelectColumnPropertySignatures<TTable>[K]>,
+              Schema.Schema.Type<ReturnType<TRefine[K]>>
+            >
+          >
+        : never
+      : TRefine[K];
+  }
+>;
+
+export function createInsertSchema<
+  TTable extends Drizzle.Table,
+  TRefine extends InsertRefine<TTable>,
+>(
+  table: TTable,
+  refine?: {
+    [K in keyof TRefine]: K extends keyof TTable['_']['columns']
+      ? TRefine[K]
+      : Drizzle.DrizzleTypeError<`Column '${K &
+          string}' does not exist in table '${TTable['_']['name']}'`>;
+  },
+): BuildInsertSchema<
+  TTable,
+  Drizzle.Equal<TRefine, InsertRefine<TTable>> extends true ? {} : TRefine
+> {
+  const columns = Drizzle.getTableColumns(table);
+  const columnEntries = Object.entries(columns);
+
+  let schemaEntries = Object.fromEntries(
+    columnEntries.map(([name, column]) => {
+      return [name, mapColumnToSchema(column)];
+    }),
+  );
+
+  if (refine) {
+    schemaEntries = Object.assign(
+      schemaEntries,
+      Object.fromEntries(
+        Object.entries(refine).map(([name, refineColumn]) => {
+          return [
+            name,
+            typeof refineColumn === 'function' &&
+            !(Schema.isSchema(refineColumn))
+              ? refineColumn(schemaEntries as any)
+              : refineColumn,
+          ];
+        }),
+      ),
+    );
+  }
+
+  for (const [name, column] of columnEntries) {
+    if (!column.notNull) {
+      schemaEntries[name] = Schema.optional(
+        Schema.NullOr(schemaEntries[name]!),
+      ) as any;
+    } else if (column.hasDefault) {
+      schemaEntries[name] = Schema.optional(schemaEntries[name]!) as any;
+    }
+  }
+
+  return Schema.Struct(schemaEntries) as any;
+}
+
+export function createSelectSchema<
+  TTable extends Drizzle.Table,
+  TRefine extends SelectRefine<TTable>,
+>(
+  table: TTable,
+  refine?: {
+    [K in keyof TRefine]: K extends keyof TTable['_']['columns']
+      ? TRefine[K]
+      : Drizzle.DrizzleTypeError<`Column '${K &
+          string}' does not exist in table '${TTable['_']['name']}'`>;
+  },
+): BuildSelectSchema<
+  TTable,
+  Drizzle.Equal<TRefine, SelectRefine<TTable>> extends true ? {} : TRefine
+> {
+  const columns = Drizzle.getTableColumns(table);
+  const columnEntries = Object.entries(columns);
+
+  let schemaEntries = Object.fromEntries(
+    columnEntries.map(([name, column]) => {
+      return [name, mapColumnToSchema(column)];
+    }),
+  );
+
+  if (refine) {
+    schemaEntries = Object.assign(
+      schemaEntries,
+      Object.fromEntries(
+        Object.entries(refine).map(([name, refineColumn]) => {
+          return [
+            name,
+            typeof refineColumn === 'function' &&
+            !(Schema.isSchema(refineColumn))
+              ? refineColumn(schemaEntries as any)
+              : refineColumn,
+          ];
+        }),
+      ),
+    );
+  }
+
+  for (const [name, column] of columnEntries) {
+    if (!column.notNull) {
+      schemaEntries[name] = Schema.NullOr(schemaEntries[name]!);
+    }
+  }
+
+  return Schema.Struct(schemaEntries) as any;
+}
+
+function mapColumnToSchema(column: Drizzle.Column): Schema.Schema<any, any> {
+  let type: Schema.Schema<any, any> | undefined;
+
+  if (isWithEnum(column)) {
+    type = column.enumValues.length
+      ? Schema.Literal(...column.enumValues)
+      : Schema.String;
+  }
+
+  if (!type) {
+    if (Drizzle.is(column, DrizzlePg.PgUUID)) {
+      type = Schema.UUID;
+    } else if (column.dataType === 'custom') {
+      type = Schema.Any;
+    } else if (column.dataType === 'json') {
+      type = Json;
+    } else if (column.dataType === 'array') {
+      type = Schema.Array(
+        mapColumnToSchema((column as DrizzlePg.PgArray<any, any>).baseColumn),
+      );
+    } else if (column.dataType === 'number') {
+      type = Schema.Number;
+    } else if (column.dataType === 'bigint') {
+      type = Schema.BigIntFromSelf;
+    } else if (column.dataType === 'boolean') {
+      type = Schema.Boolean;
+    } else if (column.dataType === 'date') {
+      type = Schema.DateFromSelf;
+    } else if (column.dataType === 'string') {
+      let sType = Schema.String;
+
+      if (
+        (Drizzle.is(column, DrizzlePg.PgChar) ||
+          Drizzle.is(column, DrizzlePg.PgVarchar) ||
+          Drizzle.is(column, DrizzleMysql.MySqlVarChar) ||
+          Drizzle.is(column, DrizzleMysql.MySqlVarBinary) ||
+          Drizzle.is(column, DrizzleMysql.MySqlChar) ||
+          Drizzle.is(column, DrizzleSqlite.SQLiteText)) &&
+        typeof column.length === 'number'
+      ) {
+        sType = sType.pipe(Schema.maxLength(column.length));
+      }
+
+      type = sType;
+    }
+  }
+
+  if (!type) {
+    type = Schema.Any;
+  }
+
+  return type;
+}
+
+function isWithEnum(
+  column: Drizzle.Column,
+): column is typeof column & { enumValues: [string, ...string[]] } {
+  return (
+    'enumValues' in column &&
+    Array.isArray(column.enumValues) &&
+    column.enumValues.length > 0
+  );
+}

--- a/drizzle-effect/tests/mysql.test.ts
+++ b/drizzle-effect/tests/mysql.test.ts
@@ -1,0 +1,326 @@
+import { Schema } from '@effect/schema';
+import {
+  bigint,
+  binary,
+  boolean,
+  char,
+  customType,
+  date,
+  datetime,
+  decimal,
+  double,
+  float,
+  int,
+  json,
+  longtext,
+  mediumint,
+  mediumtext,
+  mysqlEnum,
+  mysqlTable,
+  real,
+  serial,
+  smallint,
+  text,
+  time,
+  timestamp,
+  tinyint,
+  tinytext,
+  varbinary,
+  varchar,
+  year,
+} from 'drizzle-orm/mysql-core';
+import { Either } from 'effect';
+import { expect, test } from 'vitest';
+import { createInsertSchema, createSelectSchema, Json } from '../src/index.ts';
+import { expectSchemaShape } from './utils.ts';
+
+const customInt = customType<{ data: number }>({
+  dataType() {
+    return 'int';
+  },
+});
+
+const testTable = mysqlTable('test', {
+  bigint: bigint('bigint', { mode: 'bigint' }).notNull(),
+  bigintNumber: bigint('bigintNumber', { mode: 'number' }).notNull(),
+  binary: binary('binary').notNull(),
+  boolean: boolean('boolean').notNull(),
+  char: char('char', { length: 4 }).notNull(),
+  charEnum: char('char', { enum: ['a', 'b', 'c'] }).notNull(),
+  customInt: customInt('customInt').notNull(),
+  date: date('date').notNull(),
+  dateString: date('dateString', { mode: 'string' }).notNull(),
+  datetime: datetime('datetime').notNull(),
+  datetimeString: datetime('datetimeString', { mode: 'string' }).notNull(),
+  decimal: decimal('decimal').notNull(),
+  double: double('double').notNull(),
+  enum: mysqlEnum('enum', ['a', 'b', 'c']).notNull(),
+  float: float('float').notNull(),
+  int: int('int').notNull(),
+  json: json('json').notNull(),
+  mediumint: mediumint('mediumint').notNull(),
+  real: real('real').notNull(),
+  serial: serial('serial').notNull(),
+  smallint: smallint('smallint').notNull(),
+  text: text('text').notNull(),
+  textEnum: text('textEnum', { enum: ['a', 'b', 'c'] }).notNull(),
+  tinytext: tinytext('tinytext').notNull(),
+  tinytextEnum: tinytext('tinytextEnum', { enum: ['a', 'b', 'c'] }).notNull(),
+  mediumtext: mediumtext('mediumtext').notNull(),
+  mediumtextEnum: mediumtext('mediumtextEnum', {
+    enum: ['a', 'b', 'c'],
+  }).notNull(),
+  longtext: longtext('longtext').notNull(),
+  longtextEnum: longtext('longtextEnum', { enum: ['a', 'b', 'c'] }).notNull(),
+  time: time('time').notNull(),
+  timestamp: timestamp('timestamp').notNull(),
+  timestampString: timestamp('timestampString', { mode: 'string' }).notNull(),
+  tinyint: tinyint('tinyint').notNull(),
+  varbinary: varbinary('varbinary', { length: 200 }).notNull(),
+  varchar: varchar('varchar', { length: 200 }).notNull(),
+  varcharEnum: varchar('varcharEnum', {
+    length: 1,
+    enum: ['a', 'b', 'c'],
+  }).notNull(),
+  year: year('year').notNull(),
+  autoIncrement: int('autoIncrement').notNull().autoincrement(),
+});
+
+const testTableRow = {
+  bigint: BigInt(1),
+  bigintNumber: 1,
+  binary: 'binary',
+  boolean: true,
+  char: 'char',
+  charEnum: 'a' as const,
+  customInt: { data: 1 },
+  date: new Date(),
+  dateString: new Date().toISOString(),
+  datetime: new Date(),
+  datetimeString: new Date().toISOString(),
+  decimal: '1.1',
+  double: 1.1,
+  enum: 'a' as const,
+  float: 1.1,
+  int: 1,
+  json: { data: 1 },
+  mediumint: 1,
+  real: 1.1,
+  serial: 1,
+  smallint: 1,
+  text: 'text',
+  textEnum: 'a' as const,
+  tinytext: 'tinytext',
+  tinytextEnum: 'a' as const,
+  mediumtext: 'mediumtext',
+  mediumtextEnum: 'a' as const,
+  longtext: 'longtext',
+  longtextEnum: 'a' as const,
+  time: '00:00:00',
+  timestamp: new Date(),
+  timestampString: new Date().toISOString(),
+  tinyint: 1,
+  varbinary: 'A'.repeat(200),
+  varchar: 'A'.repeat(200),
+  varcharEnum: 'a' as const,
+  year: 2021,
+  autoIncrement: 1,
+};
+
+test('is an instance of `Schema.Struct`', () => {
+  const schema = createInsertSchema(testTable).pick('boolean', 'varcharEnum');
+
+  const decode = Schema.decodeEither(schema);
+
+  expect(Either.isRight(decode(testTableRow))).toBeTruthy();
+  expect(
+    Either.isRight(decode({ boolean: false, varcharEnum: 'a' })),
+  ).toBeTruthy();
+
+  expect(Either.isRight(Schema.decodeUnknownEither(schema)({}))).toBeFalsy();
+  expect(
+    Either.isRight(
+      decode(testTableRow, {
+        onExcessProperty: 'error',
+      }),
+    ),
+  ).toBeFalsy();
+});
+
+test('insert valid row', () => {
+  const schema = createInsertSchema(testTable);
+
+  const result = Schema.decodeEither(schema)(testTableRow);
+
+  expect(Either.isRight(result)).toBeTruthy();
+});
+
+test('insert invalid varchar length', () => {
+  const schema = createInsertSchema(testTable);
+
+  const result = Schema.decodeEither(schema)({
+    ...testTableRow,
+    varchar: 'A'.repeat(201),
+  });
+  expect(Either.isRight(result)).toBeFalsy();
+});
+
+test('insert smaller char length should work', () => {
+  const schema = createInsertSchema(testTable);
+  const result = Schema.decodeEither(schema)({ ...testTableRow, char: 'abc' });
+
+  expect(Either.isRight(result)).toBeTruthy();
+});
+
+test('insert larger char length should fail', () => {
+  const schema = createInsertSchema(testTable);
+  const result = Schema.decodeEither(schema)({
+    ...testTableRow,
+    char: 'abcde',
+  });
+
+  expect(Either.isRight(result)).toBeFalsy();
+});
+
+test('insert schema', (t) => {
+  const actual = createInsertSchema(testTable);
+
+  const expected = Schema.Struct({
+    bigint: Schema.BigIntFromSelf,
+    bigintNumber: Schema.Number,
+    binary: Schema.String,
+    boolean: Schema.Boolean,
+    char: Schema.String.pipe(Schema.maxLength(4)),
+    charEnum: Schema.Literal('a', 'b', 'c'),
+    customInt: Schema.Any,
+    date: Schema.DateFromSelf,
+    dateString: Schema.String,
+    datetime: Schema.DateFromSelf,
+    datetimeString: Schema.String,
+    decimal: Schema.String,
+    double: Schema.Number,
+    enum: Schema.Literal('a', 'b', 'c'),
+    float: Schema.Number,
+    int: Schema.Number,
+    json: Json,
+    mediumint: Schema.Number,
+    real: Schema.Number,
+    serial: Schema.optional(Schema.Number),
+    smallint: Schema.Number,
+    text: Schema.String,
+    textEnum: Schema.Literal('a', 'b', 'c'),
+    tinytext: Schema.String,
+    tinytextEnum: Schema.Literal('a', 'b', 'c'),
+    mediumtext: Schema.String,
+    mediumtextEnum: Schema.Literal('a', 'b', 'c'),
+    longtext: Schema.String,
+    longtextEnum: Schema.Literal('a', 'b', 'c'),
+    time: Schema.String,
+    timestamp: Schema.DateFromSelf,
+    timestampString: Schema.String,
+    tinyint: Schema.Number,
+    varbinary: Schema.String.pipe(Schema.maxLength(200)),
+    varchar: Schema.String.pipe(Schema.maxLength(200)),
+    varcharEnum: Schema.Literal('a', 'b', 'c'),
+    year: Schema.Number,
+    autoIncrement: Schema.optional(Schema.Number),
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});
+
+test('select schema', (t) => {
+  const actual = createSelectSchema(testTable);
+
+  const expected = Schema.Struct({
+    bigint: Schema.BigIntFromSelf,
+    bigintNumber: Schema.Number,
+    binary: Schema.String,
+    boolean: Schema.Boolean,
+    char: Schema.String.pipe(Schema.maxLength(4)),
+    charEnum: Schema.Literal('a', 'b', 'c'),
+    customInt: Schema.Any,
+    date: Schema.DateFromSelf,
+    dateString: Schema.String,
+    datetime: Schema.DateFromSelf,
+    datetimeString: Schema.String,
+    decimal: Schema.String,
+    double: Schema.Number,
+    enum: Schema.Literal('a', 'b', 'c'),
+    float: Schema.Number,
+    int: Schema.Number,
+    json: Json,
+    mediumint: Schema.Number,
+    real: Schema.Number,
+    serial: Schema.Number,
+    smallint: Schema.Number,
+    text: Schema.String,
+    textEnum: Schema.Literal('a', 'b', 'c'),
+    tinytext: Schema.String,
+    tinytextEnum: Schema.Literal('a', 'b', 'c'),
+    mediumtext: Schema.String,
+    mediumtextEnum: Schema.Literal('a', 'b', 'c'),
+    longtext: Schema.String,
+    longtextEnum: Schema.Literal('a', 'b', 'c'),
+    time: Schema.String,
+    timestamp: Schema.DateFromSelf,
+    timestampString: Schema.String,
+    tinyint: Schema.Number,
+    varbinary: Schema.String.pipe(Schema.maxLength(200)),
+    varchar: Schema.String.pipe(Schema.maxLength(200)),
+    varcharEnum: Schema.Literal('a', 'b', 'c'),
+    year: Schema.Number,
+    autoIncrement: Schema.Number,
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});
+
+test('select schema w/ refine', (t) => {
+  const actual = createSelectSchema(testTable, {
+    bigint: (schema) => schema.bigint.pipe(Schema.positiveBigInt()),
+  });
+
+  const expected = Schema.Struct({
+    bigint: Schema.BigIntFromSelf.pipe(Schema.positiveBigInt()),
+    bigintNumber: Schema.Number,
+    binary: Schema.String,
+    boolean: Schema.Boolean,
+    char: Schema.String.pipe(Schema.maxLength(4)),
+    charEnum: Schema.Literal('a', 'b', 'c'),
+    customInt: Schema.Any,
+    date: Schema.DateFromSelf,
+    dateString: Schema.String,
+    datetime: Schema.DateFromSelf,
+    datetimeString: Schema.String,
+    decimal: Schema.String,
+    double: Schema.Number,
+    enum: Schema.Literal('a', 'b', 'c'),
+    float: Schema.Number,
+    int: Schema.Number,
+    json: Json,
+    mediumint: Schema.Number,
+    real: Schema.Number,
+    serial: Schema.Number,
+    smallint: Schema.Number,
+    text: Schema.String,
+    textEnum: Schema.Literal('a', 'b', 'c'),
+    tinytext: Schema.String,
+    tinytextEnum: Schema.Literal('a', 'b', 'c'),
+    mediumtext: Schema.String,
+    mediumtextEnum: Schema.Literal('a', 'b', 'c'),
+    longtext: Schema.String,
+    longtextEnum: Schema.Literal('a', 'b', 'c'),
+    time: Schema.String,
+    timestamp: Schema.DateFromSelf,
+    timestampString: Schema.String,
+    tinyint: Schema.Number,
+    varbinary: Schema.String.pipe(Schema.maxLength(200)),
+    varchar: Schema.String.pipe(Schema.maxLength(200)),
+    varcharEnum: Schema.Literal('a', 'b', 'c'),
+    year: Schema.Number,
+    autoIncrement: Schema.Number,
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});

--- a/drizzle-effect/tests/pg.test.ts
+++ b/drizzle-effect/tests/pg.test.ts
@@ -1,0 +1,211 @@
+import { Schema } from '@effect/schema';
+import {
+  char,
+  date,
+  integer,
+  pgEnum,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import { Either } from 'effect';
+import { expect, test } from 'vitest';
+import { createInsertSchema, createSelectSchema } from '../src/index.ts';
+import { expectSchemaShape } from './utils.ts';
+
+export const roleEnum = pgEnum('role', ['admin', 'user']);
+
+const emailRegex = /[^ @]+@[^ .@]+\.[^ .@]+/;
+
+const users = pgTable('users', {
+  a: integer('a').array(),
+  id: serial('id').primaryKey(),
+  name: text('name'),
+  email: text('email').notNull(),
+  birthdayString: date('birthday_string').notNull(),
+  birthdayDate: date('birthday_date', { mode: 'date' }).notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  role: roleEnum('role').notNull(),
+  roleText: text('role1', { enum: ['admin', 'user'] }).notNull(),
+  roleText2: text('role2', { enum: ['admin', 'user'] })
+    .notNull()
+    .default('user'),
+  profession: varchar('profession', { length: 20 }).notNull(),
+  initials: char('initials', { length: 2 }).notNull(),
+});
+
+const testUser = {
+  a: [1, 2, 3],
+  id: 1,
+  name: 'John Doe',
+  email: 'john.doe@example.com',
+  birthdayString: '1990-01-01',
+  birthdayDate: new Date('1990-01-01'),
+  createdAt: new Date(),
+  role: 'admin' as const,
+  roleText: 'admin' as const,
+  roleText2: 'admin' as const,
+  profession: 'Software Engineer',
+  initials: 'JD',
+};
+
+test('is an instance of `Schema.Struct`', () => {
+  const schema = createInsertSchema(users).pick('role', 'initials');
+
+  const decode = Schema.decodeEither(schema);
+
+  expect(Either.isRight(decode(testUser))).toBeTruthy();
+  expect(
+    Either.isRight(decode({ initials: 'AM', role: 'admin' })),
+  ).toBeTruthy();
+
+  expect(Either.isRight(Schema.decodeUnknownEither(schema)({}))).toBeFalsy();
+  expect(
+    Either.isRight(
+      decode(testUser, {
+        onExcessProperty: 'error',
+      }),
+    ),
+  ).toBeFalsy();
+});
+
+test('users insert valid user', () => {
+  const schema = createInsertSchema(users);
+
+  const result = Schema.decodeEither(schema)(testUser);
+
+  expect(Either.isRight(result)).toBeTruthy();
+});
+
+test('users insert invalid varchar', () => {
+  const schema = createInsertSchema(users);
+
+  expect(
+    Either.isRight(
+      Schema.decodeUnknownEither(schema)({
+        ...testUser,
+        profession: 'Chief Executive Officer',
+      }),
+    ),
+  ).toBeFalsy();
+});
+
+test('users insert invalid char', () => {
+  const schema = createInsertSchema(users);
+
+  expect(
+    Either.isRight(
+      Schema.decodeUnknownEither(schema)({ ...testUser, initials: 'JoDo' }),
+    ),
+  ).toBeFalsy();
+});
+
+test('users insert schema', (t) => {
+  const actual = createInsertSchema(users, {
+    id: ({ id }) => id.pipe(Schema.positive()),
+    email: ({ email }) => email.pipe(Schema.pattern(emailRegex)),
+    roleText: Schema.Literal('user', 'manager', 'admin'),
+  });
+
+  () => {
+    {
+      createInsertSchema(users, {
+        // @ts-expect-error (missing property)
+        foobar: Schema.Number,
+      });
+    }
+
+    {
+      createInsertSchema(users, {
+        // @ts-expect-error (invalid type)
+        id: 123,
+      });
+    }
+  };
+
+  const expected = Schema.Struct({
+    a: Schema.optional(Schema.NullOr(Schema.Array(Schema.Number))),
+    id: Schema.optional(Schema.Number.pipe(Schema.positive())),
+    name: Schema.optional(Schema.NullOr(Schema.String)),
+    email: Schema.String.pipe(Schema.pattern(emailRegex)),
+    birthdayString: Schema.String,
+    birthdayDate: Schema.DateFromSelf,
+    createdAt: Schema.optional(Schema.DateFromSelf),
+    role: Schema.Literal('admin', 'user'),
+    roleText: Schema.Literal('user', 'manager', 'admin'),
+    roleText2: Schema.optional(Schema.Literal('admin', 'user')),
+    profession: Schema.String.pipe(Schema.maxLength(20)),
+    initials: Schema.String.pipe(Schema.maxLength(2)),
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});
+
+test('users insert schema w/ defaults', (t) => {
+  const actual = createInsertSchema(users);
+
+  const expected = Schema.Struct({
+    a: Schema.optional(Schema.NullOr(Schema.Array(Schema.Number))),
+    id: Schema.optional(Schema.Number),
+    name: Schema.optional(Schema.NullOr(Schema.String)),
+    email: Schema.String,
+    birthdayString: Schema.String,
+    birthdayDate: Schema.DateFromSelf,
+    createdAt: Schema.optional(Schema.DateFromSelf),
+    role: Schema.Literal('admin', 'user'),
+    roleText: Schema.Literal('admin', 'user'),
+    roleText2: Schema.optional(Schema.Literal('admin', 'user')),
+    profession: Schema.String.pipe(Schema.maxLength(20)),
+    initials: Schema.String.pipe(Schema.maxLength(2)),
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});
+
+test('users select schema w/ defaults', (t) => {
+  const actual = createSelectSchema(users);
+
+  const expected = Schema.Struct({
+    a: Schema.NullOr(Schema.Array(Schema.Number)),
+    id: Schema.Number,
+    name: Schema.NullOr(Schema.String),
+    email: Schema.String,
+    birthdayString: Schema.String,
+    birthdayDate: Schema.DateFromSelf,
+    createdAt: Schema.DateFromSelf,
+    role: Schema.Literal('admin', 'user'),
+    roleText: Schema.Literal('admin', 'user'),
+    roleText2: Schema.Literal('admin', 'user'),
+    profession: Schema.String.pipe(Schema.maxLength(20)),
+    initials: Schema.String.pipe(Schema.maxLength(2)),
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});
+
+test('users select schema', (t) => {
+  const actual = createSelectSchema(users, {
+    id: ({ id }) => id.pipe(Schema.positive()),
+    email: ({ email }) => email.pipe(Schema.pattern(emailRegex)),
+    roleText: Schema.Literal('user', 'manager', 'admin'),
+  });
+
+  const expected = Schema.Struct({
+    a: Schema.NullOr(Schema.Array(Schema.Number)),
+    id: Schema.Number.pipe(Schema.positive()),
+    name: Schema.NullOr(Schema.String),
+    email: Schema.String.pipe(Schema.pattern(emailRegex)),
+    birthdayString: Schema.String,
+    birthdayDate: Schema.DateFromSelf,
+    createdAt: Schema.DateFromSelf,
+    role: Schema.Literal('admin', 'user'),
+    roleText: Schema.Literal('user', 'manager', 'admin'),
+    roleText2: Schema.Literal('admin', 'user'),
+    profession: Schema.String.pipe(Schema.maxLength(20)),
+    initials: Schema.String.pipe(Schema.maxLength(2)),
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});

--- a/drizzle-effect/tests/sqlite.test.ts
+++ b/drizzle-effect/tests/sqlite.test.ts
@@ -1,0 +1,204 @@
+import { Schema } from '@effect/schema';
+import {
+  blob,
+  integer,
+  numeric,
+  real,
+  sqliteTable,
+  text,
+} from 'drizzle-orm/sqlite-core';
+import { Either } from 'effect';
+import { expect, test } from 'vitest';
+import { createInsertSchema, createSelectSchema, Json } from '../src/index.ts';
+import { expectSchemaShape } from './utils.ts';
+
+const blobJsonSchema = Schema.Struct({
+  foo: Schema.String,
+});
+
+const users = sqliteTable('users', {
+  id: integer('id').primaryKey(),
+  boolean: integer('boolean', { mode: 'boolean' }).notNull(),
+  blobJson: blob('blob', { mode: 'json' })
+    .$type<Schema.Schema.Type<typeof blobJsonSchema>>()
+    .notNull(),
+  blobBigInt: blob('blob', { mode: 'bigint' }).notNull(),
+
+  numeric: numeric('numeric').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  createdAtMs: integer('created_at_ms', { mode: 'timestamp_ms' }).notNull(),
+  real: real('real').notNull(),
+  text: text('text', { length: 255 }),
+  role: text('role', { enum: ['admin', 'user'] })
+    .notNull()
+    .default('user'),
+});
+
+const testUser = {
+  id: 1,
+  blobJson: { foo: 'bar' },
+  blobBigInt: BigInt(123),
+  numeric: '123.45',
+  createdAt: new Date(),
+  createdAtMs: new Date(),
+  boolean: true,
+  real: 123.45,
+  text: 'foobar',
+  role: 'admin' as const,
+};
+
+test('is an instance of `Schema.Struct`', () => {
+  const schema = createInsertSchema(users).pick('role', 'boolean');
+
+  const decode = Schema.decodeEither(schema);
+
+  expect(Either.isRight(decode(testUser))).toBeTruthy();
+  expect(Either.isRight(decode({ boolean: false, role: 'user' }))).toBeTruthy();
+
+  expect(Either.isRight(Schema.decodeUnknownEither(schema)({}))).toBeFalsy();
+  expect(
+    Either.isRight(
+      decode(testUser, {
+        onExcessProperty: 'error',
+      }),
+    ),
+  ).toBeFalsy();
+});
+
+test('users insert valid user', () => {
+  const schema = createInsertSchema(users);
+
+  const result = Schema.decodeEither(schema)(testUser);
+
+  expect(Either.isRight(result)).toBeTruthy();
+});
+
+test('users insert invalid text length', () => {
+  const schema = createInsertSchema(users);
+
+  const result = Schema.decodeEither(schema)({
+    ...testUser,
+    text: 'a'.repeat(256),
+  });
+
+  expect(Either.isRight(result)).toBeFalsy();
+});
+
+test('users insert schema', (t) => {
+  const actual = createInsertSchema(users, {
+    id: ({ id }) => id.pipe(Schema.positive()),
+    blobJson: blobJsonSchema,
+    role: Schema.Literal('admin', 'manager', 'user'),
+  });
+
+  () => {
+    {
+      createInsertSchema(users, {
+        // @ts-expect-error (unknown property)
+        foobar: Schema.Number,
+      });
+    }
+
+    {
+      createInsertSchema(users, {
+        // @ts-expect-error (invalid type)
+        id: 123,
+      });
+    }
+  };
+
+  const expected = Schema.Struct({
+    id: Schema.optional(Schema.Number.pipe(Schema.positive())),
+    blobJson: blobJsonSchema,
+    blobBigInt: Schema.BigIntFromSelf,
+    numeric: Schema.String,
+    createdAt: Schema.DateFromSelf,
+    createdAtMs: Schema.DateFromSelf,
+    boolean: Schema.Boolean,
+    real: Schema.Number,
+    text: Schema.optional(
+      Schema.NullOr(Schema.String.pipe(Schema.maxLength(255))),
+    ),
+    role: Schema.optional(Schema.Literal('admin', 'manager', 'user')),
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});
+
+test('users insert schema w/ defaults', (t) => {
+  const actual = createInsertSchema(users);
+
+  const expected = Schema.Struct({
+    id: Schema.optional(Schema.Number),
+    blobJson: Json,
+    blobBigInt: Schema.BigIntFromSelf,
+    numeric: Schema.String,
+    createdAt: Schema.DateFromSelf,
+    createdAtMs: Schema.DateFromSelf,
+    boolean: Schema.Boolean,
+    real: Schema.Number,
+    text: Schema.optional(
+      Schema.NullOr(Schema.String.pipe(Schema.maxLength(255))),
+    ),
+    role: Schema.optional(Schema.Literal('admin', 'user')),
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});
+
+test('users select schema w/ defaults', (t) => {
+  const actual = createSelectSchema(users);
+
+  const expected = Schema.Struct({
+    id: Schema.Number,
+    blobJson: Json,
+    blobBigInt: Schema.BigIntFromSelf,
+    numeric: Schema.String,
+    createdAt: Schema.DateFromSelf,
+    createdAtMs: Schema.DateFromSelf,
+    boolean: Schema.Boolean,
+    real: Schema.Number,
+    text: Schema.NullOr(Schema.String.pipe(Schema.maxLength(255))),
+    role: Schema.Literal('admin', 'user'),
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});
+
+test('users select schema', (t) => {
+  const actual = createSelectSchema(users, {
+    blobJson: Json,
+    role: Schema.Literal('admin', 'manager', 'user'),
+  });
+
+  () => {
+    {
+      createSelectSchema(users, {
+        // @ts-expect-error (missing property)
+        foobar: z.number(),
+      });
+    }
+
+    {
+      createSelectSchema(users, {
+        // @ts-expect-error (invalid type)
+        id: 123,
+      });
+    }
+  };
+
+  const expected = Schema.Struct({
+    id: Schema.Number,
+    blobJson: Json,
+    blobBigInt: Schema.BigIntFromSelf,
+    numeric: Schema.String,
+    createdAt: Schema.DateFromSelf,
+    createdAtMs: Schema.DateFromSelf,
+    boolean: Schema.Boolean,
+    real: Schema.Number,
+    text: Schema.NullOr(Schema.String.pipe(Schema.maxLength(255))),
+    role: Schema.Literal('admin', 'manager', 'user'),
+  });
+
+  expectSchemaShape(t, expected).from(actual);
+});

--- a/drizzle-effect/tests/tsconfig.json
+++ b/drizzle-effect/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"target": "esnext",
+		"noEmit": true,
+		"rootDir": "..",
+		"outDir": "./.cache"
+	},
+	"include": [".", "../src"]
+}

--- a/drizzle-effect/tests/utils.ts
+++ b/drizzle-effect/tests/utils.ts
@@ -1,0 +1,18 @@
+import { expect, type TaskContext } from 'vitest';
+import type { Schema } from '@effect/schema';
+
+const replacer = (_: string, value: any) =>
+  typeof value === 'bigint' ? Number(value) : value;
+
+export function expectSchemaShape<T>(
+  t: TaskContext,
+  expected: Schema.Schema<T>,
+) {
+  return {
+    from(actual: Schema.Schema<T>) {
+      expect(JSON.stringify(actual.ast, replacer, 2)).toBe(
+        JSON.stringify(expected.ast, replacer, 2),
+      );
+    },
+  };
+}

--- a/drizzle-effect/tsconfig.build.json
+++ b/drizzle-effect/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "src"
+	},
+	"include": ["src"]
+}

--- a/drizzle-effect/tsconfig.json
+++ b/drizzle-effect/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+     "strict": true,
+    "exactOptionalPropertyTypes": true,
+		"outDir": "dist",
+		"baseUrl": ".",
+		"declaration": true,
+		"paths": {
+			"~/*": ["src/*"]
+		}
+	},
+	"include": ["src", "*.ts"]
+}

--- a/drizzle-effect/vitest.config.ts
+++ b/drizzle-effect/vitest.config.ts
@@ -1,0 +1,25 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: [
+			'tests/**/*.test.ts',
+		],
+		exclude: [
+			'tests/bun/**/*',
+		],
+		typecheck: {
+			tsconfig: 'tsconfig.json',
+		},
+		testTimeout: 100000,
+		hookTimeout: 100000,
+		isolate: false,
+		poolOptions: {
+			threads: {
+				singleThread: true,
+			},
+		},
+	},
+	plugins: [tsconfigPaths()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,45 @@ importers:
         specifier: ^7.2.2
         version: 7.2.2
 
+  drizzle-schema:
+    devDependencies:
+      '@effect/schema':
+        specifier: ^0.68.26
+        version: 0.68.26(effect@3.5.6)
+      '@rollup/plugin-terser':
+        specifier: ^0.4.1
+        version: 0.4.1(rollup@3.27.2)
+      '@rollup/plugin-typescript':
+        specifier: ^11.1.0
+        version: 11.1.1(rollup@3.27.2)(tslib@2.6.2)(typescript@5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme))
+      '@types/node':
+        specifier: ^18.15.10
+        version: 18.19.33
+      cpy:
+        specifier: ^10.1.0
+        version: 10.1.0
+      drizzle-orm:
+        specifier: link:../drizzle-orm/dist
+        version: link:../drizzle-orm/dist
+      effect:
+        specifier: ^3.5.6
+        version: 3.5.6
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.0
+      rollup:
+        specifier: ^3.20.7
+        version: 3.27.2
+      vite-tsconfig-paths:
+        specifier: ^4.3.2
+        version: 4.3.2(typescript@5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme))(vite@5.3.3(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0))
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.0(@types/node@18.19.33)(@vitest/ui@1.6.0)(lightningcss@1.25.1)(terser@5.31.0)
+      zx:
+        specifier: ^7.2.2
+        version: 7.2.2
+
   drizzle-typebox:
     devDependencies:
       '@rollup/plugin-terser':
@@ -1741,6 +1780,11 @@ packages:
   '@drizzle-team/studio@0.0.5':
     resolution: {integrity: sha512-ps5qF0tMxWRVu+V5gvCRrQNqlY92aTnIKdq27gm9LZMSdaKYZt6AVvSK1dlUMzs6Rt0Jm80b+eWct6xShBKhIw==}
 
+  '@effect/schema@0.68.26':
+    resolution: {integrity: sha512-o1O/ZmlHXRe9t548YrQ9sudjRWJqCtsU9KnQHzvZm5pHSc4reuZVQufCXctcR0aETf9OFOYUuETrxjEQehq/Lg==}
+    peerDependencies:
+      effect: ^3.5.6
+
   '@electric-sql/pglite@0.1.5':
     resolution: {integrity: sha512-eymv4ONNvoPZQTvOQIi5dbpR+J5HzEv0qQH9o/y3gvNheJV/P/NFcrbsfJZYTsDKoq7DKrTiFNexsRkJKy8x9Q==}
 
@@ -2418,10 +2462,12 @@ packages:
   '@humanwhocodes/config-array@0.11.11':
     resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/config-array@0.11.13':
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -2429,9 +2475,11 @@ packages:
 
   '@humanwhocodes/object-schema@1.2.1':
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/object-schema@2.0.1':
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+    deprecated: Use @eslint/object-schema instead
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
@@ -3761,6 +3809,7 @@ packages:
   are-we-there-yet@3.0.1:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -4690,6 +4739,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.5.6:
+    resolution: {integrity: sha512-3PMiC+XMaLkHx9Nlxfr6ot/8/gVq9aEjMlBvyKzJx0p4h1ZyNEjPxvAZQ9tlxAtXBvmfRpmIwHxG99hi8qhEtQ==}
+
   electron-to-chromium@1.4.783:
     resolution: {integrity: sha512-bT0jEz/Xz1fahQpbZ1D7LgmPYZ3iHVY39NcWWro1+hA2IvjiPeaXtfSqrQ+nXjApMvQRE2ASt1itSLRrebHMRQ==}
 
@@ -5185,6 +5237,10 @@ packages:
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
+  fast-check@3.20.0:
+    resolution: {integrity: sha512-pZIjqLpOZgdSLecec4GKC3Zq5702MZ34upMKxojnNVSWA0K64V3pXOBT1Wdsrc3AphLtzRBbsi8bRWF4TUGmUg==}
+    engines: {node: '>=8.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -5410,6 +5466,7 @@ packages:
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -5506,13 +5563,16 @@ packages:
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -5731,6 +5791,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -6910,6 +6971,7 @@ packages:
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   npx-import@1.1.4:
     resolution: {integrity: sha512-3ShymTWOgqGyNlh5lMJAejLuIv3W1K3fbI5Ewc6YErZU3Sp0PqsNs8UIU1O8z5+KVl/Du5ag56Gza9vdorGEoA==}
@@ -7441,6 +7503,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
     hasBin: true
@@ -7697,6 +7762,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@5.0.0:
@@ -9217,8 +9283,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.583.0
-      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
+      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
+      '@aws-sdk/client-sts': 3.583.0
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -9304,11 +9370,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.583.0':
+  '@aws-sdk/client-sso-oidc@3.583.0(@aws-sdk/client-sts@3.583.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
+      '@aws-sdk/client-sts': 3.583.0
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -9347,6 +9413,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.2
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.478.0':
@@ -9613,11 +9680,11 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/client-sts@3.583.0(@aws-sdk/client-sso-oidc@3.583.0)':
+  '@aws-sdk/client-sts@3.583.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.583.0
+      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/core': 3.582.0
       '@aws-sdk/credential-provider-node': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -9656,7 +9723,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.2
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.477.0':
@@ -9811,7 +9877,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.583.0(@aws-sdk/client-sso-oidc@3.583.0)(@aws-sdk/client-sts@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
+      '@aws-sdk/client-sts': 3.583.0
       '@aws-sdk/credential-provider-env': 3.577.0
       '@aws-sdk/credential-provider-process': 3.577.0
       '@aws-sdk/credential-provider-sso': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
@@ -10018,7 +10084,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.577.0(@aws-sdk/client-sts@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.583.0(@aws-sdk/client-sso-oidc@3.583.0)
+      '@aws-sdk/client-sts': 3.583.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.0.0
       '@smithy/types': 3.0.0
@@ -10219,7 +10285,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.568.0(@aws-sdk/client-sso-oidc@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.583.0
+      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/types': 3.567.0
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
@@ -10228,7 +10294,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.577.0(@aws-sdk/client-sso-oidc@3.583.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.583.0
+      '@aws-sdk/client-sso-oidc': 3.583.0(@aws-sdk/client-sts@3.583.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.0.0
       '@smithy/shared-ini-file-loader': 3.0.0
@@ -11351,6 +11417,11 @@ snapshots:
     optional: true
 
   '@drizzle-team/studio@0.0.5': {}
+
+  '@effect/schema@0.68.26(effect@3.5.6)':
+    dependencies:
+      effect: 3.5.6
+      fast-check: 3.20.0
 
   '@electric-sql/pglite@0.1.5': {}
 
@@ -14924,6 +14995,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effect@3.5.6: {}
+
   electron-to-chromium@1.4.783: {}
 
   emittery@1.0.3: {}
@@ -15716,6 +15789,10 @@ snapshots:
   ext@1.7.0:
     dependencies:
       type: 2.7.2
+
+  fast-check@3.20.0:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -18080,6 +18157,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pure-rand@6.1.0: {}
+
   qrcode-terminal@0.11.0: {}
 
   qs@6.11.0:
@@ -19458,6 +19537,23 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@1.6.0(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.1
+      vite: 5.3.3(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@1.6.0(@types/node@20.10.1)(lightningcss@1.25.1)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
@@ -19503,6 +19599,17 @@ snapshots:
       - supports-color
       - typescript
 
+  vite-tsconfig-paths@4.3.2(typescript@5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme))(vite@5.3.3(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0)):
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 3.0.3(typescript@5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme))
+    optionalDependencies:
+      vite: 5.3.3(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   vite-tsconfig-paths@4.3.2(typescript@5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme))(vite@5.3.3(@types/node@20.12.12)(lightningcss@1.25.1)(terser@5.31.0)):
     dependencies:
       debug: 4.3.4
@@ -19521,6 +19628,17 @@ snapshots:
       rollup: 4.18.0
     optionalDependencies:
       '@types/node': 18.15.10
+      fsevents: 2.3.3
+      lightningcss: 1.25.1
+      terser: 5.31.0
+
+  vite@5.2.12(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0):
+    dependencies:
+      esbuild: 0.20.2
+      postcss: 8.4.38
+      rollup: 4.18.0
+    optionalDependencies:
+      '@types/node': 18.19.33
       fsevents: 2.3.3
       lightningcss: 1.25.1
       terser: 5.31.0
@@ -19554,6 +19672,17 @@ snapshots:
       rollup: 4.18.0
     optionalDependencies:
       '@types/node': 18.15.10
+      fsevents: 2.3.3
+      lightningcss: 1.25.1
+      terser: 5.31.0
+
+  vite@5.3.3(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.39
+      rollup: 4.18.0
+    optionalDependencies:
+      '@types/node': 18.19.33
       fsevents: 2.3.3
       lightningcss: 1.25.1
       terser: 5.31.0
@@ -19604,6 +19733,40 @@ snapshots:
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 18.15.10
+      '@vitest/ui': 1.6.0(vitest@1.6.0)
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@1.6.0(@types/node@18.19.33)(@vitest/ui@1.6.0)(lightningcss@1.25.1)(terser@5.31.0):
+    dependencies:
+      '@vitest/expect': 1.6.0
+      '@vitest/runner': 1.6.0
+      '@vitest/snapshot': 1.6.0
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
+      acorn-walk: 8.3.2
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      tinybench: 2.8.0
+      tinypool: 0.8.4
+      vite: 5.2.12(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0)
+      vite-node: 1.6.0(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0)
+      why-is-node-running: 2.2.2
+    optionalDependencies:
+      '@types/node': 18.19.33
       '@vitest/ui': 1.6.0(vitest@1.6.0)
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,45 @@ importers:
         specifier: 5.4.5
         version: 5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme)
 
+  drizzle-effect:
+    devDependencies:
+      '@effect/schema':
+        specifier: ^0.69.1
+        version: 0.69.1(effect@3.5.6)
+      '@rollup/plugin-terser':
+        specifier: ^0.4.1
+        version: 0.4.1(rollup@3.27.2)
+      '@rollup/plugin-typescript':
+        specifier: ^11.1.0
+        version: 11.1.1(rollup@3.27.2)(tslib@2.6.2)(typescript@5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme))
+      '@types/node':
+        specifier: ^18.15.10
+        version: 18.19.33
+      cpy:
+        specifier: ^10.1.0
+        version: 10.1.0
+      drizzle-orm:
+        specifier: link:../drizzle-orm/dist
+        version: link:../drizzle-orm/dist
+      effect:
+        specifier: ^3.5.6
+        version: 3.5.6
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.0
+      rollup:
+        specifier: ^3.20.7
+        version: 3.27.2
+      vite-tsconfig-paths:
+        specifier: ^4.3.2
+        version: 4.3.2(typescript@5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme))(vite@5.3.3(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0))
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.0(@types/node@18.19.33)(@vitest/ui@1.6.0)(lightningcss@1.25.1)(terser@5.31.0)
+      zx:
+        specifier: ^7.2.2
+        version: 7.2.2
+
   drizzle-orm:
     devDependencies:
       '@aws-sdk/client-rds-data':
@@ -199,45 +238,6 @@ importers:
       zod:
         specifier: ^3.20.2
         version: 3.23.7
-      zx:
-        specifier: ^7.2.2
-        version: 7.2.2
-
-  drizzle-schema:
-    devDependencies:
-      '@effect/schema':
-        specifier: ^0.68.26
-        version: 0.68.26(effect@3.5.6)
-      '@rollup/plugin-terser':
-        specifier: ^0.4.1
-        version: 0.4.1(rollup@3.27.2)
-      '@rollup/plugin-typescript':
-        specifier: ^11.1.0
-        version: 11.1.1(rollup@3.27.2)(tslib@2.6.2)(typescript@5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme))
-      '@types/node':
-        specifier: ^18.15.10
-        version: 18.19.33
-      cpy:
-        specifier: ^10.1.0
-        version: 10.1.0
-      drizzle-orm:
-        specifier: link:../drizzle-orm/dist
-        version: link:../drizzle-orm/dist
-      effect:
-        specifier: ^3.5.6
-        version: 3.5.6
-      rimraf:
-        specifier: ^5.0.0
-        version: 5.0.0
-      rollup:
-        specifier: ^3.20.7
-        version: 3.27.2
-      vite-tsconfig-paths:
-        specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.5(patch_hash=q3iy4fwdhi5sis3wty7d4nbsme))(vite@5.3.3(@types/node@18.19.33)(lightningcss@1.25.1)(terser@5.31.0))
-      vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.19.33)(@vitest/ui@1.6.0)(lightningcss@1.25.1)(terser@5.31.0)
       zx:
         specifier: ^7.2.2
         version: 7.2.2
@@ -1780,10 +1780,10 @@ packages:
   '@drizzle-team/studio@0.0.5':
     resolution: {integrity: sha512-ps5qF0tMxWRVu+V5gvCRrQNqlY92aTnIKdq27gm9LZMSdaKYZt6AVvSK1dlUMzs6Rt0Jm80b+eWct6xShBKhIw==}
 
-  '@effect/schema@0.68.26':
-    resolution: {integrity: sha512-o1O/ZmlHXRe9t548YrQ9sudjRWJqCtsU9KnQHzvZm5pHSc4reuZVQufCXctcR0aETf9OFOYUuETrxjEQehq/Lg==}
+  '@effect/schema@0.69.1':
+    resolution: {integrity: sha512-+Gq3KrQh02B8nxUnha9Df8lCwKwWnK2XgEk7JDY+67/BrJSbGxVf0TjBRRJdlsH8xsqJ+HkCApSngGKPXbWDVQ==}
     peerDependencies:
-      effect: ^3.5.6
+      effect: ^3.5.7
 
   '@electric-sql/pglite@0.1.5':
     resolution: {integrity: sha512-eymv4ONNvoPZQTvOQIi5dbpR+J5HzEv0qQH9o/y3gvNheJV/P/NFcrbsfJZYTsDKoq7DKrTiFNexsRkJKy8x9Q==}
@@ -11418,7 +11418,7 @@ snapshots:
 
   '@drizzle-team/studio@0.0.5': {}
 
-  '@effect/schema@0.68.26(effect@3.5.6)':
+  '@effect/schema@0.69.1(effect@3.5.6)':
     dependencies:
       effect: 3.5.6
       fast-check: 3.20.0
@@ -13842,7 +13842,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.0.1
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.12.12)(@vitest/ui@1.6.0)(lightningcss@1.25.1)(terser@5.31.0)
+      vitest: 1.6.0(@types/node@18.19.33)(@vitest/ui@1.6.0)(lightningcss@1.25.1)(terser@5.31.0)
 
   '@vitest/utils@1.6.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 packages:
   - drizzle-orm
   - drizzle-zod
-  - drizzle-schema
+  - drizzle-effect
   - drizzle-typebox
   - drizzle-valibot
   - integration-tests

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - drizzle-orm
   - drizzle-zod
+  - drizzle-schema
   - drizzle-typebox
   - drizzle-valibot
   - integration-tests


### PR DESCRIPTION
This is a proposal to add a package similar to `drizzle-zod` and heavily based on it, with analogical features, integrated with the [effect ecosystem](https://effect.website), [@effect/schema documentation](https://github.com/effect-ts/effect/tree/main/packages/schema).

This is a new version of [this pull request](https://github.com/drizzle-team/drizzle-orm/pull/2613)

One big difference is I would like this to have MIT license if possible.

Feature requests:
https://github.com/drizzle-team/drizzle-orm/issues/2187
https://github.com/Effect-TS/effect/issues/3208

todo:
 - [x] insert schemas
 - [x] insert refine
 - [x] select schemas
 - [x] select refine
 - [x] schema is an instance of `Schema.Struct`
 - [x] package cleanup
 
todos in case of interest in merging:
 - [ ] review [this discord comment](https://discord.com/channels/795981131316985866/1293508500332216350/1293560618502066226)
 - [ ] upgrade to `Schema` from core `effect`