### PR TITLE
Mark drivers for querying as external in esbuild config

### DIFF
--- a/drizzle-kit/build.dev.ts
+++ b/drizzle-kit/build.dev.ts
@@ -1,6 +1,15 @@
 import * as esbuild from 'esbuild';
 import { cpSync } from 'node:fs';
 
+const driversPackages = [
+	// postgres drivers
+	"pg", "postgres", "@vercel/postgres", "@neondatabase/serverless",
+	//  mysql drivers
+	"mysql2", "@planetscale/database",
+	// sqlite drivers
+	"@libsql/client", "better-sqlite3"
+];
+
 esbuild.buildSync({
 	entryPoints: ['./src/utils.ts'],
 	bundle: true,
@@ -8,7 +17,7 @@ esbuild.buildSync({
 	format: 'cjs',
 	target: 'node16',
 	platform: 'node',
-	external: ['drizzle-orm', 'pg-native', 'esbuild'],
+	external: ['drizzle-orm', 'esbuild', ...driversPackages],
 	banner: {
 		js: `#!/usr/bin/env -S node --loader @esbuild-kit/esm-loader --no-warnings`,
 	},
@@ -27,8 +36,7 @@ esbuild.buildSync({
 		'glob',
 		'esbuild',
 		'drizzle-orm',
-		'pg-native',
-		'better-sqlite3',
+		...driversPackages
 	],
 	banner: {
 		js: `#!/usr/bin/env -S node --loader ./dist/loader.mjs --no-warnings`,

--- a/drizzle-kit/build.ts
+++ b/drizzle-kit/build.ts
@@ -3,6 +3,15 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import * as tsup from 'tsup';
 import pkg from './package.json';
 
+const driversPackages = [
+	// postgres drivers
+	"pg", "postgres", "@vercel/postgres", "@neondatabase/serverless",
+	//  mysql drivers
+	"mysql2", "@planetscale/database",
+	// sqlite drivers
+	"@libsql/client", "better-sqlite3"
+];
+
 esbuild.buildSync({
 	entryPoints: ['./src/utils.ts'],
 	bundle: true,
@@ -11,14 +20,12 @@ esbuild.buildSync({
 	target: 'node16',
 	platform: 'node',
 	external: [
-		'@libsql/client',
 		'commander',
 		'json-diff',
 		'glob',
 		'esbuild',
 		'drizzle-orm',
-		'pg-native',
-		'better-sqlite3',
+		...driversPackages
 	],
 	banner: {
 		js: `#!/usr/bin/env node`,
@@ -33,14 +40,12 @@ esbuild.buildSync({
 	target: 'node16',
 	platform: 'node',
 	external: [
-		'@libsql/client',
 		'commander',
 		'json-diff',
 		'glob',
 		'esbuild',
 		'drizzle-orm',
-		'pg-native',
-		'better-sqlite3',
+		...driversPackages
 	],
 	banner: {
 		js: `#!/usr/bin/env node`,
@@ -58,11 +63,9 @@ esbuild.buildSync({
 		'process.env.DRIZZLE_KIT_VERSION': `"${pkg.version}"`,
 	},
 	external: [
-		'@libsql/client',
 		'esbuild',
 		'drizzle-orm',
-		'pg-native',
-		'better-sqlite3',
+		...driversPackages
 	],
 	banner: {
 		js: `#!/usr/bin/env node`,


### PR DESCRIPTION
Part of https://github.com/drizzle-team/drizzle-orm/issues/2722

This function checks if it is possible to import this package

```ts
checkPackage = async (it) => {
      try {
        await import(it);
        return true;
      } catch (e2) {
        return false;
      }
    };
```

But since these packages are not marked as external, esbuild includes them in the build, which uselessly inflates the weight of the package

```ts
if (await checkPackage("pg")) {
        console.log(withStyle.info(`Using 'pg' driver for database querying`));
        const pg = await Promise.resolve().then(() => __toESM(require_lib4()));
        // ....
```

![image](https://github.com/user-attachments/assets/a45c1fa7-e6e3-42f0-9114-3cba7556cf40)

As a result, it turns out that it checks if the package is installed but does not use it

### Before

![image](https://github.com/user-attachments/assets/0ce8affe-433c-4f7f-a7f6-1478cbcee12d)


### After 

![image](https://github.com/user-attachments/assets/da8ce3c8-d5ab-4c0b-8e13-62d6c7bfe0e6)
