### PR TITLE
[core] Fix composite primary keys in TablesRelationalConfig

### DIFF
--- a/drizzle-orm/src/mysql-core/primary-keys.ts
+++ b/drizzle-orm/src/mysql-core/primary-keys.ts
@@ -1,4 +1,5 @@
 import { entityKind } from '~/entity.ts';
+import { PrimaryKeyBuilder as BasePrimaryKeyBuilder } from '~/primary-key.ts';
 import type { AnyMySqlColumn, MySqlColumn } from './columns/index.ts';
 import { MySqlTable } from './table.ts';
 
@@ -22,7 +23,7 @@ export function primaryKey(...config: any) {
 	return new PrimaryKeyBuilder(config);
 }
 
-export class PrimaryKeyBuilder {
+export class PrimaryKeyBuilder extends BasePrimaryKeyBuilder {
 	static readonly [entityKind]: string = 'MySqlPrimaryKeyBuilder';
 
 	/** @internal */
@@ -35,6 +36,7 @@ export class PrimaryKeyBuilder {
 		columns: MySqlColumn[],
 		name?: string,
 	) {
+		super();
 		this.columns = columns;
 		this.name = name;
 	}

--- a/drizzle-orm/src/pg-core/primary-keys.ts
+++ b/drizzle-orm/src/pg-core/primary-keys.ts
@@ -1,4 +1,5 @@
 import { entityKind } from '~/entity.ts';
+import { PrimaryKeyBuilder as BasePrimaryKeyBuilder } from '~/primary-key.ts';
 import type { AnyPgColumn, PgColumn } from './columns/index.ts';
 import { PgTable } from './table.ts';
 
@@ -22,7 +23,7 @@ export function primaryKey(...config: any) {
 	return new PrimaryKeyBuilder(config);
 }
 
-export class PrimaryKeyBuilder {
+export class PrimaryKeyBuilder extends BasePrimaryKeyBuilder {
 	static readonly [entityKind]: string = 'PgPrimaryKeyBuilder';
 
 	/** @internal */
@@ -35,6 +36,7 @@ export class PrimaryKeyBuilder {
 		columns: PgColumn[],
 		name?: string,
 	) {
+		super();
 		this.columns = columns;
 		this.name = name;
 	}

--- a/drizzle-orm/src/primary-key.ts
+++ b/drizzle-orm/src/primary-key.ts
@@ -9,3 +9,9 @@ export abstract class PrimaryKey {
 
 	constructor(readonly table: Table, readonly columns: AnyColumn[]) {}
 }
+
+export abstract class PrimaryKeyBuilder {
+	static readonly [entityKind]: string = 'PrimaryKeyBuilder';
+
+	abstract columns: AnyColumn[];
+}

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -1,7 +1,7 @@
 import { type AnyTable, getTableUniqueName, type InferModelFromColumns, Table } from '~/table.ts';
 import { type AnyColumn, Column } from './column.ts';
 import { entityKind, is } from './entity.ts';
-import { PrimaryKeyBuilder } from './pg-core/primary-keys.ts';
+import { PrimaryKeyBuilder } from './primary-key.ts';
 import {
 	and,
 	asc,

--- a/drizzle-orm/src/sqlite-core/primary-keys.ts
+++ b/drizzle-orm/src/sqlite-core/primary-keys.ts
@@ -1,4 +1,5 @@
 import { entityKind } from '~/entity.ts';
+import { PrimaryKeyBuilder as BasePrimaryKeyBuilder } from '~/primary-key.ts';
 import type { AnySQLiteColumn, SQLiteColumn } from './columns/index.ts';
 import { SQLiteTable } from './table.ts';
 
@@ -21,7 +22,7 @@ export function primaryKey(...config: any) {
 	}
 	return new PrimaryKeyBuilder(config);
 }
-export class PrimaryKeyBuilder {
+export class PrimaryKeyBuilder extends BasePrimaryKeyBuilder {
 	static readonly [entityKind]: string = 'SQLitePrimaryKeyBuilder';
 
 	declare _: {
@@ -38,6 +39,7 @@ export class PrimaryKeyBuilder {
 		columns: SQLiteColumn[],
 		name?: string,
 	) {
+		super();
 		this.columns = columns;
 		this.name = name;
 	}

--- a/drizzle-orm/tests/is.test.ts
+++ b/drizzle-orm/tests/is.test.ts
@@ -1,5 +1,5 @@
 import { describe, test } from 'vitest';
-import { Column, is } from '~/index.ts';
+import { Column, entityKind, is } from '~/index.ts';
 import { PgArray, PgColumn, PgSerial, pgTable, serial } from '~/pg-core/index.ts';
 
 const pgExampleTable = pgTable('test', {
@@ -12,5 +12,29 @@ describe.concurrent('is', () => {
 		expect(is(pgExampleTable.a, PgColumn)).toBe(true);
 		expect(is(pgExampleTable.a, PgArray)).toBe(true);
 		expect(is(pgExampleTable.a, PgSerial)).toBe(false);
+	});
+
+	test('entityKind prototype chain', ({ expect }) => {
+		class A1 {
+			static readonly [entityKind]: string = 'A';
+		}
+		class A2 {
+			static readonly [entityKind]: string = 'A';
+		}
+
+		class B1 extends A1 {
+			static readonly [entityKind]: string = 'B';
+		}
+
+		class B2 extends B1 {
+			static readonly [entityKind]: string = 'B';
+		}
+
+		const b1 = new B1();
+
+		expect(is(b1, B1)).toBe(true);
+		expect(is(b1, A1)).toBe(true);
+		expect(is(b1, B2)).toBe(true);
+		expect(is(b1, A2)).toBe(true);
 	});
 });

--- a/drizzle-orm/tests/relation.test.ts
+++ b/drizzle-orm/tests/relation.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 
 import { pgSchema, pgTable } from '~/pg-core/index.ts';
 import { createTableRelationsHelpers, extractTablesRelationalConfig } from '~/relations.ts';
+import { integer, primaryKey, sqliteTable } from '~/sqlite-core/index.ts';
 
 test('tables with same name in different schemas', () => {
 	const folder = pgSchema('folder');
@@ -35,4 +36,23 @@ test('tables with same name in different schemas', () => {
 	);
 
 	expect(Object.keys(relationsConfig)).toHaveLength(2);
+});
+
+test('composite primary key', () => {
+	const compositeIndexTable = sqliteTable('compositeIndex', {
+		id1: integer('id1'),
+		id2: integer('id2'),
+	}, (table) => ({
+		pk: primaryKey({ columns: [table.id1, table.id2] }),
+	}));
+
+	const relationsConfig = extractTablesRelationalConfig(
+		{ compositeIndexTable },
+		createTableRelationsHelpers,
+	);
+
+	expect(relationsConfig.tables['compositeIndexTable']?.primaryKey).toEqual([
+		compositeIndexTable.id1,
+		compositeIndexTable.id2,
+	]);
 });


### PR DESCRIPTION
- Added a base `PrimaryKeyBuilder` class that each flavored implementation extends
- Updated `extractTableRelationalConfig` to detect base `PrimaryKeyBuilder` class instead of using the `PgPrimaryKeyBuilder` class