### PR TITLE
bugfix: Fix a bug with default values for columns of type string

### DIFF
--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -481,7 +481,7 @@ export const fromDatabase = async (
 			default: columnDefault === null
 				? undefined
 				: /^-?[\d.]+(?:e-?\d+)?$/.test(columnDefault)
-						&& !columnType.startsWith('decimal')
+						&& !['decimal', 'char', 'varchar'].some(type => columnType.startsWith(type))
 				? Number(columnDefault)
 				: isDefaultAnExpression
 				? clearDefaults(columnDefault, collation)

--- a/drizzle-kit/tests/introspect/mysql.test.ts
+++ b/drizzle-kit/tests/introspect/mysql.test.ts
@@ -1,6 +1,6 @@
 import Docker from 'dockerode';
 import { SQL, sql } from 'drizzle-orm';
-import { int, mysqlTable, text } from 'drizzle-orm/mysql-core';
+import { int, mysqlTable, text, char, varchar } from 'drizzle-orm/mysql-core';
 import * as fs from 'fs';
 import getPort from 'get-port';
 import { Connection, createConnection } from 'mysql2/promise';
@@ -115,6 +115,48 @@ test('generated always column virtual: link to another column', async () => {
 		client,
 		schema,
 		'generated-link-column-virtual',
+		'drizzle',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+
+	await client.query(`drop table users;`);
+});
+
+test('Default value of character type column: char', async () => {
+	const schema = {
+		users: mysqlTable('users', {
+			id: int('id'),
+			sortKey: char('sortKey', { length: 255 }).default('0'),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectMySQLToFile(
+		client,
+		schema,
+		'default-value-char-column',
+		'drizzle',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+
+	await client.query(`drop table users;`);
+});
+
+test('Default value of character type column: varchar', async () => {
+	const schema = {
+		users: mysqlTable('users', {
+			id: int('id'),
+			sortKey: varchar('sortKey', { length: 255 }).default('0'),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectMySQLToFile(
+		client,
+		schema,
+		'default-value-varchar-column',
 		'drizzle',
 	);
 


### PR DESCRIPTION
close drizzle-team/drizzle-kit-mirror#404

Fixed a bug that caused the default value of a column of type character to be a number instead of a string when the default value was a string consisting only of numbers.