### PR TITLE
Replace jsonb parser in node-postgres with identity function

### DIFF
--- a/drizzle-orm/src/node-postgres/driver.ts
+++ b/drizzle-orm/src/node-postgres/driver.ts
@@ -42,6 +42,7 @@ export class NodePgDriver {
 		types.setTypeParser(types.builtins.TIMESTAMP, (val) => val);
 		types.setTypeParser(types.builtins.DATE, (val) => val);
 		types.setTypeParser(types.builtins.INTERVAL, (val) => val);
+		types.setTypeParser(types.builtins.JSONB, (val) => val);
 	}
 }
 


### PR DESCRIPTION
Avoid double Json.parse (since jsonb type already does json parse)

Resolves #3018