### PR TITLE
bugfix: Fix a bug that caused output without specifying index name

### DIFF
--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -13,7 +13,6 @@ import {
 	PrimaryKey,
 	UniqueConstraint,
 } from './serializer/mysqlSchema';
-import { indexName } from './serializer/mysqlSerializer';
 import { unescapeSingleQuotes } from './utils';
 
 const mysqlImportsList = new Set([
@@ -924,12 +923,9 @@ const createTableIndexes = (
 
 		idxKey = casing(idxKey);
 
-		const indexGeneratedName = indexName(tableName, it.columns);
-		const escapedIndexName = indexGeneratedName === it.name ? '' : `"${it.name}"`;
-
-		statement += `\n\t`;
+		statement += `\t\t${idxKey}: `;
 		statement += it.isUnique ? 'uniqueIndex(' : 'index(';
-		statement += `${escapedIndexName})`;
+		statement += `"${it.name}")`;
 		statement += `.on(${
 			it.columns
 				.map((it) => `table.${casing(it)}`)


### PR DESCRIPTION
close drizzle-team/drizzle-orm#3420

Fixed a bug that caused empty index names to be output when executing the introspect command with auto-generated index names.
This fix is necessary because the specification of the index name is mandatory.
https://github.com/drizzle-team/drizzle-orm/blob/55231b0320d2a42f06a73f3cc49c4f57a8c32885/drizzle-orm/src/mysql-core/indexes.ts#L102-L108