### PR TITLE
fix: Add union undefined as accepted optional type

### DIFF
--- a/drizzle-orm/src/table.ts
+++ b/drizzle-orm/src/table.ts
@@ -175,7 +175,7 @@ export type InferModelFromColumns<
 						MapColumnName<Key, TColumns[Key], TConfig['dbColumnNames']>,
 						TColumns[Key]
 					>
-				]?: GetColumnData<TColumns[Key], 'query'>;
+				]?: GetColumnData<TColumns[Key], 'query'> | undefined;
 			}
 		: {
 			[


### PR DESCRIPTION
Encounter #2550 while playing around with `drizzle-zod`. This adds `| undefined` to the end of the `OptionalKey` columns:

```ts
{
  id?: number | undefined
}
```

It should be the same as the previous one:

```ts
{
  id?: number
}
```
