### PR TITLE
fix: use Deno's native TS support

### DIFF
--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -57,6 +57,13 @@ const assertES5 = async (unregister: () => void) => {
 };
 
 export const safeRegister = async () => {
+	// Deno supports loading .ts/.tsx files natively
+	if (process.versions.deno) {
+		return {
+			unregister: () => {},
+		};
+	}
+
 	const { register } = await import('esbuild-register/dist/node');
 	let res: { unregister: () => void };
 	try {
@@ -627,7 +634,7 @@ export const drizzleConfigFromFile = async (
 
 	console.log(chalk.grey(`Reading config file '${path}'`));
 	const { unregister } = await safeRegister();
-	const required = require(`${path}`);
+	const required = await import(`${path}`);
 	const content = required.default ?? required;
 	unregister();
 

--- a/drizzle-kit/src/serializer/mysqlImports.ts
+++ b/drizzle-kit/src/serializer/mysqlImports.ts
@@ -21,7 +21,7 @@ export const prepareFromMySqlImports = async (imports: string[]) => {
 	const { unregister } = await safeRegister();
 	for (let i = 0; i < imports.length; i++) {
 		const it = imports[i];
-		const i0: Record<string, unknown> = require(`${it}`);
+		const i0: Record<string, unknown> = await import(`${it}`);
 		const prepared = prepareFromExports(i0);
 
 		tables.push(...prepared.tables);

--- a/drizzle-kit/src/serializer/pgImports.ts
+++ b/drizzle-kit/src/serializer/pgImports.ts
@@ -40,7 +40,7 @@ export const prepareFromPgImports = async (imports: string[]) => {
 	for (let i = 0; i < imports.length; i++) {
 		const it = imports[i];
 
-		const i0: Record<string, unknown> = require(`${it}`);
+		const i0: Record<string, unknown> = await import(`${it}`);
 		const prepared = prepareFromExports(i0);
 
 		tables.push(...prepared.tables);

--- a/drizzle-kit/src/serializer/sqliteImports.ts
+++ b/drizzle-kit/src/serializer/sqliteImports.ts
@@ -21,7 +21,7 @@ export const prepareFromSqliteImports = async (imports: string[]) => {
 	for (let i = 0; i < imports.length; i++) {
 		const it = imports[i];
 
-		const i0: Record<string, unknown> = require(`${it}`);
+		const i0: Record<string, unknown> = await import(`${it}`);
 		const prepared = prepareFromExports(i0);
 
 		tables.push(...prepared.tables);

--- a/drizzle-kit/src/serializer/studio.ts
+++ b/drizzle-kit/src/serializer/studio.ts
@@ -76,7 +76,7 @@ export const preparePgSchema = async (path: string | string[]) => {
 	for (let i = 0; i < imports.length; i++) {
 		const it = imports[i];
 
-		const i0: Record<string, unknown> = require(`${it}`);
+		const i0: Record<string, unknown> = await import(`${it}`);
 		const i0values = Object.entries(i0);
 
 		i0values.forEach(([k, t]) => {
@@ -114,7 +114,7 @@ export const prepareMySqlSchema = async (path: string | string[]) => {
 	for (let i = 0; i < imports.length; i++) {
 		const it = imports[i];
 
-		const i0: Record<string, unknown> = require(`${it}`);
+		const i0: Record<string, unknown> = await import(`${it}`);
 		const i0values = Object.entries(i0);
 
 		i0values.forEach(([k, t]) => {
@@ -151,7 +151,7 @@ export const prepareSQLiteSchema = async (path: string | string[]) => {
 	for (let i = 0; i < imports.length; i++) {
 		const it = imports[i];
 
-		const i0: Record<string, unknown> = require(`${it}`);
+		const i0: Record<string, unknown> = await import(`${it}`);
 		const i0values = Object.entries(i0);
 
 		i0values.forEach(([k, t]) => {


### PR DESCRIPTION
This PR skips registering the `esbuild` loader when Deno is detected. Deno supports running TypeScript code natively and doesn't need the loader.

I've updated the `require` calls to use `import()` instead as using `require` is not valid in ESM contexts. It only worked when the `esbuild` loader was present.