### PR TITLE
[Pg-kit] non-native type mismatch in drizzle-kit push command.

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1006,12 +1006,7 @@ export const fromDatabase = async (
 
 					columnToReturn[columnName] = {
 						name: columnName,
-						type:
-							// filter vectors, but in future we should filter any extension that was installed by user
-							columnAdditionalDT === 'USER-DEFINED'
-								&& !['vector', 'geometry'].includes(enumType)
-								? enumType
-								: columnTypeMapped,
+						type: columnTypeMapped,
 						typeSchema: enumsToReturn[`${typeSchema}.${enumType}`] !== undefined
 							? enumsToReturn[`${typeSchema}.${enumType}`].schema
 							: undefined,


### PR DESCRIPTION
An error is occurring in drizzle-kit when running on tables that have non-native data types defined by extensions such as PostGIS, for example.

If we create a table like:
```sql
CREATE TABLE public.address (
	id serial4 NOT NULL,
	city_id int4 NOT NULL,
	postal_code varchar(20) NOT NULL,
	street varchar(255) NOT NULL,
	house_number varchar(10) NULL,
	district varchar(150) NOT NULL,
	complement varchar(255) NULL,
	"location" public.geography(point, 4326) NOT NULL,
	CONSTRAINT address_pk PRIMARY KEY (id)
);

ALTER TABLE public.address ADD CONSTRAINT address_city_fk FOREIGN KEY (city_id) REFERENCES public.city(id);
```

And a schema like:
```typescript
export const address = pgTable(
  'address',
  {
    id: serial('id').notNull(),
    cityId: integer('city_id').notNull(),
    postalCode: varchar('postal_code', { length: 20 }).notNull(),
    street: varchar('street', { length: 255 }).notNull(),
    houseNumber: varchar('house_number', { length: 10 }),
    district: varchar('district', { length: 150 }).notNull(),
    complement: varchar('complement', { length: 255 }),
    location: geography('location', { type: 'Point' }).notNull()
  },
  (table) => {
    return {
      pk: primaryKey({ name: 'address_pk', columns: [table.id] }),
      cityFk: foreignKey({
        name: 'address_city_fk',
        columns: [table.cityId],
        foreignColumns: [city.id]
      })
    }
  }
```

Note: the postgis implementation has been suppressed here.

Soon after, if you run the `drizzle-kit push` command on the above structure, the following data-loss warning will occur even if the types from the actual table and the scheme matches.

<img width="1015" alt="Screenshot 2024-08-31 at 12 38 26" src="https://github.com/user-attachments/assets/4a2198e0-8151-4342-b851-b0f2e61906d5">

I managed to get rid of the error by changing the following code in the `drizzle-kit` `pgSerializer.ts` file

From:
```typescript
...
columnToReturn[columnName] = {
    name: columnName,
    type:
        // filter vectors, but in future we should filter any extension that was installed by user
	columnAdditionalDT === 'USER-DEFINED'
		&& !['vector', 'geometry'].includes(enumType)
		? enumType
		: columnTypeMapped,
...
```

To:
```typescript
...
columnToReturn[columnName] = {
    name: columnName,
    type: columnTypeMapped,
...
```

It will also work if you add `geography` or the mismatched type you need in the  `!['vector', 'geometry']` array like:

```typescript
...
!['vector', 'geometry', 'geography']
...
```

Fix #2886