### PR TITLE
Fix: Improve handling of unsigned types and decimal parsing during introspection

### DIFF
--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -151,6 +151,7 @@ export const schemaToTypeScript = (
 			const columnImports = Object.values(it.columns)
 				.map((col) => {
 					let patched = importsPatch[col.type] ?? col.type;
+					patched = patched.replace(" unsigned", "")
 					patched = patched.startsWith('varchar(') ? 'varchar' : patched;
 					patched = patched.startsWith('char(') ? 'char' : patched;
 					patched = patched.startsWith('binary(') ? 'binary' : patched;

--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -606,9 +606,7 @@ const column = (
 			| undefined;
 
 		if (lowered.length > 7) {
-			const [precision, scale] = lowered
-				.slice(8, lowered.length - 1)
-				.split(',');
+			const [precision, scale] = lowered.match(/decimal\((\d+),(\d+)\)/)?.slice(1) ?? [];
 			params = { precision, scale };
 		}
 


### PR DESCRIPTION
This potentially fixes the first problem described in https://github.com/drizzle-team/drizzle-orm/issues/2950.

Let's say we have a table called `sample` with `width` as `smallint unsigned`:
```
CREATE TABLE `sample` (
  `id` INT AUTO_INCREMENT PRIMARY KEY,
  `width` smallint unsigned DEFAULT NULL,
  `duration` decimal(10,5) unsigned DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```

During the introspection process, `width` has the following data:
```
    width: {
      default: undefined,
      autoincrement: false,
      name: 'width',
      type: 'smallint unsigned',
      primaryKey: false,
      notNull: false,
      onUpdate: undefined
    },
```

`mysqlImportsList` does not include `smallint unsigned`, thus it will get filtered out during:

```
			const columnImports = Object.values(it.columns)
				.map((col) => {
					let patched = importsPatch[col.type] ?? col.type;
					patched = patched.startsWith('varchar(') ? 'varchar' : patched;
					patched = patched.startsWith('char(') ? 'char' : patched;
					patched = patched.startsWith('binary(') ? 'binary' : patched;
					patched = patched.startsWith('decimal(') ? 'decimal' : patched;
					patched = patched.startsWith('smallint(') ? 'smallint' : patched;
					patched = patched.startsWith('enum(') ? 'mysqlEnum' : patched;
					patched = patched.startsWith('datetime(') ? 'datetime' : patched;
					patched = patched.startsWith('varbinary(') ? 'varbinary' : patched;
					patched = patched.startsWith('int(') ? 'int' : patched;
					patched = patched.startsWith('double(') ? 'double' : patched;
					return patched;
				})
				.filter((type) => {
					return mysqlImportsList.has(type);
				});
```

The easiest patch that I can think of is to replace `" unsigned"` (with a space in front) with `""`.