### PR TITLE
[Pg] Fixed postgres-js serialization of Date objects

### DIFF
--- a/drizzle-orm/src/postgres-js/driver.ts
+++ b/drizzle-orm/src/postgres-js/driver.ts
@@ -26,11 +26,17 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 	$client: Sql;
 } {
 	const transparentParser = (val: any) => val;
+	const dateSerializer = (val: unknown): unknown => {
+    if (Object.prototype.toString.call(val) === '[object Date]') {
+      return (val as Date).toISOString()
+    }
+    return val
+  }
 
 	// Override postgres.js default date parsers: https://github.com/porsager/postgres/discussions/761
 	for (const type of ['1184', '1082', '1083', '1114', '1182', '1185', '1115', '1231']) {
 		client.options.parsers[type as any] = transparentParser;
-		client.options.serializers[type as any] = transparentParser;
+		client.options.serializers[type as any] = dateSerializer;
 	}
 	client.options.serializers['114'] = transparentParser;
 	client.options.serializers['3802'] = transparentParser;

--- a/integration-tests/tests/pg/postgres-js.test.ts
+++ b/integration-tests/tests/pg/postgres-js.test.ts
@@ -431,6 +431,33 @@ test('test mode string for timestamp with timezone in different timezone', async
 	await db.execute(sql`drop table if exists ${table}`);
 });
 
+test('date object passed to sql tagged function', async () => {
+	const table = pgTable('all_columns', {
+		id: serial('id').primaryKey(),
+		timestamp: timestamp('timestamp_string', { mode: 'date', precision: 3 }).notNull(),
+	});
+
+	await db.execute(sql`drop table if exists ${table}`);
+
+	await db.execute(sql`
+		create table ${table} (
+					id serial primary key,
+					timestamp_string timestamp(3) not null
+			)
+	`);
+
+	const queryDate = new Date('2022-01-01 02:00:00.123456');
+
+	const result = db.execute<{
+		id: number;
+		timestamp_string: string;
+	}>(sql`select * from ${table} where ${table.timestamp} = ${queryDate}`);
+
+	expect(result).to.not.throw();
+
+	await db.execute(sql`drop table if exists ${table}`);
+});
+
 skipTests([
 	'migrator : default migration strategy',
 	'migrator : migrate with custom schema',


### PR DESCRIPTION
Until version 0.29.x it was possible to pass Date objects in queries while using the postgres-js adapter.

Since 0.30.x when PR #1659 was merged, passing a Date object will result in an error: `The "string" argument must be of type string or an instance of Buffer or ArrayBuffer`.

This PR adds a test to detect the problems and fixes the issues #1993 and #2009.