### PR TITLE
bugfix: fix TypeBox/Zod numberic type generation

### DIFF
--- a/drizzle-typebox/src/index.ts
+++ b/drizzle-typebox/src/index.ts
@@ -82,7 +82,7 @@ type MaybeOptional<
 type GetTypeboxType<TColumn extends Column> = TColumn['_']['dataType'] extends infer TDataType
 	? TDataType extends 'custom' ? TAny
 	: TDataType extends 'json' ? Json
-	: TColumn extends { enumValues: [string, ...string[]] }
+	: Equal<TColumn['enumValues'], undefined> extends false
 		? Equal<TColumn['enumValues'], [string, ...string[]]> extends true ? TString
 		: TUnion<TUnionLiterals<TColumn['enumValues']>>
 	: TDataType extends 'array' ? TArray<

--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -43,7 +43,7 @@ type MaybeOptional<
 type GetZodType<TColumn extends Column> = TColumn['_']['dataType'] extends infer TDataType
 	? TDataType extends 'custom' ? z.ZodAny
 	: TDataType extends 'json' ? z.ZodType<Json>
-	: TColumn extends { enumValues: [string, ...string[]] }
+	: Equal<TColumn['enumValues'], undefined> extends false
 		? Equal<TColumn['enumValues'], [string, ...string[]]> extends true ? z.ZodString : z.ZodEnum<TColumn['enumValues']>
 	: TDataType extends 'array' ? z.ZodArray<GetZodType<Assume<TColumn['_'], { baseColumn: Column }>['baseColumn']>>
 	: TDataType extends 'bigint' ? z.ZodBigInt


### PR DESCRIPTION
Fix https://github.com/drizzle-team/drizzle-orm/issues/2524

Before this patch:
```
type StringLike = string & { _: never };

export const enum1 = pgEnum('enum1', ['A' as StringLike, 'B' as StringLike]);
export const enum2 = pgEnum('enum2', ['A', 'B']);

export const table = pgTable('table', {
  number: integer('a_number'),
  string: text('a_string'),
  enum1: enum1('enum1'),
  enum2: enum2('enum2'),
});

type T = typeof table;
// type T_number = TUnion<[TLiteral<string>]>
type T_number = GetTypeboxType<T['number']>;
// type T_string = TString
type T_string = GetTypeboxType<T['string']>;
// type T_enum1 = TUnion<[TLiteral<StringLike>, TLiteral<StringLike>]>
type T_enum1 = GetTypeboxType<T['enum1']>;
// type T_enum2 = TUnion<[TLiteral<"A">, TLiteral<"B">]>
type T_enum2 = GetTypeboxType<T['enum2']>;
```

After this patch:
```
type StringLike = string & { _: never };

export const enum1 = pgEnum('enum1', ['A' as StringLike, 'B' as StringLike]);
export const enum2 = pgEnum('enum2', ['A', 'B']);

export const table = pgTable('table', {
  number: integer('a_number'),
  string: text('a_string'),
  enum1: enum1('enum1'),
  enum2: enum2('enum2'),
});

type T = typeof table;
// type T_number = TNumber
type T_number = GetTypeboxType<T['number']>;
// type T_string = TString
type T_string = GetTypeboxType<T['string']>;
// type T_enum1 = TUnion<[TLiteral<StringLike>, TLiteral<StringLike>]>
type T_enum1 = GetTypeboxType<T['enum1']>;
// type T_enum2 = TUnion<[TLiteral<"A">, TLiteral<"B">]>
type T_enum2 = GetTypeboxType<T['enum2']>;
```