### PR TITLE
[Pg] Fix deeply nested queries failing due to table name length

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -55,7 +55,7 @@ import {
 } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { Columns, getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import { type Casing, hashString, orderSelectedFields, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type { PgSession } from './session.ts';
 import { PgViewBase } from './view-base.ts';
@@ -126,6 +126,19 @@ export class PgDialect {
 
 	escapeString(str: string): string {
 		return `'${str.replace(/'/g, "''")}'`;
+	}
+
+	private shortenTableAlias(alias: string): string {
+		const maxTableNameLength = 63;
+		const hashLength = 4;
+		const cutoffIndex = maxTableNameLength - hashLength - 1;
+
+		if (alias.length <= maxTableNameLength) return alias;
+
+		const prefix = alias.slice(0, alias.length - cutoffIndex - 1);
+		const remainder = alias.slice(alias.length - cutoffIndex);
+
+		return `${hashString(prefix, hashLength)}_${remainder}`;
 	}
 
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
@@ -758,7 +771,7 @@ export class PgDialect {
 				const normalizedRelation = V1.normalizeRelation(schema, tableNamesMap, relation);
 				const relationTableName = getTableUniqueName(relation.referencedTable);
 				const relationTableTsName = tableNamesMap[relationTableName]!;
-				const relationTableAlias = `${tableAlias}_${selectedRelationTsKey}`;
+				const relationTableAlias = this.shortenTableAlias(`${tableAlias}_${selectedRelationTsKey}`);
 				const joinOn = and(
 					...normalizedRelation.fields.map((field, i) =>
 						eq(
@@ -814,7 +827,7 @@ export class PgDialect {
 				sql.join(
 					selection.map(({ field, tsKey, isJson }) =>
 						isJson
-							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
+							? sql`${sql.identifier(this.shortenTableAlias(`${tableAlias}_${tsKey}`))}.${sql.identifier('data')}`
 							: is(field, SQL.Aliased)
 							? field.sql
 							: field

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -323,3 +323,19 @@ export function isConfig(data: any): boolean {
 }
 
 export type NeonAuthToken = string | (() => string | Promise<string>);
+
+/**
+ * An extremely weak hash function used to compress a string into fewer characters.
+ */
+export function hashString(value: string, length: number = 6): string {
+	let buffer = 0;
+
+	for (let index = 0; index < value.length; index++) {
+		const character = value.codePointAt(index) ?? 0;
+		buffer += character;
+		buffer *= 0x5555;
+		buffer &= 0x7fffffff;
+	}
+
+	return buffer.toString(36).slice(-length).padStart(length, '0');
+}


### PR DESCRIPTION
Postgres has a [63 character limit](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS) on table and table alias names. Defining a relation with a long name, or using a query which retrieves multiple levels of relations, could generate a relation table alias name which exceeds this limit.

This PR fixes that by trimming off the beginning of the relation table alias names if they exceed this 63 character limit. The beginning was chosen, as I believe the end is more likely to contain information useful for identifying the relation in a query.

Node's `crypto` and the Crypto Web API are not available for use due to the available libraries configured in TypeScript. The replacement `hashString` function uses a completely made up hashing algorithm - it does not need to be secure. It just needs to generate unique outputs. I tested it to ensure it generates different outputs given similar strings.

Compared to #2991, this PR does not use Node's `crypto` package, and attempts to preserve the relation names instead of hashing the entire alias.

Fixes #2066. Closes #2991.