### PR TITLE
drizzle-kit/commands/migrate: fix "you code" typo

### DIFF
--- a/drizzle-kit/src/cli/commands/migrate.ts
+++ b/drizzle-kit/src/cli/commands/migrate.ts
@@ -776,7 +776,7 @@ export const writeResult = ({
 
 	if (type === 'custom') {
 		console.log('Prepared empty file for your custom SQL migration!');
-		sql = '-- Custom SQL migration file, put you code below! --';
+		sql = '-- Custom SQL migration file, put your code below! --';
 	}
 
 	journal.entries.push({


### PR DESCRIPTION
"put you code below" 
should be
"put your code below"