### PR TITLE
[drizzle-orm]: add CASE WHEN expression

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditional.ts
+++ b/drizzle-orm/src/sql/expressions/conditional.ts
@@ -1,0 +1,38 @@
+import type { Column, GetColumnData } from "~/column.ts";
+
+import { type SQL, sql, type SQLWrapper } from "../sql.ts";
+
+type ExpressionType<T> = T extends Column ? GetColumnData<T, "raw"> : T extends SQL<infer I> ? I : unknown;
+
+export const caseWhen = (condition: SQL | undefined) => {
+  const sqlChunks: SQL[] = [];
+  sqlChunks.push(sql`CASE `);
+
+  const when = <AccType = null>(condition: SQL | undefined) => {
+    sqlChunks.push(sql`WHEN ${condition} `);
+
+    const end = <FinalType = null>() => {
+      sqlChunks.push(sql`END`);
+      return sql.join(sqlChunks) as SQL<FinalType>;
+    };
+
+    return {
+      then: <T extends SQL | SQLWrapper | Column>(value: T) => {
+        sqlChunks.push(sql`THEN ${value} `);
+
+        return {
+          when: when<Exclude<AccType, null> | ExpressionType<T>>,
+          else: <E>(value: E) => {
+            sqlChunks.push(sql`ELSE ${value} `);
+            return {
+              end: end<Exclude<AccType, null> | ExpressionType<T> | ExpressionType<E>>,
+            };
+          },
+          end: end<AccType | ExpressionType<T> | null>,
+        };
+      },
+    };
+  };
+
+  return when(condition);
+};

--- a/drizzle-orm/src/sql/expressions/index.ts
+++ b/drizzle-orm/src/sql/expressions/index.ts
@@ -1,2 +1,3 @@
+export * from './conditional.ts';
 export * from './conditions.ts';
 export * from './select.ts';


### PR DESCRIPTION
Humble attempt at a typed `CASE WHEN` expression. Not quite sure I'm using the right Drizzle types everywhere, please let me know. 

Usage:
```ts
caseWhen(eq(table1.column, 'condition1')).then('bar1')
  .when(eq(table1.column, 'condition2')).then(table2.otherColumn)
  // [ .when( ... ]
  .else(sql<string>`'default'`)
  .end()
```

Closes #1065.