### PR TITLE
[drizzle-zod]: Create Existing View Schema

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -188,6 +188,11 @@ export function getTableColumns<T extends Table>(table: T): T['_']['columns'] {
 	return table[Table.Symbol.Columns];
 }
 
+export function getViewColumns<TName extends string, TExisting extends boolean, TSelection extends Record<string, Column>, TView extends View<TName, TExisting, TSelection>>(view: TView): TView["_"]["selectedFields"]  {
+	//-- Type assertion is required here
+	return view[ViewBaseConfig].selectedFields as TView["_"]["selectedFields"];
+}
+
 /** @internal */
 export function getTableLikeName(table: TableLike): string | undefined {
 	return is(table, Subquery)

--- a/drizzle-zod/tests/mysql.test.ts
+++ b/drizzle-zod/tests/mysql.test.ts
@@ -16,6 +16,7 @@ import {
 	mediumtext,
 	mysqlEnum,
 	mysqlTable,
+	mysqlView,
 	real,
 	serial,
 	smallint,
@@ -30,7 +31,7 @@ import {
 } from 'drizzle-orm/mysql-core';
 import { expect, test } from 'vitest';
 import { z } from 'zod';
-import { createInsertSchema, createSelectSchema, jsonSchema } from '~/index';
+import { createExistingViewSchema, createInsertSchema, createSelectSchema, jsonSchema } from '~/index';
 import { expectSchemaShape } from './utils.ts';
 
 const customInt = customType<{ data: number }>({
@@ -79,6 +80,47 @@ const testTable = mysqlTable('test', {
 	year: year('year').notNull(),
 	autoIncrement: int('autoIncrement').notNull().autoincrement(),
 });
+
+const testView = mysqlView('vwTest', {
+	bigint: bigint('bigint', { mode: 'bigint' }).notNull(),
+	bigintNumber: bigint('bigintNumber', { mode: 'number' }).notNull(),
+	binary: binary('binary').notNull(),
+	boolean: boolean('boolean').notNull(),
+	char: char('char', { length: 4 }).notNull(),
+	charEnum: char('char', { enum: ['a', 'b', 'c'] }).notNull(),
+	customInt: customInt('customInt').notNull(),
+	date: date('date').notNull(),
+	dateString: date('dateString', { mode: 'string' }).notNull(),
+	datetime: datetime('datetime').notNull(),
+	datetimeString: datetime('datetimeString', { mode: 'string' }).notNull(),
+	decimal: decimal('decimal').notNull(),
+	double: double('double').notNull(),
+	enum: mysqlEnum('enum', ['a', 'b', 'c']).notNull(),
+	float: float('float').notNull(),
+	int: int('int').notNull(),
+	json: json('json').notNull(),
+	mediumint: mediumint('mediumint').notNull(),
+	real: real('real').notNull(),
+	serial: serial('serial').notNull(),
+	smallint: smallint('smallint').notNull(),
+	text: text('text').notNull(),
+	textEnum: text('textEnum', { enum: ['a', 'b', 'c'] }).notNull(),
+	tinytext: tinytext('tinytext').notNull(),
+	tinytextEnum: tinytext('tinytextEnum', { enum: ['a', 'b', 'c'] }).notNull(),
+	mediumtext: mediumtext('mediumtext').notNull(),
+	mediumtextEnum: mediumtext('mediumtextEnum', { enum: ['a', 'b', 'c'] }).notNull(),
+	longtext: longtext('longtext').notNull(),
+	longtextEnum: longtext('longtextEnum', { enum: ['a', 'b', 'c'] }).notNull(),
+	time: time('time').notNull(),
+	timestamp: timestamp('timestamp').notNull(),
+	timestampString: timestamp('timestampString', { mode: 'string' }).notNull(),
+	tinyint: tinyint('tinyint').notNull(),
+	varbinary: varbinary('varbinary', { length: 200 }).notNull(),
+	varchar: varchar('varchar', { length: 200 }).notNull(),
+	varcharEnum: varchar('varcharEnum', { length: 1, enum: ['a', 'b', 'c'] }).notNull(),
+	year: year('year').notNull(),
+	autoIncrement: int('autoIncrement').notNull().autoincrement(),
+}).existing();
 
 const testTableRow = {
 	bigint: BigInt(1),
@@ -241,6 +283,102 @@ test('select schema', (t) => {
 
 test('select schema w/ refine', (t) => {
 	const actual = createSelectSchema(testTable, {
+		bigint: (schema) => schema.bigint.positive(),
+	});
+
+	const expected = z.object({
+		bigint: z.bigint().positive(),
+		bigintNumber: z.number(),
+		binary: z.string(),
+		boolean: z.boolean(),
+		char: z.string().length(5),
+		charEnum: z.enum(['a', 'b', 'c']),
+		customInt: z.any(),
+		date: z.date(),
+		dateString: z.string(),
+		datetime: z.date(),
+		datetimeString: z.string(),
+		decimal: z.string(),
+		double: z.number(),
+		enum: z.enum(['a', 'b', 'c']),
+		float: z.number(),
+		int: z.number(),
+		json: jsonSchema,
+		mediumint: z.number(),
+		real: z.number(),
+		serial: z.number(),
+		smallint: z.number(),
+		text: z.string(),
+		textEnum: z.enum(['a', 'b', 'c']),
+		tinytext: z.string(),
+		tinytextEnum: z.enum(['a', 'b', 'c']),
+		mediumtext: z.string(),
+		mediumtextEnum: z.enum(['a', 'b', 'c']),
+		longtext: z.string(),
+		longtextEnum: z.enum(['a', 'b', 'c']),
+		time: z.string(),
+		timestamp: z.date(),
+		timestampString: z.string(),
+		tinyint: z.number(),
+		varbinary: z.string().max(200),
+		varchar: z.string().max(200),
+		varcharEnum: z.enum(['a', 'b', 'c']),
+		year: z.number(),
+		autoIncrement: z.number(),
+	});
+
+	expectSchemaShape(t, expected).from(actual);
+});
+
+test('view schema', (t) => {
+	const actual = createExistingViewSchema(testView);
+
+	const expected = z.object({
+		bigint: z.bigint(),
+		bigintNumber: z.number(),
+		binary: z.string(),
+		boolean: z.boolean(),
+		char: z.string().length(4),
+		charEnum: z.enum(['a', 'b', 'c']),
+		customInt: z.any(),
+		date: z.date(),
+		dateString: z.string(),
+		datetime: z.date(),
+		datetimeString: z.string(),
+		decimal: z.string(),
+		double: z.number(),
+		enum: z.enum(['a', 'b', 'c']),
+		float: z.number(),
+		int: z.number(),
+		json: jsonSchema,
+		mediumint: z.number(),
+		real: z.number(),
+		serial: z.number(),
+		smallint: z.number(),
+		text: z.string(),
+		textEnum: z.enum(['a', 'b', 'c']),
+		tinytext: z.string(),
+		tinytextEnum: z.enum(['a', 'b', 'c']),
+		mediumtext: z.string(),
+		mediumtextEnum: z.enum(['a', 'b', 'c']),
+		longtext: z.string(),
+		longtextEnum: z.enum(['a', 'b', 'c']),
+		time: z.string(),
+		timestamp: z.date(),
+		timestampString: z.string(),
+		tinyint: z.number(),
+		varbinary: z.string().max(200),
+		varchar: z.string().max(200),
+		varcharEnum: z.enum(['a', 'b', 'c']),
+		year: z.number(),
+		autoIncrement: z.number(),
+	});
+
+	expectSchemaShape(t, expected).from(actual);
+});
+
+test('view schema w/ refine', (t) => {
+	const actual = createExistingViewSchema(testView, {
 		bigint: (schema) => schema.bigint.positive(),
 	});
 


### PR DESCRIPTION
Created a new function that takes a view (existing) and returns a Zod Schema for the selected columns. This lets us have a single source of truth for the shape of our views in both our database and how that data goes over the wire.

To support this change, a new utility function was added to `drizzle-orm` that's used to get the selected columns of the existing view called `getViewColumns`. 