### PR TITLE
[Pg] Fix introspecting `varchar[]` doesn't parse length correctly

### DIFF
--- a/drizzle-kit/src/introspect-pg.ts
+++ b/drizzle-kit/src/introspect-pg.ts
@@ -740,18 +740,14 @@ const column = (
 		const split = lowered.split(' ');
 
 		let out: string;
-		if (lowered.length !== 7) {
+		const length = lowered.substring(lowered.indexOf('(') + 1, lowered.indexOf(')'))
+		if (length) {
 			out = `${
 				withCasing(
 					name,
 					casing,
 				)
-			}: varchar("${name}", { length: ${
-				lowered.substring(
-					8,
-					lowered.length - 1,
-				)
-			} })`;
+			}: varchar("${name}", { length: ${length} })`;
 		} else {
 			out = `${withCasing(name, casing)}: varchar("${name}")`;
 		}

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -1,6 +1,6 @@
 import { PGlite } from '@electric-sql/pglite';
 import { SQL, sql } from 'drizzle-orm';
-import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { integer, pgTable, text, varchar } from 'drizzle-orm/pg-core';
 import { introspectPgToFile } from 'tests/schemaDiffer';
 import { expect, test } from 'vitest';
 
@@ -181,6 +181,30 @@ test('generated column: link to another column', async () => {
 		client,
 		schema,
 		'generated-link-column',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
+test('varchar array column', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		users: pgTable('users', {
+			id: integer('id').generatedAlwaysAsIdentity(),
+			numbers: integer('numbers').array(),
+			tag: varchar('tag'),
+			tagWithLength: varchar('tag', { length: 64 }),
+			tags: varchar('tags').array(),
+			tagsWithLength: varchar('tags_with_length', { length: 64 }).array()
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'varchar-array-column',
 	);
 
 	expect(statements.length).toBe(0);


### PR DESCRIPTION
Fixes #1633

The change finds length of the varchar by finding `(` and `)` characters, instead of fixed values. It also handles the case when no length is provided.

--- 

I have also considered removing `[]` from the `lowered` variable and that would work with other types also. Here is the commit for that -  https://github.com/drizzle-team/drizzle-orm/commit/79b0609fe801c467f30292a815cd1c039f341df5

Lmk which one you prefer.
