### PR TITLE
Kit: Handle optional DB aliases and casing

### DIFF
--- a/drizzle-kit/src/api.ts
+++ b/drizzle-kit/src/api.ts
@@ -15,6 +15,7 @@ import { pgSuggestions } from './cli/commands/pgPushUtils';
 import { updateUpToV6 as upPgV6, updateUpToV7 as upPgV7 } from './cli/commands/pgUp';
 import { sqlitePushIntrospect } from './cli/commands/sqliteIntrospect';
 import { logSuggestionsAndReturn } from './cli/commands/sqlitePushUtils';
+import type { CasingType } from './cli/validations/common';
 import { originUUID } from './global';
 import { fillPgSnapshot } from './migrationPreparator';
 import { MySqlSchema as MySQLSchemaKit, mysqlSchema, squashMysqlScheme } from './serializer/mysqlSchema';
@@ -33,6 +34,7 @@ export const generateDrizzleJson = (
 	imports: Record<string, unknown>,
 	prevId?: string,
 	schemaFilters?: string[],
+	casing?: CasingType,
 ): PgSchemaKit => {
 	const prepared = prepareFromExports(imports);
 
@@ -43,6 +45,7 @@ export const generateDrizzleJson = (
 		prepared.enums,
 		prepared.schemas,
 		prepared.sequences,
+		casing,
 		schemaFilters,
 	);
 
@@ -140,6 +143,7 @@ export const pushSchema = async (
 export const generateSQLiteDrizzleJson = async (
 	imports: Record<string, unknown>,
 	prevId?: string,
+	casing?: CasingType,
 ): Promise<SQLiteSchemaKit> => {
 	const { prepareFromExports } = await import('./serializer/sqliteImports');
 
@@ -147,7 +151,7 @@ export const generateSQLiteDrizzleJson = async (
 
 	const id = randomUUID();
 
-	const snapshot = generateSqliteSnapshot(prepared.tables);
+	const snapshot = generateSqliteSnapshot(prepared.tables, casing);
 
 	return {
 		...snapshot,
@@ -243,6 +247,7 @@ export const pushSQLiteSchema = async (
 export const generateMySQLDrizzleJson = async (
 	imports: Record<string, unknown>,
 	prevId?: string,
+	casing?: CasingType,
 ): Promise<MySQLSchemaKit> => {
 	const { prepareFromExports } = await import('./serializer/mysqlImports');
 
@@ -250,7 +255,7 @@ export const generateMySQLDrizzleJson = async (
 
 	const id = randomUUID();
 
-	const snapshot = generateMySqlSnapshot(prepared.tables);
+	const snapshot = generateMySqlSnapshot(prepared.tables, casing);
 
 	return {
 		...snapshot,

--- a/drizzle-kit/src/cli/commands/migrate.ts
+++ b/drizzle-kit/src/cli/commands/migrate.ts
@@ -169,7 +169,7 @@ export const prepareAndMigratePg = async (config: GenerateConfig) => {
 		const { prev, cur, custom } = await preparePgMigrationSnapshot(
 			snapshots,
 			schemaPath,
-			casing
+			casing,
 		);
 
 		const validatedPrev = pgSchema.parse(prev);
@@ -222,7 +222,7 @@ export const preparePgPush = async (
 	schemaPath: string | string[],
 	snapshot: PgSchema,
 	schemaFilter: string[],
-	casing: CasingType | undefined
+	casing: CasingType | undefined,
 ) => {
 	const { prev, cur } = await preparePgDbPushSnapshot(
 		snapshot,
@@ -314,7 +314,7 @@ export const prepareMySQLPush = async (
 		const { prev, cur } = await prepareMySqlDbPushSnapshot(
 			snapshot,
 			schemaPath,
-			casing
+			casing,
 		);
 
 		const validatedPrev = mysqlSchema.parse(prev);
@@ -353,7 +353,7 @@ export const prepareAndMigrateMysql = async (config: GenerateConfig) => {
 		const { prev, cur, custom } = await prepareMySqlMigrationSnapshot(
 			snapshots,
 			schemaPath,
-			casing
+			casing,
 		);
 
 		const validatedPrev = mysqlSchema.parse(prev);
@@ -412,7 +412,7 @@ export const prepareAndMigrateSqlite = async (config: GenerateConfig) => {
 		const { prev, cur, custom } = await prepareSqliteMigrationSnapshot(
 			snapshots,
 			schemaPath,
-			casing
+			casing,
 		);
 
 		const validatedPrev = sqliteSchema.parse(prev);
@@ -473,7 +473,7 @@ export const prepareAndMigrateLibSQL = async (config: GenerateConfig) => {
 		const { prev, cur, custom } = await prepareSqliteMigrationSnapshot(
 			snapshots,
 			schemaPath,
-			casing
+			casing,
 		);
 
 		const validatedPrev = sqliteSchema.parse(prev);
@@ -525,7 +525,7 @@ export const prepareAndMigrateLibSQL = async (config: GenerateConfig) => {
 export const prepareSQLitePush = async (
 	schemaPath: string | string[],
 	snapshot: SQLiteSchema,
-	casing: CasingType | undefined
+	casing: CasingType | undefined,
 ) => {
 	const { prev, cur } = await prepareSQLiteDbPushSnapshot(snapshot, schemaPath, casing);
 
@@ -557,7 +557,7 @@ export const prepareSQLitePush = async (
 export const prepareLibSQLPush = async (
 	schemaPath: string | string[],
 	snapshot: SQLiteSchema,
-	casing: CasingType | undefined
+	casing: CasingType | undefined,
 ) => {
 	const { prev, cur } = await prepareSQLiteDbPushSnapshot(snapshot, schemaPath, casing);
 

--- a/drizzle-kit/src/cli/commands/migrate.ts
+++ b/drizzle-kit/src/cli/commands/migrate.ts
@@ -33,7 +33,7 @@ import {
 } from '../../snapshotsDiffer';
 import { assertV1OutFolder, Journal, prepareMigrationFolder } from '../../utils';
 import { prepareMigrationMetadata } from '../../utils/words';
-import { Prefix } from '../validations/common';
+import { CasingType, Prefix } from '../validations/common';
 import { withStyle } from '../validations/outputs';
 import {
 	isRenamePromptItem,
@@ -156,6 +156,7 @@ export const columnsResolver = async (
 export const prepareAndMigratePg = async (config: GenerateConfig) => {
 	const outFolder = config.out;
 	const schemaPath = config.schema;
+	const casing = config.casing;
 
 	try {
 		assertV1OutFolder(outFolder);
@@ -168,6 +169,7 @@ export const prepareAndMigratePg = async (config: GenerateConfig) => {
 		const { prev, cur, custom } = await preparePgMigrationSnapshot(
 			snapshots,
 			schemaPath,
+			casing
 		);
 
 		const validatedPrev = pgSchema.parse(prev);
@@ -220,10 +222,12 @@ export const preparePgPush = async (
 	schemaPath: string | string[],
 	snapshot: PgSchema,
 	schemaFilter: string[],
+	casing: CasingType | undefined
 ) => {
 	const { prev, cur } = await preparePgDbPushSnapshot(
 		snapshot,
 		schemaPath,
+		casing,
 		schemaFilter,
 	);
 
@@ -304,11 +308,13 @@ function mysqlSchemaSuggestions(
 export const prepareMySQLPush = async (
 	schemaPath: string | string[],
 	snapshot: MySqlSchema,
+	casing: CasingType | undefined,
 ) => {
 	try {
 		const { prev, cur } = await prepareMySqlDbPushSnapshot(
 			snapshot,
 			schemaPath,
+			casing
 		);
 
 		const validatedPrev = mysqlSchema.parse(prev);
@@ -337,6 +343,7 @@ export const prepareMySQLPush = async (
 export const prepareAndMigrateMysql = async (config: GenerateConfig) => {
 	const outFolder = config.out;
 	const schemaPath = config.schema;
+	const casing = config.casing;
 
 	try {
 		// TODO: remove
@@ -346,6 +353,7 @@ export const prepareAndMigrateMysql = async (config: GenerateConfig) => {
 		const { prev, cur, custom } = await prepareMySqlMigrationSnapshot(
 			snapshots,
 			schemaPath,
+			casing
 		);
 
 		const validatedPrev = mysqlSchema.parse(prev);
@@ -395,6 +403,7 @@ export const prepareAndMigrateMysql = async (config: GenerateConfig) => {
 export const prepareAndMigrateSqlite = async (config: GenerateConfig) => {
 	const outFolder = config.out;
 	const schemaPath = config.schema;
+	const casing = config.casing;
 
 	try {
 		assertV1OutFolder(outFolder);
@@ -403,6 +412,7 @@ export const prepareAndMigrateSqlite = async (config: GenerateConfig) => {
 		const { prev, cur, custom } = await prepareSqliteMigrationSnapshot(
 			snapshots,
 			schemaPath,
+			casing
 		);
 
 		const validatedPrev = sqliteSchema.parse(prev);
@@ -454,6 +464,7 @@ export const prepareAndMigrateSqlite = async (config: GenerateConfig) => {
 export const prepareAndMigrateLibSQL = async (config: GenerateConfig) => {
 	const outFolder = config.out;
 	const schemaPath = config.schema;
+	const casing = config.casing;
 
 	try {
 		assertV1OutFolder(outFolder);
@@ -462,6 +473,7 @@ export const prepareAndMigrateLibSQL = async (config: GenerateConfig) => {
 		const { prev, cur, custom } = await prepareSqliteMigrationSnapshot(
 			snapshots,
 			schemaPath,
+			casing
 		);
 
 		const validatedPrev = sqliteSchema.parse(prev);
@@ -513,8 +525,9 @@ export const prepareAndMigrateLibSQL = async (config: GenerateConfig) => {
 export const prepareSQLitePush = async (
 	schemaPath: string | string[],
 	snapshot: SQLiteSchema,
+	casing: CasingType | undefined
 ) => {
-	const { prev, cur } = await prepareSQLiteDbPushSnapshot(snapshot, schemaPath);
+	const { prev, cur } = await prepareSQLiteDbPushSnapshot(snapshot, schemaPath, casing);
 
 	const validatedPrev = sqliteSchema.parse(prev);
 	const validatedCur = sqliteSchema.parse(cur);
@@ -544,8 +557,9 @@ export const prepareSQLitePush = async (
 export const prepareLibSQLPush = async (
 	schemaPath: string | string[],
 	snapshot: SQLiteSchema,
+	casing: CasingType | undefined
 ) => {
-	const { prev, cur } = await prepareSQLiteDbPushSnapshot(snapshot, schemaPath);
+	const { prev, cur } = await prepareSQLiteDbPushSnapshot(snapshot, schemaPath, casing);
 
 	const validatedPrev = sqliteSchema.parse(prev);
 	const validatedCur = sqliteSchema.parse(cur);

--- a/drizzle-kit/src/cli/commands/push.ts
+++ b/drizzle-kit/src/cli/commands/push.ts
@@ -11,6 +11,7 @@ import { libSqlLogSuggestionsAndReturn } from './libSqlPushUtils';
 import { filterStatements, logSuggestionsAndReturn } from './mysqlPushUtils';
 import { pgSuggestions } from './pgPushUtils';
 import { logSuggestionsAndReturn as sqliteSuggestions } from './sqlitePushUtils';
+import { CasingType } from '../validations/common';
 
 export const mysqlPush = async (
 	schemaPath: string | string[],
@@ -19,6 +20,7 @@ export const mysqlPush = async (
 	strict: boolean,
 	verbose: boolean,
 	force: boolean,
+	casing: CasingType | undefined
 ) => {
 	const { connectToMySQL } = await import('../connections');
 	const { mysqlPushIntrospect } = await import('./mysqlIntrospect');
@@ -28,7 +30,7 @@ export const mysqlPush = async (
 	const { schema } = await mysqlPushIntrospect(db, database, tablesFilter);
 	const { prepareMySQLPush } = await import('./migrate');
 
-	const statements = await prepareMySQLPush(schemaPath, schema);
+	const statements = await prepareMySQLPush(schemaPath, schema, casing);
 
 	const filteredStatements = filterStatements(
 		statements.statements ?? [],
@@ -159,6 +161,7 @@ export const pgPush = async (
 	tablesFilter: string[],
 	schemasFilter: string[],
 	force: boolean,
+	casing: CasingType | undefined
 ) => {
 	const { preparePostgresDB } = await import('../connections');
 	const { pgPushIntrospect } = await import('./pgIntrospect');
@@ -168,7 +171,7 @@ export const pgPush = async (
 
 	const { preparePgPush } = await import('./migrate');
 
-	const statements = await preparePgPush(schemaPath, schema, schemasFilter);
+	const statements = await preparePgPush(schemaPath, schema, schemasFilter, casing);
 
 	try {
 		if (statements.sqlStatements.length === 0) {
@@ -268,6 +271,7 @@ export const sqlitePush = async (
 	credentials: SqliteCredentials,
 	tablesFilter: string[],
 	force: boolean,
+	casing: CasingType | undefined
 ) => {
 	const { connectToSQLite } = await import('../connections');
 	const { sqlitePushIntrospect } = await import('./sqliteIntrospect');
@@ -276,7 +280,7 @@ export const sqlitePush = async (
 	const { schema } = await sqlitePushIntrospect(db, tablesFilter);
 	const { prepareSQLitePush } = await import('./migrate');
 
-	const statements = await prepareSQLitePush(schemaPath, schema);
+	const statements = await prepareSQLitePush(schemaPath, schema, casing);
 
 	if (statements.sqlStatements.length === 0) {
 		render(`\n[${chalk.blue('i')}] No changes detected`);
@@ -386,6 +390,7 @@ export const libSQLPush = async (
 	credentials: LibSQLCredentials,
 	tablesFilter: string[],
 	force: boolean,
+	casing: CasingType | undefined
 ) => {
 	const { connectToLibSQL } = await import('../connections');
 	const { sqlitePushIntrospect } = await import('./sqliteIntrospect');
@@ -395,7 +400,7 @@ export const libSQLPush = async (
 
 	const { prepareLibSQLPush } = await import('./migrate');
 
-	const statements = await prepareLibSQLPush(schemaPath, schema);
+	const statements = await prepareLibSQLPush(schemaPath, schema, casing);
 
 	if (statements.sqlStatements.length === 0) {
 		render(`\n[${chalk.blue('i')}] No changes detected`);

--- a/drizzle-kit/src/cli/commands/push.ts
+++ b/drizzle-kit/src/cli/commands/push.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { render } from 'hanji';
 import { fromJson } from '../../sqlgenerator';
 import { Select } from '../selector-ui';
+import { CasingType } from '../validations/common';
 import { LibSQLCredentials } from '../validations/libsql';
 import type { MysqlCredentials } from '../validations/mysql';
 import { withStyle } from '../validations/outputs';
@@ -11,7 +12,6 @@ import { libSqlLogSuggestionsAndReturn } from './libSqlPushUtils';
 import { filterStatements, logSuggestionsAndReturn } from './mysqlPushUtils';
 import { pgSuggestions } from './pgPushUtils';
 import { logSuggestionsAndReturn as sqliteSuggestions } from './sqlitePushUtils';
-import { CasingType } from '../validations/common';
 
 export const mysqlPush = async (
 	schemaPath: string | string[],
@@ -20,7 +20,7 @@ export const mysqlPush = async (
 	strict: boolean,
 	verbose: boolean,
 	force: boolean,
-	casing: CasingType | undefined
+	casing: CasingType | undefined,
 ) => {
 	const { connectToMySQL } = await import('../connections');
 	const { mysqlPushIntrospect } = await import('./mysqlIntrospect');
@@ -161,7 +161,7 @@ export const pgPush = async (
 	tablesFilter: string[],
 	schemasFilter: string[],
 	force: boolean,
-	casing: CasingType | undefined
+	casing: CasingType | undefined,
 ) => {
 	const { preparePostgresDB } = await import('../connections');
 	const { pgPushIntrospect } = await import('./pgIntrospect');
@@ -271,7 +271,7 @@ export const sqlitePush = async (
 	credentials: SqliteCredentials,
 	tablesFilter: string[],
 	force: boolean,
-	casing: CasingType | undefined
+	casing: CasingType | undefined,
 ) => {
 	const { connectToSQLite } = await import('../connections');
 	const { sqlitePushIntrospect } = await import('./sqliteIntrospect');
@@ -390,7 +390,7 @@ export const libSQLPush = async (
 	credentials: LibSQLCredentials,
 	tablesFilter: string[],
 	force: boolean,
-	casing: CasingType | undefined
+	casing: CasingType | undefined,
 ) => {
 	const { connectToLibSQL } = await import('../connections');
 	const { sqlitePushIntrospect } = await import('./sqliteIntrospect');

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -9,6 +9,7 @@ import { prepareFilenames } from '../../serializer';
 import { pullParams, pushParams } from '../validations/cli';
 import {
 	Casing,
+	CasingType,
 	CliConfig,
 	configCommonSchema,
 	configMigrations,
@@ -124,6 +125,7 @@ export type GenerateConfig = {
 	prefix: Prefix;
 	custom: boolean;
 	bundle: boolean;
+	casing?: CasingType;
 };
 
 export const prepareGenerateConfig = async (
@@ -137,12 +139,13 @@ export const prepareGenerateConfig = async (
 		dialect?: Dialect;
 		driver?: Driver;
 		prefix?: Prefix;
+		casing?: CasingType
 	},
 	from: 'config' | 'cli',
 ): Promise<GenerateConfig> => {
 	const config = from === 'config' ? await drizzleConfigFromFile(options.config) : options;
 
-	const { schema, out, breakpoints, dialect, driver } = config;
+	const { schema, out, breakpoints, dialect, driver, casing } = config;
 
 	if (!schema || !dialect) {
 		console.log(error('Please provide required params:'));
@@ -170,6 +173,7 @@ export const prepareGenerateConfig = async (
 		schema: schema,
 		out: out || 'drizzle',
 		bundle: driver === 'expo',
+		casing
 	};
 };
 
@@ -224,6 +228,7 @@ export const preparePushConfig = async (
 		force: boolean;
 		tablesFilter: string[];
 		schemasFilter: string[];
+		casing?: CasingType;
 	}
 > => {
 	const raw = flattenDatabaseCredentials(
@@ -292,6 +297,7 @@ export const preparePushConfig = async (
 			verbose: config.verbose ?? false,
 			force: (options.force as boolean) ?? false,
 			credentials: parsed.data,
+			casing: config.casing,
 			tablesFilter,
 			schemasFilter,
 		};
@@ -310,6 +316,7 @@ export const preparePushConfig = async (
 			verbose: config.verbose ?? false,
 			force: (options.force as boolean) ?? false,
 			credentials: parsed.data,
+			casing: config.casing,
 			tablesFilter,
 			schemasFilter,
 		};
@@ -328,6 +335,7 @@ export const preparePushConfig = async (
 			verbose: config.verbose ?? false,
 			force: (options.force as boolean) ?? false,
 			credentials: parsed.data,
+			casing: config.casing,
 			tablesFilter,
 			schemasFilter,
 		};
@@ -346,6 +354,7 @@ export const preparePushConfig = async (
 			verbose: config.verbose ?? false,
 			force: (options.force as boolean) ?? false,
 			credentials: parsed.data,
+			casing: config.casing,
 			tablesFilter,
 			schemasFilter,
 		};

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -139,7 +139,7 @@ export const prepareGenerateConfig = async (
 		dialect?: Dialect;
 		driver?: Driver;
 		prefix?: Prefix;
-		casing?: CasingType
+		casing?: CasingType;
 	},
 	from: 'config' | 'cli',
 ): Promise<GenerateConfig> => {
@@ -173,7 +173,7 @@ export const prepareGenerateConfig = async (
 		schema: schema,
 		out: out || 'drizzle',
 		bundle: driver === 'expo',
-		casing
+		casing,
 	};
 };
 

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -720,6 +720,7 @@ export const drizzleConfigFromFile = async (
 	// --- get response and then check by each dialect independently
 	const res = configCommonSchema.safeParse(content);
 	if (!res.success) {
+		console.log(res.error);
 		if (!('dialect' in content)) {
 			console.log(error("Please specify 'dialect' param in config file"));
 		}

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -249,7 +249,7 @@ export const push = command({
 				'schemaFilters',
 				'extensionsFilters',
 				'tablesFilter',
-				'casing'
+				'casing',
 			],
 		);
 

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -41,7 +41,7 @@ const optionDriver = string()
 	.enum(...drivers)
 	.desc('Database driver');
 
-const optionCasing = string().enum('camel', 'snake').desc('Casing for serialization');
+const optionCasing = string().enum('camelCase', 'snake_case').desc('Casing for serialization');
 
 export const generate = command({
 	name: 'generate',

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -41,12 +41,15 @@ const optionDriver = string()
 	.enum(...drivers)
 	.desc('Database driver');
 
+const optionCasing = string().enum('camel', 'snake').desc('Casing for serialization');
+
 export const generate = command({
 	name: 'generate',
 	options: {
 		config: optionConfig,
 		dialect: optionDialect,
 		driver: optionDriver,
+		casing: optionCasing,
 		schema: string().desc('Path to a schema file or folder'),
 		out: optionOut,
 		name: string().desc('Migration file name'),
@@ -63,7 +66,7 @@ export const generate = command({
 			'generate',
 			opts,
 			['prefix', 'name', 'custom'],
-			['driver', 'breakpoints', 'schema', 'out', 'dialect'],
+			['driver', 'breakpoints', 'schema', 'out', 'dialect', 'casing'],
 		);
 		return prepareGenerateConfig(opts, from);
 	},
@@ -212,6 +215,7 @@ export const push = command({
 	options: {
 		config: optionConfig,
 		dialect: optionDialect,
+		casing: optionCasing,
 		schema: string().desc('Path to a schema file or folder'),
 		...optionsFilters,
 		...optionsDatabaseCredentials,
@@ -245,6 +249,7 @@ export const push = command({
 				'schemaFilters',
 				'extensionsFilters',
 				'tablesFilter',
+				'casing'
 			],
 		);
 
@@ -263,6 +268,7 @@ export const push = command({
 			tablesFilter,
 			schemasFilter,
 			force,
+			casing,
 		} = config;
 
 		try {
@@ -275,6 +281,7 @@ export const push = command({
 					strict,
 					verbose,
 					force,
+					casing,
 				);
 			} else if (dialect === 'postgresql') {
 				if ('driver' in credentials) {
@@ -307,6 +314,7 @@ export const push = command({
 					tablesFilter,
 					schemasFilter,
 					force,
+					casing,
 				);
 			} else if (dialect === 'sqlite') {
 				const { sqlitePush } = await import('./commands/push');
@@ -317,6 +325,7 @@ export const push = command({
 					credentials,
 					tablesFilter,
 					force,
+					casing,
 				);
 			} else if (dialect === 'turso') {
 				const { libSQLPush } = await import('./commands/push');
@@ -327,6 +336,7 @@ export const push = command({
 					credentials,
 					tablesFilter,
 					force,
+					casing,
 				);
 			} else {
 				assertUnreachable(dialect);

--- a/drizzle-kit/src/cli/validations/cli.ts
+++ b/drizzle-kit/src/cli/validations/cli.ts
@@ -17,7 +17,7 @@ export type CliConfigGenerate = TypeOf<typeof cliConfigGenerate>;
 
 export const pushParams = object({
 	dialect: dialect,
-	casing: casingType,
+	casing: casingType.optional(),
 	schema: union([string(), string().array()]),
 	tablesFilter: union([string(), string().array()]).optional(),
 	schemaFilter: union([string(), string().array()])

--- a/drizzle-kit/src/cli/validations/cli.ts
+++ b/drizzle-kit/src/cli/validations/cli.ts
@@ -1,6 +1,6 @@
 import { boolean, intersection, literal, object, string, TypeOf, union } from 'zod';
 import { dialect } from '../../schemaValidator';
-import { casing, prefix } from './common';
+import { casing, casingType, prefix } from './common';
 
 export const cliConfigGenerate = object({
 	dialect: dialect.optional(),
@@ -17,6 +17,7 @@ export type CliConfigGenerate = TypeOf<typeof cliConfigGenerate>;
 
 export const pushParams = object({
 	dialect: dialect,
+	casing: casingType,
 	schema: union([string(), string().array()]),
 	tablesFilter: union([string(), string().array()]).optional(),
 	schemaFilter: union([string(), string().array()])

--- a/drizzle-kit/src/cli/validations/common.ts
+++ b/drizzle-kit/src/cli/validations/common.ts
@@ -84,7 +84,7 @@ export type Prefix = (typeof prefixes)[number];
 	const _: Prefix = '' as TypeOf<typeof prefix>;
 }
 
-export const casingTypes = ['snake', 'camel'] as const;
+export const casingTypes = ['snake_case', 'camelCase'] as const;
 export const casingType = enum_(casingTypes);
 export type CasingType = (typeof casingTypes)[number];
 

--- a/drizzle-kit/src/cli/validations/common.ts
+++ b/drizzle-kit/src/cli/validations/common.ts
@@ -109,7 +109,7 @@ export const configCommonSchema = object({
 	schemaFilter: union([string(), string().array()]).default(['public']),
 	migrations: configMigrations,
 	dbCredentials: any().optional(),
-	casing: casingType
+	casing: casingType,
 }).passthrough();
 
 export const casing = union([literal('camel'), literal('preserve')]).default(

--- a/drizzle-kit/src/cli/validations/common.ts
+++ b/drizzle-kit/src/cli/validations/common.ts
@@ -109,7 +109,7 @@ export const configCommonSchema = object({
 	schemaFilter: union([string(), string().array()]).default(['public']),
 	migrations: configMigrations,
 	dbCredentials: any().optional(),
-	casing: casingType,
+	casing: casingType.optional(),
 }).passthrough();
 
 export const casing = union([literal('camel'), literal('preserve')]).default(

--- a/drizzle-kit/src/cli/validations/common.ts
+++ b/drizzle-kit/src/cli/validations/common.ts
@@ -84,6 +84,10 @@ export type Prefix = (typeof prefixes)[number];
 	const _: Prefix = '' as TypeOf<typeof prefix>;
 }
 
+export const casingTypes = ['snake', 'camel'] as const;
+export const casingType = enum_(casingTypes);
+export type CasingType = (typeof casingTypes)[number];
+
 export const sqliteDriver = union(sqliteDriversLiterals);
 export const postgresDriver = union(postgresqlDriversLiterals);
 export const driver = union([sqliteDriver, postgresDriver]);
@@ -105,6 +109,7 @@ export const configCommonSchema = object({
 	schemaFilter: union([string(), string().array()]).default(['public']),
 	migrations: configMigrations,
 	dbCredentials: any().optional(),
+	casing: casingType
 }).passthrough();
 
 export const casing = union([literal('camel'), literal('preserve')]).default(

--- a/drizzle-kit/src/index.ts
+++ b/drizzle-kit/src/index.ts
@@ -117,7 +117,7 @@ export type Config =
 		schema?: string | string[];
 		verbose?: boolean;
 		strict?: boolean;
-		casing: 'camel' | 'snake';
+		casing?: 'camel' | 'snake';
 		migrations?: {
 			table?: string;
 			schema?: string;

--- a/drizzle-kit/src/index.ts
+++ b/drizzle-kit/src/index.ts
@@ -117,6 +117,7 @@ export type Config =
 		schema?: string | string[];
 		verbose?: boolean;
 		strict?: boolean;
+		casing: 'camel' | 'snake';
 		migrations?: {
 			table?: string;
 			schema?: string;

--- a/drizzle-kit/src/migrationPreparator.ts
+++ b/drizzle-kit/src/migrationPreparator.ts
@@ -4,12 +4,14 @@ import { serializeMySql, serializePg, serializeSQLite } from './serializer';
 import { dryMySql, MySqlSchema, mysqlSchema } from './serializer/mysqlSchema';
 import { dryPg, PgSchema, pgSchema, PgSchemaInternal } from './serializer/pgSchema';
 import { drySQLite, SQLiteSchema, sqliteSchema } from './serializer/sqliteSchema';
+import { CasingType } from './cli/validations/common';
 
 export const prepareMySqlDbPushSnapshot = async (
 	prev: MySqlSchema,
 	schemaPath: string | string[],
+	casing: CasingType | undefined,
 ): Promise<{ prev: MySqlSchema; cur: MySqlSchema }> => {
-	const serialized = await serializeMySql(schemaPath);
+	const serialized = await serializeMySql(schemaPath, casing);
 
 	const id = randomUUID();
 	const idPrev = prev.id;
@@ -23,8 +25,9 @@ export const prepareMySqlDbPushSnapshot = async (
 export const prepareSQLiteDbPushSnapshot = async (
 	prev: SQLiteSchema,
 	schemaPath: string | string[],
+	casing: CasingType | undefined,
 ): Promise<{ prev: SQLiteSchema; cur: SQLiteSchema }> => {
-	const serialized = await serializeSQLite(schemaPath);
+	const serialized = await serializeSQLite(schemaPath, casing);
 
 	const id = randomUUID();
 	const idPrev = prev.id;
@@ -44,9 +47,10 @@ export const prepareSQLiteDbPushSnapshot = async (
 export const preparePgDbPushSnapshot = async (
 	prev: PgSchema,
 	schemaPath: string | string[],
+	casing: CasingType | undefined,
 	schemaFilter: string[] = ['public'],
 ): Promise<{ prev: PgSchema; cur: PgSchema }> => {
-	const serialized = await serializePg(schemaPath, schemaFilter);
+	const serialized = await serializePg(schemaPath, casing, schemaFilter);
 
 	const id = randomUUID();
 	const idPrev = prev.id;
@@ -60,11 +64,12 @@ export const preparePgDbPushSnapshot = async (
 export const prepareMySqlMigrationSnapshot = async (
 	migrationFolders: string[],
 	schemaPath: string | string[],
+	casing: CasingType | undefined,
 ): Promise<{ prev: MySqlSchema; cur: MySqlSchema; custom: MySqlSchema }> => {
 	const prevSnapshot = mysqlSchema.parse(
 		preparePrevSnapshot(migrationFolders, dryMySql),
 	);
-	const serialized = await serializeMySql(schemaPath);
+	const serialized = await serializeMySql(schemaPath, casing);
 
 	const id = randomUUID();
 	const idPrev = prevSnapshot.id;
@@ -87,11 +92,12 @@ export const prepareMySqlMigrationSnapshot = async (
 export const prepareSqliteMigrationSnapshot = async (
 	snapshots: string[],
 	schemaPath: string | string[],
+	casing: CasingType | undefined,
 ): Promise<{ prev: SQLiteSchema; cur: SQLiteSchema; custom: SQLiteSchema }> => {
 	const prevSnapshot = sqliteSchema.parse(
 		preparePrevSnapshot(snapshots, drySQLite),
 	);
-	const serialized = await serializeSQLite(schemaPath);
+	const serialized = await serializeSQLite(schemaPath, casing);
 
 	const id = randomUUID();
 	const idPrev = prevSnapshot.id;
@@ -133,9 +139,10 @@ export const fillPgSnapshot = ({
 export const preparePgMigrationSnapshot = async (
 	snapshots: string[],
 	schemaPath: string | string[],
+	casing: CasingType | undefined
 ): Promise<{ prev: PgSchema; cur: PgSchema; custom: PgSchema }> => {
 	const prevSnapshot = pgSchema.parse(preparePrevSnapshot(snapshots, dryPg));
-	const serialized = await serializePg(schemaPath);
+	const serialized = await serializePg(schemaPath, casing);
 
 	const id = randomUUID();
 	const idPrev = prevSnapshot.id;

--- a/drizzle-kit/src/migrationPreparator.ts
+++ b/drizzle-kit/src/migrationPreparator.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from 'crypto';
 import fs from 'fs';
+import { CasingType } from './cli/validations/common';
 import { serializeMySql, serializePg, serializeSQLite } from './serializer';
 import { dryMySql, MySqlSchema, mysqlSchema } from './serializer/mysqlSchema';
 import { dryPg, PgSchema, pgSchema, PgSchemaInternal } from './serializer/pgSchema';
 import { drySQLite, SQLiteSchema, sqliteSchema } from './serializer/sqliteSchema';
-import { CasingType } from './cli/validations/common';
 
 export const prepareMySqlDbPushSnapshot = async (
 	prev: MySqlSchema,
@@ -139,7 +139,7 @@ export const fillPgSnapshot = ({
 export const preparePgMigrationSnapshot = async (
 	snapshots: string[],
 	schemaPath: string | string[],
-	casing: CasingType | undefined
+	casing: CasingType | undefined,
 ): Promise<{ prev: PgSchema; cur: PgSchema; custom: PgSchema }> => {
 	const prevSnapshot = pgSchema.parse(preparePrevSnapshot(snapshots, dryPg));
 	const serialized = await serializePg(schemaPath, casing);

--- a/drizzle-kit/src/serializer/index.ts
+++ b/drizzle-kit/src/serializer/index.ts
@@ -21,7 +21,7 @@ export const sqlToStr = (sql: SQL, casing: CasingType | undefined) => {
 		escapeString: () => {
 			throw new Error("we don't support params for `sql` default values");
 		},
-		casing: new CasingCache(casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined),
+		casing: new CasingCache(casing),
 	}).sql;
 };
 
@@ -36,7 +36,7 @@ export const sqlToStrGenerated = (sql: SQL, casing: CasingType | undefined) => {
 		escapeString: () => {
 			throw new Error("we don't support params for `sql` default values");
 		},
-		casing: new CasingCache(casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined),
+		casing: new CasingCache(casing),
 	}).sql;
 };
 

--- a/drizzle-kit/src/serializer/index.ts
+++ b/drizzle-kit/src/serializer/index.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { SQL } from 'drizzle-orm';
+import { SQL, Table } from 'drizzle-orm';
 import fs from 'fs';
 import * as glob from 'glob';
 import Path from 'path';
@@ -7,8 +7,10 @@ import { error } from '../cli/views';
 import type { MySqlSchemaInternal } from './mysqlSchema';
 import type { PgSchemaInternal } from './pgSchema';
 import type { SQLiteSchemaInternal } from './sqliteSchema';
+import { CasingType } from 'src/cli/validations/common';
+import { CasingCache } from 'drizzle-orm/casing';
 
-export const sqlToStr = (sql: SQL) => {
+export const sqlToStr = (sql: SQL, casing: CasingType | undefined) => {
 	return sql.toQuery({
 		escapeName: () => {
 			throw new Error("we don't support params for `sql` default values");
@@ -19,10 +21,11 @@ export const sqlToStr = (sql: SQL) => {
 		escapeString: () => {
 			throw new Error("we don't support params for `sql` default values");
 		},
+		casing: new CasingCache(casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined)
 	}).sql;
 };
 
-export const sqlToStrGenerated = (sql: SQL) => {
+export const sqlToStrGenerated = (sql: SQL, casing: CasingType | undefined) => {
 	return sql.toQuery({
 		escapeName: () => {
 			throw new Error("we don't support params for `sql` default values");
@@ -33,11 +36,13 @@ export const sqlToStrGenerated = (sql: SQL) => {
 		escapeString: () => {
 			throw new Error("we don't support params for `sql` default values");
 		},
+		casing: new CasingCache(casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined)
 	}).sql;
 };
 
 export const serializeMySql = async (
 	path: string | string[],
+	casing: CasingType | undefined,
 ): Promise<MySqlSchemaInternal> => {
 	const filenames = prepareFilenames(path);
 
@@ -48,11 +53,12 @@ export const serializeMySql = async (
 
 	const { tables } = await prepareFromMySqlImports(filenames);
 
-	return generateMySqlSnapshot(tables);
+	return generateMySqlSnapshot(tables, casing);
 };
 
 export const serializePg = async (
 	path: string | string[],
+	casing: CasingType | undefined,
 	schemaFilter?: string[],
 ): Promise<PgSchemaInternal> => {
 	const filenames = prepareFilenames(path);
@@ -64,18 +70,19 @@ export const serializePg = async (
 		filenames,
 	);
 
-	return generatePgSnapshot(tables, enums, schemas, sequences, schemaFilter);
+	return generatePgSnapshot(tables, enums, schemas, sequences, casing, schemaFilter);
 };
 
 export const serializeSQLite = async (
 	path: string | string[],
+	casing: CasingType | undefined,
 ): Promise<SQLiteSchemaInternal> => {
 	const filenames = prepareFilenames(path);
 
 	const { prepareFromSqliteImports } = await import('./sqliteImports');
 	const { generateSqliteSnapshot } = await import('./sqliteSerializer');
 	const { tables } = await prepareFromSqliteImports(filenames);
-	return generateSqliteSnapshot(tables);
+	return generateSqliteSnapshot(tables, casing);
 };
 
 export const prepareFilenames = (path: string | string[]) => {

--- a/drizzle-kit/src/serializer/index.ts
+++ b/drizzle-kit/src/serializer/index.ts
@@ -1,14 +1,14 @@
 import chalk from 'chalk';
 import { SQL, Table } from 'drizzle-orm';
+import { CasingCache } from 'drizzle-orm/casing';
 import fs from 'fs';
 import * as glob from 'glob';
 import Path from 'path';
+import { CasingType } from 'src/cli/validations/common';
 import { error } from '../cli/views';
 import type { MySqlSchemaInternal } from './mysqlSchema';
 import type { PgSchemaInternal } from './pgSchema';
 import type { SQLiteSchemaInternal } from './sqliteSchema';
-import { CasingType } from 'src/cli/validations/common';
-import { CasingCache } from 'drizzle-orm/casing';
 
 export const sqlToStr = (sql: SQL, casing: CasingType | undefined) => {
 	return sql.toQuery({
@@ -21,7 +21,7 @@ export const sqlToStr = (sql: SQL, casing: CasingType | undefined) => {
 		escapeString: () => {
 			throw new Error("we don't support params for `sql` default values");
 		},
-		casing: new CasingCache(casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined)
+		casing: new CasingCache(casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined),
 	}).sql;
 };
 
@@ -36,7 +36,7 @@ export const sqlToStrGenerated = (sql: SQL, casing: CasingType | undefined) => {
 		escapeString: () => {
 			throw new Error("we don't support params for `sql` default values");
 		},
-		casing: new CasingCache(casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined)
+		casing: new CasingCache(casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined),
 	}).sql;
 };
 

--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -1,9 +1,11 @@
 import chalk from 'chalk';
 import { getTableName, is } from 'drizzle-orm';
 import { SQL } from 'drizzle-orm';
+import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 import { AnyMySqlTable, MySqlDialect, type PrimaryKey as PrimaryKeyORM, uniqueKeyName } from 'drizzle-orm/mysql-core';
 import { getTableConfig } from 'drizzle-orm/mysql-core';
 import { RowDataPacket } from 'mysql2/promise';
+import { CasingType } from 'src/cli/validations/common';
 import { withStyle } from '../cli/validations/outputs';
 import { IntrospectStage, IntrospectStatus } from '../cli/views';
 import {
@@ -16,10 +18,8 @@ import {
 	Table,
 	UniqueConstraint,
 } from '../serializer/mysqlSchema';
-import { getColumnCasing, type DB } from '../utils';
+import { type DB, getColumnCasing } from '../utils';
 import { sqlToStr } from '.';
-import { CasingType } from 'src/cli/validations/common';
-import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 // import { MySqlColumnWithAutoIncrement } from "drizzle-orm/mysql-core";
 // import { MySqlDateBaseColumn } from "drizzle-orm/mysql-core";
 

--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -31,9 +31,7 @@ export const generateMySqlSnapshot = (
 	tables: AnyMySqlTable[],
 	casing: CasingType | undefined,
 ): MySqlSchemaInternal => {
-	const dialect = new MySqlDialect({
-		casing: casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined,
-	});
+	const dialect = new MySqlDialect({ casing });
 	const result: Record<string, Table> = {};
 	const internal: MySqlKitInternals = { tables: {}, indexes: {} };
 	for (const table of tables) {

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -120,9 +120,7 @@ export const generatePgSnapshot = (
 	casing: CasingType | undefined,
 	schemaFilter?: string[],
 ): PgSchemaInternal => {
-	const dialect = new PgDialect({
-		casing: casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined,
-	});
+	const dialect = new PgDialect({ casing });
 	const result: Record<string, Table> = {};
 	const sequencesToReturn: Record<string, Sequence> = {};
 

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { getTableName, is, SQL } from 'drizzle-orm';
+import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 import {
 	AnyPgTable,
 	ExtraConfigColumn,
@@ -14,6 +15,7 @@ import {
 	uniqueKeyName,
 } from 'drizzle-orm/pg-core';
 import { getTableConfig } from 'drizzle-orm/pg-core';
+import { CasingType } from 'src/cli/validations/common';
 import { vectorOps } from 'src/extensions/vector';
 import { withStyle } from '../cli/validations/outputs';
 import type { IntrospectStage, IntrospectStatus } from '../cli/views';
@@ -32,8 +34,6 @@ import type {
 } from '../serializer/pgSchema';
 import { type DB, getColumnCasing, isPgArrayType } from '../utils';
 import { sqlToStr } from '.';
-import { CasingType } from 'src/cli/validations/common';
-import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 
 export const indexName = (tableName: string, columns: string[]) => {
 	return `${tableName}_${columns.join('_')}_index`;
@@ -289,7 +289,7 @@ export const generatePgSnapshot = (
 		primaryKeys.map((pk) => {
 			const originalColumnNames = pk.columns.map((c) => c.name);
 			const columnNames = pk.columns.map((c) => getColumnCasing(c, casing));
-			
+
 			let name = pk.getName();
 			if (casing !== undefined) {
 				for (let i = 0; i < originalColumnNames.length; i++) {

--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { getTableName, is, SQL } from 'drizzle-orm';
+import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 import {
 	// AnySQLiteColumnBuilder,
 	AnySQLiteTable,
@@ -8,6 +9,7 @@ import {
 	SQLiteSyncDialect,
 	uniqueKeyName,
 } from 'drizzle-orm/sqlite-core';
+import { CasingType } from 'src/cli/validations/common';
 import { withStyle } from '../cli/validations/outputs';
 import type { IntrospectStage, IntrospectStatus } from '../cli/views';
 import type {
@@ -22,8 +24,6 @@ import type {
 } from '../serializer/sqliteSchema';
 import { getColumnCasing, type SQLiteDB } from '../utils';
 import { sqlToStr } from '.';
-import { CasingType } from 'src/cli/validations/common';
-import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 
 export const generateSqliteSnapshot = (
 	tables: AnySQLiteTable[],
@@ -266,7 +266,7 @@ export const generateSqliteSnapshot = (
 
 				primaryKeysObject[name] = {
 					columns: columnNames,
-					name
+					name,
 				};
 			} else {
 				columnsObject[getColumnCasing(it.columns[0], casing)].primaryKey = true;

--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -29,9 +29,7 @@ export const generateSqliteSnapshot = (
 	tables: AnySQLiteTable[],
 	casing: CasingType | undefined,
 ): SQLiteSchemaInternal => {
-	const dialect = new SQLiteSyncDialect({
-		casing: casing === 'camel' ? 'camelCase' : casing === 'snake' ? 'snake_case' : undefined,
-	});
+	const dialect = new SQLiteSyncDialect({ casing });
 	const result: Record<string, Table> = {};
 	const internal: SQLiteKitInternals = { indexes: {} };
 	for (const table of tables) {

--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -11,6 +11,8 @@ import { backwardCompatibleMysqlSchema } from './serializer/mysqlSchema';
 import { backwardCompatiblePgSchema } from './serializer/pgSchema';
 import { backwardCompatibleSqliteSchema } from './serializer/sqliteSchema';
 import type { ProxyParams } from './serializer/studio';
+import { CasingType } from './cli/validations/common';
+import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 
 export type Proxy = (params: ProxyParams) => Promise<any[]>;
 
@@ -355,4 +357,13 @@ export function findAddedAndRemoved(columnNames1: string[], columnNames2: string
 	const removedColumns = columnNames1.filter((it) => !set2.has(it));
 
 	return { addedColumns, removedColumns };
+}
+
+export function getColumnCasing(column: { keyAsName: boolean; name: string | undefined; }, casing: CasingType | undefined) {
+	if (!column.name) return '';
+	return !column.keyAsName || casing === undefined
+	? column.name
+	: casing === 'camel'
+		? toCamelCase(column.name)
+		: toSnakeCase(column.name)
 }

--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -1,9 +1,11 @@
 import type { RunResult } from 'better-sqlite3';
 import chalk from 'chalk';
+import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { parse } from 'url';
 import type { NamedWithSchema } from './cli/commands/migrate';
+import { CasingType } from './cli/validations/common';
 import { info } from './cli/views';
 import { assertUnreachable, snapshotVersion } from './global';
 import type { Dialect } from './schemaValidator';
@@ -11,8 +13,6 @@ import { backwardCompatibleMysqlSchema } from './serializer/mysqlSchema';
 import { backwardCompatiblePgSchema } from './serializer/pgSchema';
 import { backwardCompatibleSqliteSchema } from './serializer/sqliteSchema';
 import type { ProxyParams } from './serializer/studio';
-import { CasingType } from './cli/validations/common';
-import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 
 export type Proxy = (params: ProxyParams) => Promise<any[]>;
 
@@ -359,11 +359,14 @@ export function findAddedAndRemoved(columnNames1: string[], columnNames2: string
 	return { addedColumns, removedColumns };
 }
 
-export function getColumnCasing(column: { keyAsName: boolean; name: string | undefined; }, casing: CasingType | undefined) {
+export function getColumnCasing(
+	column: { keyAsName: boolean; name: string | undefined },
+	casing: CasingType | undefined,
+) {
 	if (!column.name) return '';
 	return !column.keyAsName || casing === undefined
-	? column.name
-	: casing === 'camel'
+		? column.name
+		: casing === 'camel'
 		? toCamelCase(column.name)
-		: toSnakeCase(column.name)
+		: toSnakeCase(column.name);
 }

--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -366,7 +366,7 @@ export function getColumnCasing(
 	if (!column.name) return '';
 	return !column.keyAsName || casing === undefined
 		? column.name
-		: casing === 'camel'
+		: casing === 'camelCase'
 		? toCamelCase(column.name)
 		: toSnakeCase(column.name);
 }

--- a/drizzle-kit/tests/cli-generate.test.ts
+++ b/drizzle-kit/tests/cli-generate.test.ts
@@ -38,6 +38,7 @@ test('generate #1', async (t) => {
 		schema: 'schema.ts',
 		out: 'drizzle',
 		bundle: false,
+		casing: undefined,
 	});
 });
 
@@ -57,6 +58,7 @@ test('generate #2', async (t) => {
 		schema: 'schema.ts',
 		out: 'out',
 		bundle: false,
+		casing: undefined,
 	});
 });
 
@@ -73,6 +75,7 @@ test('generate #3', async (t) => {
 		schema: './schema.ts',
 		out: 'drizzle',
 		bundle: false,
+		casing: undefined,
 	});
 });
 
@@ -90,6 +93,7 @@ test('generate #4', async (t) => {
 		schema: './schema.ts',
 		out: 'drizzle',
 		bundle: false,
+		casing: undefined,
 	});
 });
 
@@ -106,6 +110,7 @@ test('generate #5', async (t) => {
 		schema: './schema.ts',
 		out: 'drizzle',
 		bundle: false,
+		casing: undefined,
 	});
 });
 
@@ -122,6 +127,7 @@ test('generate #6', async (t) => {
 		schema: './schema.ts',
 		out: 'drizzle',
 		bundle: false,
+		casing: undefined,
 	});
 });
 
@@ -141,6 +147,7 @@ test('generate #7', async (t) => {
 		schema: './schema.ts',
 		out: 'drizzle',
 		bundle: false,
+		casing: undefined,
 	});
 });
 
@@ -158,6 +165,7 @@ test('generate #8', async (t) => {
 		schema: './schema.ts',
 		out: 'drizzle',
 		bundle: true, // expo driver
+		casing: undefined,
 	});
 });
 
@@ -178,6 +186,7 @@ test('generate #9', async (t) => {
 		schema: 'schema.ts',
 		out: 'out',
 		bundle: false,
+		casing: undefined,
 	});
 });
 

--- a/drizzle-kit/tests/cli-migrate.test.ts
+++ b/drizzle-kit/tests/cli-migrate.test.ts
@@ -24,7 +24,6 @@ test('migrate #1', async (t) => {
 		},
 		schema: undefined, // drizzle migrations table schema
 		table: undefined, // drizzle migrations table name
-		casing: undefined,
 	});
 });
 
@@ -40,7 +39,6 @@ test('migrate #2', async (t) => {
 		},
 		schema: undefined, // drizzle migrations table schema
 		table: undefined, // drizzle migrations table name
-		casing: undefined,
 	});
 });
 
@@ -58,7 +56,6 @@ test('migrate #3', async (t) => {
 		},
 		schema: undefined, // drizzle migrations table schema
 		table: undefined, // drizzle migrations table name
-		casing: undefined,
 	});
 });
 
@@ -77,7 +74,6 @@ test('migrate #4', async (t) => {
 		},
 		schema: undefined, // drizzle migrations table schema
 		table: undefined, // drizzle migrations table name
-		casing: undefined,
 	});
 });
 
@@ -97,7 +93,6 @@ test('migrate #5', async (t) => {
 		},
 		schema: 'custom', // drizzle migrations table schema
 		table: 'custom', // drizzle migrations table name
-		casing: undefined,
 	});
 });
 

--- a/drizzle-kit/tests/cli-migrate.test.ts
+++ b/drizzle-kit/tests/cli-migrate.test.ts
@@ -24,6 +24,7 @@ test('migrate #1', async (t) => {
 		},
 		schema: undefined, // drizzle migrations table schema
 		table: undefined, // drizzle migrations table name
+		casing: undefined,
 	});
 });
 
@@ -39,6 +40,7 @@ test('migrate #2', async (t) => {
 		},
 		schema: undefined, // drizzle migrations table schema
 		table: undefined, // drizzle migrations table name
+		casing: undefined,
 	});
 });
 
@@ -56,6 +58,7 @@ test('migrate #3', async (t) => {
 		},
 		schema: undefined, // drizzle migrations table schema
 		table: undefined, // drizzle migrations table name
+		casing: undefined,
 	});
 });
 
@@ -74,6 +77,7 @@ test('migrate #4', async (t) => {
 		},
 		schema: undefined, // drizzle migrations table schema
 		table: undefined, // drizzle migrations table name
+		casing: undefined,
 	});
 });
 
@@ -93,6 +97,7 @@ test('migrate #5', async (t) => {
 		},
 		schema: 'custom', // drizzle migrations table schema
 		table: 'custom', // drizzle migrations table name
+		casing: undefined,
 	});
 });
 

--- a/drizzle-kit/tests/cli-push.test.ts
+++ b/drizzle-kit/tests/cli-push.test.ts
@@ -15,6 +15,7 @@ import { push } from '../src/cli/schema';
 
 test('push #1', async (t) => {
 	const res = await brotest(push, '');
+	console.log(res);
 	if (res.type !== 'handler') assert.fail(res.type, 'handler');
 	expect(res.options).toStrictEqual({
 		dialect: 'postgresql',
@@ -27,6 +28,7 @@ test('push #1', async (t) => {
 		tablesFilter: [],
 		strict: false,
 		verbose: false,
+		casing: undefined,
 	});
 });
 
@@ -45,6 +47,7 @@ test('push #2', async (t) => {
 		tablesFilter: [],
 		strict: false,
 		verbose: false,
+		casing: undefined,
 	});
 });
 
@@ -65,6 +68,7 @@ test('push #3', async (t) => {
 		tablesFilter: [],
 		strict: false,
 		verbose: false,
+		casing: undefined,
 	});
 });
 
@@ -86,6 +90,7 @@ test('push #4', async (t) => {
 		tablesFilter: [],
 		strict: false,
 		verbose: false,
+		casing: undefined,
 	});
 });
 
@@ -108,6 +113,7 @@ test('push #5', async (t) => {
 		strict: false,
 		force: false,
 		verbose: false,
+		casing: undefined,
 	});
 });
 

--- a/drizzle-kit/tests/cli-push.test.ts
+++ b/drizzle-kit/tests/cli-push.test.ts
@@ -15,7 +15,6 @@ import { push } from '../src/cli/schema';
 
 test('push #1', async (t) => {
 	const res = await brotest(push, '');
-	console.log(res);
 	if (res.type !== 'handler') assert.fail(res.type, 'handler');
 	expect(res.options).toStrictEqual({
 		dialect: 'postgresql',

--- a/drizzle-kit/tests/mysql.test.ts
+++ b/drizzle-kit/tests/mysql.test.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { index, json, mysqlSchema, mysqlTable, primaryKey, serial, text, uniqueIndex } from 'drizzle-orm/mysql-core';
+import { foreignKey, index, int, json, mysqlSchema, mysqlTable, primaryKey, serial, text, unique, uniqueIndex } from 'drizzle-orm/mysql-core';
 import { expect, test } from 'vitest';
 import { diffTestSchemasMysql } from './schemaDiffer';
 
@@ -554,4 +554,182 @@ test('add table with indexes', async () => {
 		'CREATE INDEX `indexColMultiple` ON `users` (`email`,`email`);',
 		'CREATE INDEX `indexColExpr` ON `users` ((lower(`email`)),`email`);',
 	]);
+});
+
+test('optional db aliases (snake case)', async () => {
+	const from = {};
+
+	const t1 = mysqlTable(
+		't1',
+		{
+			t1Id1: int().notNull().primaryKey(),
+			t1Col2: int().notNull(),
+			t1Col3: int().notNull(),
+			t2Ref: int().notNull().references(() => t2.t2Id),
+			t1Uni: int().notNull(),
+			t1UniIdx: int().notNull(),
+			t1Idx: int().notNull(),
+		},
+		(table) => ({
+			uni: unique('t1_uni').on(table.t1Uni),
+			uniIdx: uniqueIndex('t1_uni_idx').on(table.t1UniIdx),
+			idx: index('t1_idx').on(table.t1Idx),
+			fk: foreignKey({
+				columns: [table.t1Col2, table.t1Col3],
+				foreignColumns: [t3.t3Id1, t3.t3Id2],
+			}),
+		}),
+	)
+
+	const t2 = mysqlTable(
+		't2',
+		{
+			t2Id: serial().primaryKey()
+		}
+	);
+
+	const t3 = mysqlTable(
+		't3',
+		{
+			t3Id1: int(),
+			t3Id2: int(),
+		},
+		(table) => ({
+			pk: primaryKey({
+				columns: [table.t3Id1, table.t3Id2],
+			}),
+		}),
+	);
+
+	const to = {
+		t1,
+		t2,
+		t3
+	};
+
+	const { sqlStatements } = await diffTestSchemasMysql(from, to, [], false, 'snake');
+
+	const st1 = `CREATE TABLE \`t1\` (
+	\`t1_id1\` int NOT NULL,
+	\`t1_col2\` int NOT NULL,
+	\`t1_col3\` int NOT NULL,
+	\`t2_ref\` int NOT NULL,
+	\`t1_uni\` int NOT NULL,
+	\`t1_uni_idx\` int NOT NULL,
+	\`t1_idx\` int NOT NULL,
+	CONSTRAINT \`t1_t1_id1\` PRIMARY KEY(\`t1_id1\`),
+	CONSTRAINT \`t1_uni\` UNIQUE(\`t1_uni\`),
+	CONSTRAINT \`t1_uni_idx\` UNIQUE(\`t1_uni_idx\`)
+);
+`;
+
+	const st2 = `CREATE TABLE \`t2\` (
+	\`t2_id\` serial AUTO_INCREMENT NOT NULL,
+	CONSTRAINT \`t2_t2_id\` PRIMARY KEY(\`t2_id\`)
+);
+`;
+
+	const st3 = `CREATE TABLE \`t3\` (
+	\`t3_id1\` int NOT NULL,
+	\`t3_id2\` int NOT NULL,
+	CONSTRAINT \`t3_t3_id1_t3_id2_pk\` PRIMARY KEY(\`t3_id1\`,\`t3_id2\`)
+);
+`;
+
+	const st4 = `ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t2_ref_t2_t2_id_fk\` FOREIGN KEY (\`t2_ref\`) REFERENCES \`t2\`(\`t2_id\`) ON DELETE no action ON UPDATE no action;`;
+
+	const st5 = `ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t1_col2_t1_col3_t3_t3_id1_t3_id2_fk\` FOREIGN KEY (\`t1_col2\`,\`t1_col3\`) REFERENCES \`t3\`(\`t3_id1\`,\`t3_id2\`) ON DELETE no action ON UPDATE no action;`;
+
+	const st6 = `CREATE INDEX \`t1_idx\` ON \`t1\` (\`t1_idx\`);`;
+
+	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6]);
+});
+
+test('optional db aliases (camel case)', async () => {
+	const from = {};
+
+	const t1 = mysqlTable(
+		't1',
+		{
+			t1_id1: int().notNull().primaryKey(),
+			t1_col2: int().notNull(),
+			t1_col3: int().notNull(),
+			t2_ref: int().notNull().references(() => t2.t2_id),
+			t1_uni: int().notNull(),
+			t1_uni_idx: int().notNull(),
+			t1_idx: int().notNull(),
+		},
+		(table) => ({
+			uni: unique('t1Uni').on(table.t1_uni),
+			uni_idx: uniqueIndex('t1UniIdx').on(table.t1_uni_idx),
+			idx: index('t1Idx').on(table.t1_idx),
+			fk: foreignKey({
+				columns: [table.t1_col2, table.t1_col3],
+				foreignColumns: [t3.t3_id1, t3.t3_id2],
+			}),
+		}),
+	)
+
+	const t2 = mysqlTable(
+		't2',
+		{
+			t2_id: serial().primaryKey()
+		}
+	);
+
+	const t3 = mysqlTable(
+		't3',
+		{
+			t3_id1: int(),
+			t3_id2: int(),
+		},
+		(table) => ({
+			pk: primaryKey({
+				columns: [table.t3_id1, table.t3_id2],
+			}),
+		}),
+	);
+
+	const to = {
+		t1,
+		t2,
+		t3
+	};
+
+	const { sqlStatements } = await diffTestSchemasMysql(from, to, [], false, 'camel');
+
+	const st1 = `CREATE TABLE \`t1\` (
+	\`t1Id1\` int NOT NULL,
+	\`t1Col2\` int NOT NULL,
+	\`t1Col3\` int NOT NULL,
+	\`t2Ref\` int NOT NULL,
+	\`t1Uni\` int NOT NULL,
+	\`t1UniIdx\` int NOT NULL,
+	\`t1Idx\` int NOT NULL,
+	CONSTRAINT \`t1_t1Id1\` PRIMARY KEY(\`t1Id1\`),
+	CONSTRAINT \`t1Uni\` UNIQUE(\`t1Uni\`),
+	CONSTRAINT \`t1UniIdx\` UNIQUE(\`t1UniIdx\`)
+);
+`;
+
+	const st2 = `CREATE TABLE \`t2\` (
+	\`t2Id\` serial AUTO_INCREMENT NOT NULL,
+	CONSTRAINT \`t2_t2Id\` PRIMARY KEY(\`t2Id\`)
+);
+`;
+
+	const st3 = `CREATE TABLE \`t3\` (
+	\`t3Id1\` int NOT NULL,
+	\`t3Id2\` int NOT NULL,
+	CONSTRAINT \`t3_t3Id1_t3Id2_pk\` PRIMARY KEY(\`t3Id1\`,\`t3Id2\`)
+);
+`;
+
+	const st4 = `ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t2Ref_t2_t2Id_fk\` FOREIGN KEY (\`t2Ref\`) REFERENCES \`t2\`(\`t2Id\`) ON DELETE no action ON UPDATE no action;`;
+
+	const st5 = `ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t1Col2_t1Col3_t3_t3Id1_t3Id2_fk\` FOREIGN KEY (\`t1Col2\`,\`t1Col3\`) REFERENCES \`t3\`(\`t3Id1\`,\`t3Id2\`) ON DELETE no action ON UPDATE no action;`;
+
+	const st6 = `CREATE INDEX \`t1Idx\` ON \`t1\` (\`t1Idx\`);`;
+
+	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6]);
 });

--- a/drizzle-kit/tests/mysql.test.ts
+++ b/drizzle-kit/tests/mysql.test.ts
@@ -1,5 +1,17 @@
 import { sql } from 'drizzle-orm';
-import { foreignKey, index, int, json, mysqlSchema, mysqlTable, primaryKey, serial, text, unique, uniqueIndex } from 'drizzle-orm/mysql-core';
+import {
+	foreignKey,
+	index,
+	int,
+	json,
+	mysqlSchema,
+	mysqlTable,
+	primaryKey,
+	serial,
+	text,
+	unique,
+	uniqueIndex,
+} from 'drizzle-orm/mysql-core';
 import { expect, test } from 'vitest';
 import { diffTestSchemasMysql } from './schemaDiffer';
 
@@ -579,13 +591,13 @@ test('optional db aliases (snake case)', async () => {
 				foreignColumns: [t3.t3Id1, t3.t3Id2],
 			}),
 		}),
-	)
+	);
 
 	const t2 = mysqlTable(
 		't2',
 		{
-			t2Id: serial().primaryKey()
-		}
+			t2Id: serial().primaryKey(),
+		},
 	);
 
 	const t3 = mysqlTable(
@@ -604,7 +616,7 @@ test('optional db aliases (snake case)', async () => {
 	const to = {
 		t1,
 		t2,
-		t3
+		t3,
 	};
 
 	const { sqlStatements } = await diffTestSchemasMysql(from, to, [], false, 'snake');
@@ -636,9 +648,11 @@ test('optional db aliases (snake case)', async () => {
 );
 `;
 
-	const st4 = `ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t2_ref_t2_t2_id_fk\` FOREIGN KEY (\`t2_ref\`) REFERENCES \`t2\`(\`t2_id\`) ON DELETE no action ON UPDATE no action;`;
+	const st4 =
+		`ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t2_ref_t2_t2_id_fk\` FOREIGN KEY (\`t2_ref\`) REFERENCES \`t2\`(\`t2_id\`) ON DELETE no action ON UPDATE no action;`;
 
-	const st5 = `ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t1_col2_t1_col3_t3_t3_id1_t3_id2_fk\` FOREIGN KEY (\`t1_col2\`,\`t1_col3\`) REFERENCES \`t3\`(\`t3_id1\`,\`t3_id2\`) ON DELETE no action ON UPDATE no action;`;
+	const st5 =
+		`ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t1_col2_t1_col3_t3_t3_id1_t3_id2_fk\` FOREIGN KEY (\`t1_col2\`,\`t1_col3\`) REFERENCES \`t3\`(\`t3_id1\`,\`t3_id2\`) ON DELETE no action ON UPDATE no action;`;
 
 	const st6 = `CREATE INDEX \`t1_idx\` ON \`t1\` (\`t1_idx\`);`;
 
@@ -668,13 +682,13 @@ test('optional db aliases (camel case)', async () => {
 				foreignColumns: [t3.t3_id1, t3.t3_id2],
 			}),
 		}),
-	)
+	);
 
 	const t2 = mysqlTable(
 		't2',
 		{
-			t2_id: serial().primaryKey()
-		}
+			t2_id: serial().primaryKey(),
+		},
 	);
 
 	const t3 = mysqlTable(
@@ -693,7 +707,7 @@ test('optional db aliases (camel case)', async () => {
 	const to = {
 		t1,
 		t2,
-		t3
+		t3,
 	};
 
 	const { sqlStatements } = await diffTestSchemasMysql(from, to, [], false, 'camel');
@@ -725,9 +739,11 @@ test('optional db aliases (camel case)', async () => {
 );
 `;
 
-	const st4 = `ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t2Ref_t2_t2Id_fk\` FOREIGN KEY (\`t2Ref\`) REFERENCES \`t2\`(\`t2Id\`) ON DELETE no action ON UPDATE no action;`;
+	const st4 =
+		`ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t2Ref_t2_t2Id_fk\` FOREIGN KEY (\`t2Ref\`) REFERENCES \`t2\`(\`t2Id\`) ON DELETE no action ON UPDATE no action;`;
 
-	const st5 = `ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t1Col2_t1Col3_t3_t3Id1_t3Id2_fk\` FOREIGN KEY (\`t1Col2\`,\`t1Col3\`) REFERENCES \`t3\`(\`t3Id1\`,\`t3Id2\`) ON DELETE no action ON UPDATE no action;`;
+	const st5 =
+		`ALTER TABLE \`t1\` ADD CONSTRAINT \`t1_t1Col2_t1Col3_t3_t3Id1_t3Id2_fk\` FOREIGN KEY (\`t1Col2\`,\`t1Col3\`) REFERENCES \`t3\`(\`t3Id1\`,\`t3Id2\`) ON DELETE no action ON UPDATE no action;`;
 
 	const st6 = `CREATE INDEX \`t1Idx\` ON \`t1\` (\`t1Idx\`);`;
 

--- a/drizzle-kit/tests/mysql.test.ts
+++ b/drizzle-kit/tests/mysql.test.ts
@@ -619,7 +619,7 @@ test('optional db aliases (snake case)', async () => {
 		t3,
 	};
 
-	const { sqlStatements } = await diffTestSchemasMysql(from, to, [], false, 'snake');
+	const { sqlStatements } = await diffTestSchemasMysql(from, to, [], false, 'snake_case');
 
 	const st1 = `CREATE TABLE \`t1\` (
 	\`t1_id1\` int NOT NULL,
@@ -710,7 +710,7 @@ test('optional db aliases (camel case)', async () => {
 		t3,
 	};
 
-	const { sqlStatements } = await diffTestSchemasMysql(from, to, [], false, 'camel');
+	const { sqlStatements } = await diffTestSchemasMysql(from, to, [], false, 'camelCase');
 
 	const st1 = `CREATE TABLE \`t1\` (
 	\`t1Id1\` int NOT NULL,

--- a/drizzle-kit/tests/pg-tables.test.ts
+++ b/drizzle-kit/tests/pg-tables.test.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 import {
 	AnyPgColumn,
+	foreignKey,
 	geometry,
 	index,
 	integer,
@@ -12,6 +13,8 @@ import {
 	primaryKey,
 	serial,
 	text,
+	unique,
+	uniqueIndex,
 	vector,
 } from 'drizzle-orm/pg-core';
 import { expect, test } from 'vitest';
@@ -638,4 +641,200 @@ test('create table with tsvector', async () => {
 		'CREATE TABLE IF NOT EXISTS "posts" (\n\t"id" serial PRIMARY KEY NOT NULL,\n\t"title" text NOT NULL,\n\t"description" text NOT NULL\n);\n',
 		`CREATE INDEX IF NOT EXISTS "title_search_index" ON "posts" USING gin (to_tsvector('english', "title"));`,
 	]);
+});
+
+test('optional db aliases (snake case)', async () => {
+	const from = {};
+
+	const t1 = pgTable(
+		't1',
+		{
+			t1Id1: integer().notNull().primaryKey(),
+			t1Col2: integer().notNull(),
+			t1Col3: integer().notNull(),
+			t2Ref: integer().notNull().references(() => t2.t2Id),
+			t1Uni: integer().notNull(),
+			t1UniIdx: integer().notNull(),
+			t1Idx: integer().notNull(),
+		},
+		(table) => ({
+			uni: unique('t1_uni').on(table.t1Uni),
+			uniIdx: uniqueIndex('t1_uni_idx').on(table.t1UniIdx),
+			idx: index('t1_idx').on(table.t1Idx).where(sql`${table.t1Idx} > 0`),
+			fk: foreignKey({
+				columns: [table.t1Col2, table.t1Col3],
+				foreignColumns: [t3.t3Id1, t3.t3Id2],
+			}),
+		}),
+	)
+
+	const t2 = pgTable(
+		't2',
+		{
+			t2Id: serial().primaryKey()
+		}
+	);
+
+	const t3 = pgTable(
+		't3',
+		{
+			t3Id1: integer(),
+			t3Id2: integer(),
+		},
+		(table) => ({
+			pk: primaryKey({
+				columns: [table.t3Id1, table.t3Id2],
+			}),
+		}),
+	);
+
+	const to = {
+		t1,
+		t2,
+		t3
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, [], false, 'snake');
+
+	const st1 = `CREATE TABLE IF NOT EXISTS "t1" (
+	"t1_id1" integer PRIMARY KEY NOT NULL,
+	"t1_col2" integer NOT NULL,
+	"t1_col3" integer NOT NULL,
+	"t2_ref" integer NOT NULL,
+	"t1_uni" integer NOT NULL,
+	"t1_uni_idx" integer NOT NULL,
+	"t1_idx" integer NOT NULL,
+	CONSTRAINT "t1_uni" UNIQUE("t1_uni")
+);
+`;
+
+	const st2 = `CREATE TABLE IF NOT EXISTS "t2" (
+	"t2_id" serial PRIMARY KEY NOT NULL
+);
+`;
+
+	const st3 = `CREATE TABLE IF NOT EXISTS "t3" (
+	"t3_id1" integer,
+	"t3_id2" integer,
+	CONSTRAINT "t3_t3_id1_t3_id2_pk" PRIMARY KEY("t3_id1","t3_id2")
+);
+`;
+
+	const st4 = `DO $$ BEGIN
+ ALTER TABLE "t1" ADD CONSTRAINT "t1_t2_ref_t2_t2_id_fk" FOREIGN KEY ("t2_ref") REFERENCES "public"."t2"("t2_id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+`;
+
+	const st5 = `DO $$ BEGIN
+ ALTER TABLE "t1" ADD CONSTRAINT "t1_t1_col2_t1_col3_t3_t3_id1_t3_id2_fk" FOREIGN KEY ("t1_col2","t1_col3") REFERENCES "public"."t3"("t3_id1","t3_id2") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+`;
+
+	const st6 = `CREATE UNIQUE INDEX IF NOT EXISTS "t1_uni_idx" ON "t1" USING btree ("t1_uni_idx");`;
+
+	const st7 = `CREATE INDEX IF NOT EXISTS "t1_idx" ON "t1" USING btree ("t1_idx") WHERE "t1"."t1_idx" > 0;`;
+
+	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6, st7]);
+});
+
+test('optional db aliases (camel case)', async () => {
+	const from = {};
+
+	const t1 = pgTable(
+		't1',
+		{
+			t1_id1: integer().notNull().primaryKey(),
+			t1_col2: integer().notNull(),
+			t1_col3: integer().notNull(),
+			t2_ref: integer().notNull().references(() => t2.t2_id),
+			t1_uni: integer().notNull(),
+			t1_uni_idx: integer().notNull(),
+			t1_idx: integer().notNull(),
+		},
+		(table) => ({
+			uni: unique('t1Uni').on(table.t1_uni),
+			uni_idx: uniqueIndex('t1UniIdx').on(table.t1_uni_idx),
+			idx: index('t1Idx').on(table.t1_idx).where(sql`${table.t1_idx} > 0`),
+			fk: foreignKey({
+				columns: [table.t1_col2, table.t1_col3],
+				foreignColumns: [t3.t3_id1, t3.t3_id2],
+			}),
+		}),
+	)
+
+	const t2 = pgTable(
+		't2',
+		{
+			t2_id: serial().primaryKey()
+		}
+	);
+
+	const t3 = pgTable(
+		't3',
+		{
+			t3_id1: integer(),
+			t3_id2: integer(),
+		},
+		(table) => ({
+			pk: primaryKey({
+				columns: [table.t3_id1, table.t3_id2],
+			}),
+		}),
+	);
+
+	const to = {
+		t1,
+		t2,
+		t3
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, [], false, 'camel');
+
+	const st1 = `CREATE TABLE IF NOT EXISTS "t1" (
+	"t1Id1" integer PRIMARY KEY NOT NULL,
+	"t1Col2" integer NOT NULL,
+	"t1Col3" integer NOT NULL,
+	"t2Ref" integer NOT NULL,
+	"t1Uni" integer NOT NULL,
+	"t1UniIdx" integer NOT NULL,
+	"t1Idx" integer NOT NULL,
+	CONSTRAINT "t1Uni" UNIQUE("t1Uni")
+);
+`;
+
+	const st2 = `CREATE TABLE IF NOT EXISTS "t2" (
+	"t2Id" serial PRIMARY KEY NOT NULL
+);
+`;
+
+	const st3 = `CREATE TABLE IF NOT EXISTS "t3" (
+	"t3Id1" integer,
+	"t3Id2" integer,
+	CONSTRAINT "t3_t3Id1_t3Id2_pk" PRIMARY KEY("t3Id1","t3Id2")
+);
+`;
+
+	const st4 = `DO $$ BEGIN
+ ALTER TABLE "t1" ADD CONSTRAINT "t1_t2Ref_t2_t2Id_fk" FOREIGN KEY ("t2Ref") REFERENCES "public"."t2"("t2Id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+`;
+
+	const st5 = `DO $$ BEGIN
+ ALTER TABLE "t1" ADD CONSTRAINT "t1_t1Col2_t1Col3_t3_t3Id1_t3Id2_fk" FOREIGN KEY ("t1Col2","t1Col3") REFERENCES "public"."t3"("t3Id1","t3Id2") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+`;
+
+	const st6 = `CREATE UNIQUE INDEX IF NOT EXISTS "t1UniIdx" ON "t1" USING btree ("t1UniIdx");`;
+
+	const st7 = `CREATE INDEX IF NOT EXISTS "t1Idx" ON "t1" USING btree ("t1Idx") WHERE "t1"."t1Idx" > 0;`;
+
+	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6, st7]);
 });

--- a/drizzle-kit/tests/pg-tables.test.ts
+++ b/drizzle-kit/tests/pg-tables.test.ts
@@ -694,7 +694,7 @@ test('optional db aliases (snake case)', async () => {
 		t3,
 	};
 
-	const { sqlStatements } = await diffTestSchemas(from, to, [], false, 'snake');
+	const { sqlStatements } = await diffTestSchemas(from, to, [], false, 'snake_case');
 
 	const st1 = `CREATE TABLE IF NOT EXISTS "t1" (
 	"t1_id1" integer PRIMARY KEY NOT NULL,
@@ -792,7 +792,7 @@ test('optional db aliases (camel case)', async () => {
 		t3,
 	};
 
-	const { sqlStatements } = await diffTestSchemas(from, to, [], false, 'camel');
+	const { sqlStatements } = await diffTestSchemas(from, to, [], false, 'camelCase');
 
 	const st1 = `CREATE TABLE IF NOT EXISTS "t1" (
 	"t1Id1" integer PRIMARY KEY NOT NULL,

--- a/drizzle-kit/tests/pg-tables.test.ts
+++ b/drizzle-kit/tests/pg-tables.test.ts
@@ -666,13 +666,13 @@ test('optional db aliases (snake case)', async () => {
 				foreignColumns: [t3.t3Id1, t3.t3Id2],
 			}),
 		}),
-	)
+	);
 
 	const t2 = pgTable(
 		't2',
 		{
-			t2Id: serial().primaryKey()
-		}
+			t2Id: serial().primaryKey(),
+		},
 	);
 
 	const t3 = pgTable(
@@ -691,7 +691,7 @@ test('optional db aliases (snake case)', async () => {
 	const to = {
 		t1,
 		t2,
-		t3
+		t3,
 	};
 
 	const { sqlStatements } = await diffTestSchemas(from, to, [], false, 'snake');
@@ -764,13 +764,13 @@ test('optional db aliases (camel case)', async () => {
 				foreignColumns: [t3.t3_id1, t3.t3_id2],
 			}),
 		}),
-	)
+	);
 
 	const t2 = pgTable(
 		't2',
 		{
-			t2_id: serial().primaryKey()
-		}
+			t2_id: serial().primaryKey(),
+		},
 	);
 
 	const t3 = pgTable(
@@ -789,7 +789,7 @@ test('optional db aliases (camel case)', async () => {
 	const to = {
 		t1,
 		t2,
-		t3
+		t3,
 	};
 
 	const { sqlStatements } = await diffTestSchemas(from, to, [], false, 'camel');

--- a/drizzle-kit/tests/schemaDiffer.ts
+++ b/drizzle-kit/tests/schemaDiffer.ts
@@ -17,6 +17,7 @@ import {
 	tablesResolver,
 } from 'src/cli/commands/migrate';
 import { logSuggestionsAndReturn } from 'src/cli/commands/sqlitePushUtils';
+import { CasingType } from 'src/cli/validations/common';
 import { schemaToTypeScript as schemaToTypeScriptMySQL } from 'src/introspect-mysql';
 import { schemaToTypeScript } from 'src/introspect-pg';
 import { schemaToTypeScript as schemaToTypeScriptSQLite } from 'src/introspect-sqlite';
@@ -412,8 +413,9 @@ export const diffTestSchemasPush = async (
 	renamesArr: string[],
 	cli: boolean = false,
 	schemas: string[] = ['public'],
+	casing?: CasingType | undefined
 ) => {
-	const { sqlStatements } = await applyPgDiffs(left);
+	const { sqlStatements } = await applyPgDiffs(left, casing);
 	for (const st of sqlStatements) {
 		await client.query(st);
 	}
@@ -443,6 +445,7 @@ export const diffTestSchemasPush = async (
 		leftEnums,
 		leftSchemas,
 		leftSequences,
+		casing
 	);
 
 	const { version: v1, dialect: d1, ...rest1 } = introspectedSchema;
@@ -503,7 +506,7 @@ export const diffTestSchemasPush = async (
 	}
 };
 
-export const applyPgDiffs = async (sn: PostgresSchema) => {
+export const applyPgDiffs = async (sn: PostgresSchema, casing: CasingType | undefined) => {
 	const dryRun = {
 		version: '7',
 		dialect: 'postgresql',
@@ -528,7 +531,7 @@ export const applyPgDiffs = async (sn: PostgresSchema) => {
 
 	const sequences = Object.values(sn).filter((it) => isPgSequence(it)) as PgSequence[];
 
-	const serialized1 = generatePgSnapshot(tables, enums, schemas, sequences);
+	const serialized1 = generatePgSnapshot(tables, enums, schemas, sequences, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = serialized1;
 
@@ -564,6 +567,7 @@ export const diffTestSchemas = async (
 	right: PostgresSchema,
 	renamesArr: string[],
 	cli: boolean = false,
+	casing?: CasingType | undefined
 ) => {
 	const leftTables = Object.values(left).filter((it) => is(it, PgTable)) as PgTable[];
 
@@ -586,12 +590,14 @@ export const diffTestSchemas = async (
 		leftEnums,
 		leftSchemas,
 		leftSequences,
+		casing
 	);
 	const serialized2 = generatePgSnapshot(
 		rightTables,
 		rightEnums,
 		rightSchemas,
 		rightSequences,
+		casing
 	);
 
 	const { version: v1, dialect: d1, ...rest1 } = serialized1;
@@ -657,8 +663,9 @@ export const diffTestSchemasPushMysql = async (
 	renamesArr: string[],
 	schema: string,
 	cli: boolean = false,
+	casing?: CasingType | undefined
 ) => {
-	const { sqlStatements } = await applyMySqlDiffs(left);
+	const { sqlStatements } = await applyMySqlDiffs(left, casing);
 	for (const st of sqlStatements) {
 		await client.query(st);
 	}
@@ -675,7 +682,7 @@ export const diffTestSchemasPushMysql = async (
 
 	const leftTables = Object.values(right).filter((it) => is(it, MySqlTable)) as MySqlTable[];
 
-	const serialized2 = generateMySqlSnapshot(leftTables);
+	const serialized2 = generateMySqlSnapshot(leftTables, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = introspectedSchema;
 	const { version: v2, dialect: d2, ...rest2 } = serialized2;
@@ -729,7 +736,7 @@ export const diffTestSchemasPushMysql = async (
 	}
 };
 
-export const applyMySqlDiffs = async (sn: MysqlSchema) => {
+export const applyMySqlDiffs = async (sn: MysqlSchema, casing: CasingType | undefined) => {
 	const dryRun = {
 		version: '5',
 		dialect: 'mysql',
@@ -747,7 +754,7 @@ export const applyMySqlDiffs = async (sn: MysqlSchema) => {
 
 	const tables = Object.values(sn).filter((it) => is(it, MySqlTable)) as MySqlTable[];
 
-	const serialized1 = generateMySqlSnapshot(tables);
+	const serialized1 = generateMySqlSnapshot(tables, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = serialized1;
 
@@ -780,13 +787,14 @@ export const diffTestSchemasMysql = async (
 	right: MysqlSchema,
 	renamesArr: string[],
 	cli: boolean = false,
+	casing?: CasingType | undefined
 ) => {
 	const leftTables = Object.values(left).filter((it) => is(it, MySqlTable)) as MySqlTable[];
 
 	const rightTables = Object.values(right).filter((it) => is(it, MySqlTable)) as MySqlTable[];
 
-	const serialized1 = generateMySqlSnapshot(leftTables);
-	const serialized2 = generateMySqlSnapshot(rightTables);
+	const serialized1 = generateMySqlSnapshot(leftTables, casing);
+	const serialized2 = generateMySqlSnapshot(rightTables, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = serialized1;
 	const { version: v2, dialect: d2, ...rest2 } = serialized2;
@@ -845,6 +853,7 @@ export const diffTestSchemasPushSqlite = async (
 	renamesArr: string[],
 	cli: boolean = false,
 	seedStatements: string[] = [],
+	casing?: CasingType | undefined
 ) => {
 	const { sqlStatements } = await applySqliteDiffs(left, 'push');
 
@@ -871,7 +880,7 @@ export const diffTestSchemasPushSqlite = async (
 
 	const rightTables = Object.values(right).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
-	const serialized2 = generateSqliteSnapshot(rightTables);
+	const serialized2 = generateSqliteSnapshot(rightTables, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = introspectedSchema;
 	const { version: v2, dialect: d2, ...rest2 } = serialized2;
@@ -962,6 +971,7 @@ export async function diffTestSchemasPushLibSQL(
 	renamesArr: string[],
 	cli: boolean = false,
 	seedStatements: string[] = [],
+	casing?: CasingType | undefined
 ) {
 	const { sqlStatements } = await applyLibSQLDiffs(left, 'push');
 
@@ -995,7 +1005,7 @@ export async function diffTestSchemasPushLibSQL(
 
 	const leftTables = Object.values(right).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
-	const serialized2 = generateSqliteSnapshot(leftTables);
+	const serialized2 = generateSqliteSnapshot(leftTables, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = introspectedSchema;
 	const { version: v2, dialect: d2, ...rest2 } = serialized2;
@@ -1088,6 +1098,7 @@ export async function diffTestSchemasPushLibSQL(
 export const applySqliteDiffs = async (
 	sn: SqliteSchema,
 	action?: 'push' | undefined,
+	casing?: CasingType | undefined,
 ) => {
 	const dryRun = {
 		version: '6',
@@ -1106,7 +1117,7 @@ export const applySqliteDiffs = async (
 
 	const tables = Object.values(sn).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
-	const serialized1 = generateSqliteSnapshot(tables);
+	const serialized1 = generateSqliteSnapshot(tables, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = serialized1;
 
@@ -1136,6 +1147,7 @@ export const applySqliteDiffs = async (
 export const applyLibSQLDiffs = async (
 	sn: SqliteSchema,
 	action?: 'push' | undefined,
+	casing?: CasingType | undefined,
 ) => {
 	const dryRun = {
 		version: '6',
@@ -1154,7 +1166,7 @@ export const applyLibSQLDiffs = async (
 
 	const tables = Object.values(sn).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
-	const serialized1 = generateSqliteSnapshot(tables);
+	const serialized1 = generateSqliteSnapshot(tables, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = serialized1;
 
@@ -1186,13 +1198,14 @@ export const diffTestSchemasSqlite = async (
 	right: SqliteSchema,
 	renamesArr: string[],
 	cli: boolean = false,
+	casing?: CasingType | undefined
 ) => {
 	const leftTables = Object.values(left).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
 	const rightTables = Object.values(right).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
-	const serialized1 = generateSqliteSnapshot(leftTables);
-	const serialized2 = generateSqliteSnapshot(rightTables);
+	const serialized1 = generateSqliteSnapshot(leftTables, casing);
+	const serialized2 = generateSqliteSnapshot(rightTables, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = serialized1;
 	const { version: v2, dialect: d2, ...rest2 } = serialized2;
@@ -1246,13 +1259,14 @@ export const diffTestSchemasLibSQL = async (
 	right: SqliteSchema,
 	renamesArr: string[],
 	cli: boolean = false,
+	casing?: CasingType | undefined
 ) => {
 	const leftTables = Object.values(left).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
 	const rightTables = Object.values(right).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
-	const serialized1 = generateSqliteSnapshot(leftTables);
-	const serialized2 = generateSqliteSnapshot(rightTables);
+	const serialized1 = generateSqliteSnapshot(leftTables, casing);
+	const serialized2 = generateSqliteSnapshot(rightTables, casing);
 
 	const { version: v1, dialect: d1, ...rest1 } = serialized1;
 	const { version: v2, dialect: d2, ...rest2 } = serialized2;
@@ -1308,9 +1322,10 @@ export const introspectPgToFile = async (
 	initSchema: PostgresSchema,
 	testName: string,
 	schemas: string[] = ['public'],
+	casing?: CasingType | undefined
 ) => {
 	// put in db
-	const { sqlStatements } = await applyPgDiffs(initSchema);
+	const { sqlStatements } = await applyPgDiffs(initSchema, casing);
 	for (const st of sqlStatements) {
 		await client.query(st);
 	}
@@ -1340,6 +1355,7 @@ export const introspectPgToFile = async (
 		response.enums,
 		response.schemas,
 		response.sequences,
+		casing
 	);
 
 	const { version: v2, dialect: d2, ...rest2 } = afterFileImports;
@@ -1368,6 +1384,7 @@ export const introspectPgToFile = async (
 		leftEnums,
 		leftSchemas,
 		leftSequences,
+		casing
 	);
 
 	const { version: initV, dialect: initD, ...initRest } = initSnapshot;
@@ -1411,9 +1428,10 @@ export const introspectMySQLToFile = async (
 	initSchema: MysqlSchema,
 	testName: string,
 	schema: string,
+	casing?: CasingType | undefined
 ) => {
 	// put in db
-	const { sqlStatements } = await applyMySqlDiffs(initSchema);
+	const { sqlStatements } = await applyMySqlDiffs(initSchema, casing);
 	for (const st of sqlStatements) {
 		await client.query(st);
 	}
@@ -1437,7 +1455,7 @@ export const introspectMySQLToFile = async (
 		`tests/introspect/mysql/${testName}.ts`,
 	]);
 
-	const afterFileImports = generateMySqlSnapshot(response.tables);
+	const afterFileImports = generateMySqlSnapshot(response.tables, casing);
 
 	const { version: v2, dialect: d2, ...rest2 } = afterFileImports;
 
@@ -1454,7 +1472,7 @@ export const introspectMySQLToFile = async (
 
 	const leftTables = Object.values(initSchema).filter((it) => is(it, MySqlTable)) as MySqlTable[];
 
-	const initSnapshot = generateMySqlSnapshot(leftTables);
+	const initSnapshot = generateMySqlSnapshot(leftTables, casing);
 
 	const { version: initV, dialect: initD, ...initRest } = initSnapshot;
 
@@ -1493,6 +1511,7 @@ export const introspectSQLiteToFile = async (
 	client: Database,
 	initSchema: SqliteSchema,
 	testName: string,
+	casing?: CasingType | undefined
 ) => {
 	// put in db
 	const { sqlStatements } = await applySqliteDiffs(initSchema);
@@ -1521,7 +1540,7 @@ export const introspectSQLiteToFile = async (
 		`tests/introspect/sqlite/${testName}.ts`,
 	]);
 
-	const afterFileImports = generateSqliteSnapshot(response.tables);
+	const afterFileImports = generateSqliteSnapshot(response.tables, casing);
 
 	const { version: v2, dialect: d2, ...rest2 } = afterFileImports;
 
@@ -1538,7 +1557,7 @@ export const introspectSQLiteToFile = async (
 
 	const leftTables = Object.values(initSchema).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
-	const initSnapshot = generateSqliteSnapshot(leftTables);
+	const initSnapshot = generateSqliteSnapshot(leftTables, casing);
 
 	const { version: initV, dialect: initD, ...initRest } = initSnapshot;
 

--- a/drizzle-kit/tests/schemaDiffer.ts
+++ b/drizzle-kit/tests/schemaDiffer.ts
@@ -413,7 +413,7 @@ export const diffTestSchemasPush = async (
 	renamesArr: string[],
 	cli: boolean = false,
 	schemas: string[] = ['public'],
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	const { sqlStatements } = await applyPgDiffs(left, casing);
 	for (const st of sqlStatements) {
@@ -445,7 +445,7 @@ export const diffTestSchemasPush = async (
 		leftEnums,
 		leftSchemas,
 		leftSequences,
-		casing
+		casing,
 	);
 
 	const { version: v1, dialect: d1, ...rest1 } = introspectedSchema;
@@ -567,7 +567,7 @@ export const diffTestSchemas = async (
 	right: PostgresSchema,
 	renamesArr: string[],
 	cli: boolean = false,
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	const leftTables = Object.values(left).filter((it) => is(it, PgTable)) as PgTable[];
 
@@ -590,14 +590,14 @@ export const diffTestSchemas = async (
 		leftEnums,
 		leftSchemas,
 		leftSequences,
-		casing
+		casing,
 	);
 	const serialized2 = generatePgSnapshot(
 		rightTables,
 		rightEnums,
 		rightSchemas,
 		rightSequences,
-		casing
+		casing,
 	);
 
 	const { version: v1, dialect: d1, ...rest1 } = serialized1;
@@ -663,7 +663,7 @@ export const diffTestSchemasPushMysql = async (
 	renamesArr: string[],
 	schema: string,
 	cli: boolean = false,
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	const { sqlStatements } = await applyMySqlDiffs(left, casing);
 	for (const st of sqlStatements) {
@@ -787,7 +787,7 @@ export const diffTestSchemasMysql = async (
 	right: MysqlSchema,
 	renamesArr: string[],
 	cli: boolean = false,
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	const leftTables = Object.values(left).filter((it) => is(it, MySqlTable)) as MySqlTable[];
 
@@ -853,7 +853,7 @@ export const diffTestSchemasPushSqlite = async (
 	renamesArr: string[],
 	cli: boolean = false,
 	seedStatements: string[] = [],
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	const { sqlStatements } = await applySqliteDiffs(left, 'push');
 
@@ -971,7 +971,7 @@ export async function diffTestSchemasPushLibSQL(
 	renamesArr: string[],
 	cli: boolean = false,
 	seedStatements: string[] = [],
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) {
 	const { sqlStatements } = await applyLibSQLDiffs(left, 'push');
 
@@ -1198,7 +1198,7 @@ export const diffTestSchemasSqlite = async (
 	right: SqliteSchema,
 	renamesArr: string[],
 	cli: boolean = false,
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	const leftTables = Object.values(left).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
@@ -1259,7 +1259,7 @@ export const diffTestSchemasLibSQL = async (
 	right: SqliteSchema,
 	renamesArr: string[],
 	cli: boolean = false,
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	const leftTables = Object.values(left).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
 
@@ -1322,7 +1322,7 @@ export const introspectPgToFile = async (
 	initSchema: PostgresSchema,
 	testName: string,
 	schemas: string[] = ['public'],
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	// put in db
 	const { sqlStatements } = await applyPgDiffs(initSchema, casing);
@@ -1355,7 +1355,7 @@ export const introspectPgToFile = async (
 		response.enums,
 		response.schemas,
 		response.sequences,
-		casing
+		casing,
 	);
 
 	const { version: v2, dialect: d2, ...rest2 } = afterFileImports;
@@ -1384,7 +1384,7 @@ export const introspectPgToFile = async (
 		leftEnums,
 		leftSchemas,
 		leftSequences,
-		casing
+		casing,
 	);
 
 	const { version: initV, dialect: initD, ...initRest } = initSnapshot;
@@ -1428,7 +1428,7 @@ export const introspectMySQLToFile = async (
 	initSchema: MysqlSchema,
 	testName: string,
 	schema: string,
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	// put in db
 	const { sqlStatements } = await applyMySqlDiffs(initSchema, casing);
@@ -1511,7 +1511,7 @@ export const introspectSQLiteToFile = async (
 	client: Database,
 	initSchema: SqliteSchema,
 	testName: string,
-	casing?: CasingType | undefined
+	casing?: CasingType | undefined,
 ) => {
 	// put in db
 	const { sqlStatements } = await applySqliteDiffs(initSchema);

--- a/drizzle-kit/tests/sqlite-tables.test.ts
+++ b/drizzle-kit/tests/sqlite-tables.test.ts
@@ -1,5 +1,15 @@
 import { sql } from 'drizzle-orm';
-import { AnySQLiteColumn, foreignKey, index, int, primaryKey, sqliteTable, text, unique, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import {
+	AnySQLiteColumn,
+	foreignKey,
+	index,
+	int,
+	primaryKey,
+	sqliteTable,
+	text,
+	unique,
+	uniqueIndex,
+} from 'drizzle-orm/sqlite-core';
 import { expect, test } from 'vitest';
 import { diffTestSchemasSqlite } from './schemaDiffer';
 
@@ -421,13 +431,13 @@ test('optional db aliases (snake case)', async () => {
 				foreignColumns: [t3.t3Id1, t3.t3Id2],
 			}),
 		}),
-	)
+	);
 
 	const t2 = sqliteTable(
 		't2',
 		{
-			t2Id: int().primaryKey({ autoIncrement: true })
-		}
+			t2Id: int().primaryKey({ autoIncrement: true }),
+		},
 	);
 
 	const t3 = sqliteTable(
@@ -446,7 +456,7 @@ test('optional db aliases (snake case)', async () => {
 	const to = {
 		t1,
 		t2,
-		t3
+		t3,
 	};
 
 	const { sqlStatements } = await diffTestSchemasSqlite(from, to, [], false, 'snake');
@@ -508,13 +518,13 @@ test('optional db aliases (camel case)', async () => {
 				foreignColumns: [t3.t3_id1, t3.t3_id2],
 			}),
 		}),
-	)
+	);
 
 	const t2 = sqliteTable(
 		't2',
 		{
-			t2_id: int().primaryKey({ autoIncrement: true })
-		}
+			t2_id: int().primaryKey({ autoIncrement: true }),
+		},
 	);
 
 	const t3 = sqliteTable(
@@ -533,7 +543,7 @@ test('optional db aliases (camel case)', async () => {
 	const to = {
 		t1,
 		t2,
-		t3
+		t3,
 	};
 
 	const { sqlStatements } = await diffTestSchemasSqlite(from, to, [], false, 'camel');

--- a/drizzle-kit/tests/sqlite-tables.test.ts
+++ b/drizzle-kit/tests/sqlite-tables.test.ts
@@ -459,7 +459,7 @@ test('optional db aliases (snake case)', async () => {
 		t3,
 	};
 
-	const { sqlStatements } = await diffTestSchemasSqlite(from, to, [], false, 'snake');
+	const { sqlStatements } = await diffTestSchemasSqlite(from, to, [], false, 'snake_case');
 
 	const st1 = `CREATE TABLE \`t1\` (
 	\`t1_id1\` integer PRIMARY KEY NOT NULL,
@@ -546,7 +546,7 @@ test('optional db aliases (camel case)', async () => {
 		t3,
 	};
 
-	const { sqlStatements } = await diffTestSchemasSqlite(from, to, [], false, 'camel');
+	const { sqlStatements } = await diffTestSchemasSqlite(from, to, [], false, 'camelCase');
 
 	const st1 = `CREATE TABLE \`t1\` (
 	\`t1Id1\` integer PRIMARY KEY NOT NULL,

--- a/drizzle-kit/tests/sqlite-tables.test.ts
+++ b/drizzle-kit/tests/sqlite-tables.test.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { AnySQLiteColumn, index, int, primaryKey, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import { AnySQLiteColumn, foreignKey, index, int, primaryKey, sqliteTable, text, unique, uniqueIndex } from 'drizzle-orm/sqlite-core';
 import { expect, test } from 'vitest';
 import { diffTestSchemasSqlite } from './schemaDiffer';
 
@@ -396,4 +396,178 @@ test('add table with indexes', async () => {
 		'CREATE INDEX `indexColMultiple` ON `users` (`email`,`email`);',
 		'CREATE INDEX `indexColExpr` ON `users` ((lower("email")),`email`);',
 	]);
+});
+
+test('optional db aliases (snake case)', async () => {
+	const from = {};
+
+	const t1 = sqliteTable(
+		't1',
+		{
+			t1Id1: int().notNull().primaryKey(),
+			t1Col2: int().notNull(),
+			t1Col3: int().notNull(),
+			t2Ref: int().notNull().references(() => t2.t2Id),
+			t1Uni: int().notNull(),
+			t1UniIdx: int().notNull(),
+			t1Idx: int().notNull(),
+		},
+		(table) => ({
+			uni: unique('t1_uni').on(table.t1Uni),
+			uniIdx: uniqueIndex('t1_uni_idx').on(table.t1UniIdx),
+			idx: index('t1_idx').on(table.t1Idx),
+			fk: foreignKey({
+				columns: [table.t1Col2, table.t1Col3],
+				foreignColumns: [t3.t3Id1, t3.t3Id2],
+			}),
+		}),
+	)
+
+	const t2 = sqliteTable(
+		't2',
+		{
+			t2Id: int().primaryKey({ autoIncrement: true })
+		}
+	);
+
+	const t3 = sqliteTable(
+		't3',
+		{
+			t3Id1: int(),
+			t3Id2: int(),
+		},
+		(table) => ({
+			pk: primaryKey({
+				columns: [table.t3Id1, table.t3Id2],
+			}),
+		}),
+	);
+
+	const to = {
+		t1,
+		t2,
+		t3
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite(from, to, [], false, 'snake');
+
+	const st1 = `CREATE TABLE \`t1\` (
+	\`t1_id1\` integer PRIMARY KEY NOT NULL,
+	\`t1_col2\` integer NOT NULL,
+	\`t1_col3\` integer NOT NULL,
+	\`t2_ref\` integer NOT NULL,
+	\`t1_uni\` integer NOT NULL,
+	\`t1_uni_idx\` integer NOT NULL,
+	\`t1_idx\` integer NOT NULL,
+	FOREIGN KEY (\`t2_ref\`) REFERENCES \`t2\`(\`t2_id\`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (\`t1_col2\`,\`t1_col3\`) REFERENCES \`t3\`(\`t3_id1\`,\`t3_id2\`) ON UPDATE no action ON DELETE no action
+);
+`;
+
+	const st2 = `CREATE UNIQUE INDEX \`t1_uni_idx\` ON \`t1\` (\`t1_uni_idx\`);`;
+
+	const st3 = `CREATE INDEX \`t1_idx\` ON \`t1\` (\`t1_idx\`);`;
+
+	const st4 = `CREATE UNIQUE INDEX \`t1_uni\` ON \`t1\` (\`t1_uni\`);`;
+
+	const st5 = `CREATE TABLE \`t2\` (
+	\`t2_id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+`;
+
+	const st6 = `CREATE TABLE \`t3\` (
+	\`t3_id1\` integer,
+	\`t3_id2\` integer,
+	PRIMARY KEY(\`t3_id1\`, \`t3_id2\`)
+);
+`;
+
+	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6]);
+});
+
+test('optional db aliases (camel case)', async () => {
+	const from = {};
+
+	const t1 = sqliteTable(
+		't1',
+		{
+			t1_id1: int().notNull().primaryKey(),
+			t1_col2: int().notNull(),
+			t1_col3: int().notNull(),
+			t2_ref: int().notNull().references(() => t2.t2_id),
+			t1_uni: int().notNull(),
+			t1_uni_idx: int().notNull(),
+			t1_idx: int().notNull(),
+		},
+		(table) => ({
+			uni: unique('t1Uni').on(table.t1_uni),
+			uni_idx: uniqueIndex('t1UniIdx').on(table.t1_uni_idx),
+			idx: index('t1Idx').on(table.t1_idx),
+			fk: foreignKey({
+				columns: [table.t1_col2, table.t1_col3],
+				foreignColumns: [t3.t3_id1, t3.t3_id2],
+			}),
+		}),
+	)
+
+	const t2 = sqliteTable(
+		't2',
+		{
+			t2_id: int().primaryKey({ autoIncrement: true })
+		}
+	);
+
+	const t3 = sqliteTable(
+		't3',
+		{
+			t3_id1: int(),
+			t3_id2: int(),
+		},
+		(table) => ({
+			pk: primaryKey({
+				columns: [table.t3_id1, table.t3_id2],
+			}),
+		}),
+	);
+
+	const to = {
+		t1,
+		t2,
+		t3
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite(from, to, [], false, 'camel');
+
+	const st1 = `CREATE TABLE \`t1\` (
+	\`t1Id1\` integer PRIMARY KEY NOT NULL,
+	\`t1Col2\` integer NOT NULL,
+	\`t1Col3\` integer NOT NULL,
+	\`t2Ref\` integer NOT NULL,
+	\`t1Uni\` integer NOT NULL,
+	\`t1UniIdx\` integer NOT NULL,
+	\`t1Idx\` integer NOT NULL,
+	FOREIGN KEY (\`t2Ref\`) REFERENCES \`t2\`(\`t2Id\`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (\`t1Col2\`,\`t1Col3\`) REFERENCES \`t3\`(\`t3Id1\`,\`t3Id2\`) ON UPDATE no action ON DELETE no action
+);
+`;
+
+	const st2 = `CREATE UNIQUE INDEX \`t1UniIdx\` ON \`t1\` (\`t1UniIdx\`);`;
+
+	const st3 = `CREATE INDEX \`t1Idx\` ON \`t1\` (\`t1Idx\`);`;
+
+	const st4 = `CREATE UNIQUE INDEX \`t1Uni\` ON \`t1\` (\`t1Uni\`);`;
+
+	const st5 = `CREATE TABLE \`t2\` (
+	\`t2Id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+`;
+
+	const st6 = `CREATE TABLE \`t3\` (
+	\`t3Id1\` integer,
+	\`t3Id2\` integer,
+	PRIMARY KEY(\`t3Id1\`, \`t3Id2\`)
+);
+`;
+
+	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6]);
 });

--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -68,9 +68,8 @@ export abstract class Column<
 
 	declare readonly _: ColumnTypeConfig<T, TTypeConfig>;
 
-	/** @internal */
-	readonly keyAsName: boolean;
 	readonly name: string;
+	readonly keyAsName: boolean;
 	readonly primary: boolean;
 	readonly notNull: boolean;
 	readonly default: T['data'] | SQL | undefined;

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -228,15 +228,18 @@ export class IndexedColumn {
 	static readonly [entityKind]: string = 'IndexedColumn';
 	constructor(
 		name: string | undefined,
+		keyAsName: boolean,
 		type: string,
 		indexConfig: IndexedExtraConfigType,
 	) {
 		this.name = name;
+		this.keyAsName = keyAsName;
 		this.type = type;
 		this.indexConfig = indexConfig;
 	}
 
 	name: string | undefined;
+	keyAsName: boolean;
 	type: string;
 	indexConfig: IndexedExtraConfigType;
 }

--- a/drizzle-orm/src/pg-core/indexes.ts
+++ b/drizzle-orm/src/pg-core/indexes.ts
@@ -118,7 +118,7 @@ export class IndexBuilderOn {
 					return it;
 				}
 				it = it as ExtraConfigColumn;
-				const clonedIndexedColumn = new IndexedColumn(it.name, it.columnType!, it.indexConfig!);
+				const clonedIndexedColumn = new IndexedColumn(it.name, !!it.keyAsName, it.columnType!, it.indexConfig!);
 				it.indexConfig = JSON.parse(JSON.stringify(it.defaultConfig));
 				return clonedIndexedColumn;
 			}),
@@ -135,7 +135,7 @@ export class IndexBuilderOn {
 					return it;
 				}
 				it = it as ExtraConfigColumn;
-				const clonedIndexedColumn = new IndexedColumn(it.name, it.columnType!, it.indexConfig!);
+				const clonedIndexedColumn = new IndexedColumn(it.name, !!it.keyAsName, it.columnType!, it.indexConfig!);
 				it.indexConfig = it.defaultConfig;
 				return clonedIndexedColumn;
 			}),
@@ -166,7 +166,7 @@ export class IndexBuilderOn {
 					return it;
 				}
 				it = it as ExtraConfigColumn;
-				const clonedIndexedColumn = new IndexedColumn(it.name, it.columnType!, it.indexConfig!);
+				const clonedIndexedColumn = new IndexedColumn(it.name, !!it.keyAsName, it.columnType!, it.indexConfig!);
 				it.indexConfig = JSON.parse(JSON.stringify(it.defaultConfig));
 				return clonedIndexedColumn;
 			}),


### PR DESCRIPTION
A `casing` option was added to Drizzle config that accepts either `camel` or `snake`. The first option transforms any column without an alias into camel case and the latter does the same but transforms into snake case. If unset or undefined, no transformation is performed.