### PR TITLE
[Pg] Add missing support for `vector`, `point` types to `drizzle-zod`

### DIFF
--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -9,7 +9,7 @@ import {
 	type Table,
 } from 'drizzle-orm';
 import { MySqlChar, MySqlVarBinary, MySqlVarChar } from 'drizzle-orm/mysql-core';
-import { type PgArray, PgChar, PgUUID, PgVarchar } from 'drizzle-orm/pg-core';
+import { type PgArray, PgChar, PgPointTuple, PgUUID, PgVarchar, PgVector } from 'drizzle-orm/pg-core';
 import { SQLiteText } from 'drizzle-orm/sqlite-core';
 import { z } from 'zod';
 
@@ -43,9 +43,9 @@ type MaybeOptional<
 type GetZodType<TColumn extends Column> = TColumn['_']['dataType'] extends infer TDataType
 	? TDataType extends 'custom' ? z.ZodAny
 	: TDataType extends 'json' ? z.ZodType<Json>
+	: TDataType extends 'array' ? DetermineArrayType<TColumn>
 	: TColumn extends { enumValues: [string, ...string[]] }
 		? Equal<TColumn['enumValues'], [string, ...string[]]> extends true ? z.ZodString : z.ZodEnum<TColumn['enumValues']>
-	: TDataType extends 'array' ? z.ZodArray<GetZodType<Assume<TColumn['_'], { baseColumn: Column }>['baseColumn']>>
 	: TDataType extends 'bigint' ? z.ZodBigInt
 	: TDataType extends 'number' ? z.ZodNumber
 	: TDataType extends 'string' ? z.ZodString
@@ -53,6 +53,26 @@ type GetZodType<TColumn extends Column> = TColumn['_']['dataType'] extends infer
 	: TDataType extends 'date' ? z.ZodDate
 	: z.ZodAny
 	: never;
+
+
+type MapPrimitiveToZod<T> =
+	T extends number ? z.ZodNumber
+	: T extends string ? z.ZodString
+	: T extends boolean ? z.ZodBoolean
+	: never;
+
+type MaPrimitiveTupleToZod<T extends [...any[]]> =
+	T extends [infer Inner, ...infer Rest] ? [MapPrimitiveToZod<Inner>, ...MaPrimitiveTupleToZod<Rest>]
+	: []
+
+
+type DetermineArrayType<TColumn extends Column> =
+	Assume<TColumn['_'], { baseColumn: Column }>['baseColumn'] extends never ?
+		TColumn["_"]["data"] extends [any, ...any[]] ? z.ZodTuple<MaPrimitiveTupleToZod<TColumn["_"]["data"]>>
+		: TColumn["_"]["data"] extends (infer Inner)[] ? z.ZodArray<MapPrimitiveToZod<Inner>>
+		: never
+	: z.ZodArray<GetZodType<Assume<TColumn['_'], { baseColumn: Column }>['baseColumn']>>;
+
 
 type ValueOrUpdater<T, TUpdaterArg> = T | ((arg: TUpdaterArg) => T);
 

--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -211,6 +211,9 @@ function mapColumnToSchema(column: Column): z.ZodTypeAny {
 		} else if (is(column, PgPointTuple)) {
 			type = z.tuple([z.number(), z.number()]);
 		} else if (column.dataType === 'array') {
+			if (!("baseColumn" in column) || !column["baseColumn"]) {
+				throw new Error(`Expected name: ${column.name}, type: ${column.columnType} to be an array column with a base column but there is no base colum.`);
+			}
 			type = z.array(mapColumnToSchema((column as PgArray<any, any>).baseColumn));
 		} else if (column.dataType === 'number') {
 			type = z.number();

--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -206,6 +206,10 @@ function mapColumnToSchema(column: Column): z.ZodTypeAny {
 			type = z.any();
 		} else if (column.dataType === 'json') {
 			type = jsonSchema;
+		} else if (is(column, PgVector)) {
+			type = z.array(z.number());
+		} else if (is(column, PgPointTuple)) {
+			type = z.tuple([z.number(), z.number()]);
 		} else if (column.dataType === 'array') {
 			type = z.array(mapColumnToSchema((column as PgArray<any, any>).baseColumn));
 		} else if (column.dataType === 'number') {

--- a/drizzle-zod/tests/pg.test.ts
+++ b/drizzle-zod/tests/pg.test.ts
@@ -1,4 +1,4 @@
-import { char, date, integer, pgEnum, pgTable, serial, text, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { char, date, integer, pgEnum, pgTable, point, serial, text, timestamp, varchar, doublePrecision, vector } from 'drizzle-orm/pg-core';
 import { expect, test } from 'vitest';
 import { z } from 'zod';
 import { createInsertSchema, createSelectSchema } from '../src';
@@ -160,4 +160,30 @@ test('users select schema w/ defaults', (t) => {
 	});
 
 	expectSchemaShape(t, expected).from(actual);
+});
+
+
+const arrayTypes = pgTable('special', {
+	vector: vector("vector", { dimensions: 3 }),
+	point: point("point").notNull(),
+	names: text("names").array(),
+	numbers: integer("numbers").array(),
+	doubles: doublePrecision("doubles").array(),
+});
+
+
+test('arrayTypes insert schema', (t) => {
+	const actual = createInsertSchema(arrayTypes);
+
+	const expected = z.object({
+		vector: z.array(z.number()).nullable().optional(),
+		point: z.tuple([z.number(), z.number()]),
+		names: z.array(z.string()).nullable().optional(),
+		numbers: z.array(z.number()).nullable().optional(),
+		doubles: z.array(z.number()).nullable().optional(),
+	});
+
+
+	expectSchemaShape(t, expected).from(actual);
+
 });

--- a/drizzle-zod/tests/utils.ts
+++ b/drizzle-zod/tests/utils.ts
@@ -7,9 +7,9 @@ export function expectSchemaShape<T extends z.ZodRawShape>(t: TaskContext, expec
 			expect(Object.keys(actual.shape)).toStrictEqual(Object.keys(expected.shape));
 
 			for (const key of Object.keys(actual.shape)) {
-				expect(actual.shape[key]!._def.typeName).toStrictEqual(expected.shape[key]?._def.typeName);
+				expect(actual.shape[key]!._def.typeName, `key: ${key}`).toStrictEqual(expected.shape[key]?._def.typeName);
 				if (actual.shape[key]?._def.typeName === 'ZodOptional') {
-					expect(actual.shape[key]!._def.innerType._def.typeName).toStrictEqual(
+					expect(actual.shape[key]!._def.innerType._def.typeName, `key: ${key}`).toStrictEqual(
 						actual.shape[key]!._def.innerType._def.typeName,
 					);
 				}


### PR DESCRIPTION
Currently, `drizzle-zod` excepts any column that has a `dataType` as `"array"` to be an array that also has a `baseColumn`. This turns out to not be true for types such as `vector` and `point`, among others.. which results in passing an `undefined` where none is expected which leads to a runtime crash.

This PR adds a test that replicates the crash, and adds support for `vector` and `point` -- and there might be other types which could be supported similarly easily.

 It also detects the case that was causing a runtime crash and now throws a more useful error message, which would easily flag future cases where the solution is probably just adding yet another `is` check. This is solely based on my own preference, however, so definitely not dying on a hill for that commit.
 
 I also noticed that the resulting types for the schemas were wrong, which I attempted to fix. The result seems very clunky though.
 
 Finally, as an additional optional and very benign improvement, I modified the `expectSchemaShape` to output the names of the keys that fail to match for easier debugging.
 
 Fixes #2424 