### PR TITLE
[Pg-kit] SQL error due to double quotes around postgresql non native types

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -160,7 +160,7 @@ class PgCreateTableConvertor extends Convertor {
 
 			const type = isPgNativeType(column.type)
 				? column.type
-				: `${schemaPrefix}"${column.type}"`;
+				: `${schemaPrefix}${column.type}`;
 			const generated = column.generated;
 
 			const generatedStatement = generated ? ` GENERATED ALWAYS AS (${generated?.as}) STORED` : '';


### PR DESCRIPTION
Changed the portion of the SQL generator code that concatenates the column type to the SQL statement, preventing the addition of double quotes. 

Postgresql will raise an exception if the type is surrounded by double quotes like `"time(0)"`, `"vetor(0)"` or `"geography(Point,4326)"`.

`SQL Error [42704]: ERROR: type "geography(Point,4326)" does not exist`

Fix #1804