### PR TITLE
Validate TS schema with Drizzle Kit

### DIFF
--- a/drizzle-kit/src/serializer/index.ts
+++ b/drizzle-kit/src/serializer/index.ts
@@ -68,7 +68,7 @@ export const serializePg = async (
 
 	const { tables, enums, schemas, sequences } = await prepareFromPgImports(
 		filenames,
-		casing
+		casing,
 	);
 
 	return generatePgSnapshot(tables, enums, schemas, sequences, casing, schemaFilter);

--- a/drizzle-kit/src/serializer/index.ts
+++ b/drizzle-kit/src/serializer/index.ts
@@ -51,7 +51,7 @@ export const serializeMySql = async (
 	const { prepareFromMySqlImports } = await import('./mysqlImports');
 	const { generateMySqlSnapshot } = await import('./mysqlSerializer');
 
-	const { tables } = await prepareFromMySqlImports(filenames);
+	const { tables } = await prepareFromMySqlImports(filenames, casing);
 
 	return generateMySqlSnapshot(tables, casing);
 };
@@ -68,6 +68,7 @@ export const serializePg = async (
 
 	const { tables, enums, schemas, sequences } = await prepareFromPgImports(
 		filenames,
+		casing
 	);
 
 	return generatePgSnapshot(tables, enums, schemas, sequences, casing, schemaFilter);
@@ -81,7 +82,7 @@ export const serializeSQLite = async (
 
 	const { prepareFromSqliteImports } = await import('./sqliteImports');
 	const { generateSqliteSnapshot } = await import('./sqliteSerializer');
-	const { tables } = await prepareFromSqliteImports(filenames);
+	const { tables } = await prepareFromSqliteImports(filenames, casing);
 	return generateSqliteSnapshot(tables, casing);
 };
 

--- a/drizzle-kit/src/serializer/mysqlImports.ts
+++ b/drizzle-kit/src/serializer/mysqlImports.ts
@@ -1,8 +1,8 @@
 import { is } from 'drizzle-orm';
 import { AnyMySqlTable, MySqlTable, MySqlView } from 'drizzle-orm/mysql-core';
-import { safeRegister } from '../cli/commands/utils';
-import { printValidationErrors, validateMySqlSchema } from 'src/validate-schema/validate';
 import { CasingType } from 'src/cli/validations/common';
+import { printValidationErrors, validateMySqlSchema } from 'src/validate-schema/validate';
+import { safeRegister } from '../cli/commands/utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnyMySqlTable[] = [];

--- a/drizzle-kit/src/serializer/mysqlImports.ts
+++ b/drizzle-kit/src/serializer/mysqlImports.ts
@@ -1,18 +1,23 @@
 import { is } from 'drizzle-orm';
-import { AnyMySqlTable, MySqlTable } from 'drizzle-orm/mysql-core';
+import { AnyMySqlTable, MySqlTable, MySqlView } from 'drizzle-orm/mysql-core';
 import { safeRegister } from '../cli/commands/utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnyMySqlTable[] = [];
+	const views: MySqlView[] = [];
 
 	const i0values = Object.values(exports);
 	i0values.forEach((t) => {
 		if (is(t, MySqlTable)) {
 			tables.push(t);
 		}
+
+		if (is(t, MySqlView)) {
+			views.push(t);
+		}
 	});
 
-	return { tables };
+	return { tables, views };
 };
 
 export const prepareFromMySqlImports = async (imports: string[]) => {

--- a/drizzle-kit/src/serializer/mysqlImports.ts
+++ b/drizzle-kit/src/serializer/mysqlImports.ts
@@ -1,6 +1,8 @@
 import { is } from 'drizzle-orm';
 import { AnyMySqlTable, MySqlTable, MySqlView } from 'drizzle-orm/mysql-core';
 import { safeRegister } from '../cli/commands/utils';
+import { printValidationErrors, validateMySqlSchema } from 'src/validate-schema/validate';
+import { CasingType } from 'src/cli/validations/common';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnyMySqlTable[] = [];
@@ -20,8 +22,9 @@ export const prepareFromExports = (exports: Record<string, unknown>) => {
 	return { tables, views };
 };
 
-export const prepareFromMySqlImports = async (imports: string[]) => {
+export const prepareFromMySqlImports = async (imports: string[], casing: CasingType | undefined) => {
 	const tables: AnyMySqlTable[] = [];
+	const views: MySqlView[] = [];
 
 	const { unregister } = await safeRegister();
 	for (let i = 0; i < imports.length; i++) {
@@ -30,7 +33,15 @@ export const prepareFromMySqlImports = async (imports: string[]) => {
 		const prepared = prepareFromExports(i0);
 
 		tables.push(...prepared.tables);
+		views.push(...prepared.views);
 	}
 	unregister();
+
+	const errors = validateMySqlSchema(casing, tables, views);
+	if (errors.messages.length > 0) {
+		printValidationErrors(errors.messages);
+		process.exit(1);
+	}
+
 	return { tables: Array.from(new Set(tables)) };
 };

--- a/drizzle-kit/src/serializer/pgImports.ts
+++ b/drizzle-kit/src/serializer/pgImports.ts
@@ -1,5 +1,5 @@
 import { is } from 'drizzle-orm';
-import { AnyPgTable, isPgEnum, isPgSequence, PgEnum, PgSchema, PgSequence, PgTable } from 'drizzle-orm/pg-core';
+import { AnyPgTable, isPgEnum, isPgSequence, PgEnum, PgMaterializedView, PgSchema, PgSequence, PgTable, PgView } from 'drizzle-orm/pg-core';
 import { safeRegister } from '../cli/commands/utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
@@ -7,6 +7,8 @@ export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const enums: PgEnum<any>[] = [];
 	const schemas: PgSchema[] = [];
 	const sequences: PgSequence[] = [];
+	const views: PgView[] = [];
+	const materializedViews: PgMaterializedView[] = [];
 
 	const i0values = Object.values(exports);
 	i0values.forEach((t) => {
@@ -25,9 +27,17 @@ export const prepareFromExports = (exports: Record<string, unknown>) => {
 		if (isPgSequence(t)) {
 			sequences.push(t);
 		}
+
+		if (is(t, PgView)) {
+			views.push(t);
+		}
+
+		if (is(t, PgMaterializedView)) {
+			materializedViews.push(t);
+		}
 	});
 
-	return { tables, enums, schemas, sequences };
+	return { tables, enums, schemas, sequences, views, materializedViews };
 };
 
 export const prepareFromPgImports = async (imports: string[]) => {

--- a/drizzle-kit/src/serializer/pgImports.ts
+++ b/drizzle-kit/src/serializer/pgImports.ts
@@ -1,8 +1,18 @@
 import { is } from 'drizzle-orm';
-import { AnyPgTable, isPgEnum, isPgSequence, PgEnum, PgMaterializedView, PgSchema, PgSequence, PgTable, PgView } from 'drizzle-orm/pg-core';
-import { safeRegister } from '../cli/commands/utils';
-import { printValidationErrors, validatePgSchema } from 'src/validate-schema/validate';
+import {
+	AnyPgTable,
+	isPgEnum,
+	isPgSequence,
+	PgEnum,
+	PgMaterializedView,
+	PgSchema,
+	PgSequence,
+	PgTable,
+	PgView,
+} from 'drizzle-orm/pg-core';
 import { CasingType } from 'src/cli/validations/common';
+import { printValidationErrors, validatePgSchema } from 'src/validate-schema/validate';
+import { safeRegister } from '../cli/commands/utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnyPgTable[] = [];
@@ -42,7 +52,7 @@ export const prepareFromExports = (exports: Record<string, unknown>) => {
 	return { tables, enums, schemas, sequences, views, materializedViews };
 };
 
-export const prepareFromPgImports = async (imports: string[], casing: CasingType | undefined,) => {
+export const prepareFromPgImports = async (imports: string[], casing: CasingType | undefined) => {
 	let tables: AnyPgTable[] = [];
 	let enums: PgEnum<any>[] = [];
 	let schemas: PgSchema[] = [];

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -29,7 +29,14 @@ import type {
 	Table,
 	UniqueConstraint,
 } from '../serializer/pgSchema';
-import { type DB, getColumnCasing, getIdentitySequenceName, getForeignKeyName, getPrimaryKeyName, isPgArrayType } from '../utils';
+import {
+	type DB,
+	getColumnCasing,
+	getForeignKeyName,
+	getIdentitySequenceName,
+	getPrimaryKeyName,
+	isPgArrayType,
+} from '../utils';
 import { sqlToStr } from '.';
 
 export const indexName = (tableName: string, columns: string[]) => {

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import { getTableName, is, SQL } from 'drizzle-orm';
 import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 import {
@@ -16,8 +15,6 @@ import {
 } from 'drizzle-orm/pg-core';
 import { getTableConfig } from 'drizzle-orm/pg-core';
 import { CasingType } from 'src/cli/validations/common';
-import { vectorOps } from 'src/extensions/vector';
-import { withStyle } from '../cli/validations/outputs';
 import type { IntrospectStage, IntrospectStatus } from '../cli/views';
 import type {
 	Column as Column,
@@ -32,7 +29,7 @@ import type {
 	Table,
 	UniqueConstraint,
 } from '../serializer/pgSchema';
-import { type DB, getColumnCasing, isPgArrayType } from '../utils';
+import { type DB, getColumnCasing, getIdentitySequenceName, getForeignKeyName, getPrimaryKeyName, isPgArrayType } from '../utils';
 import { sqlToStr } from '.';
 
 export const indexName = (tableName: string, columns: string[]) => {
@@ -194,7 +191,7 @@ export const generatePgSnapshot = (
 				identity: identity
 					? {
 						type: identity.type,
-						name: identity.sequenceName ?? `${tableName}_${name}_seq`,
+						name: getIdentitySequenceName(identity.sequenceName, tableName, name),
 						schema: schema ?? 'public',
 						increment,
 						startWith,
@@ -205,40 +202,6 @@ export const generatePgSnapshot = (
 					}
 					: undefined,
 			};
-
-			if (column.isUnique) {
-				const existingUnique = uniqueConstraintObject[column.uniqueName!];
-				if (typeof existingUnique !== 'undefined') {
-					console.log(
-						`\n${
-							withStyle.errorWarning(`We\'ve found duplicated unique constraint names in ${
-								chalk.underline.blue(
-									tableName,
-								)
-							} table. 
-          The unique constraint ${
-								chalk.underline.blue(
-									column.uniqueName,
-								)
-							} on the ${
-								chalk.underline.blue(
-									name,
-								)
-							} column is confilcting with a unique constraint name already defined for ${
-								chalk.underline.blue(
-									existingUnique.columns.join(','),
-								)
-							} columns\n`)
-						}`,
-					);
-					process.exit(1);
-				}
-				uniqueConstraintObject[column.uniqueName!] = {
-					name: column.uniqueName!,
-					nullsNotDistinct: column.uniqueType === 'not distinct',
-					columns: [columnToSet.name],
-				};
-			}
 
 			if (column.default !== undefined) {
 				if (is(column.default, SQL)) {
@@ -285,15 +248,8 @@ export const generatePgSnapshot = (
 		});
 
 		primaryKeys.map((pk) => {
-			const originalColumnNames = pk.columns.map((c) => c.name);
+			const name = getPrimaryKeyName(pk, casing);
 			const columnNames = pk.columns.map((c) => getColumnCasing(c, casing));
-
-			let name = pk.getName();
-			if (casing !== undefined) {
-				for (let i = 0; i < originalColumnNames.length; i++) {
-					name = name.replace(originalColumnNames[i], columnNames[i]);
-				}
-			}
 
 			primaryKeysObject[name] = {
 				name,
@@ -303,35 +259,7 @@ export const generatePgSnapshot = (
 
 		uniqueConstraints?.map((unq) => {
 			const columnNames = unq.columns.map((c) => getColumnCasing(c, casing));
-
 			const name = unq.name ?? uniqueKeyName(table, columnNames);
-
-			const existingUnique = uniqueConstraintObject[name];
-			if (typeof existingUnique !== 'undefined') {
-				console.log(
-					`\n${
-						withStyle.errorWarning(`We\'ve found duplicated unique constraint names in ${
-							chalk.underline.blue(
-								tableName,
-							)
-						} table. 
-        The unique constraint ${
-							chalk.underline.blue(
-								name,
-							)
-						} on the ${
-							chalk.underline.blue(
-								columnNames.join(','),
-							)
-						} columns is confilcting with a unique constraint name already defined for ${
-							chalk.underline.blue(
-								existingUnique.columns.join(','),
-							)
-						} columns\n`)
-					}`,
-				);
-				process.exit(1);
-			}
 
 			uniqueConstraintObject[name] = {
 				name: unq.name!,
@@ -341,6 +269,7 @@ export const generatePgSnapshot = (
 		});
 
 		const fks: ForeignKey[] = foreignKeys.map((fk) => {
+			const name = getForeignKeyName(fk, casing);
 			const tableFrom = tableName;
 			const onDelete = fk.onDelete;
 			const onUpdate = fk.onUpdate;
@@ -351,20 +280,8 @@ export const generatePgSnapshot = (
 			// getTableConfig(reference.foreignTable).schema || "public";
 			const schemaTo = getTableConfig(reference.foreignTable).schema;
 
-			const originalColumnsFrom = reference.columns.map((it) => it.name);
 			const columnsFrom = reference.columns.map((it) => getColumnCasing(it, casing));
-			const originalColumnsTo = reference.foreignColumns.map((it) => it.name);
 			const columnsTo = reference.foreignColumns.map((it) => getColumnCasing(it, casing));
-
-			let name = fk.getName();
-			if (casing !== undefined) {
-				for (let i = 0; i < originalColumnsFrom.length; i++) {
-					name = name.replace(originalColumnsFrom[i], columnsFrom[i]);
-				}
-				for (let i = 0; i < originalColumnsTo.length; i++) {
-					name = name.replace(originalColumnsTo[i], columnsTo[i]);
-				}
-			}
 
 			return {
 				name,
@@ -387,64 +304,8 @@ export const generatePgSnapshot = (
 
 			let indexColumnNames: string[] = [];
 			columns.forEach((it) => {
-				if (is(it, SQL)) {
-					if (typeof value.config.name === 'undefined') {
-						console.log(
-							`\n${
-								withStyle.errorWarning(
-									`Please specify an index name in ${
-										getTableName(
-											value.config.table,
-										)
-									} table that has "${
-										dialect.sqlToQuery(it).sql
-									}" expression. We can generate index names for indexes on columns only; for expressions in indexes, you need to specify the name yourself.`,
-								)
-							}`,
-						);
-						process.exit(1);
-					}
-				}
-				it = it as IndexedColumn;
+				if (is(it, SQL)) return;
 				const name = getColumnCasing(it as IndexedColumn, casing);
-				if (
-					!is(it, SQL)
-					&& it.type! === 'PgVector'
-					&& typeof it.indexConfig!.opClass === 'undefined'
-				) {
-					console.log(
-						`\n${
-							withStyle.errorWarning(
-								`You are specifying an index on the ${
-									chalk.blueBright(
-										name,
-									)
-								} column inside the ${
-									chalk.blueBright(
-										tableName,
-									)
-								} table with the ${
-									chalk.blueBright(
-										'vector',
-									)
-								} type without specifying an operator class. Vector extension doesn't have a default operator class, so you need to specify one of the available options. Here is a list of available op classes for the vector extension: [${
-									vectorOps
-										.map((it) => `${chalk.underline(`${it}`)}`)
-										.join(
-											', ',
-										)
-								}].\n\nYou can specify it using current syntax: ${
-									chalk.underline(
-										`index("${value.config.name}").using("${value.config.method}", table.${name}.op("${
-											vectorOps[0]
-										}"))`,
-									)
-								}\n\nYou can check the "pg_vector" docs for more info: https://github.com/pgvector/pgvector?tab=readme-ov-file#indexing\n`,
-							)
-						}`,
-					);
-					process.exit(1);
-				}
 				indexColumnNames.push(name);
 			});
 
@@ -478,31 +339,6 @@ export const generatePgSnapshot = (
 				},
 			);
 
-			// check for index names duplicates
-			if (typeof indexesInSchema[schema ?? 'public'] !== 'undefined') {
-				if (indexesInSchema[schema ?? 'public'].includes(name)) {
-					console.log(
-						`\n${
-							withStyle.errorWarning(
-								`We\'ve found duplicated index name across ${
-									chalk.underline.blue(
-										schema ?? 'public',
-									)
-								} schema. Please rename your index in either the ${
-									chalk.underline.blue(
-										tableName,
-									)
-								} table or the table with the duplicated index name`,
-							)
-						}`,
-					);
-					process.exit(1);
-				}
-				indexesInSchema[schema ?? 'public'].push(name);
-			} else {
-				indexesInSchema[schema ?? 'public'] = [name];
-			}
-
 			indexesObject[name] = {
 				name,
 				columns: indexColumns,
@@ -531,32 +367,25 @@ export const generatePgSnapshot = (
 
 	for (const sequence of sequences) {
 		const name = sequence.seqName!;
-		if (
-			typeof sequencesToReturn[`${sequence.schema ?? 'public'}.${name}`]
-				=== 'undefined'
-		) {
-			const increment = stringFromIdentityProperty(sequence?.seqOptions?.increment) ?? '1';
-			const minValue = stringFromIdentityProperty(sequence?.seqOptions?.minValue)
-				?? (parseFloat(increment) < 0 ? '-9223372036854775808' : '1');
-			const maxValue = stringFromIdentityProperty(sequence?.seqOptions?.maxValue)
-				?? (parseFloat(increment) < 0 ? '-1' : '9223372036854775807');
-			const startWith = stringFromIdentityProperty(sequence?.seqOptions?.startWith)
-				?? (parseFloat(increment) < 0 ? maxValue : minValue);
-			const cache = stringFromIdentityProperty(sequence?.seqOptions?.cache) ?? '1';
+		const increment = stringFromIdentityProperty(sequence?.seqOptions?.increment) ?? '1';
+		const minValue = stringFromIdentityProperty(sequence?.seqOptions?.minValue)
+			?? (parseFloat(increment) < 0 ? '-9223372036854775808' : '1');
+		const maxValue = stringFromIdentityProperty(sequence?.seqOptions?.maxValue)
+			?? (parseFloat(increment) < 0 ? '-1' : '9223372036854775807');
+		const startWith = stringFromIdentityProperty(sequence?.seqOptions?.startWith)
+			?? (parseFloat(increment) < 0 ? maxValue : minValue);
+		const cache = stringFromIdentityProperty(sequence?.seqOptions?.cache) ?? '1';
 
-			sequencesToReturn[`${sequence.schema ?? 'public'}.${name}`] = {
-				name,
-				schema: sequence.schema ?? 'public',
-				increment,
-				startWith,
-				minValue,
-				maxValue,
-				cache,
-				cycle: sequence.seqOptions?.cycle ?? false,
-			};
-		} else {
-			// duplicate seq error
-		}
+		sequencesToReturn[`${sequence.schema ?? 'public'}.${name}`] = {
+			name,
+			schema: sequence.schema ?? 'public',
+			increment,
+			startWith,
+			minValue,
+			maxValue,
+			cache,
+			cycle: sequence.seqOptions?.cycle ?? false,
+		};
 	}
 
 	const enumsToReturn: Record<string, Enum> = enums.reduce<{

--- a/drizzle-kit/src/serializer/sqliteImports.ts
+++ b/drizzle-kit/src/serializer/sqliteImports.ts
@@ -1,8 +1,8 @@
 import { is } from 'drizzle-orm';
 import { AnySQLiteTable, SQLiteTable, SQLiteView } from 'drizzle-orm/sqlite-core';
-import { safeRegister } from '../cli/commands/utils';
-import { printValidationErrors, validateSQLiteSchema } from 'src/validate-schema/validate';
 import { CasingType } from 'src/cli/validations/common';
+import { printValidationErrors, validateSQLiteSchema } from 'src/validate-schema/validate';
+import { safeRegister } from '../cli/commands/utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnySQLiteTable[] = [];

--- a/drizzle-kit/src/serializer/sqliteImports.ts
+++ b/drizzle-kit/src/serializer/sqliteImports.ts
@@ -1,17 +1,23 @@
 import { is } from 'drizzle-orm';
-import { AnySQLiteTable, SQLiteTable } from 'drizzle-orm/sqlite-core';
+import { AnySQLiteTable, SQLiteTable, SQLiteView } from 'drizzle-orm/sqlite-core';
 import { safeRegister } from '../cli/commands/utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnySQLiteTable[] = [];
+	const views: SQLiteView[] = [];
+
 	const i0values = Object.values(exports);
 	i0values.forEach((t) => {
 		if (is(t, SQLiteTable)) {
 			tables.push(t);
 		}
+
+		if (is(t, SQLiteView)) {
+			views.push(t);
+		}
 	});
 
-	return { tables };
+	return { tables, views };
 };
 
 export const prepareFromSqliteImports = async (imports: string[]) => {

--- a/drizzle-kit/src/serializer/sqliteImports.ts
+++ b/drizzle-kit/src/serializer/sqliteImports.ts
@@ -1,6 +1,8 @@
 import { is } from 'drizzle-orm';
 import { AnySQLiteTable, SQLiteTable, SQLiteView } from 'drizzle-orm/sqlite-core';
 import { safeRegister } from '../cli/commands/utils';
+import { printValidationErrors, validateSQLiteSchema } from 'src/validate-schema/validate';
+import { CasingType } from 'src/cli/validations/common';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnySQLiteTable[] = [];
@@ -20,8 +22,9 @@ export const prepareFromExports = (exports: Record<string, unknown>) => {
 	return { tables, views };
 };
 
-export const prepareFromSqliteImports = async (imports: string[]) => {
+export const prepareFromSqliteImports = async (imports: string[], casing: CasingType | undefined) => {
 	const tables: AnySQLiteTable[] = [];
+	const views: SQLiteView[] = [];
 
 	const { unregister } = await safeRegister();
 	for (let i = 0; i < imports.length; i++) {
@@ -31,9 +34,15 @@ export const prepareFromSqliteImports = async (imports: string[]) => {
 		const prepared = prepareFromExports(i0);
 
 		tables.push(...prepared.tables);
+		views.push(...prepared.views);
 	}
-
 	unregister();
+
+	const errors = validateSQLiteSchema(casing, tables, views);
+	if (errors.messages.length > 0) {
+		printValidationErrors(errors.messages);
+		process.exit(1);
+	}
 
 	return { tables: Array.from(new Set(tables)) };
 };

--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -1,5 +1,6 @@
 import type { RunResult } from 'better-sqlite3';
 import chalk from 'chalk';
+import type { Column } from 'drizzle-orm';
 import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
@@ -13,7 +14,6 @@ import { backwardCompatibleMysqlSchema } from './serializer/mysqlSchema';
 import { backwardCompatiblePgSchema } from './serializer/pgSchema';
 import { backwardCompatibleSqliteSchema } from './serializer/sqliteSchema';
 import type { ProxyParams } from './serializer/studio';
-import type { Column } from 'drizzle-orm';
 
 export type Proxy = (params: ProxyParams) => Promise<any[]>;
 
@@ -372,10 +372,13 @@ export function getColumnCasing(
 		: toSnakeCase(column.name);
 }
 
-export function getForeignKeyName(fk: { getName: () => string; reference: () => {
-	columns: Column[];
-	foreignColumns: Column[];
-} }, casing: CasingType | undefined) {
+export function getForeignKeyName(fk: {
+	getName: () => string;
+	reference: () => {
+		columns: Column[];
+		foreignColumns: Column[];
+	};
+}, casing: CasingType | undefined) {
 	let name = fk.getName();
 	const reference = fk.reference();
 	const originalColumnsFrom = reference.columns.map((it) => it.name);

--- a/drizzle-kit/src/validate-schema/db.ts
+++ b/drizzle-kit/src/validate-schema/db.ts
@@ -1,30 +1,30 @@
-import { fmtValue, getCollisionsByKey, Schema } from './utils';
-import { ValidateSchema } from './schema';
 import { SchemaValidationErrors, ValidationError } from './errors';
+import { ValidateSchema } from './schema';
+import { fmtValue, getCollisionsByKey, Schema } from './utils';
 
 export class ValidateDatabase {
-  errors: ValidationError[] = [];
-  /** Mainly used for testing */
-  errorCodes: Set<number> = new Set();
+	errors: ValidationError[] = [];
+	/** Mainly used for testing */
+	errorCodes: Set<number> = new Set();
 
-  validateSchema(schemaName?: string | undefined) {
-    return new ValidateSchema(this.errors, this.errorCodes, schemaName);
-  }
+	validateSchema(schemaName?: string | undefined) {
+		return new ValidateSchema(this.errors, this.errorCodes, schemaName);
+	}
 
-  schemaNameCollisions(schemas: Schema[]) {
-    const collisions = getCollisionsByKey(schemas, 'schemaName');
-    
-    if (collisions.length > 0) {
-      const errors: ValidationError[] = collisions.map(
-        (schema) => ({
-          message: `Database has duplicate schema ${fmtValue(schema, true)}`,
-          hint: 'Each schema must have a unique name. Rename any of the conflicting schemas',
-        })
-      );
-      this.errors.push(...errors);
-      this.errorCodes.add(SchemaValidationErrors.SchemaNameCollisions);
-    }
+	schemaNameCollisions(schemas: Schema[]) {
+		const collisions = getCollisionsByKey(schemas, 'schemaName');
 
-    return this;
-  }
+		if (collisions.length > 0) {
+			const errors: ValidationError[] = collisions.map(
+				(schema) => ({
+					message: `Database has duplicate schema ${fmtValue(schema, true)}`,
+					hint: 'Each schema must have a unique name. Rename any of the conflicting schemas',
+				}),
+			);
+			this.errors.push(...errors);
+			this.errorCodes.add(SchemaValidationErrors.SchemaNameCollisions);
+		}
+
+		return this;
+	}
 }

--- a/drizzle-kit/src/validate-schema/db.ts
+++ b/drizzle-kit/src/validate-schema/db.ts
@@ -1,9 +1,9 @@
-import { getCollisionsByKey, Schema } from './utils';
+import { fmtValue, getCollisionsByKey, Schema } from './utils';
 import { ValidateSchema } from './schema';
-import { SchemaValidationErrors } from './errors';
+import { SchemaValidationErrors, ValidationError } from './errors';
 
 export class ValidateDatabase {
-  errors: string[] = [];
+  errors: ValidationError[] = [];
   /** Mainly used for testing */
   errorCodes: Set<number> = new Set();
 
@@ -15,10 +15,13 @@ export class ValidateDatabase {
     const collisions = getCollisionsByKey(schemas, 'schemaName');
     
     if (collisions.length > 0) {
-      const messages = collisions.map(
-        (schema) => `Database has duplicate schema "${schema}"`
+      const errors: ValidationError[] = collisions.map(
+        (schema) => ({
+          message: `Database has duplicate schema ${fmtValue(schema, true)}`,
+          hint: 'Each schema must have a unique name. Rename any of the conflicting schemas',
+        })
       );
-      this.errors.push(...messages);
+      this.errors.push(...errors);
       this.errorCodes.add(SchemaValidationErrors.SchemaNameCollisions);
     }
 

--- a/drizzle-kit/src/validate-schema/db.ts
+++ b/drizzle-kit/src/validate-schema/db.ts
@@ -1,0 +1,19 @@
+import { getCollisionsByKey, Schema } from './utils';
+import { ValidateSchema } from './schema';
+
+export class ValidateDatabase {
+  errors: string[] = [];
+
+  validateSchema(schemaName?: string | undefined) {
+    return new ValidateSchema(this.errors, schemaName);
+  }
+
+  schemaNameCollisions(schemas: Schema[]) {
+    const collisions = getCollisionsByKey(schemas, 'schemaName');
+    const messages = collisions.map(
+      (schema) => `Database has duplicate schema "${schema}"`
+    )
+    this.errors.push(...messages);
+    return this;
+  }
+}

--- a/drizzle-kit/src/validate-schema/db.ts
+++ b/drizzle-kit/src/validate-schema/db.ts
@@ -1,19 +1,27 @@
 import { getCollisionsByKey, Schema } from './utils';
 import { ValidateSchema } from './schema';
+import { SchemaValidationErrors } from './errors';
 
 export class ValidateDatabase {
   errors: string[] = [];
+  /** Mainly used for testing */
+  errorCodes: Set<number> = new Set();
 
   validateSchema(schemaName?: string | undefined) {
-    return new ValidateSchema(this.errors, schemaName);
+    return new ValidateSchema(this.errors, this.errorCodes, schemaName);
   }
 
   schemaNameCollisions(schemas: Schema[]) {
     const collisions = getCollisionsByKey(schemas, 'schemaName');
-    const messages = collisions.map(
-      (schema) => `Database has duplicate schema "${schema}"`
-    )
-    this.errors.push(...messages);
+    
+    if (collisions.length > 0) {
+      const messages = collisions.map(
+        (schema) => `Database has duplicate schema "${schema}"`
+      );
+      this.errors.push(...messages);
+      this.errorCodes.add(SchemaValidationErrors.SchemaNameCollisions);
+    }
+
     return this;
   }
 }

--- a/drizzle-kit/src/validate-schema/enum.ts
+++ b/drizzle-kit/src/validate-schema/enum.ts
@@ -1,0 +1,14 @@
+import { getCollisions } from './utils';
+
+export class ValidateEnum {
+  constructor(private errors: string[], private schema: string | undefined, private name: string) {}
+
+  valueCollisions(enumValues: string[]) {
+    const collisions = getCollisions(enumValues);
+    const messages = collisions.map(
+      (value) => `Enum ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has duplicate value "${value}"`
+    );
+    this.errors.push(...messages);
+    return this;
+  }
+}

--- a/drizzle-kit/src/validate-schema/enum.ts
+++ b/drizzle-kit/src/validate-schema/enum.ts
@@ -2,22 +2,28 @@ import { SchemaValidationErrors, ValidationError } from './errors';
 import { entityName, fmtValue, getCollisions } from './utils';
 
 export class ValidateEnum {
-  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+	constructor(
+		private errors: ValidationError[],
+		private errorCodes: Set<number>,
+		private schema: string | undefined,
+		private name: string,
+	) {}
 
-  valueCollisions(enumValues: string[]) {
-    const collisions = getCollisions(enumValues);
+	valueCollisions(enumValues: string[]) {
+		const collisions = getCollisions(enumValues);
 
-    if (collisions.length > 0) {
-      const errors: ValidationError[] = collisions.map(
-        (value) => ({
-          message: `Enum ${entityName(this.schema, this.name, true)} has duplicate value ${fmtValue(value, true)}`,
-          hint: 'Each value in an enum must be unique. Remove every instance of the conflicting value until only one remains'
-        })
-      );
-      this.errors.push(...errors);
-      this.errorCodes.add(SchemaValidationErrors.EnumValueCollisions);
-    }
+		if (collisions.length > 0) {
+			const errors: ValidationError[] = collisions.map(
+				(value) => ({
+					message: `Enum ${entityName(this.schema, this.name, true)} has duplicate value ${fmtValue(value, true)}`,
+					hint:
+						'Each value in an enum must be unique. Remove every instance of the conflicting value until only one remains',
+				}),
+			);
+			this.errors.push(...errors);
+			this.errorCodes.add(SchemaValidationErrors.EnumValueCollisions);
+		}
 
-    return this;
-  }
+		return this;
+	}
 }

--- a/drizzle-kit/src/validate-schema/enum.ts
+++ b/drizzle-kit/src/validate-schema/enum.ts
@@ -1,14 +1,20 @@
+import { SchemaValidationErrors } from './errors';
 import { getCollisions } from './utils';
 
 export class ValidateEnum {
-  constructor(private errors: string[], private schema: string | undefined, private name: string) {}
+  constructor(private errors: string[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
 
   valueCollisions(enumValues: string[]) {
     const collisions = getCollisions(enumValues);
-    const messages = collisions.map(
-      (value) => `Enum ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has duplicate value "${value}"`
-    );
-    this.errors.push(...messages);
+
+    if (collisions.length > 0) {
+      const messages = collisions.map(
+        (value) => `Enum ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has duplicate value "${value}"`
+      );
+      this.errors.push(...messages);
+      this.errorCodes.add(SchemaValidationErrors.EnumValueCollisions);
+    }
+
     return this;
   }
 }

--- a/drizzle-kit/src/validate-schema/enum.ts
+++ b/drizzle-kit/src/validate-schema/enum.ts
@@ -1,17 +1,20 @@
-import { SchemaValidationErrors } from './errors';
-import { getCollisions } from './utils';
+import { SchemaValidationErrors, ValidationError } from './errors';
+import { entityName, fmtValue, getCollisions } from './utils';
 
 export class ValidateEnum {
-  constructor(private errors: string[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
 
   valueCollisions(enumValues: string[]) {
     const collisions = getCollisions(enumValues);
 
     if (collisions.length > 0) {
-      const messages = collisions.map(
-        (value) => `Enum ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has duplicate value "${value}"`
+      const errors: ValidationError[] = collisions.map(
+        (value) => ({
+          message: `Enum ${entityName(this.schema, this.name, true)} has duplicate value ${fmtValue(value, true)}`,
+          hint: 'Each value in an enum must be unique. Remove every instance of the conflicting value until only one remains'
+        })
       );
-      this.errors.push(...messages);
+      this.errors.push(...errors);
       this.errorCodes.add(SchemaValidationErrors.EnumValueCollisions);
     }
 

--- a/drizzle-kit/src/validate-schema/errors.ts
+++ b/drizzle-kit/src/validate-schema/errors.ts
@@ -1,0 +1,24 @@
+export enum SchemaValidationErrors {
+  // Database
+  SchemaNameCollisions = 1,
+  // Schema
+  SchemaEntityNameCollisions = 2,
+  SchemaConstraintNameCollisions = 3,
+  // Enum
+  EnumValueCollisions = 4,
+  // Sequence
+  SequenceIncrementByZero = 5,
+  SequenceInvalidMinMax = 12,
+  // Table
+  TableColumnNameCollisions = 6,
+  // Foreign key
+  ForeignKeyMismatchingColumnCount = 7,
+  ForeignKeyMismatchingDataTypes = 8,
+  ForeignKeyColumnsMixingTables = 9,
+  ForeignKeyForeignColumnsMixingTables = 13,
+  // Primary key
+  PrimaryKeyColumnsMixingTables = 14,
+  // Index
+  IndexRequiresName = 10,
+  IndexVectorColumnRequiresOp = 11,
+};

--- a/drizzle-kit/src/validate-schema/errors.ts
+++ b/drizzle-kit/src/validate-schema/errors.ts
@@ -22,3 +22,8 @@ export enum SchemaValidationErrors {
   IndexRequiresName = 10,
   IndexVectorColumnRequiresOp = 11,
 };
+
+export interface ValidationError {
+  message: string;
+  hint: string;
+}

--- a/drizzle-kit/src/validate-schema/errors.ts
+++ b/drizzle-kit/src/validate-schema/errors.ts
@@ -1,29 +1,29 @@
 export enum SchemaValidationErrors {
-  // Database
-  SchemaNameCollisions = 1,
-  // Schema
-  SchemaEntityNameCollisions = 2,
-  SchemaConstraintNameCollisions = 3,
-  // Enum
-  EnumValueCollisions = 4,
-  // Sequence
-  SequenceIncrementByZero = 5,
-  SequenceInvalidMinMax = 12,
-  // Table
-  TableColumnNameCollisions = 6,
-  // Foreign key
-  ForeignKeyMismatchingColumnCount = 7,
-  ForeignKeyMismatchingDataTypes = 8,
-  ForeignKeyColumnsMixingTables = 9,
-  ForeignKeyForeignColumnsMixingTables = 13,
-  // Primary key
-  PrimaryKeyColumnsMixingTables = 14,
-  // Index
-  IndexRequiresName = 10,
-  IndexVectorColumnRequiresOp = 11,
-};
+	// Database
+	SchemaNameCollisions = 1,
+	// Schema
+	SchemaEntityNameCollisions = 2,
+	SchemaConstraintNameCollisions = 3,
+	// Enum
+	EnumValueCollisions = 4,
+	// Sequence
+	SequenceIncrementByZero = 5,
+	SequenceInvalidMinMax = 12,
+	// Table
+	TableColumnNameCollisions = 6,
+	// Foreign key
+	ForeignKeyMismatchingColumnCount = 7,
+	ForeignKeyMismatchingDataTypes = 8,
+	ForeignKeyColumnsMixingTables = 9,
+	ForeignKeyForeignColumnsMixingTables = 13,
+	// Primary key
+	PrimaryKeyColumnsMixingTables = 14,
+	// Index
+	IndexRequiresName = 10,
+	IndexVectorColumnRequiresOp = 11,
+}
 
 export interface ValidationError {
-  message: string;
-  hint: string;
+	message: string;
+	hint: string;
 }

--- a/drizzle-kit/src/validate-schema/foreign-key.ts
+++ b/drizzle-kit/src/validate-schema/foreign-key.ts
@@ -1,0 +1,65 @@
+import { Table } from './utils';
+
+export class ValidateForeignKey {
+  constructor(private errors: string[], private schema: string | undefined, private name: string) {}
+
+  mismatchingColumnCount(foreignKey: Table['foreignKeys'][number]) {
+    const { columns, foreignColumns }  = foreignKey.reference;
+
+    if (columns.length !== foreignColumns.length) {
+      this.errors.push(`Foreign key ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has ${columns.length.toString()} column${columns.length === 1 ? '' : 's'} but references ${foreignColumns.length.toString()}`);
+    }
+
+    return this;
+  }
+
+  mismatchingDataTypes(foreignKey: Table['foreignKeys'][number]) {
+    const { columns, foreignColumns }  = foreignKey.reference;
+
+    const types = `(${columns.map((c) => c.getSQLType()).join(', ')})`;
+    const foreignTypes = `(${foreignColumns.map((c) => c.getSQLType()).join(', ')})`;
+
+    if (types !== foreignTypes) {
+      this.errors.push(`Column data types in foreign key ${this.schema ? `"${this.schema}".` : ''}"${this.name}" do not match. Types ${types} are different from ${foreignTypes}`);
+    }
+
+    return this;
+  }
+
+  /** Only applies to composite foreign keys */
+  columnsMixingTables(foreignKey: Table['foreignKeys'][number], tables: Pick<Table, 'columns' | 'schema' | 'name'>[]) {
+    const { columns, foreignColumns }  = foreignKey.reference;
+
+    if (columns.length < 1 || foreignColumns.length < 1) {
+      return this;
+    }
+
+    let acc = new Set<string>();
+    for (const column of columns) {
+      const table = tables.find((t) => t.columns.find((c) => c.name === column.name))!;
+      const name = `${table.schema ? `"${table.schema}".` : ''}"${table.name}"`;
+
+      if (!acc.has(name)) {
+        this.errors.push(`Composite foreign key ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has columns from multiple tables`);
+        break;
+      }
+
+      acc.add(name);
+    }
+
+    acc = new Set<string>();
+    for (const column of foreignColumns) {
+      const table = tables.find((t) => t.columns.find((c) => c.name === column.name))!;
+      const name = `${table.schema ? `"${table.schema}".` : ''}"${table.name}"`;
+
+      if (!acc.has(name)) {
+        this.errors.push(`Composite foreign key ${this.schema ? `"${this.schema}".` : ''}"${this.name}" references columns from multiple tables`);
+        break;
+      }
+
+      acc.add(name);
+    }
+
+    return this;
+  }
+}

--- a/drizzle-kit/src/validate-schema/foreign-key.ts
+++ b/drizzle-kit/src/validate-schema/foreign-key.ts
@@ -21,8 +21,8 @@ export class ValidateForeignKey {
   mismatchingDataTypes(foreignKey: Table['foreignKeys'][number]) {
     const { columns, foreignColumns }  = foreignKey.reference;
 
-    const types = `(${columns.map((c) => c.getSQLType()).join(', ')})`;
-    const foreignTypes = `(${foreignColumns.map((c) => c.getSQLType()).join(', ')})`;
+    const types = `(${columns.map((c) => c.sqlType).join(', ')})`;
+    const foreignTypes = `(${foreignColumns.map((c) => c.sqlType).join(', ')})`;
 
     if (types !== foreignTypes) {
       this.errors.push({

--- a/drizzle-kit/src/validate-schema/foreign-key.ts
+++ b/drizzle-kit/src/validate-schema/foreign-key.ts
@@ -1,3 +1,4 @@
+import { Dialect } from 'drizzle-orm';
 import { SchemaValidationErrors, ValidationError } from './errors';
 import { entityName, fmtValue, Table } from './utils';
 
@@ -18,16 +19,43 @@ export class ValidateForeignKey {
     return this;
   }
 
-  mismatchingDataTypes(foreignKey: Table['foreignKeys'][number]) {
+  mismatchingDataTypes(foreignKey: Table['foreignKeys'][number], dialect: Dialect) {
     const { columns, foreignColumns }  = foreignKey.reference;
 
-    const types = `(${columns.map((c) => c.sqlType).join(', ')})`;
-    const foreignTypes = `(${foreignColumns.map((c) => c.sqlType).join(', ')})`;
+    const typeAliases: Record<string, string> = {
+      serial: dialect === 'mysql' ? 'bigint unsigned' : 'integer',
+      bigserial: 'bigint',
+      smallserial: 'smallint',
+    };
+    const typeAliasesUsed: Record<string, boolean> = Object.keys(typeAliases).reduce((acc, type) => ({ ...acc, [type]: false }), {});
+
+    const map = (c: { sqlType: string }) => {
+      if (typeAliases[c.sqlType]) {
+        typeAliasesUsed[c.sqlType] = true;
+        return typeAliases[c.sqlType];
+      }
+      return c.sqlType;
+    };
+
+    const types = `(${columns.map(map).join(', ')})`;
+    const foreignTypes = `(${foreignColumns.map(map).join(', ')})`;
 
     if (types !== foreignTypes) {
+      let hint = `Type${columns.length > 1 ? 's' : ''} ${fmtValue(types, false)} ${columns.length > 1 ? 'are' : 'is'} different from ${fmtValue(foreignTypes, false)}. The data types must be the same`;
+
+      const usedAliases = Object.values(typeAliasesUsed).filter((used) => used)
+
+      if (usedAliases.length > 0) {
+        const list = Object.entries(typeAliasesUsed).map(([type]) => {
+          return `${fmtValue(type, false)} is an alias for ${fmtValue(typeAliases[type], false)}`;
+        });
+        const listStr = list.length > 1 ? `${list.slice(0, -1).join(', ')} and ${list.slice(-1)}` : list[0];
+        hint += `.\nRemember that ${listStr}`;
+      }
+
       this.errors.push({
         message: `Column data types in foreign key ${entityName(this.schema, this.name, true)} do not match`,
-        hint: `Type${columns.length > 1 ? 's' : ''} ${fmtValue(types, false)} ${columns.length > 1 ? 'are' : 'is'} different from ${fmtValue(foreignTypes, false)}. The data types must be the same`
+        hint
       });
       this.errorCodes.add(SchemaValidationErrors.ForeignKeyMismatchingDataTypes);
     }

--- a/drizzle-kit/src/validate-schema/foreign-key.ts
+++ b/drizzle-kit/src/validate-schema/foreign-key.ts
@@ -3,104 +3,118 @@ import { SchemaValidationErrors, ValidationError } from './errors';
 import { entityName, fmtValue, Table } from './utils';
 
 export class ValidateForeignKey {
-  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+	constructor(
+		private errors: ValidationError[],
+		private errorCodes: Set<number>,
+		private schema: string | undefined,
+		private name: string,
+	) {}
 
-  mismatchingColumnCount(foreignKey: Table['foreignKeys'][number]) {
-    const { columns, foreignColumns }  = foreignKey.reference;
+	mismatchingColumnCount(foreignKey: Table['foreignKeys'][number]) {
+		const { columns, foreignColumns } = foreignKey.reference;
 
-    if (columns.length !== foreignColumns.length) {
-      this.errors.push({
-        message: `Foreign key ${entityName(this.schema, this.name, true)} has ${fmtValue(columns.length.toString(), false)} column${columns.length === 1 ? '' : 's'} but references ${fmtValue(foreignColumns.length.toString(), false)}`,
-        hint: 'The amount of columns in the foreign key must match the amount of referenced columns'
-      });
-      this.errorCodes.add(SchemaValidationErrors.ForeignKeyMismatchingColumnCount);
-    }
+		if (columns.length !== foreignColumns.length) {
+			this.errors.push({
+				message: `Foreign key ${entityName(this.schema, this.name, true)} has ${
+					fmtValue(columns.length.toString(), false)
+				} column${columns.length === 1 ? '' : 's'} but references ${fmtValue(foreignColumns.length.toString(), false)}`,
+				hint: 'The amount of columns in the foreign key must match the amount of referenced columns',
+			});
+			this.errorCodes.add(SchemaValidationErrors.ForeignKeyMismatchingColumnCount);
+		}
 
-    return this;
-  }
+		return this;
+	}
 
-  mismatchingDataTypes(foreignKey: Table['foreignKeys'][number], dialect: Dialect) {
-    const { columns, foreignColumns }  = foreignKey.reference;
+	mismatchingDataTypes(foreignKey: Table['foreignKeys'][number], dialect: Dialect) {
+		const { columns, foreignColumns } = foreignKey.reference;
 
-    const typeAliases: Record<string, string> = {
-      serial: dialect === 'mysql' ? 'bigint unsigned' : 'integer',
-      bigserial: 'bigint',
-      smallserial: 'smallint',
-    };
-    const typeAliasesUsed: Record<string, boolean> = Object.keys(typeAliases).reduce((acc, type) => ({ ...acc, [type]: false }), {});
+		const typeAliases: Record<string, string> = {
+			serial: dialect === 'mysql' ? 'bigint unsigned' : 'integer',
+			bigserial: 'bigint',
+			smallserial: 'smallint',
+		};
+		const typeAliasesUsed: Record<string, boolean> = Object.keys(typeAliases).reduce(
+			(acc, type) => ({ ...acc, [type]: false }),
+			{},
+		);
 
-    const map = (c: { sqlType: string }) => {
-      if (typeAliases[c.sqlType]) {
-        typeAliasesUsed[c.sqlType] = true;
-        return typeAliases[c.sqlType];
-      }
-      return c.sqlType;
-    };
+		const map = (c: { sqlType: string }) => {
+			if (typeAliases[c.sqlType]) {
+				typeAliasesUsed[c.sqlType] = true;
+				return typeAliases[c.sqlType];
+			}
+			return c.sqlType;
+		};
 
-    const types = `(${columns.map(map).join(', ')})`;
-    const foreignTypes = `(${foreignColumns.map(map).join(', ')})`;
+		const types = `(${columns.map(map).join(', ')})`;
+		const foreignTypes = `(${foreignColumns.map(map).join(', ')})`;
 
-    if (types !== foreignTypes) {
-      let hint = `Type${columns.length > 1 ? 's' : ''} ${fmtValue(types, false)} ${columns.length > 1 ? 'are' : 'is'} different from ${fmtValue(foreignTypes, false)}. The data types must be the same`;
+		if (types !== foreignTypes) {
+			let hint = `Type${columns.length > 1 ? 's' : ''} ${fmtValue(types, false)} ${
+				columns.length > 1 ? 'are' : 'is'
+			} different from ${fmtValue(foreignTypes, false)}. The data types must be the same`;
 
-      const usedAliases = Object.values(typeAliasesUsed).filter((used) => used)
+			const usedAliases = Object.values(typeAliasesUsed).filter((used) => used);
 
-      if (usedAliases.length > 0) {
-        const list = Object.entries(typeAliasesUsed).map(([type]) => {
-          return `${fmtValue(type, false)} is an alias for ${fmtValue(typeAliases[type], false)}`;
-        });
-        const listStr = list.length > 1 ? `${list.slice(0, -1).join(', ')} and ${list.slice(-1)}` : list[0];
-        hint += `.\nRemember that ${listStr}`;
-      }
+			if (usedAliases.length > 0) {
+				const list = Object.entries(typeAliasesUsed).map(([type]) => {
+					return `${fmtValue(type, false)} is an alias for ${fmtValue(typeAliases[type], false)}`;
+				});
+				const listStr = list.length > 1 ? `${list.slice(0, -1).join(', ')} and ${list.slice(-1)}` : list[0];
+				hint += `.\nRemember that ${listStr}`;
+			}
 
-      this.errors.push({
-        message: `Column data types in foreign key ${entityName(this.schema, this.name, true)} do not match`,
-        hint
-      });
-      this.errorCodes.add(SchemaValidationErrors.ForeignKeyMismatchingDataTypes);
-    }
+			this.errors.push({
+				message: `Column data types in foreign key ${entityName(this.schema, this.name, true)} do not match`,
+				hint,
+			});
+			this.errorCodes.add(SchemaValidationErrors.ForeignKeyMismatchingDataTypes);
+		}
 
-    return this;
-  }
+		return this;
+	}
 
-  /** Only applies to composite foreign keys */
-  columnsMixingTables(foreignKey: Table['foreignKeys'][number]) {
-    const { columns, foreignColumns }  = foreignKey.reference;
+	/** Only applies to composite foreign keys */
+	columnsMixingTables(foreignKey: Table['foreignKeys'][number]) {
+		const { columns, foreignColumns } = foreignKey.reference;
 
-    if (columns.length < 1 || foreignColumns.length < 1) {
-      return this;
-    }
+		if (columns.length < 1 || foreignColumns.length < 1) {
+			return this;
+		}
 
-    let acc = new Set<string>();
-    for (const column of columns) {
-      const table = column.table;
-      const name = `${table.schema ? `"${table.schema}".` : ''}"${table.name}"`;
-      acc.add(name);
-    }
+		let acc = new Set<string>();
+		for (const column of columns) {
+			const table = column.table;
+			const name = `${table.schema ? `"${table.schema}".` : ''}"${table.name}"`;
+			acc.add(name);
+		}
 
-    if (acc.size > 1) {
-      this.errors.push({
-        message: `Composite foreign key ${entityName(this.schema, this.name, true)} has columns from multiple tables`,
-        hint: 'Each column in a foreign key must be from the same table'
-      });
-      this.errorCodes.add(SchemaValidationErrors.ForeignKeyColumnsMixingTables);
-    }
+		if (acc.size > 1) {
+			this.errors.push({
+				message: `Composite foreign key ${entityName(this.schema, this.name, true)} has columns from multiple tables`,
+				hint: 'Each column in a foreign key must be from the same table',
+			});
+			this.errorCodes.add(SchemaValidationErrors.ForeignKeyColumnsMixingTables);
+		}
 
-    acc = new Set<string>();
-    for (const column of foreignColumns) {
-      const table = column.table;
-      const name = `${table.schema ? `"${table.schema}".` : ''}"${table.name}"`;
-      acc.add(name);
-    }
+		acc = new Set<string>();
+		for (const column of foreignColumns) {
+			const table = column.table;
+			const name = `${table.schema ? `"${table.schema}".` : ''}"${table.name}"`;
+			acc.add(name);
+		}
 
-    if (acc.size > 1) {
-      this.errors.push({
-        message: `Composite foreign key ${entityName(this.schema, this.name, true)} references columns from multiple tables`,
-        hint: 'Each reference column in a foreign key must be from the same table'
-      });
-      this.errorCodes.add(SchemaValidationErrors.ForeignKeyForeignColumnsMixingTables);
-    }
+		if (acc.size > 1) {
+			this.errors.push({
+				message: `Composite foreign key ${
+					entityName(this.schema, this.name, true)
+				} references columns from multiple tables`,
+				hint: 'Each reference column in a foreign key must be from the same table',
+			});
+			this.errorCodes.add(SchemaValidationErrors.ForeignKeyForeignColumnsMixingTables);
+		}
 
-    return this;
-  }
+		return this;
+	}
 }

--- a/drizzle-kit/src/validate-schema/index.ts
+++ b/drizzle-kit/src/validate-schema/index.ts
@@ -1,0 +1,30 @@
+import { is, SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { Table } from './utils';
+
+export class ValidateIndex {
+  constructor(private errors: string[], private schema: string | undefined, private name: string) {}
+
+  /** PG only */
+  requiresName(columns: Table['indexes'][number]['columns'], dialect: PgDialect) {
+    for (const column of columns) {
+      if (is(column, SQL)) {
+        this.errors.push(`Cannot automatically assign name to index in table ${this.schema ? `"${this.schema}".` : ''}"${this.name}" with expression \`${dialect.sqlToQuery(column).sql}\`. Please assign a name manually`);
+        break;
+      }
+    }
+
+    return this;
+  }
+
+  /** PG only */
+  vectorColumnRequiresOp(columns: Table['indexes'][number]['columns']) {
+    for (const column of columns) {
+      if (!is(column, SQL) && column.type === 'PgVector' && column.op === undefined) {
+        this.errors.push(`Column "${column.name}" in index ${this.schema ? `"${this.schema}".` : ''}"${this.name}" requires an operator class`);
+      }
+    }
+
+    return this;
+  }
+}

--- a/drizzle-kit/src/validate-schema/index.ts
+++ b/drizzle-kit/src/validate-schema/index.ts
@@ -1,16 +1,20 @@
 import { is, SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { Table } from './utils';
-import { SchemaValidationErrors } from './errors';
+import { entityName, fmtValue, Table } from './utils';
+import { SchemaValidationErrors, ValidationError } from './errors';
+import { vectorOps } from 'src/extensions/vector';
 
 export class ValidateIndex {
-  constructor(private errors: string[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
 
   /** PG only */
   requiresName(columns: Table['indexes'][number]['columns'], dialect: PgDialect) {
     for (const column of columns) {
       if (is(column, SQL)) {
-        this.errors.push(`Cannot automatically assign name to index in table ${this.schema ? `"${this.schema}".` : ''}"${this.name}" with expression \`${dialect.sqlToQuery(column).sql}\`. Please assign a name manually`);
+        this.errors.push({
+          message: `Cannot automatically assign name to index in table ${entityName(this.schema, this.name, true)} with expression ${fmtValue(dialect.sqlToQuery(column).sql, true)}`,
+          hint: `Indexes that contain a SQL expression within the ${fmtValue('`.on()`', false)} method cannot be automatically named. Manually assign a name to the index`
+        });
         this.errorCodes.add(SchemaValidationErrors.IndexRequiresName);
         break;
       }
@@ -23,7 +27,10 @@ export class ValidateIndex {
   vectorColumnRequiresOp(columns: Table['indexes'][number]['columns']) {
     for (const column of columns) {
       if (!is(column, SQL) && column.type === 'PgVector' && column.op === undefined) {
-        this.errors.push(`Column "${column.name}" in index ${this.schema ? `"${this.schema}".` : ''}"${this.name}" requires an operator class`);
+        this.errors.push({
+          message: `Vector column ${entityName(undefined, column.name, true)} in index ${entityName(this.schema, this.name, true)} requires an operator class`,
+          hint: `The pgvector extension does not provide a default operator class for vector columns. You must specify an operator class.\nThe following operator classes are available in Drizzle: ${vectorOps.map((op) => fmtValue(op, true)).join(', ')}.\nAn operator class can be added as such: ${fmtValue(`\`index("index_name").on(table.column.op("${vectorOps[0]}"))\``, false)}`
+        });
         this.errorCodes.add(SchemaValidationErrors.IndexVectorColumnRequiresOp);
       }
     }

--- a/drizzle-kit/src/validate-schema/index.ts
+++ b/drizzle-kit/src/validate-schema/index.ts
@@ -1,40 +1,56 @@
 import { is, SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { entityName, fmtValue, Table } from './utils';
-import { SchemaValidationErrors, ValidationError } from './errors';
 import { vectorOps } from 'src/extensions/vector';
+import { SchemaValidationErrors, ValidationError } from './errors';
+import { entityName, fmtValue, Table } from './utils';
 
 export class ValidateIndex {
-  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+	constructor(
+		private errors: ValidationError[],
+		private errorCodes: Set<number>,
+		private schema: string | undefined,
+		private name: string,
+	) {}
 
-  /** PG only */
-  requiresName(columns: Table['indexes'][number]['columns'], dialect: PgDialect) {
-    for (const column of columns) {
-      if (is(column, SQL)) {
-        this.errors.push({
-          message: `Cannot automatically assign name to index in table ${entityName(this.schema, this.name, true)} with expression ${fmtValue(dialect.sqlToQuery(column).sql, true)}`,
-          hint: `Indexes that contain a SQL expression within the ${fmtValue('`.on()`', false)} method cannot be automatically named. Manually assign a name to the index`
-        });
-        this.errorCodes.add(SchemaValidationErrors.IndexRequiresName);
-        break;
-      }
-    }
+	/** PG only */
+	requiresName(columns: Table['indexes'][number]['columns'], dialect: PgDialect) {
+		for (const column of columns) {
+			if (is(column, SQL)) {
+				this.errors.push({
+					message: `Cannot automatically assign name to index in table ${
+						entityName(this.schema, this.name, true)
+					} with expression ${fmtValue(dialect.sqlToQuery(column).sql, true)}`,
+					hint: `Indexes that contain a SQL expression within the ${
+						fmtValue('`.on()`', false)
+					} method cannot be automatically named. Manually assign a name to the index`,
+				});
+				this.errorCodes.add(SchemaValidationErrors.IndexRequiresName);
+				break;
+			}
+		}
 
-    return this;
-  }
+		return this;
+	}
 
-  /** PG only */
-  vectorColumnRequiresOp(columns: Table['indexes'][number]['columns']) {
-    for (const column of columns) {
-      if (!is(column, SQL) && column.type === 'PgVector' && column.op === undefined) {
-        this.errors.push({
-          message: `Vector column ${entityName(undefined, column.name, true)} in index ${entityName(this.schema, this.name, true)} requires an operator class`,
-          hint: `The pgvector extension does not provide a default operator class for vector columns. You must specify an operator class.\nThe following operator classes are available in Drizzle: ${vectorOps.map((op) => fmtValue(op, true)).join(', ')}.\nAn operator class can be added as such: ${fmtValue(`\`index("index_name").on(table.column.op("${vectorOps[0]}"))\``, false)}`
-        });
-        this.errorCodes.add(SchemaValidationErrors.IndexVectorColumnRequiresOp);
-      }
-    }
+	/** PG only */
+	vectorColumnRequiresOp(columns: Table['indexes'][number]['columns']) {
+		for (const column of columns) {
+			if (!is(column, SQL) && column.type === 'PgVector' && column.op === undefined) {
+				this.errors.push({
+					message: `Vector column ${entityName(undefined, column.name, true)} in index ${
+						entityName(this.schema, this.name, true)
+					} requires an operator class`,
+					hint:
+						`The pgvector extension does not provide a default operator class for vector columns. You must specify an operator class.\nThe following operator classes are available in Drizzle: ${
+							vectorOps.map((op) => fmtValue(op, true)).join(', ')
+						}.\nAn operator class can be added as such: ${
+							fmtValue(`\`index("index_name").on(table.column.op("${vectorOps[0]}"))\``, false)
+						}`,
+				});
+				this.errorCodes.add(SchemaValidationErrors.IndexVectorColumnRequiresOp);
+			}
+		}
 
-    return this;
-  }
+		return this;
+	}
 }

--- a/drizzle-kit/src/validate-schema/index.ts
+++ b/drizzle-kit/src/validate-schema/index.ts
@@ -1,15 +1,17 @@
 import { is, SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import { Table } from './utils';
+import { SchemaValidationErrors } from './errors';
 
 export class ValidateIndex {
-  constructor(private errors: string[], private schema: string | undefined, private name: string) {}
+  constructor(private errors: string[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
 
   /** PG only */
   requiresName(columns: Table['indexes'][number]['columns'], dialect: PgDialect) {
     for (const column of columns) {
       if (is(column, SQL)) {
         this.errors.push(`Cannot automatically assign name to index in table ${this.schema ? `"${this.schema}".` : ''}"${this.name}" with expression \`${dialect.sqlToQuery(column).sql}\`. Please assign a name manually`);
+        this.errorCodes.add(SchemaValidationErrors.IndexRequiresName);
         break;
       }
     }
@@ -22,6 +24,7 @@ export class ValidateIndex {
     for (const column of columns) {
       if (!is(column, SQL) && column.type === 'PgVector' && column.op === undefined) {
         this.errors.push(`Column "${column.name}" in index ${this.schema ? `"${this.schema}".` : ''}"${this.name}" requires an operator class`);
+        this.errorCodes.add(SchemaValidationErrors.IndexVectorColumnRequiresOp);
       }
     }
 

--- a/drizzle-kit/src/validate-schema/primary-key.ts
+++ b/drizzle-kit/src/validate-schema/primary-key.ts
@@ -1,0 +1,27 @@
+import { SchemaValidationErrors } from './errors';
+import { Table } from './utils';
+
+export class ValidatePrimaryKey {
+  constructor(private errors: string[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+
+  /** Only applies to composite primary keys */
+  columnsMixingTables(primaryKey: Table['primaryKeys'][number]) {
+    if (primaryKey.columns.length < 1) {
+      return this;
+    }
+
+    const acc = new Set<string>();
+    for (const column of primaryKey.columns) {
+      const table = column.table;
+      const name = `${table.schema ? `"${table.schema}".` : ''}"${table.name}"`;
+      acc.add(name);
+    }
+
+    if (acc.size > 1) {
+      this.errors.push(`Composite primary key ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has columns from multiple tables`);
+      this.errorCodes.add(SchemaValidationErrors.PrimaryKeyColumnsMixingTables);
+    }
+
+    return this;
+  }
+}

--- a/drizzle-kit/src/validate-schema/primary-key.ts
+++ b/drizzle-kit/src/validate-schema/primary-key.ts
@@ -2,28 +2,33 @@ import { SchemaValidationErrors, ValidationError } from './errors';
 import { entityName, Table } from './utils';
 
 export class ValidatePrimaryKey {
-  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+	constructor(
+		private errors: ValidationError[],
+		private errorCodes: Set<number>,
+		private schema: string | undefined,
+		private name: string,
+	) {}
 
-  /** Only applies to composite primary keys */
-  columnsMixingTables(primaryKey: Table['primaryKeys'][number]) {
-    if (primaryKey.columns.length < 1) {
-      return this;
-    }
+	/** Only applies to composite primary keys */
+	columnsMixingTables(primaryKey: Table['primaryKeys'][number]) {
+		if (primaryKey.columns.length < 1) {
+			return this;
+		}
 
-    const acc = new Set<string>();
-    for (const column of primaryKey.columns) {
-      const name = entityName(column.table.schema, column.table.name);
-      acc.add(name);
-    }
+		const acc = new Set<string>();
+		for (const column of primaryKey.columns) {
+			const name = entityName(column.table.schema, column.table.name);
+			acc.add(name);
+		}
 
-    if (acc.size > 1) {
-      this.errors.push({
-        message: `Composite primary key ${entityName(this.schema, this.name, true)} has columns from multiple tables`,
-        hint: 'Each column in a primary key must be from the same table'
-      });
-      this.errorCodes.add(SchemaValidationErrors.PrimaryKeyColumnsMixingTables);
-    }
+		if (acc.size > 1) {
+			this.errors.push({
+				message: `Composite primary key ${entityName(this.schema, this.name, true)} has columns from multiple tables`,
+				hint: 'Each column in a primary key must be from the same table',
+			});
+			this.errorCodes.add(SchemaValidationErrors.PrimaryKeyColumnsMixingTables);
+		}
 
-    return this;
-  }
+		return this;
+	}
 }

--- a/drizzle-kit/src/validate-schema/schema.ts
+++ b/drizzle-kit/src/validate-schema/schema.ts
@@ -1,0 +1,106 @@
+import { ValidateIndex } from '.';
+import { ValidateEnum } from './enum';
+import { ValidateForeignKey } from './foreign-key';
+import { ValidateSequence } from './sequence';
+import { ValidateTable } from './table';
+import { Enum, getCollisions, listStr, MaterializedView, Sequence, Table, View } from './utils';
+
+export class ValidateSchema {
+  constructor(private errors: string[], private schema: string | undefined) {}
+
+  validateEnum(enumName: string) {
+    return new ValidateEnum(this.errors, this.schema, enumName);
+  }
+
+  validateSequence(sequenceName: string) {
+    return new ValidateSequence(this.errors, this.schema, sequenceName);
+  }
+
+  validateTable(tableName: string) {
+    return new ValidateTable(this.errors, this.schema, tableName);
+  }
+
+  validateForeignKey(foreignKeyName: string) {
+    return new ValidateForeignKey(this.errors, this.schema, foreignKeyName);
+  }
+
+  validateIndex(indexName: string) {
+    return new ValidateIndex(this.errors, this.schema, indexName);
+  }
+
+  entityNameCollisions(
+    tables: Pick<Table, 'name'>[],
+    views: View[],
+    materializedViews: MaterializedView[],
+    enums: Enum[],
+    sequences: Sequence[],
+  ) {
+    const names = [
+      ...tables.map((t) => t.name),
+      ...views.map((v) => v.name),
+      ...materializedViews.map((mv) => mv.name),
+      ...enums.map((e) => e.enumName),
+      ...sequences.filter((s) => !!s.seqName).map((s) => s.seqName) as string[],
+    ];
+
+    const collisions = getCollisions(names);
+    const messages = collisions.map((name) => {
+      const inTables = tables.filter((t) => t.name === name).length;
+      const inViews = views.filter((v) => v.name === name).length;
+      const inMaterializedViews = materializedViews.filter((mv) => mv.name === name).length;
+      const inEnums = enums.filter((e) => e.enumName === name).length;
+      const inSequences = sequences.filter((s) => s.seqName === name).length;
+
+      const list = listStr(
+        [inTables, 'table', 'tables'],
+        [inViews, 'view', 'views'],
+        [inMaterializedViews, 'materialized view', 'materialized views'],
+        [inEnums, 'enum', 'enums'],
+        [inSequences, 'sequence', 'sequences'],
+      );
+
+      return `${this.schema ? `In schema "${this.schema}", ` : ''}${list} have the same name, "${name}"`;
+    });
+
+    this.errors.push(...messages);
+    return this;
+  }
+
+  constraintNameCollisions(
+    indexes: Table['indexes'],
+    foreignKeys: Table['foreignKeys'],
+    checks: Table['checks'],
+    primaryKeys: Table['primaryKeys'],
+    uniqueConstraints: Table['uniqueConstraints'],
+  ) {
+    const names = [
+      ...indexes.map((i) => i.name),
+      ...foreignKeys.map((f) => f.name),
+      ...checks.map((c) => c.name),
+      ...primaryKeys.map((p) => p.name),
+      ...uniqueConstraints.map((u) => u.name),
+    ];
+
+    const collisions = getCollisions(names);
+    const messages = collisions.map((name) => {
+      const inIndexes = indexes.filter((i) => i.name === name).length;
+      const inForeignKeys = foreignKeys.filter((f) => f.name === name).length;
+      const inChecks = checks.filter((c) => c.name === name).length;
+      const inPrimaryKeys = primaryKeys.filter((p) => p.name === name).length;
+      const inUniqueConstraints = uniqueConstraints.filter((u) => u.name === name).length;
+
+      const list = listStr(
+        [inIndexes, 'index', 'indexes'],
+        [inForeignKeys, 'foreign key', 'foreign keys'],
+        [inChecks, 'check', 'checks'],
+        [inPrimaryKeys, 'primary key', 'primary keys'],
+        [inUniqueConstraints, 'unique constraint', 'unique constraints'],
+      );
+
+      return `${this.schema ? `In schema "${this.schema}", ` : ''}${list} have the same name, "${name}"`;
+    });
+
+    this.errors.push(...messages);
+    return this;
+  }
+}

--- a/drizzle-kit/src/validate-schema/schema.ts
+++ b/drizzle-kit/src/validate-schema/schema.ts
@@ -8,129 +8,131 @@ import { ValidateTable } from './table';
 import { entityName, Enum, fmtValue, getCollisions, listStr, MaterializedView, Sequence, Table, View } from './utils';
 
 export class ValidateSchema {
-  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined) {}
+	constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined) {}
 
-  validateEnum(enumName: string) {
-    return new ValidateEnum(this.errors, this.errorCodes, this.schema, enumName);
-  }
+	validateEnum(enumName: string) {
+		return new ValidateEnum(this.errors, this.errorCodes, this.schema, enumName);
+	}
 
-  validateSequence(sequenceName: string) {
-    return new ValidateSequence(this.errors, this.errorCodes, this.schema, sequenceName);
-  }
+	validateSequence(sequenceName: string) {
+		return new ValidateSequence(this.errors, this.errorCodes, this.schema, sequenceName);
+	}
 
-  validateTable(tableName: string) {
-    return new ValidateTable(this.errors, this.errorCodes, this.schema, tableName);
-  }
+	validateTable(tableName: string) {
+		return new ValidateTable(this.errors, this.errorCodes, this.schema, tableName);
+	}
 
-  validateForeignKey(foreignKeyName: string) {
-    return new ValidateForeignKey(this.errors, this.errorCodes, this.schema, foreignKeyName);
-  }
+	validateForeignKey(foreignKeyName: string) {
+		return new ValidateForeignKey(this.errors, this.errorCodes, this.schema, foreignKeyName);
+	}
 
-  validatePrimaryKey(primaryKeyName: string) {
-    return new ValidatePrimaryKey(this.errors, this.errorCodes, this.schema, primaryKeyName);
-  }
+	validatePrimaryKey(primaryKeyName: string) {
+		return new ValidatePrimaryKey(this.errors, this.errorCodes, this.schema, primaryKeyName);
+	}
 
-  validateIndex(indexName: string) {
-    return new ValidateIndex(this.errors, this.errorCodes, this.schema, indexName);
-  }
+	validateIndex(indexName: string) {
+		return new ValidateIndex(this.errors, this.errorCodes, this.schema, indexName);
+	}
 
-  entityNameCollisions(
-    tables: Pick<Table, 'name'>[],
-    views: View[],
-    materializedViews: MaterializedView[],
-    enums: Enum[],
-    sequences: Sequence[],
-  ) {
-    const names = [
-      ...tables.map((t) => t.name),
-      ...views.map((v) => v.name),
-      ...materializedViews.map((mv) => mv.name),
-      ...enums.map((e) => e.enumName),
-      ...sequences.filter((s) => !!s.seqName).map((s) => s.seqName) as string[],
-    ];
+	entityNameCollisions(
+		tables: Pick<Table, 'name'>[],
+		views: View[],
+		materializedViews: MaterializedView[],
+		enums: Enum[],
+		sequences: Sequence[],
+	) {
+		const names = [
+			...tables.map((t) => t.name),
+			...views.map((v) => v.name),
+			...materializedViews.map((mv) => mv.name),
+			...enums.map((e) => e.enumName),
+			...sequences.filter((s) => !!s.seqName).map((s) => s.seqName) as string[],
+		];
 
-    const collisions = getCollisions(names);
+		const collisions = getCollisions(names);
 
-    if (collisions.length > 0) {
-      const messages: ValidationError[] = collisions.map((name) => {
-        const inTables = tables.filter((t) => t.name === name).length;
-        const inViews = views.filter((v) => v.name === name).length;
-        const inMaterializedViews = materializedViews.filter((mv) => mv.name === name).length;
-        const inEnums = enums.filter((e) => e.enumName === name).length;
-        const inSequences = sequences.filter((s) => s.seqName === name).length;
-  
-        const list = listStr(
-          [inTables, 'table', 'tables'],
-          [inViews, 'view', 'views'],
-          [inMaterializedViews, 'materialized view', 'materialized views'],
-          [inEnums, 'enum', 'enums'],
-          [inSequences, 'sequence', 'sequences'],
-        );
-  
-        return {
-          message: `${
-            this.schema
-              ? `In schema ${entityName(undefined, this.schema, true)}, ${list} have `
-              : `Database has ${list} with `
-          }the same name, ${fmtValue(name, true)}`,
-          hint: 'Each entity (table, view, materialized view, enum and sequence) in a schema must have a unique name. Rename any of the conflicting entities',
-        };
-      });
-  
-      this.errors.push(...messages);
-      this.errorCodes.add(SchemaValidationErrors.SchemaEntityNameCollisions);
-    }
+		if (collisions.length > 0) {
+			const messages: ValidationError[] = collisions.map((name) => {
+				const inTables = tables.filter((t) => t.name === name).length;
+				const inViews = views.filter((v) => v.name === name).length;
+				const inMaterializedViews = materializedViews.filter((mv) => mv.name === name).length;
+				const inEnums = enums.filter((e) => e.enumName === name).length;
+				const inSequences = sequences.filter((s) => s.seqName === name).length;
 
-    return this;
-  }
+				const list = listStr(
+					[inTables, 'table', 'tables'],
+					[inViews, 'view', 'views'],
+					[inMaterializedViews, 'materialized view', 'materialized views'],
+					[inEnums, 'enum', 'enums'],
+					[inSequences, 'sequence', 'sequences'],
+				);
 
-  constraintNameCollisions(
-    indexes: Table['indexes'],
-    foreignKeys: Table['foreignKeys'],
-    checks: Table['checks'],
-    primaryKeys: Table['primaryKeys'],
-    uniqueConstraints: Table['uniqueConstraints'],
-  ) {
-    const names = [
-      ...indexes.map((i) => i.name),
-      ...foreignKeys.map((f) => f.name),
-      ...checks.map((c) => c.name),
-      ...primaryKeys.map((p) => p.name),
-      ...uniqueConstraints.map((u) => u.name),
-    ];
+				return {
+					message: `${
+						this.schema
+							? `In schema ${entityName(undefined, this.schema, true)}, ${list} have `
+							: `Database has ${list} with `
+					}the same name, ${fmtValue(name, true)}`,
+					hint:
+						'Each entity (table, view, materialized view, enum and sequence) in a schema must have a unique name. Rename any of the conflicting entities',
+				};
+			});
 
-    const collisions = getCollisions(names);
+			this.errors.push(...messages);
+			this.errorCodes.add(SchemaValidationErrors.SchemaEntityNameCollisions);
+		}
 
-    if (collisions.length > 0) {
-      const messages: ValidationError[] = collisions.map((name) => {
-        const inIndexes = indexes.filter((i) => i.name === name).length;
-        const inForeignKeys = foreignKeys.filter((f) => f.name === name).length;
-        const inChecks = checks.filter((c) => c.name === name).length;
-        const inPrimaryKeys = primaryKeys.filter((p) => p.name === name).length;
-        const inUniqueConstraints = uniqueConstraints.filter((u) => u.name === name).length;
-  
-        const list = listStr(
-          [inIndexes, 'index', 'indexes'],
-          [inForeignKeys, 'foreign key', 'foreign keys'],
-          [inChecks, 'check', 'checks'],
-          [inPrimaryKeys, 'primary key', 'primary keys'],
-          [inUniqueConstraints, 'unique constraint', 'unique constraints'],
-        );
-  
-        return {
-          message: `${
-            this.schema
-              ? `In schema ${entityName(undefined, this.schema, true)}, ${list} have `
-              : `Database has ${list} with `
-          }the same name, ${fmtValue(name, true)}`,
-          hint: 'Each constraint (primary key, foreign key, check and unique) and index in a schema must have a unique name. Rename any of the conflicting constraints/indexes',
-        };
-      });
-  
-      this.errors.push(...messages);
-      this.errorCodes.add(SchemaValidationErrors.SchemaConstraintNameCollisions);
-    }
+		return this;
+	}
 
-    return this;
-  }
+	constraintNameCollisions(
+		indexes: Table['indexes'],
+		foreignKeys: Table['foreignKeys'],
+		checks: Table['checks'],
+		primaryKeys: Table['primaryKeys'],
+		uniqueConstraints: Table['uniqueConstraints'],
+	) {
+		const names = [
+			...indexes.map((i) => i.name),
+			...foreignKeys.map((f) => f.name),
+			...checks.map((c) => c.name),
+			...primaryKeys.map((p) => p.name),
+			...uniqueConstraints.map((u) => u.name),
+		];
+
+		const collisions = getCollisions(names);
+
+		if (collisions.length > 0) {
+			const messages: ValidationError[] = collisions.map((name) => {
+				const inIndexes = indexes.filter((i) => i.name === name).length;
+				const inForeignKeys = foreignKeys.filter((f) => f.name === name).length;
+				const inChecks = checks.filter((c) => c.name === name).length;
+				const inPrimaryKeys = primaryKeys.filter((p) => p.name === name).length;
+				const inUniqueConstraints = uniqueConstraints.filter((u) => u.name === name).length;
+
+				const list = listStr(
+					[inIndexes, 'index', 'indexes'],
+					[inForeignKeys, 'foreign key', 'foreign keys'],
+					[inChecks, 'check', 'checks'],
+					[inPrimaryKeys, 'primary key', 'primary keys'],
+					[inUniqueConstraints, 'unique constraint', 'unique constraints'],
+				);
+
+				return {
+					message: `${
+						this.schema
+							? `In schema ${entityName(undefined, this.schema, true)}, ${list} have `
+							: `Database has ${list} with `
+					}the same name, ${fmtValue(name, true)}`,
+					hint:
+						'Each constraint (primary key, foreign key, check and unique) and index in a schema must have a unique name. Rename any of the conflicting constraints/indexes',
+				};
+			});
+
+			this.errors.push(...messages);
+			this.errorCodes.add(SchemaValidationErrors.SchemaConstraintNameCollisions);
+		}
+
+		return this;
+	}
 }

--- a/drizzle-kit/src/validate-schema/schema.ts
+++ b/drizzle-kit/src/validate-schema/schema.ts
@@ -68,7 +68,11 @@ export class ValidateSchema {
         );
   
         return {
-          message: `${this.schema ? `In schema ${entityName(undefined, this.schema, true)}, ` : ''}${list} have the same name, ${fmtValue(name, true)}`,
+          message: `${
+            this.schema
+              ? `In schema ${entityName(undefined, this.schema, true)}, ${list} have `
+              : `Database has ${list} with `
+          }the same name, ${fmtValue(name, true)}`,
           hint: 'Each entity (table, view, materialized view, enum and sequence) in a schema must have a unique name. Rename any of the conflicting entities',
         };
       });
@@ -114,7 +118,11 @@ export class ValidateSchema {
         );
   
         return {
-          message: `${this.schema ? `In schema ${entityName(undefined, this.schema, true)}, ` : ''}${list} have the same name, ${fmtValue(name, true)}`,
+          message: `${
+            this.schema
+              ? `In schema ${entityName(undefined, this.schema, true)}, ${list} have `
+              : `Database has ${list} with `
+          }the same name, ${fmtValue(name, true)}`,
           hint: 'Each constraint (primary key, foreign key, check and unique) and index in a schema must have a unique name. Rename any of the conflicting constraints/indexes',
         };
       });

--- a/drizzle-kit/src/validate-schema/sequence.ts
+++ b/drizzle-kit/src/validate-schema/sequence.ts
@@ -1,7 +1,8 @@
+import { SchemaValidationErrors } from './errors';
 import { Sequence } from './utils';
 
 export class ValidateSequence {
-  constructor(private errors: string[], private schema: string | undefined, private name: string) {}
+  constructor(private errors: string[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
 
   incorrectvalues(sequence: Sequence) {
     let { increment, maxValue, minValue } = sequence.seqOptions ?? {};
@@ -10,10 +11,14 @@ export class ValidateSequence {
 
     if (Number(increment) === 0) {
       this.errors.push(`${baseMessage}is set to increment by 0, which is an invalid value`);
+      this.errorCodes.add(SchemaValidationErrors.SequenceIncrementByZero)
     }
 
     if (minValue && maxValue && Number(minValue) > Number(maxValue)) {
       this.errors.push(`${baseMessage}has a minimum value greater than its max value`);
+      this.errorCodes.add(SchemaValidationErrors.SequenceInvalidMinMax);
     }
+
+    return this;
   }
 }

--- a/drizzle-kit/src/validate-schema/sequence.ts
+++ b/drizzle-kit/src/validate-schema/sequence.ts
@@ -1,0 +1,19 @@
+import { Sequence } from './utils';
+
+export class ValidateSequence {
+  constructor(private errors: string[], private schema: string | undefined, private name: string) {}
+
+  incorrectvalues(sequence: Sequence) {
+    let { increment, maxValue, minValue } = sequence.seqOptions ?? {};
+    increment ??= 1;
+    const baseMessage = `Sequence ${this.schema ? `"${this.schema}".` : ''}"${this.name}" `;
+
+    if (Number(increment) === 0) {
+      this.errors.push(`${baseMessage}is set to increment by 0, which is an invalid value`);
+    }
+
+    if (minValue && maxValue && Number(minValue) > Number(maxValue)) {
+      this.errors.push(`${baseMessage}has a minimum value greater than its max value`);
+    }
+  }
+}

--- a/drizzle-kit/src/validate-schema/sequence.ts
+++ b/drizzle-kit/src/validate-schema/sequence.ts
@@ -2,29 +2,35 @@ import { SchemaValidationErrors, ValidationError } from './errors';
 import { entityName, fmtValue, Sequence } from './utils';
 
 export class ValidateSequence {
-  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+	constructor(
+		private errors: ValidationError[],
+		private errorCodes: Set<number>,
+		private schema: string | undefined,
+		private name: string,
+	) {}
 
-  incorrectvalues(sequence: Sequence) {
-    let { increment, maxValue, minValue } = sequence.seqOptions ?? {};
-    increment ??= 1;
-    const baseMessage = `Sequence ${entityName(this.schema, this.name)} `;
+	incorrectvalues(sequence: Sequence) {
+		let { increment, maxValue, minValue } = sequence.seqOptions ?? {};
+		increment ??= 1;
+		const baseMessage = `Sequence ${entityName(this.schema, this.name)} `;
 
-    if (Number(increment) === 0) {
-      this.errors.push({
-        message: `${baseMessage}is set to increment by ${fmtValue('0', false)}`,
-        hint: 'Sequences must increment by a non-zero value. Set the increment value to one that is greater or less than zero'
-      });
-      this.errorCodes.add(SchemaValidationErrors.SequenceIncrementByZero)
-    }
+		if (Number(increment) === 0) {
+			this.errors.push({
+				message: `${baseMessage}is set to increment by ${fmtValue('0', false)}`,
+				hint:
+					'Sequences must increment by a non-zero value. Set the increment value to one that is greater or less than zero',
+			});
+			this.errorCodes.add(SchemaValidationErrors.SequenceIncrementByZero);
+		}
 
-    if (minValue && maxValue && Number(minValue) > Number(maxValue)) {
-      this.errors.push({
-        message: `${baseMessage}has a minimum value greater than its max value`,
-        hint: 'Sequences must have a minimum value that is less than or equal to its maximum value'
-      });
-      this.errorCodes.add(SchemaValidationErrors.SequenceInvalidMinMax);
-    }
+		if (minValue && maxValue && Number(minValue) > Number(maxValue)) {
+			this.errors.push({
+				message: `${baseMessage}has a minimum value greater than its max value`,
+				hint: 'Sequences must have a minimum value that is less than or equal to its maximum value',
+			});
+			this.errorCodes.add(SchemaValidationErrors.SequenceInvalidMinMax);
+		}
 
-    return this;
-  }
+		return this;
+	}
 }

--- a/drizzle-kit/src/validate-schema/table.ts
+++ b/drizzle-kit/src/validate-schema/table.ts
@@ -1,0 +1,15 @@
+import { getCollisions, Table } from './utils';
+
+export class ValidateTable {
+  constructor(private errors: string[], private schema: string | undefined, private name: string) {}
+
+  columnNameCollisions(tableColumns: Table['columns']) {
+    const columnNames = tableColumns.map((c) => c.name);
+    const collisions = getCollisions(columnNames);
+    const messages = collisions.map(
+      (name) => `Table ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has duplicate column "${name}"`
+    );
+    this.errors.push(...messages);
+    return this;
+  }
+}

--- a/drizzle-kit/src/validate-schema/table.ts
+++ b/drizzle-kit/src/validate-schema/table.ts
@@ -3,34 +3,39 @@ import { SchemaValidationErrors, ValidationError } from './errors';
 import { entityName, fmtValue, getCollisions, Table } from './utils';
 
 export class ValidateTable {
-  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+	constructor(
+		private errors: ValidationError[],
+		private errorCodes: Set<number>,
+		private schema: string | undefined,
+		private name: string,
+	) {}
 
-  columnNameCollisions(tableColumns: Table['columns'], casing: CasingType | undefined) {
-    const columnNames = tableColumns.map((c) => c.name);
-    const collisions = getCollisions(columnNames);
+	columnNameCollisions(tableColumns: Table['columns'], casing: CasingType | undefined) {
+		const columnNames = tableColumns.map((c) => c.name);
+		const collisions = getCollisions(columnNames);
 
-    if (collisions.length > 0) {
-      let hint = 'Each column in a table must have a unique name. Rename any of the conflicting columns';
-      const example = [fmtValue('firstName', true), fmtValue('first_name', true)];
+		if (collisions.length > 0) {
+			let hint = 'Each column in a table must have a unique name. Rename any of the conflicting columns';
+			const example = [fmtValue('firstName', true), fmtValue('first_name', true)];
 
-      if (casing !== undefined) {
-        hint += `.\nRemember that you configured Drizzle to use ${
-          casing === 'camelCase' ? 'camel' : 'snake'
-        } case, which means that columns without an explicit alias will be transformed. Example: ${
-          (casing === 'camelCase' ? example.reverse() : example).join(fmtValue(' -> ', false))
-        }`;
-      }
+			if (casing !== undefined) {
+				hint += `.\nRemember that you configured Drizzle to use ${
+					casing === 'camelCase' ? 'camel' : 'snake'
+				} case, which means that columns without an explicit alias will be transformed. Example: ${
+					(casing === 'camelCase' ? example.reverse() : example).join(fmtValue(' -> ', false))
+				}`;
+			}
 
-      const errors: ValidationError[] = collisions.map(
-        (name) => ({
-          message: `Table ${entityName(this.schema, this.name, true)} has duplicate column ${fmtValue(name, true)}`,
-          hint
-        })
-      );
-      this.errors.push(...errors);
-      this.errorCodes.add(SchemaValidationErrors.TableColumnNameCollisions);
-    }
+			const errors: ValidationError[] = collisions.map(
+				(name) => ({
+					message: `Table ${entityName(this.schema, this.name, true)} has duplicate column ${fmtValue(name, true)}`,
+					hint,
+				}),
+			);
+			this.errors.push(...errors);
+			this.errorCodes.add(SchemaValidationErrors.TableColumnNameCollisions);
+		}
 
-    return this;
-  }
+		return this;
+	}
 }

--- a/drizzle-kit/src/validate-schema/table.ts
+++ b/drizzle-kit/src/validate-schema/table.ts
@@ -1,18 +1,33 @@
-import { SchemaValidationErrors } from './errors';
-import { getCollisions, Table } from './utils';
+import { CasingType } from 'src/cli/validations/common';
+import { SchemaValidationErrors, ValidationError } from './errors';
+import { entityName, fmtValue, getCollisions, Table } from './utils';
 
 export class ValidateTable {
-  constructor(private errors: string[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
+  constructor(private errors: ValidationError[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
 
-  columnNameCollisions(tableColumns: Table['columns']) {
+  columnNameCollisions(tableColumns: Table['columns'], casing: CasingType | undefined) {
     const columnNames = tableColumns.map((c) => c.name);
     const collisions = getCollisions(columnNames);
 
     if (collisions.length > 0) {
-      const messages = collisions.map(
-        (name) => `Table ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has duplicate column "${name}"`
+      let hint = 'Each column in a table must have a unique name. Rename any of the conflicting columns';
+      const example = [fmtValue('firstName', true), fmtValue('first_name', true)];
+
+      if (casing !== undefined) {
+        hint += `.\nRemember that you configured Drizzle to use ${
+          casing === 'camelCase' ? 'camel' : 'snake'
+        } case, which means that columns without an explicit alias will be transformed. Example: ${
+          (casing === 'camelCase' ? example.reverse() : example).join(fmtValue(' -> ', false))
+        }`;
+      }
+
+      const errors: ValidationError[] = collisions.map(
+        (name) => ({
+          message: `Table ${entityName(this.schema, this.name, true)} has duplicate column ${fmtValue(name, true)}`,
+          hint
+        })
       );
-      this.errors.push(...messages);
+      this.errors.push(...errors);
       this.errorCodes.add(SchemaValidationErrors.TableColumnNameCollisions);
     }
 

--- a/drizzle-kit/src/validate-schema/table.ts
+++ b/drizzle-kit/src/validate-schema/table.ts
@@ -1,15 +1,21 @@
+import { SchemaValidationErrors } from './errors';
 import { getCollisions, Table } from './utils';
 
 export class ValidateTable {
-  constructor(private errors: string[], private schema: string | undefined, private name: string) {}
+  constructor(private errors: string[], private errorCodes: Set<number>, private schema: string | undefined, private name: string) {}
 
   columnNameCollisions(tableColumns: Table['columns']) {
     const columnNames = tableColumns.map((c) => c.name);
     const collisions = getCollisions(columnNames);
-    const messages = collisions.map(
-      (name) => `Table ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has duplicate column "${name}"`
-    );
-    this.errors.push(...messages);
+
+    if (collisions.length > 0) {
+      const messages = collisions.map(
+        (name) => `Table ${this.schema ? `"${this.schema}".` : ''}"${this.name}" has duplicate column "${name}"`
+      );
+      this.errors.push(...messages);
+      this.errorCodes.add(SchemaValidationErrors.TableColumnNameCollisions);
+    }
+
     return this;
   }
 }

--- a/drizzle-kit/src/validate-schema/utils.ts
+++ b/drizzle-kit/src/validate-schema/utils.ts
@@ -76,7 +76,7 @@ export type Table = {
   foreignKeys: { name: string; reference: {
     columns: {
       name: string;
-      getSQLType: () => string;
+      sqlType: string;
       table: {
         name: string;
         schema?: string;
@@ -84,7 +84,7 @@ export type Table = {
     }[];
     foreignColumns: {
       name: string;
-      getSQLType: () => string;
+      sqlType: string;
       table: {
         name: string;
         schema?: string;

--- a/drizzle-kit/src/validate-schema/utils.ts
+++ b/drizzle-kit/src/validate-schema/utils.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import { SQL } from 'drizzle-orm';
 import { getMaterializedViewConfig, PgEnum } from 'drizzle-orm/pg-core';
 
@@ -48,10 +49,19 @@ export function listStr<
   }
 
   if (in_.length === 1) {
-    return in_[0];
+    return fmtValue(in_[0], false);
   }
 
-  return `${[...in_.slice(0, -1)].join(', ')} and ${in_.slice(-1)}`;
+  return fmtValue(`${[...in_.slice(0, -1)].join(', ')} and ${in_.slice(-1)}`, false);
+}
+
+export function entityName(schema: string | undefined, name: string, fmt?: boolean) {
+  const str = `${schema ? `"${schema}".` : ''}"${name}"`;
+  return fmt ? chalk.underline.bold(str) : str;
+}
+
+export function fmtValue(value: string, withQuotes: boolean) {
+  return chalk.bold(withQuotes ? `"${value}"` : value);
 }
 
 export type Table = {

--- a/drizzle-kit/src/validate-schema/utils.ts
+++ b/drizzle-kit/src/validate-schema/utils.ts
@@ -67,15 +67,27 @@ export type Table = {
     columns: {
       name: string;
       getSQLType: () => string;
+      table: {
+        name: string;
+        schema?: string;
+      };
     }[];
     foreignColumns: {
       name: string;
       getSQLType: () => string;
+      table: {
+        name: string;
+        schema?: string;
+      };
     }[];
   } }[];
   checks: { name: string }[];
-  primaryKeys: { name?: string; columns: {
+  primaryKeys: { name: string; columns: {
     name: string;
+    table: {
+      name: string;
+      schema?: string;
+    };
   }[]; }[];
   uniqueConstraints: { name: string }[];
 };

--- a/drizzle-kit/src/validate-schema/utils.ts
+++ b/drizzle-kit/src/validate-schema/utils.ts
@@ -3,106 +3,118 @@ import { SQL } from 'drizzle-orm';
 import { getMaterializedViewConfig, PgEnum } from 'drizzle-orm/pg-core';
 
 export function getCollisions<T extends any>(values: T[]): T[] {
-  const acc = new Set<T>();
-  const collisions = new Set<T>();
-  
-  for (const value of values) {
-    if (acc.has(value)) {
-      collisions.add(value);
-    }
-    acc.add(value);
-  }
+	const acc = new Set<T>();
+	const collisions = new Set<T>();
 
-  return Array.from(collisions);
+	for (const value of values) {
+		if (acc.has(value)) {
+			collisions.add(value);
+		}
+		acc.add(value);
+	}
+
+	return Array.from(collisions);
 }
 
 export function getCollisionsByKey<T extends Record<string, any>, K extends keyof T>(values: T[], key: K): T[K][] {
-  const acc = new Set<T[K]>();
-  const collisions = new Set<T[K]>();
-  
-  for (const value of values) {
-    const valueKey = value[key];
-    if (acc.has(valueKey)) {
-      collisions.add(valueKey);
-    }
-    acc.add(valueKey);
-  }
+	const acc = new Set<T[K]>();
+	const collisions = new Set<T[K]>();
 
-  return Array.from(collisions);
+	for (const value of values) {
+		const valueKey = value[key];
+		if (acc.has(valueKey)) {
+			collisions.add(valueKey);
+		}
+		acc.add(valueKey);
+	}
+
+	return Array.from(collisions);
 }
 
 export function listStr<
-  TCount extends number,
-  TSingular extends string,
-  TPlural extends string
+	TCount extends number,
+	TSingular extends string,
+	TPlural extends string,
 >(...list: [TCount, TSingular, TPlural][]) {
-  let in_: string[] = [];
+	let in_: string[] = [];
 
-  for (const [count, singular, plural] of list) {
-    if (count > 0) {
-      in_.push(`${count} ${count === 1 ? singular : plural}`);
-    }
-  }
+	for (const [count, singular, plural] of list) {
+		if (count > 0) {
+			in_.push(`${count} ${count === 1 ? singular : plural}`);
+		}
+	}
 
-  if (in_.length === 0) {
-    return '';
-  }
+	if (in_.length === 0) {
+		return '';
+	}
 
-  if (in_.length === 1) {
-    return fmtValue(in_[0], false);
-  }
+	if (in_.length === 1) {
+		return fmtValue(in_[0], false);
+	}
 
-  return fmtValue(`${[...in_.slice(0, -1)].join(', ')} and ${in_.slice(-1)}`, false);
+	return fmtValue(`${[...in_.slice(0, -1)].join(', ')} and ${in_.slice(-1)}`, false);
 }
 
 export function entityName(schema: string | undefined, name: string, fmt?: boolean) {
-  const str = `${schema ? `"${schema}".` : ''}"${name}"`;
-  return fmt ? chalk.underline.bold(str) : str;
+	const str = `${schema ? `"${schema}".` : ''}"${name}"`;
+	return fmt ? chalk.underline.bold(str) : str;
 }
 
 export function fmtValue(value: string, withQuotes: boolean) {
-  return chalk.bold(withQuotes ? `"${value}"` : value);
+	return chalk.bold(withQuotes ? `"${value}"` : value);
 }
 
 export type Table = {
-  name: string;
-  schema?: string;
-  columns: { name: string }[];
-  indexes: { name: string; columns: ({
-    name: string;
-    type: string;
-    op?: string;
-  } | SQL)[] }[];
-  foreignKeys: { name: string; reference: {
-    columns: {
-      name: string;
-      sqlType: string;
-      table: {
-        name: string;
-        schema?: string;
-      };
-    }[];
-    foreignColumns: {
-      name: string;
-      sqlType: string;
-      table: {
-        name: string;
-        schema?: string;
-      };
-    }[];
-  } }[];
-  checks: { name: string }[];
-  primaryKeys: { name: string; columns: {
-    name: string;
-    table: {
-      name: string;
-      schema?: string;
-    };
-  }[]; }[];
-  uniqueConstraints: { name: string }[];
+	name: string;
+	schema?: string;
+	columns: { name: string }[];
+	indexes: {
+		name: string;
+		columns: ({
+			name: string;
+			type: string;
+			op?: string;
+		} | SQL)[];
+	}[];
+	foreignKeys: {
+		name: string;
+		reference: {
+			columns: {
+				name: string;
+				sqlType: string;
+				table: {
+					name: string;
+					schema?: string;
+				};
+			}[];
+			foreignColumns: {
+				name: string;
+				sqlType: string;
+				table: {
+					name: string;
+					schema?: string;
+				};
+			}[];
+		};
+	}[];
+	checks: { name: string }[];
+	primaryKeys: {
+		name: string;
+		columns: {
+			name: string;
+			table: {
+				name: string;
+				schema?: string;
+			};
+		}[];
+	}[];
+	uniqueConstraints: { name: string }[];
 };
-export type View = { name: string, schema?: string };
+export type View = { name: string; schema?: string };
 export type MaterializedView = ReturnType<typeof getMaterializedViewConfig>;
-export type Schema = { schemaName: string; };
+export type Schema = { schemaName: string };
 export type Enum = PgEnum<any>;
-export type Sequence = { seqName: string; seqOptions?: { increment?: number | string; minValue?: number | string; maxValue?: number | string; } };
+export type Sequence = {
+	seqName: string;
+	seqOptions?: { increment?: number | string; minValue?: number | string; maxValue?: number | string };
+};

--- a/drizzle-kit/src/validate-schema/utils.ts
+++ b/drizzle-kit/src/validate-schema/utils.ts
@@ -1,0 +1,86 @@
+import { SQL } from 'drizzle-orm';
+import { getMaterializedViewConfig, PgEnum } from 'drizzle-orm/pg-core';
+
+export function getCollisions<T extends any>(values: T[]): T[] {
+  const acc = new Set<T>();
+  const collisions = new Set<T>();
+  
+  for (const value of values) {
+    if (acc.has(value)) {
+      collisions.add(value);
+    }
+    acc.add(value);
+  }
+
+  return Array.from(collisions);
+}
+
+export function getCollisionsByKey<T extends Record<string, any>, K extends keyof T>(values: T[], key: K): T[K][] {
+  const acc = new Set<T[K]>();
+  const collisions = new Set<T[K]>();
+  
+  for (const value of values) {
+    const valueKey = value[key];
+    if (acc.has(valueKey)) {
+      collisions.add(valueKey);
+    }
+    acc.add(valueKey);
+  }
+
+  return Array.from(collisions);
+}
+
+export function listStr<
+  TCount extends number,
+  TSingular extends string,
+  TPlural extends string
+>(...list: [TCount, TSingular, TPlural][]) {
+  let in_: string[] = [];
+
+  for (const [count, singular, plural] of list) {
+    if (count > 0) {
+      in_.push(`${count} ${count === 1 ? singular : plural}`);
+    }
+  }
+
+  if (in_.length === 0) {
+    return '';
+  }
+
+  if (in_.length === 1) {
+    return in_[0];
+  }
+
+  return `${[...in_.slice(0, -1)].join(', ')} and ${in_.slice(-1)}`;
+}
+
+export type Table = {
+  name: string;
+  schema?: string;
+  columns: { name: string }[];
+  indexes: { name: string; columns: ({
+    name: string;
+    type: string;
+    op?: string;
+  } | SQL)[] }[];
+  foreignKeys: { name: string; reference: {
+    columns: {
+      name: string;
+      getSQLType: () => string;
+    }[];
+    foreignColumns: {
+      name: string;
+      getSQLType: () => string;
+    }[];
+  } }[];
+  checks: { name: string }[];
+  primaryKeys: { name?: string; columns: {
+    name: string;
+  }[]; }[];
+  uniqueConstraints: { name: string }[];
+};
+export type View = { name: string, schema?: string };
+export type MaterializedView = ReturnType<typeof getMaterializedViewConfig>;
+export type Schema = { schemaName: string; };
+export type Enum = PgEnum<any>;
+export type Sequence = { seqName: string; seqOptions?: { increment?: number | string; minValue?: number | string; maxValue?: number | string; } };

--- a/drizzle-kit/src/validate-schema/validate.ts
+++ b/drizzle-kit/src/validate-schema/validate.ts
@@ -12,20 +12,12 @@ import { indexName as mysqlIndexName } from 'src/serializer/mysqlSerializer';
 import { render } from 'hanji';
 import { ValidationError } from './errors';
 
-export function printValidationErrors(errors: ValidationError[], exitOnError: boolean) {
+export function printValidationErrors(errors: ValidationError[]) {
   for (const { message, hint } of errors) {
     console.log(`${chalk.bgRed.bold(' Error ')} ${chalk.red(`${message}.`)}\n${chalk.underline.dim('Hint')}${chalk.dim(': ')}${chalk.dim(`${hint}.`)}\n`);
   }
 
-  if (errors.length === 0) {
-    render(`[${chalk.green('✓')}] Schema is valid`);
-  } else {
-    render(`[${chalk.red('x')}] Found ${errors.length} error${errors.length > 1 ? 's' : ''} in your schema`);
-  }
-
-  if (exitOnError && errors.length > 0) {
-    process.exit(1);
-  }
+  render(`[${chalk.red('x')}] Found ${errors.length} error${errors.length > 1 ? 's' : ''} in your schema`);
 }
 
 export function validatePgSchema(

--- a/drizzle-kit/src/validate-schema/validate.ts
+++ b/drizzle-kit/src/validate-schema/validate.ts
@@ -121,7 +121,7 @@ export function validatePgSchema(
                   const tableConfig = getPgTableConfig(column.table);
                   return {
                     name: getColumnCasing(column, casing),
-                    getSQLType: column.getSQLType,
+                    sqlType: column.getSQLType(),
                     table: {
                       name: tableConfig.name,
                       schema: tableConfig.schema
@@ -134,7 +134,7 @@ export function validatePgSchema(
                   const tableConfig = getPgTableConfig(column.table);
                   return {
                     name: getColumnCasing(column, casing),
-                    getSQLType: column.getSQLType,
+                    sqlType: column.getSQLType(),
                     table: {
                       name: tableConfig.name,
                       schema: tableConfig.schema
@@ -328,7 +328,7 @@ export function validateMySqlSchema(
                   const tableConfig = getMySqlTableConfig(column.table);
                   return {
                     name: getColumnCasing(column, casing),
-                    getSQLType: column.getSQLType,
+                    sqlType: column.getSQLType(),
                     table: {
                       name: tableConfig.name,
                       schema: tableConfig.schema
@@ -341,7 +341,7 @@ export function validateMySqlSchema(
                   const tableConfig = getMySqlTableConfig(column.table);
                   return {
                     name: getColumnCasing(column, casing),
-                    getSQLType: column.getSQLType,
+                    sqlType: column.getSQLType(),
                     table: {
                       name: tableConfig.name,
                       schema: tableConfig.schema
@@ -406,7 +406,8 @@ export function validateMySqlSchema(
     };
   })();
 
-  const v = new ValidateDatabase().validateSchema(undefined);
+  const vDb = new ValidateDatabase();
+  const v = vDb.validateSchema(undefined);
 
   v
     .constraintNameCollisions(
@@ -441,6 +442,11 @@ export function validateMySqlSchema(
       .validatePrimaryKey(primaryKey.name)
       .columnsMixingTables(primaryKey);
   }
+
+  return {
+    messages: vDb.errors,
+    codes: vDb.errorCodes
+  };
 }
 
 export function validateSQLiteSchema(

--- a/drizzle-kit/src/validate-schema/validate.ts
+++ b/drizzle-kit/src/validate-schema/validate.ts
@@ -242,7 +242,7 @@ export function validatePgSchema(
         .validateForeignKey(foreignKey.name)
         .columnsMixingTables(foreignKey)
         .mismatchingColumnCount(foreignKey)
-        .mismatchingDataTypes(foreignKey);
+        .mismatchingDataTypes(foreignKey, 'pg');
     }
 
     for (const primaryKey of schema.primaryKeys) {
@@ -434,7 +434,7 @@ export function validateMySqlSchema(
       .validateForeignKey(foreignKey.name)
       .columnsMixingTables(foreignKey)
       .mismatchingColumnCount(foreignKey)
-      .mismatchingDataTypes(foreignKey);
+      .mismatchingDataTypes(foreignKey, 'mysql');
   }
 
   for (const primaryKey of group.primaryKeys) {

--- a/drizzle-kit/src/validate-schema/validate.ts
+++ b/drizzle-kit/src/validate-schema/validate.ts
@@ -1,0 +1,233 @@
+import { getTableConfig as getPgTableConfig, getViewConfig as getPgViewConfig, getMaterializedViewConfig as getPgMaterializedViewConfig, PgEnum, PgMaterializedView, pgSchema, PgSchema, PgSequence, PgTable, PgView, IndexedColumn, uniqueKeyName as pgUniqueKeyName, PgColumn, PgDialect } from 'drizzle-orm/pg-core';
+import { Sequence as SequenceCommon, Table as TableCommon } from './utils';
+import { MySqlTable, MySqlView } from 'drizzle-orm/mysql-core';
+import { SQLiteTable, SQLiteView } from 'drizzle-orm/sqlite-core';
+import { GeneratedIdentityConfig, getTableName, is, SQL } from 'drizzle-orm';
+import { ValidateDatabase } from './db';
+import { CasingType } from 'src/cli/validations/common';
+import { getColumnCasing, getForeignKeyName, getIdentitySequenceName } from 'src/utils';
+import { indexName as pgIndexName } from 'src/serializer/pgSerializer';
+
+export function validatePgSchema(
+  casing: CasingType | undefined,
+  schemas: PgSchema[],
+  tables: PgTable[],
+  views: PgView[],
+  materializedViews: PgMaterializedView[],
+  enums: PgEnum<any>[],
+  sequences: PgSequence[],
+) {
+  const dialect = new PgDialect({ casing });
+  const tableConfigs = tables.map((table) => getPgTableConfig(table));
+  const viewConfigs = views.map((view) => getPgViewConfig(view));
+  const materializedViewConfigs = materializedViews.map((view) => getPgMaterializedViewConfig(view));
+
+  const allSchemas = [
+    pgSchema('public'),
+    ...schemas
+  ].map((schema) => {
+    const schemaTables = tableConfigs
+      .filter((table) => (table.schema ?? 'public') === schema.schemaName)
+      .map((table) => ({
+        ...table,
+        columns: table.columns.map((column) => ({
+          ...column,
+          name: getColumnCasing(column, casing)
+        }))
+      }));
+
+    const schemaEnums = enums.filter((enum_) => (enum_.schema ?? 'public') === schema.schemaName);
+    
+    const schemaSequences = [
+      // Sequences defined with `pgSequence`
+      ...sequences.filter((sequence): sequence is PgSequence & { seqName: string } => (sequence.schema ?? 'public') === schema.schemaName && !!sequence.seqName),
+      // Sequences defined with `column.generatedAlwaysAsIdentity`
+      ...schemaTables
+        .map(
+          (table) => table.columns
+            .filter((column): column is PgColumn & { generatedIdentity: GeneratedIdentityConfig } => !!column.generatedIdentity)
+            .map((column) => ({
+              seqName: getIdentitySequenceName(column.generatedIdentity.sequenceName, table.name, column.name),
+              seqOptions: column.generatedIdentity.sequenceOptions
+            }))
+        ).flat(1)
+    ] satisfies SequenceCommon[];
+    
+    const schemaViews = viewConfigs.filter((view) => (view.schema ?? 'public') === schema.schemaName);
+    
+    const schemaMaterializedViews = materializedViewConfigs.filter((materializedView) => (materializedView.schema ?? 'public') === schema.schemaName);
+
+    const schemaIndexes = schemaTables.map(
+      (table) => table.indexes.map(
+        (index) => {
+          const indexColumns = index.config.columns
+            .filter((column): column is IndexedColumn => !is(column, SQL));
+
+          const indexColumnNames = indexColumns
+            .map((column) => column.name)
+            .filter((c) => c !== undefined);
+
+          return {
+            name: index.config.name
+              ? index.config.name
+              : indexColumns.length === index.config.columns.length
+                ? pgIndexName(table.name, indexColumnNames)
+                : '',
+            columns: index.config.columns.map((column) => {
+              if (is(column, SQL)) {
+                return column;
+              }
+              const c = column as IndexedColumn;
+              return {
+                type: c.type,
+                op: c.indexConfig.opClass,
+                name: getColumnCasing(c, casing),
+              }
+            })
+          };
+        }
+      )
+    ).flat(1) satisfies TableCommon['indexes'];
+
+    const schemaForeignKeys = schemaTables.map(
+      (table) => table.foreignKeys.map(
+        (fk) => {
+          const ref = fk.reference();
+          return {
+            name: getForeignKeyName(fk, casing),
+            reference: {
+              columns: ref.columns.map(
+                (column) => ({
+                  name: getColumnCasing(column, casing),
+                  getSQLType: column.getSQLType
+                })
+              ),
+              foreignColumns: ref.foreignColumns.map(
+                (column) => ({
+                  name: getColumnCasing(column, casing),
+                  getSQLType: column.getSQLType
+                })
+              ),
+            }
+          };
+        }
+      )
+    ).flat(1) satisfies TableCommon['foreignKeys'];
+
+    const schemaChecks = schemaTables.map(
+      (table) => table.checks.map(
+        (check) => ({
+          name: check.name
+        })
+      )
+    ).flat(1) satisfies TableCommon['checks'];
+
+    const schemaPrimaryKeys = schemaTables.map(
+      (table) => table.primaryKeys.map(
+        (pk) => ({
+          name: pk.name,
+          columns: pk.columns.map(
+            (column) => ({
+              name: getColumnCasing(column, casing)
+            })
+          )
+        })
+      )
+    ).flat(1) satisfies TableCommon['primaryKeys'];
+
+    const schemaUniqueConstraints = schemaTables.map(
+      (table) => table.uniqueConstraints.map(
+        (unique) => {
+          const columnNames = unique.columns.map((column) => getColumnCasing(column, casing));
+
+          return {
+            name: unique.name ?? pgUniqueKeyName(tables.find((t) => getTableName(t) === table.name)!, columnNames)
+          };
+        }
+      )
+    ).flat(1) satisfies TableCommon['uniqueConstraints'];
+
+    return {
+      name: schema.schemaName,
+      tables: schemaTables,
+      enums: schemaEnums,
+      sequences: schemaSequences,
+      views: schemaViews,
+      materializedViews: schemaMaterializedViews,
+      indexes: schemaIndexes,
+      foreignKeys: schemaForeignKeys,
+      checks: schemaChecks,
+      primaryKeys: schemaPrimaryKeys,
+      uniqueConstraints: schemaUniqueConstraints
+    };
+  });
+  const allTables = allSchemas.map((schema) => schema.tables).flat(1);
+
+  const vDb = new ValidateDatabase();
+  vDb.schemaNameCollisions(schemas);
+
+  for (const schema of allSchemas) {
+    const v = vDb.validateSchema(schema.name ?? 'public');
+
+    v
+      .constraintNameCollisions(
+        schema.indexes,
+        schema.foreignKeys,
+        schema.checks,
+        schema.primaryKeys,
+        schema.uniqueConstraints
+      )
+      .entityNameCollisions(
+        schema.tables,
+        schema.views,
+        schema.materializedViews,
+        schema.enums,
+        schema.sequences
+      );
+
+    for (const enum_ of schema.enums) {
+      v.validateEnum(enum_.enumName).valueCollisions(enum_.enumValues);
+    }
+
+    for (const sequence of schema.sequences) {
+      v.validateSequence(sequence.seqName).incorrectvalues(sequence);
+    }
+
+    for (const table of schema.tables) {
+      v.validateTable(table.name).columnNameCollisions(table.columns);
+    }
+
+    for (const foreignKey of schema.foreignKeys) {
+      v
+        .validateForeignKey(foreignKey.name)
+        .columnsMixingTables(foreignKey, allTables)
+        .mismatchingColumnCount(foreignKey)
+        .mismatchingDataTypes(foreignKey);
+    }
+
+    for (const index of schema.indexes) {
+      v
+        .validateIndex(index.name)
+        .requiresName(index.columns, dialect)
+        .vectorColumnRequiresOp(index.columns);
+    }
+  }
+
+  return vDb.errors;
+}
+
+export function validateMySqlSchema(
+  casing: CasingType | undefined,
+  tables: MySqlTable[],
+  views: MySqlView[],
+) {
+
+}
+
+export function validateSQLiteSchema(
+  casing: CasingType | undefined,
+  tables: SQLiteTable[],
+  views: SQLiteView[],
+) {
+
+}

--- a/drizzle-kit/src/validate-schema/validate.ts
+++ b/drizzle-kit/src/validate-schema/validate.ts
@@ -1,623 +1,684 @@
 import chalk from 'chalk';
-import { getTableConfig as getPgTableConfig, getViewConfig as getPgViewConfig, getMaterializedViewConfig as getPgMaterializedViewConfig, PgEnum, PgMaterializedView, PgSchema, PgSequence, PgTable, PgView, IndexedColumn as PgIndexColumn, uniqueKeyName as pgUniqueKeyName, PgColumn, PgDialect } from 'drizzle-orm/pg-core';
-import { Sequence as SequenceCommon, Table as TableCommon } from './utils';
-import { MySqlTable, MySqlView, getTableConfig as getMySqlTableConfig, getViewConfig as getMySqlViewConfig, MySqlColumn, uniqueKeyName as mysqlUniqueKeyName } from 'drizzle-orm/mysql-core';
-import { SQLiteColumn, SQLiteTable, SQLiteView, getTableConfig as getSQLiteTableConfig, getViewConfig as getSQLiteViewConfig, uniqueKeyName as sqliteUniqueKeyName } from 'drizzle-orm/sqlite-core';
 import { GeneratedIdentityConfig, getTableName, is, SQL } from 'drizzle-orm';
-import { ValidateDatabase } from './db';
-import { CasingType } from 'src/cli/validations/common';
-import { getColumnCasing, getForeignKeyName, getIdentitySequenceName, getPrimaryKeyName } from 'src/utils';
-import { indexName as pgIndexName } from 'src/serializer/pgSerializer';
-import { indexName as mysqlIndexName } from 'src/serializer/mysqlSerializer';
+import {
+	getTableConfig as getMySqlTableConfig,
+	getViewConfig as getMySqlViewConfig,
+	MySqlColumn,
+	MySqlTable,
+	MySqlView,
+	uniqueKeyName as mysqlUniqueKeyName,
+} from 'drizzle-orm/mysql-core';
+import {
+	getMaterializedViewConfig as getPgMaterializedViewConfig,
+	getTableConfig as getPgTableConfig,
+	getViewConfig as getPgViewConfig,
+	IndexedColumn as PgIndexColumn,
+	PgColumn,
+	PgDialect,
+	PgEnum,
+	PgMaterializedView,
+	PgSchema,
+	PgSequence,
+	PgTable,
+	PgView,
+	uniqueKeyName as pgUniqueKeyName,
+} from 'drizzle-orm/pg-core';
+import {
+	getTableConfig as getSQLiteTableConfig,
+	getViewConfig as getSQLiteViewConfig,
+	SQLiteColumn,
+	SQLiteTable,
+	SQLiteView,
+	uniqueKeyName as sqliteUniqueKeyName,
+} from 'drizzle-orm/sqlite-core';
 import { render } from 'hanji';
+import { CasingType } from 'src/cli/validations/common';
+import { indexName as mysqlIndexName } from 'src/serializer/mysqlSerializer';
+import { indexName as pgIndexName } from 'src/serializer/pgSerializer';
+import { getColumnCasing, getForeignKeyName, getIdentitySequenceName, getPrimaryKeyName } from 'src/utils';
+import { ValidateDatabase } from './db';
 import { ValidationError } from './errors';
+import { Sequence as SequenceCommon, Table as TableCommon } from './utils';
 
 export function printValidationErrors(errors: ValidationError[]) {
-  for (const { message, hint } of errors) {
-    console.log(`${chalk.bgRed.bold(' Error ')} ${chalk.red(`${message}.`)}\n${chalk.underline.dim('Hint')}${chalk.dim(': ')}${chalk.dim(`${hint}.`)}\n`);
-  }
+	for (const { message, hint } of errors) {
+		console.log(
+			`${chalk.bgRed.bold(' Error ')} ${chalk.red(`${message}.`)}\n${chalk.underline.dim('Hint')}${chalk.dim(': ')}${
+				chalk.dim(`${hint}.`)
+			}\n`,
+		);
+	}
 
-  render(`[${chalk.red('x')}] Found ${errors.length} error${errors.length > 1 ? 's' : ''} in your schema`);
+	render(`[${chalk.red('x')}] Found ${errors.length} error${errors.length > 1 ? 's' : ''} in your schema`);
 }
 
 export function validatePgSchema(
-  casing: CasingType | undefined,
-  schemas: PgSchema[],
-  tables: PgTable[],
-  views: PgView[],
-  materializedViews: PgMaterializedView[],
-  enums: PgEnum<any>[],
-  sequences: PgSequence[],
+	casing: CasingType | undefined,
+	schemas: PgSchema[],
+	tables: PgTable[],
+	views: PgView[],
+	materializedViews: PgMaterializedView[],
+	enums: PgEnum<any>[],
+	sequences: PgSequence[],
 ) {
-  const dialect = new PgDialect({ casing });
-  const tableConfigs = tables.map((table) => getPgTableConfig(table));
-  const viewConfigs = views.map((view) => getPgViewConfig(view));
-  const materializedViewConfigs = materializedViews.map((view) => getPgMaterializedViewConfig(view));
+	const dialect = new PgDialect({ casing });
+	const tableConfigs = tables.map((table) => getPgTableConfig(table));
+	const viewConfigs = views.map((view) => getPgViewConfig(view));
+	const materializedViewConfigs = materializedViews.map((view) => getPgMaterializedViewConfig(view));
 
-  const group = [
-    new PgSchema('public'),
-    ...schemas
-  ].map((schema) => {
-    const schemaTables = tableConfigs
-      .filter((table) => (table.schema ?? 'public') === schema.schemaName)
-      .map((table) => ({
-        ...table,
-        columns: table.columns.map((column) => ({
-          ...column,
-          name: getColumnCasing(column, casing)
-        }))
-      }));
+	const group = [
+		new PgSchema('public'),
+		...schemas,
+	].map((schema) => {
+		const schemaTables = tableConfigs
+			.filter((table) => (table.schema ?? 'public') === schema.schemaName)
+			.map((table) => ({
+				...table,
+				columns: table.columns.map((column) => ({
+					...column,
+					name: getColumnCasing(column, casing),
+				})),
+			}));
 
-    const schemaEnums = enums.filter((enum_) => (enum_.schema ?? 'public') === schema.schemaName);
-    
-    const schemaSequences = [
-      // Sequences defined with `pgSequence`
-      ...sequences.filter((sequence): sequence is PgSequence & { seqName: string } => (sequence.schema ?? 'public') === schema.schemaName && !!sequence.seqName),
-      // Sequences defined with `column.generatedAlwaysAsIdentity`
-      ...schemaTables
-        .map(
-          (table) => table.columns
-            .filter((column): column is PgColumn & { generatedIdentity: GeneratedIdentityConfig } => !!column.generatedIdentity)
-            .map((column) => ({
-              seqName: getIdentitySequenceName(column.generatedIdentity.sequenceName, table.name, column.name),
-              seqOptions: column.generatedIdentity.sequenceOptions
-            }))
-        ).flat(1)
-    ] satisfies SequenceCommon[];
-    
-    const schemaViews = viewConfigs.filter((view) => (view.schema ?? 'public') === schema.schemaName);
-    
-    const schemaMaterializedViews = materializedViewConfigs.filter((materializedView) => (materializedView.schema ?? 'public') === schema.schemaName);
+		const schemaEnums = enums.filter((enum_) => (enum_.schema ?? 'public') === schema.schemaName);
 
-    const schemaIndexes = schemaTables.map(
-      (table) => table.indexes.map(
-        (index) => {
-          const indexColumns = index.config.columns
-            .filter((column): column is PgIndexColumn => !is(column, SQL));
+		const schemaSequences = [
+			// Sequences defined with `pgSequence`
+			...sequences.filter((sequence): sequence is PgSequence & { seqName: string } =>
+				(sequence.schema ?? 'public') === schema.schemaName && !!sequence.seqName
+			),
+			// Sequences defined with `column.generatedAlwaysAsIdentity`
+			...schemaTables
+				.map(
+					(table) =>
+						table.columns
+							.filter((column): column is PgColumn & { generatedIdentity: GeneratedIdentityConfig } =>
+								!!column.generatedIdentity
+							)
+							.map((column) => ({
+								seqName: getIdentitySequenceName(column.generatedIdentity.sequenceName, table.name, column.name),
+								seqOptions: column.generatedIdentity.sequenceOptions,
+							})),
+				).flat(1),
+		] satisfies SequenceCommon[];
 
-          const indexColumnNames = indexColumns
-            .map((column) => column.name)
-            .filter((c) => c !== undefined);
+		const schemaViews = viewConfigs.filter((view) => (view.schema ?? 'public') === schema.schemaName);
 
-          return {
-            name: index.config.name
-              ? index.config.name
-              : indexColumns.length === index.config.columns.length
-                ? pgIndexName(table.name, indexColumnNames)
-                : '',
-            columns: index.config.columns.map((column) => {
-              if (is(column, SQL)) {
-                return column;
-              }
-              const c = column as PgIndexColumn;
-              return {
-                type: c.type,
-                op: c.indexConfig.opClass,
-                name: getColumnCasing(c, casing),
-              }
-            })
-          };
-        }
-      )
-    ).flat(1) satisfies TableCommon['indexes'];
+		const schemaMaterializedViews = materializedViewConfigs.filter((materializedView) =>
+			(materializedView.schema ?? 'public') === schema.schemaName
+		);
 
-    const schemaForeignKeys = schemaTables.map(
-      (table) => table.foreignKeys.map(
-        (fk) => {
-          const ref = fk.reference();
-          return {
-            name: getForeignKeyName(fk, casing),
-            reference: {
-              columns: ref.columns.map(
-                (column) => {
-                  const tableConfig = getPgTableConfig(column.table);
-                  return {
-                    name: getColumnCasing(column, casing),
-                    sqlType: column.getSQLType(),
-                    table: {
-                      name: tableConfig.name,
-                      schema: tableConfig.schema
-                    }
-                  };
-                }
-              ),
-              foreignColumns: ref.foreignColumns.map(
-                (column) => {
-                  const tableConfig = getPgTableConfig(column.table);
-                  return {
-                    name: getColumnCasing(column, casing),
-                    sqlType: column.getSQLType(),
-                    table: {
-                      name: tableConfig.name,
-                      schema: tableConfig.schema
-                    }
-                  };
-                }
-              ),
-            }
-          };
-        }
-      )
-    ).flat(1) satisfies TableCommon['foreignKeys'];
+		const schemaIndexes = schemaTables.map(
+			(table) =>
+				table.indexes.map(
+					(index) => {
+						const indexColumns = index.config.columns
+							.filter((column): column is PgIndexColumn => !is(column, SQL));
 
-    const schemaChecks = schemaTables.map(
-      (table) => table.checks.map(
-        (check) => ({
-          name: check.name
-        })
-      )
-    ).flat(1) satisfies TableCommon['checks'];
+						const indexColumnNames = indexColumns
+							.map((column) => column.name)
+							.filter((c) => c !== undefined);
 
-    const schemaPrimaryKeys = schemaTables.map(
-      (table) => table.primaryKeys.map(
-        (pk) => ({
-          name: getPrimaryKeyName(pk, casing),
-          columns: pk.columns.map(
-            (column) => {
-              const tableConfig = getPgTableConfig(column.table);
-              return {
-                name: getColumnCasing(column, casing),
-                table: {
-                  name: tableConfig.name,
-                  schema: tableConfig.schema
-                }
-              }
-            }
-          )
-        })
-      )
-    ).flat(1) satisfies TableCommon['primaryKeys'];
+						return {
+							name: index.config.name
+								? index.config.name
+								: indexColumns.length === index.config.columns.length
+								? pgIndexName(table.name, indexColumnNames)
+								: '',
+							columns: index.config.columns.map((column) => {
+								if (is(column, SQL)) {
+									return column;
+								}
+								const c = column as PgIndexColumn;
+								return {
+									type: c.type,
+									op: c.indexConfig.opClass,
+									name: getColumnCasing(c, casing),
+								};
+							}),
+						};
+					},
+				),
+		).flat(1) satisfies TableCommon['indexes'];
 
-    const schemaUniqueConstraints = schemaTables.map(
-      (table) => table.uniqueConstraints.map(
-        (unique) => {
-          const columnNames = unique.columns.map((column) => getColumnCasing(column, casing));
+		const schemaForeignKeys = schemaTables.map(
+			(table) =>
+				table.foreignKeys.map(
+					(fk) => {
+						const ref = fk.reference();
+						return {
+							name: getForeignKeyName(fk, casing),
+							reference: {
+								columns: ref.columns.map(
+									(column) => {
+										const tableConfig = getPgTableConfig(column.table);
+										return {
+											name: getColumnCasing(column, casing),
+											sqlType: column.getSQLType(),
+											table: {
+												name: tableConfig.name,
+												schema: tableConfig.schema,
+											},
+										};
+									},
+								),
+								foreignColumns: ref.foreignColumns.map(
+									(column) => {
+										const tableConfig = getPgTableConfig(column.table);
+										return {
+											name: getColumnCasing(column, casing),
+											sqlType: column.getSQLType(),
+											table: {
+												name: tableConfig.name,
+												schema: tableConfig.schema,
+											},
+										};
+									},
+								),
+							},
+						};
+					},
+				),
+		).flat(1) satisfies TableCommon['foreignKeys'];
 
-          return {
-            name: unique.name ?? pgUniqueKeyName(tables.find((t) => getTableName(t) === table.name && getPgTableConfig(t).schema === table.schema)!, columnNames)
-          };
-        }
-      )
-    ).flat(1) satisfies TableCommon['uniqueConstraints'];
+		const schemaChecks = schemaTables.map(
+			(table) =>
+				table.checks.map(
+					(check) => ({
+						name: check.name,
+					}),
+				),
+		).flat(1) satisfies TableCommon['checks'];
 
-    return {
-      name: schema.schemaName,
-      tables: schemaTables,
-      enums: schemaEnums,
-      sequences: schemaSequences,
-      views: schemaViews,
-      materializedViews: schemaMaterializedViews,
-      indexes: schemaIndexes,
-      foreignKeys: schemaForeignKeys,
-      checks: schemaChecks,
-      primaryKeys: schemaPrimaryKeys,
-      uniqueConstraints: schemaUniqueConstraints
-    };
-  });
+		const schemaPrimaryKeys = schemaTables.map(
+			(table) =>
+				table.primaryKeys.map(
+					(pk) => ({
+						name: getPrimaryKeyName(pk, casing),
+						columns: pk.columns.map(
+							(column) => {
+								const tableConfig = getPgTableConfig(column.table);
+								return {
+									name: getColumnCasing(column, casing),
+									table: {
+										name: tableConfig.name,
+										schema: tableConfig.schema,
+									},
+								};
+							},
+						),
+					}),
+				),
+		).flat(1) satisfies TableCommon['primaryKeys'];
 
-  const vDb = new ValidateDatabase();
-  vDb.schemaNameCollisions(schemas);
+		const schemaUniqueConstraints = schemaTables.map(
+			(table) =>
+				table.uniqueConstraints.map(
+					(unique) => {
+						const columnNames = unique.columns.map((column) => getColumnCasing(column, casing));
 
-  for (const schema of group) {
-    const v = vDb.validateSchema(schema.name ?? 'public');
+						return {
+							name: unique.name ?? pgUniqueKeyName(
+								tables.find((t) => getTableName(t) === table.name && getPgTableConfig(t).schema === table.schema)!,
+								columnNames,
+							),
+						};
+					},
+				),
+		).flat(1) satisfies TableCommon['uniqueConstraints'];
 
-    v
-      .constraintNameCollisions(
-        schema.indexes,
-        schema.foreignKeys,
-        schema.checks,
-        schema.primaryKeys,
-        schema.uniqueConstraints
-      )
-      .entityNameCollisions(
-        schema.tables,
-        schema.views,
-        schema.materializedViews,
-        schema.enums,
-        schema.sequences
-      );
+		return {
+			name: schema.schemaName,
+			tables: schemaTables,
+			enums: schemaEnums,
+			sequences: schemaSequences,
+			views: schemaViews,
+			materializedViews: schemaMaterializedViews,
+			indexes: schemaIndexes,
+			foreignKeys: schemaForeignKeys,
+			checks: schemaChecks,
+			primaryKeys: schemaPrimaryKeys,
+			uniqueConstraints: schemaUniqueConstraints,
+		};
+	});
 
-    for (const enum_ of schema.enums) {
-      v.validateEnum(enum_.enumName).valueCollisions(enum_.enumValues);
-    }
+	const vDb = new ValidateDatabase();
+	vDb.schemaNameCollisions(schemas);
 
-    for (const sequence of schema.sequences) {
-      v.validateSequence(sequence.seqName).incorrectvalues(sequence);
-    }
+	for (const schema of group) {
+		const v = vDb.validateSchema(schema.name ?? 'public');
 
-    for (const table of schema.tables) {
-      v.validateTable(table.name).columnNameCollisions(table.columns, casing);
-    }
+		v
+			.constraintNameCollisions(
+				schema.indexes,
+				schema.foreignKeys,
+				schema.checks,
+				schema.primaryKeys,
+				schema.uniqueConstraints,
+			)
+			.entityNameCollisions(
+				schema.tables,
+				schema.views,
+				schema.materializedViews,
+				schema.enums,
+				schema.sequences,
+			);
 
-    for (const foreignKey of schema.foreignKeys) {
-      v
-        .validateForeignKey(foreignKey.name)
-        .columnsMixingTables(foreignKey)
-        .mismatchingColumnCount(foreignKey)
-        .mismatchingDataTypes(foreignKey, 'pg');
-    }
+		for (const enum_ of schema.enums) {
+			v.validateEnum(enum_.enumName).valueCollisions(enum_.enumValues);
+		}
 
-    for (const primaryKey of schema.primaryKeys) {
-      v
-        .validatePrimaryKey(primaryKey.name)
-        .columnsMixingTables(primaryKey);
-    }
+		for (const sequence of schema.sequences) {
+			v.validateSequence(sequence.seqName).incorrectvalues(sequence);
+		}
 
-    for (const index of schema.indexes) {
-      v
-        .validateIndex(index.name)
-        .requiresName(index.columns, dialect)
-        .vectorColumnRequiresOp(index.columns);
-    }
-  }
+		for (const table of schema.tables) {
+			v.validateTable(table.name).columnNameCollisions(table.columns, casing);
+		}
 
-  return {
-    messages: vDb.errors,
-    codes: vDb.errorCodes
-  };
+		for (const foreignKey of schema.foreignKeys) {
+			v
+				.validateForeignKey(foreignKey.name)
+				.columnsMixingTables(foreignKey)
+				.mismatchingColumnCount(foreignKey)
+				.mismatchingDataTypes(foreignKey, 'pg');
+		}
+
+		for (const primaryKey of schema.primaryKeys) {
+			v
+				.validatePrimaryKey(primaryKey.name)
+				.columnsMixingTables(primaryKey);
+		}
+
+		for (const index of schema.indexes) {
+			v
+				.validateIndex(index.name)
+				.requiresName(index.columns, dialect)
+				.vectorColumnRequiresOp(index.columns);
+		}
+	}
+
+	return {
+		messages: vDb.errors,
+		codes: vDb.errorCodes,
+	};
 }
 
 export function validateMySqlSchema(
-  casing: CasingType | undefined,
-  tables: MySqlTable[],
-  views: MySqlView[],
+	casing: CasingType | undefined,
+	tables: MySqlTable[],
+	views: MySqlView[],
 ) {
-  const tableConfigs = tables.map((table) => getMySqlTableConfig(table));
-  const viewConfigs = views.map((view) => getMySqlViewConfig(view));
+	const tableConfigs = tables.map((table) => getMySqlTableConfig(table));
+	const viewConfigs = views.map((view) => getMySqlViewConfig(view));
 
-  const group = (() => {
-    const dbTables = tableConfigs
-      .map((table) => ({
-        ...table,
-        columns: table.columns.map((column) => ({
-          ...column,
-          name: getColumnCasing(column, casing)
-        }))
-      }));
-  
-    const dbViews = viewConfigs;
-  
-    const dbIndexes = dbTables.map(
-      (table) => table.indexes.map(
-        (index) => {
-          const indexColumns = index.config.columns
-            .filter((column): column is MySqlColumn => !is(column, SQL));
-  
-          const indexColumnNames = indexColumns
-            .map((column) => column.name)
-            .filter((c) => c !== undefined);
-  
-          return {
-            name: index.config.name
-              ? index.config.name
-              : indexColumns.length === index.config.columns.length
-                ? mysqlIndexName(table.name, indexColumnNames)
-                : '',
-            columns: index.config.columns.map((column) => {
-              if (is(column, SQL)) {
-                return column;
-              }
-  
-              return {
-                type: '',
-                name: getColumnCasing(column as MySqlColumn, casing),
-              }
-            })
-          };
-        }
-      )
-    ).flat(1) satisfies TableCommon['indexes'];
-  
-    const dbForeignKeys = dbTables.map(
-      (table) => table.foreignKeys.map(
-        (fk) => {
-          const ref = fk.reference();
-          return {
-            name: getForeignKeyName(fk, casing),
-            reference: {
-              columns: ref.columns.map(
-                (column) => {
-                  const tableConfig = getMySqlTableConfig(column.table);
-                  return {
-                    name: getColumnCasing(column, casing),
-                    sqlType: column.getSQLType(),
-                    table: {
-                      name: tableConfig.name,
-                      schema: tableConfig.schema
-                    }
-                  };
-                }
-              ),
-              foreignColumns: ref.foreignColumns.map(
-                (column) => {
-                  const tableConfig = getMySqlTableConfig(column.table);
-                  return {
-                    name: getColumnCasing(column, casing),
-                    sqlType: column.getSQLType(),
-                    table: {
-                      name: tableConfig.name,
-                      schema: tableConfig.schema
-                    }
-                  };
-                }
-              ),
-            }
-          };
-        }
-      )
-    ).flat(1) satisfies TableCommon['foreignKeys'];
-  
-    const dbChecks = dbTables.map(
-      (table) => table.checks.map(
-        (check) => ({
-          name: check.name
-        })
-      )
-    ).flat(1) satisfies TableCommon['checks'];
-  
-    const dbPrimaryKeys = dbTables.map(
-      (table) => table.primaryKeys.map(
-        (pk) => ({
-          name: getPrimaryKeyName(pk, casing),
-          columns: pk.columns.map(
-            (column) => {
-              const tableConfig = getMySqlTableConfig(column.table);
-              return {
-                name: getColumnCasing(column, casing),
-                table: {
-                  name: tableConfig.name,
-                  schema: tableConfig.schema
-                }
-              }
-            }
-          )
-        })
-      )
-    ).flat(1) satisfies TableCommon['primaryKeys'];
-  
-    const dbUniqueConstraints = dbTables.map(
-      (table) => table.uniqueConstraints.map(
-        (unique) => {
-          const columnNames = unique.columns.map((column) => getColumnCasing(column, casing));
-  
-          return {
-            name: unique.name ?? mysqlUniqueKeyName(tables.find((t) => getTableName(t) === table.name && getMySqlTableConfig(t).schema === table.schema)!, columnNames)
-          };
-        }
-      )
-    ).flat(1) satisfies TableCommon['uniqueConstraints'];
+	const group = (() => {
+		const dbTables = tableConfigs
+			.map((table) => ({
+				...table,
+				columns: table.columns.map((column) => ({
+					...column,
+					name: getColumnCasing(column, casing),
+				})),
+			}));
 
-    return {
-      tables: dbTables,
-      views: dbViews,
-      indexes: dbIndexes,
-      foreignKeys: dbForeignKeys,
-      checks: dbChecks,
-      primaryKeys: dbPrimaryKeys,
-      uniqueConstraints: dbUniqueConstraints
-    };
-  })();
+		const dbViews = viewConfigs;
 
-  const vDb = new ValidateDatabase();
-  const v = vDb.validateSchema(undefined);
+		const dbIndexes = dbTables.map(
+			(table) =>
+				table.indexes.map(
+					(index) => {
+						const indexColumns = index.config.columns
+							.filter((column): column is MySqlColumn => !is(column, SQL));
 
-  v
-    .constraintNameCollisions(
-      group.indexes,
-      group.foreignKeys,
-      group.checks,
-      group.primaryKeys,
-      group.uniqueConstraints
-    )
-    .entityNameCollisions(
-      group.tables,
-      group.views,
-      [],
-      [],
-      []
-    );
+						const indexColumnNames = indexColumns
+							.map((column) => column.name)
+							.filter((c) => c !== undefined);
 
-  for (const table of group.tables) {
-    v.validateTable(table.name).columnNameCollisions(table.columns, casing);
-  }
+						return {
+							name: index.config.name
+								? index.config.name
+								: indexColumns.length === index.config.columns.length
+								? mysqlIndexName(table.name, indexColumnNames)
+								: '',
+							columns: index.config.columns.map((column) => {
+								if (is(column, SQL)) {
+									return column;
+								}
 
-  for (const foreignKey of group.foreignKeys) {
-    v
-      .validateForeignKey(foreignKey.name)
-      .columnsMixingTables(foreignKey)
-      .mismatchingColumnCount(foreignKey)
-      .mismatchingDataTypes(foreignKey, 'mysql');
-  }
+								return {
+									type: '',
+									name: getColumnCasing(column as MySqlColumn, casing),
+								};
+							}),
+						};
+					},
+				),
+		).flat(1) satisfies TableCommon['indexes'];
 
-  for (const primaryKey of group.primaryKeys) {
-    v
-      .validatePrimaryKey(primaryKey.name)
-      .columnsMixingTables(primaryKey);
-  }
+		const dbForeignKeys = dbTables.map(
+			(table) =>
+				table.foreignKeys.map(
+					(fk) => {
+						const ref = fk.reference();
+						return {
+							name: getForeignKeyName(fk, casing),
+							reference: {
+								columns: ref.columns.map(
+									(column) => {
+										const tableConfig = getMySqlTableConfig(column.table);
+										return {
+											name: getColumnCasing(column, casing),
+											sqlType: column.getSQLType(),
+											table: {
+												name: tableConfig.name,
+												schema: tableConfig.schema,
+											},
+										};
+									},
+								),
+								foreignColumns: ref.foreignColumns.map(
+									(column) => {
+										const tableConfig = getMySqlTableConfig(column.table);
+										return {
+											name: getColumnCasing(column, casing),
+											sqlType: column.getSQLType(),
+											table: {
+												name: tableConfig.name,
+												schema: tableConfig.schema,
+											},
+										};
+									},
+								),
+							},
+						};
+					},
+				),
+		).flat(1) satisfies TableCommon['foreignKeys'];
 
-  return {
-    messages: vDb.errors,
-    codes: vDb.errorCodes
-  };
+		const dbChecks = dbTables.map(
+			(table) =>
+				table.checks.map(
+					(check) => ({
+						name: check.name,
+					}),
+				),
+		).flat(1) satisfies TableCommon['checks'];
+
+		const dbPrimaryKeys = dbTables.map(
+			(table) =>
+				table.primaryKeys.map(
+					(pk) => ({
+						name: getPrimaryKeyName(pk, casing),
+						columns: pk.columns.map(
+							(column) => {
+								const tableConfig = getMySqlTableConfig(column.table);
+								return {
+									name: getColumnCasing(column, casing),
+									table: {
+										name: tableConfig.name,
+										schema: tableConfig.schema,
+									},
+								};
+							},
+						),
+					}),
+				),
+		).flat(1) satisfies TableCommon['primaryKeys'];
+
+		const dbUniqueConstraints = dbTables.map(
+			(table) =>
+				table.uniqueConstraints.map(
+					(unique) => {
+						const columnNames = unique.columns.map((column) => getColumnCasing(column, casing));
+
+						return {
+							name: unique.name ?? mysqlUniqueKeyName(
+								tables.find((t) => getTableName(t) === table.name && getMySqlTableConfig(t).schema === table.schema)!,
+								columnNames,
+							),
+						};
+					},
+				),
+		).flat(1) satisfies TableCommon['uniqueConstraints'];
+
+		return {
+			tables: dbTables,
+			views: dbViews,
+			indexes: dbIndexes,
+			foreignKeys: dbForeignKeys,
+			checks: dbChecks,
+			primaryKeys: dbPrimaryKeys,
+			uniqueConstraints: dbUniqueConstraints,
+		};
+	})();
+
+	const vDb = new ValidateDatabase();
+	const v = vDb.validateSchema(undefined);
+
+	v
+		.constraintNameCollisions(
+			group.indexes,
+			group.foreignKeys,
+			group.checks,
+			group.primaryKeys,
+			group.uniqueConstraints,
+		)
+		.entityNameCollisions(
+			group.tables,
+			group.views,
+			[],
+			[],
+			[],
+		);
+
+	for (const table of group.tables) {
+		v.validateTable(table.name).columnNameCollisions(table.columns, casing);
+	}
+
+	for (const foreignKey of group.foreignKeys) {
+		v
+			.validateForeignKey(foreignKey.name)
+			.columnsMixingTables(foreignKey)
+			.mismatchingColumnCount(foreignKey)
+			.mismatchingDataTypes(foreignKey, 'mysql');
+	}
+
+	for (const primaryKey of group.primaryKeys) {
+		v
+			.validatePrimaryKey(primaryKey.name)
+			.columnsMixingTables(primaryKey);
+	}
+
+	return {
+		messages: vDb.errors,
+		codes: vDb.errorCodes,
+	};
 }
 
 export function validateSQLiteSchema(
-  casing: CasingType | undefined,
-  tables: SQLiteTable[],
-  views: SQLiteView[],
+	casing: CasingType | undefined,
+	tables: SQLiteTable[],
+	views: SQLiteView[],
 ) {
-  const tableConfigs = tables.map((table) => getSQLiteTableConfig(table));
-  const viewConfigs = views.map((view) => getSQLiteViewConfig(view));
+	const tableConfigs = tables.map((table) => getSQLiteTableConfig(table));
+	const viewConfigs = views.map((view) => getSQLiteViewConfig(view));
 
-  const group = (() => {
-    const dbTables = tableConfigs
-      .map((table) => ({
-        ...table,
-        columns: table.columns.map((column) => ({
-          ...column,
-          name: getColumnCasing(column, casing)
-        }))
-      }));
-  
-    const dbViews = viewConfigs;
-  
-    const dbIndexes = dbTables.map(
-      (table) => table.indexes.map(
-        (index) => {
-          const indexColumns = index.config.columns
-            .filter((column): column is SQLiteColumn => !is(column, SQL));
-  
-          const indexColumnNames = indexColumns
-            .map((column) => column.name)
-            .filter((c) => c !== undefined);
-  
-          return {
-            name: index.config.name
-              ? index.config.name
-              : indexColumns.length === index.config.columns.length
-                ? mysqlIndexName(table.name, indexColumnNames)
-                : '',
-            columns: index.config.columns.map((column) => {
-              if (is(column, SQL)) {
-                return column;
-              }
-  
-              return {
-                type: '',
-                name: getColumnCasing(column as SQLiteColumn, casing),
-              }
-            })
-          };
-        }
-      )
-    ).flat(1) satisfies TableCommon['indexes'];
-  
-    const dbForeignKeys = dbTables.map(
-      (table) => table.foreignKeys.map(
-        (fk) => {
-          const ref = fk.reference();
-          return {
-            name: getForeignKeyName(fk, casing),
-            reference: {
-              columns: ref.columns.map(
-                (column) => {
-                  const tableConfig = getSQLiteTableConfig(column.table);
-                  return {
-                    name: getColumnCasing(column, casing),
-                    sqlType: column.getSQLType(),
-                    table: {
-                      name: tableConfig.name
-                    }
-                  };
-                }
-              ),
-              foreignColumns: ref.foreignColumns.map(
-                (column) => {
-                  const tableConfig = getSQLiteTableConfig(column.table);
-                  return {
-                    name: getColumnCasing(column, casing),
-                    sqlType: column.getSQLType(),
-                    table: {
-                      name: tableConfig.name
-                    }
-                  };
-                }
-              ),
-            }
-          };
-        }
-      )
-    ).flat(1) satisfies TableCommon['foreignKeys'];
-  
-    const dbChecks = dbTables.map(
-      (table) => table.checks.map(
-        (check) => ({
-          name: check.name
-        })
-      )
-    ).flat(1) satisfies TableCommon['checks'];
-  
-    const dbPrimaryKeys = dbTables.map(
-      (table) => table.primaryKeys.map(
-        (pk) => ({
-          name: getPrimaryKeyName(pk, casing),
-          columns: pk.columns.map(
-            (column) => {
-              const tableConfig = getSQLiteTableConfig(column.table);
-              return {
-                name: getColumnCasing(column, casing),
-                table: {
-                  name: tableConfig.name
-                }
-              }
-            }
-          )
-        })
-      )
-    ).flat(1) satisfies TableCommon['primaryKeys'];
-  
-    const dbUniqueConstraints = dbTables.map(
-      (table) => table.uniqueConstraints.map(
-        (unique) => {
-          const columnNames = unique.columns.map((column) => getColumnCasing(column, casing));
-  
-          return {
-            name: unique.name ?? sqliteUniqueKeyName(tables.find((t) => getTableName(t) === table.name)!, columnNames)
-          };
-        }
-      )
-    ).flat(1) satisfies TableCommon['uniqueConstraints'];
+	const group = (() => {
+		const dbTables = tableConfigs
+			.map((table) => ({
+				...table,
+				columns: table.columns.map((column) => ({
+					...column,
+					name: getColumnCasing(column, casing),
+				})),
+			}));
 
-    return {
-      tables: dbTables,
-      views: dbViews,
-      indexes: dbIndexes,
-      foreignKeys: dbForeignKeys,
-      checks: dbChecks,
-      primaryKeys: dbPrimaryKeys,
-      uniqueConstraints: dbUniqueConstraints
-    };
-  })();
+		const dbViews = viewConfigs;
 
-  const vDb = new ValidateDatabase();
-  const v = vDb.validateSchema(undefined);
+		const dbIndexes = dbTables.map(
+			(table) =>
+				table.indexes.map(
+					(index) => {
+						const indexColumns = index.config.columns
+							.filter((column): column is SQLiteColumn => !is(column, SQL));
 
-  v
-    .constraintNameCollisions(
-      group.indexes,
-      group.foreignKeys,
-      group.checks,
-      group.primaryKeys,
-      group.uniqueConstraints
-    )
-    .entityNameCollisions(
-      group.tables,
-      group.views,
-      [],
-      [],
-      []
-    );
+						const indexColumnNames = indexColumns
+							.map((column) => column.name)
+							.filter((c) => c !== undefined);
 
-  for (const table of group.tables) {
-    v.validateTable(table.name).columnNameCollisions(table.columns, casing);
-  }
+						return {
+							name: index.config.name
+								? index.config.name
+								: indexColumns.length === index.config.columns.length
+								? mysqlIndexName(table.name, indexColumnNames)
+								: '',
+							columns: index.config.columns.map((column) => {
+								if (is(column, SQL)) {
+									return column;
+								}
 
-  for (const foreignKey of group.foreignKeys) {
-    v
-      .validateForeignKey(foreignKey.name)
-      .columnsMixingTables(foreignKey)
-      .mismatchingColumnCount(foreignKey)
-      .mismatchingDataTypes(foreignKey, 'sqlite');
-  }
+								return {
+									type: '',
+									name: getColumnCasing(column as SQLiteColumn, casing),
+								};
+							}),
+						};
+					},
+				),
+		).flat(1) satisfies TableCommon['indexes'];
 
-  for (const primaryKey of group.primaryKeys) {
-    v
-      .validatePrimaryKey(primaryKey.name)
-      .columnsMixingTables(primaryKey);
-  }
+		const dbForeignKeys = dbTables.map(
+			(table) =>
+				table.foreignKeys.map(
+					(fk) => {
+						const ref = fk.reference();
+						return {
+							name: getForeignKeyName(fk, casing),
+							reference: {
+								columns: ref.columns.map(
+									(column) => {
+										const tableConfig = getSQLiteTableConfig(column.table);
+										return {
+											name: getColumnCasing(column, casing),
+											sqlType: column.getSQLType(),
+											table: {
+												name: tableConfig.name,
+											},
+										};
+									},
+								),
+								foreignColumns: ref.foreignColumns.map(
+									(column) => {
+										const tableConfig = getSQLiteTableConfig(column.table);
+										return {
+											name: getColumnCasing(column, casing),
+											sqlType: column.getSQLType(),
+											table: {
+												name: tableConfig.name,
+											},
+										};
+									},
+								),
+							},
+						};
+					},
+				),
+		).flat(1) satisfies TableCommon['foreignKeys'];
 
-  return {
-    messages: vDb.errors,
-    codes: vDb.errorCodes
-  };
+		const dbChecks = dbTables.map(
+			(table) =>
+				table.checks.map(
+					(check) => ({
+						name: check.name,
+					}),
+				),
+		).flat(1) satisfies TableCommon['checks'];
+
+		const dbPrimaryKeys = dbTables.map(
+			(table) =>
+				table.primaryKeys.map(
+					(pk) => ({
+						name: getPrimaryKeyName(pk, casing),
+						columns: pk.columns.map(
+							(column) => {
+								const tableConfig = getSQLiteTableConfig(column.table);
+								return {
+									name: getColumnCasing(column, casing),
+									table: {
+										name: tableConfig.name,
+									},
+								};
+							},
+						),
+					}),
+				),
+		).flat(1) satisfies TableCommon['primaryKeys'];
+
+		const dbUniqueConstraints = dbTables.map(
+			(table) =>
+				table.uniqueConstraints.map(
+					(unique) => {
+						const columnNames = unique.columns.map((column) => getColumnCasing(column, casing));
+
+						return {
+							name: unique.name
+								?? sqliteUniqueKeyName(tables.find((t) => getTableName(t) === table.name)!, columnNames),
+						};
+					},
+				),
+		).flat(1) satisfies TableCommon['uniqueConstraints'];
+
+		return {
+			tables: dbTables,
+			views: dbViews,
+			indexes: dbIndexes,
+			foreignKeys: dbForeignKeys,
+			checks: dbChecks,
+			primaryKeys: dbPrimaryKeys,
+			uniqueConstraints: dbUniqueConstraints,
+		};
+	})();
+
+	const vDb = new ValidateDatabase();
+	const v = vDb.validateSchema(undefined);
+
+	v
+		.constraintNameCollisions(
+			group.indexes,
+			group.foreignKeys,
+			group.checks,
+			group.primaryKeys,
+			group.uniqueConstraints,
+		)
+		.entityNameCollisions(
+			group.tables,
+			group.views,
+			[],
+			[],
+			[],
+		);
+
+	for (const table of group.tables) {
+		v.validateTable(table.name).columnNameCollisions(table.columns, casing);
+	}
+
+	for (const foreignKey of group.foreignKeys) {
+		v
+			.validateForeignKey(foreignKey.name)
+			.columnsMixingTables(foreignKey)
+			.mismatchingColumnCount(foreignKey)
+			.mismatchingDataTypes(foreignKey, 'sqlite');
+	}
+
+	for (const primaryKey of group.primaryKeys) {
+		v
+			.validatePrimaryKey(primaryKey.name)
+			.columnsMixingTables(primaryKey);
+	}
+
+	return {
+		messages: vDb.errors,
+		codes: vDb.errorCodes,
+	};
 }

--- a/drizzle-kit/tests/validate-schema/mysql.test.ts
+++ b/drizzle-kit/tests/validate-schema/mysql.test.ts
@@ -1,521 +1,532 @@
-import { expect, test } from 'vitest';
-import { validateMySqlSchema } from 'src/validate-schema/validate';
-import { bigint, foreignKey, index, int, mysqlTable, mysqlView, primaryKey, serial, text, unique } from 'drizzle-orm/mysql-core';
+import { sql } from 'drizzle-orm';
+import {
+	bigint,
+	foreignKey,
+	index,
+	int,
+	mysqlTable,
+	mysqlView,
+	primaryKey,
+	serial,
+	text,
+	unique,
+} from 'drizzle-orm/mysql-core';
 import { prepareFromExports } from 'src/serializer/mysqlImports';
 import { SchemaValidationErrors as Err } from 'src/validate-schema/errors';
-import { sql } from 'drizzle-orm';
+import { validateMySqlSchema } from 'src/validate-schema/validate';
+import { expect, test } from 'vitest';
 
 test('schema entity name collisions #1', () => {
-  const schema = {
-    table1: mysqlTable('test', {
-      id: serial().primaryKey()
-    }),
-    table2: mysqlTable('test', {
-      id: serial().primaryKey()
-    }),
-  };
+	const schema = {
+		table1: mysqlTable('test', {
+			id: serial().primaryKey(),
+		}),
+		table2: mysqlTable('test', {
+			id: serial().primaryKey(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaEntityNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaEntityNameCollisions);
 });
 
 test('schema entity name collisions #2', () => {
-  const schema = {
-    table: mysqlTable('test', {
-      id: serial().primaryKey()
-    }),
-    view: mysqlView('test', {
-      id: serial().primaryKey()
-    }).as(sql``)
-  };
+	const schema = {
+		table: mysqlTable('test', {
+			id: serial().primaryKey(),
+		}),
+		view: mysqlView('test', {
+			id: serial().primaryKey(),
+		}).as(sql``),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaEntityNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaEntityNameCollisions);
 });
 
 test('schema constraint name collisions #1', () => {
-  const schema = {
-    table1: mysqlTable('test1', {
-      id: serial().primaryKey(),
-      name: text('name').notNull()
-    }, (table) => ({
-      idx: index('name_idx').on(table.name),
-    })),
-    table2: mysqlTable('test2', {
-      id: serial().primaryKey(),
-      name: text('name').notNull()
-    }, (table) => ({
-      idx: index('name_idx').on(table.name),
-    })),
-  };
+	const schema = {
+		table1: mysqlTable('test1', {
+			id: serial().primaryKey(),
+			name: text('name').notNull(),
+		}, (table) => ({
+			idx: index('name_idx').on(table.name),
+		})),
+		table2: mysqlTable('test2', {
+			id: serial().primaryKey(),
+			name: text('name').notNull(),
+		}, (table) => ({
+			idx: index('name_idx').on(table.name),
+		})),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaConstraintNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaConstraintNameCollisions);
 });
 
 test('schema constraint name collisions #2', () => {
-  const schema = {
-    table1: mysqlTable('test1', {
-      id: serial().primaryKey(),
-      name: text('name').notNull()
-    }, (table) => ({
-      idx: index('test1_name_idx').on(table.name),
-    })),
-    table2: mysqlTable('test2', {
-      id: serial().primaryKey(),
-      name: text('name').notNull()
-    }, (table) => ({
-      unique: unique('test2_name_idx').on(table.name),
-    })),
-  };
+	const schema = {
+		table1: mysqlTable('test1', {
+			id: serial().primaryKey(),
+			name: text('name').notNull(),
+		}, (table) => ({
+			idx: index('test1_name_idx').on(table.name),
+		})),
+		table2: mysqlTable('test2', {
+			id: serial().primaryKey(),
+			name: text('name').notNull(),
+		}, (table) => ({
+			unique: unique('test2_name_idx').on(table.name),
+		})),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.SchemaConstraintNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.SchemaConstraintNameCollisions);
 });
 
 test('table column name collisions #1', () => {
-  const schema = {
-    table: mysqlTable('test', {
-      id: serial().primaryKey(),
-      firstName: text('first_name').notNull(),
-      lastName: text('last_name').notNull()
-    })
-  };
+	const schema = {
+		table: mysqlTable('test', {
+			id: serial().primaryKey(),
+			firstName: text('first_name').notNull(),
+			lastName: text('last_name').notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.TableColumnNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #2', () => {
-  const schema = {
-    table: mysqlTable('test', {
-      id: serial().primaryKey(),
-      firstName: text('first_name').notNull(),
-      lastName: text('first_name').notNull()
-    })
-  };
+	const schema = {
+		table: mysqlTable('test', {
+			id: serial().primaryKey(),
+			firstName: text('first_name').notNull(),
+			lastName: text('first_name').notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.TableColumnNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #3', () => {
-  const schema = {
-    table: mysqlTable('test', {
-      id: serial().primaryKey(),
-      firstName: text('last_name').notNull(),
-      lastName: text().notNull()
-    })
-  };
+	const schema = {
+		table: mysqlTable('test', {
+			id: serial().primaryKey(),
+			firstName: text('last_name').notNull(),
+			lastName: text().notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.TableColumnNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #4', () => {
-  const schema = {
-    table: mysqlTable('test', {
-      id: serial().primaryKey(),
-      firstName: text('last_name').notNull(),
-      lastName: text().notNull()
-    })
-  };
+	const schema = {
+		table: mysqlTable('test', {
+			id: serial().primaryKey(),
+			firstName: text('last_name').notNull(),
+			lastName: text().notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    'snake_case',
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		'snake_case',
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.TableColumnNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #5', () => {
-  const schema = {
-    table: mysqlTable('test', {
-      id: serial().primaryKey(),
-      first_name: text('lastName').notNull(),
-      last_name: text().notNull()
-    })
-  };
+	const schema = {
+		table: mysqlTable('test', {
+			id: serial().primaryKey(),
+			first_name: text('lastName').notNull(),
+			last_name: text().notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    'camelCase',
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		'camelCase',
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.TableColumnNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.TableColumnNameCollisions);
 });
 
 test('foreign key mismatching column count #2', () => {
-  const table1 = mysqlTable('test1', {
-    id: serial().primaryKey(),
-    c1: int().notNull(),
-    c2: int().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = mysqlTable('test2', {
-    c1: int().notNull(),
-    c2: int().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = mysqlTable('test1', {
+		id: serial().primaryKey(),
+		c1: int().notNull(),
+		c2: int().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = mysqlTable('test2', {
+		c1: int().notNull(),
+		c2: int().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyMismatchingColumnCount);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyMismatchingColumnCount);
 });
 
 test('foreign key mismatching data types #1', () => {
-  const table1 = mysqlTable('test1', {
-    id: serial().primaryKey(),
-    c1: int().notNull(),
-    c2: int().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = mysqlTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = mysqlTable('test1', {
+		id: serial().primaryKey(),
+		c1: int().notNull(),
+		c2: int().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = mysqlTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.ForeignKeyMismatchingDataTypes);
+	expect(messages).length(1);
+	expect(codes).contains(Err.ForeignKeyMismatchingDataTypes);
 });
 
 test('foreign key mismatching data types #2', () => {
-  const table1 = mysqlTable('test1', {
-    id: serial().primaryKey(),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = mysqlTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = mysqlTable('test1', {
+		id: serial().primaryKey(),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = mysqlTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
 });
 
 test('foreign key mismatching data types #3', () => {
-  const table1 = mysqlTable('test1', {
-    id: serial().primaryKey(),
-  });
-  const table2 = mysqlTable('test2', {
-    id: serial().primaryKey(),
-    table1Id: bigint({ mode: 'number', unsigned: true }).notNull().references(() => table1.id),
-  });
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = mysqlTable('test1', {
+		id: serial().primaryKey(),
+	});
+	const table2 = mysqlTable('test2', {
+		id: serial().primaryKey(),
+		table1Id: bigint({ mode: 'number', unsigned: true }).notNull().references(() => table1.id),
+	});
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
 });
 
 test('foreign key columns mixing tables #1', () => {
-  const table1 = mysqlTable('test1', {
-    id: serial().primaryKey(),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = mysqlTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = mysqlTable('test1', {
+		id: serial().primaryKey(),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = mysqlTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('foreign key columns mixing tables #2', () => {
-  const table1 = mysqlTable('test1', {
-    id: serial().primaryKey(),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table2.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = mysqlTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = mysqlTable('test1', {
+		id: serial().primaryKey(),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table2.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = mysqlTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(1);
+	expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('foreign key columns mixing tables #3', () => {
-  const table1 = mysqlTable('test1', {
-    id: serial().primaryKey(),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table.c2],
-    })
-  }));
-  const table2 = mysqlTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = mysqlTable('test1', {
+		id: serial().primaryKey(),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table.c2],
+		}),
+	}));
+	const table2 = mysqlTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(1);
+	expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('foreign key columns mixing tables #4', () => {
-  const table1 = mysqlTable('test1', {
-    id: serial().primaryKey(),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table2.c2],
-      foreignColumns: [table2.c1, table.c2],
-    })
-  }));
-  const table2 = mysqlTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = mysqlTable('test1', {
+		id: serial().primaryKey(),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table2.c2],
+			foreignColumns: [table2.c1, table.c2],
+		}),
+	}));
+	const table2 = mysqlTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(2);
-  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(2);
+	expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('primary key columns mixing tables #1', () => {
-  const table1 = mysqlTable('test1', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: primaryKey({
-      columns: [table2.c1, table.c2]
-    })
-  }));
-  const table2 = mysqlTable('test2', {
-    c1: int().notNull(),
-  });
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = mysqlTable('test1', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: primaryKey({
+			columns: [table2.c1, table.c2],
+		}),
+	}));
+	const table2 = mysqlTable('test2', {
+		c1: int().notNull(),
+	});
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateMySqlSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateMySqlSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
+	expect(messages).length(1);
+	expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
 });

--- a/drizzle-kit/tests/validate-schema/mysql.test.ts
+++ b/drizzle-kit/tests/validate-schema/mysql.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { validateMySqlSchema } from 'src/validate-schema/validate';
-import { foreignKey, index, int, mysqlTable, mysqlView, primaryKey, serial, text, unique } from 'drizzle-orm/mysql-core';
+import { bigint, foreignKey, index, int, mysqlTable, mysqlView, primaryKey, serial, text, unique } from 'drizzle-orm/mysql-core';
 import { prepareFromExports } from 'src/serializer/mysqlImports';
 import { SchemaValidationErrors as Err } from 'src/validate-schema/errors';
 import { sql } from 'drizzle-orm';
@@ -301,6 +301,31 @@ test('foreign key mismatching data types #2', () => {
       columns: [table.c1, table.c2]
     })
   }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+});
+
+test('foreign key mismatching data types #3', () => {
+  const table1 = mysqlTable('test1', {
+    id: serial().primaryKey(),
+  });
+  const table2 = mysqlTable('test2', {
+    id: serial().primaryKey(),
+    table1Id: bigint({ mode: 'number', unsigned: true }).notNull().references(() => table1.id),
+  });
   const schema = {
     table1,
     table2

--- a/drizzle-kit/tests/validate-schema/mysql.test.ts
+++ b/drizzle-kit/tests/validate-schema/mysql.test.ts
@@ -1,0 +1,496 @@
+import { expect, test } from 'vitest';
+import { validateMySqlSchema } from 'src/validate-schema/validate';
+import { foreignKey, index, int, mysqlTable, mysqlView, primaryKey, serial, text, unique } from 'drizzle-orm/mysql-core';
+import { prepareFromExports } from 'src/serializer/mysqlImports';
+import { SchemaValidationErrors as Err } from 'src/validate-schema/errors';
+import { sql } from 'drizzle-orm';
+
+test('schema entity name collisions #1', () => {
+  const schema = {
+    table1: mysqlTable('test', {
+      id: serial().primaryKey()
+    }),
+    table2: mysqlTable('test', {
+      id: serial().primaryKey()
+    }),
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaEntityNameCollisions);
+});
+
+test('schema entity name collisions #2', () => {
+  const schema = {
+    table: mysqlTable('test', {
+      id: serial().primaryKey()
+    }),
+    view: mysqlView('test', {
+      id: serial().primaryKey()
+    }).as(sql``)
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaEntityNameCollisions);
+});
+
+test('schema constraint name collisions #1', () => {
+  const schema = {
+    table1: mysqlTable('test1', {
+      id: serial().primaryKey(),
+      name: text('name').notNull()
+    }, (table) => ({
+      idx: index('name_idx').on(table.name),
+    })),
+    table2: mysqlTable('test2', {
+      id: serial().primaryKey(),
+      name: text('name').notNull()
+    }, (table) => ({
+      idx: index('name_idx').on(table.name),
+    })),
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaConstraintNameCollisions);
+});
+
+test('schema constraint name collisions #2', () => {
+  const schema = {
+    table1: mysqlTable('test1', {
+      id: serial().primaryKey(),
+      name: text('name').notNull()
+    }, (table) => ({
+      idx: index('test1_name_idx').on(table.name),
+    })),
+    table2: mysqlTable('test2', {
+      id: serial().primaryKey(),
+      name: text('name').notNull()
+    }, (table) => ({
+      unique: unique('test2_name_idx').on(table.name),
+    })),
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.SchemaConstraintNameCollisions);
+});
+
+test('table column name collisions #1', () => {
+  const schema = {
+    table: mysqlTable('test', {
+      id: serial().primaryKey(),
+      firstName: text('first_name').notNull(),
+      lastName: text('last_name').notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #2', () => {
+  const schema = {
+    table: mysqlTable('test', {
+      id: serial().primaryKey(),
+      firstName: text('first_name').notNull(),
+      lastName: text('first_name').notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #3', () => {
+  const schema = {
+    table: mysqlTable('test', {
+      id: serial().primaryKey(),
+      firstName: text('last_name').notNull(),
+      lastName: text().notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #4', () => {
+  const schema = {
+    table: mysqlTable('test', {
+      id: serial().primaryKey(),
+      firstName: text('last_name').notNull(),
+      lastName: text().notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    'snake_case',
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #5', () => {
+  const schema = {
+    table: mysqlTable('test', {
+      id: serial().primaryKey(),
+      first_name: text('lastName').notNull(),
+      last_name: text().notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    'camelCase',
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.TableColumnNameCollisions);
+});
+
+test('foreign key mismatching column count #2', () => {
+  const table1 = mysqlTable('test1', {
+    id: serial().primaryKey(),
+    c1: int().notNull(),
+    c2: int().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = mysqlTable('test2', {
+    c1: int().notNull(),
+    c2: int().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyMismatchingColumnCount);
+});
+
+test('foreign key mismatching data types #1', () => {
+  const table1 = mysqlTable('test1', {
+    id: serial().primaryKey(),
+    c1: int().notNull(),
+    c2: int().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = mysqlTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.ForeignKeyMismatchingDataTypes);
+});
+
+test('foreign key mismatching data types #2', () => {
+  const table1 = mysqlTable('test1', {
+    id: serial().primaryKey(),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = mysqlTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+});
+
+test('foreign key columns mixing tables #1', () => {
+  const table1 = mysqlTable('test1', {
+    id: serial().primaryKey(),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = mysqlTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('foreign key columns mixing tables #2', () => {
+  const table1 = mysqlTable('test1', {
+    id: serial().primaryKey(),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table2.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = mysqlTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('foreign key columns mixing tables #3', () => {
+  const table1 = mysqlTable('test1', {
+    id: serial().primaryKey(),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table.c2],
+    })
+  }));
+  const table2 = mysqlTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('foreign key columns mixing tables #4', () => {
+  const table1 = mysqlTable('test1', {
+    id: serial().primaryKey(),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table2.c2],
+      foreignColumns: [table2.c1, table.c2],
+    })
+  }));
+  const table2 = mysqlTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(2);
+  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('primary key columns mixing tables #1', () => {
+  const table1 = mysqlTable('test1', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: primaryKey({
+      columns: [table2.c1, table.c2]
+    })
+  }));
+  const table2 = mysqlTable('test2', {
+    c1: int().notNull(),
+  });
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateMySqlSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
+});

--- a/drizzle-kit/tests/validate-schema/pg.test.ts
+++ b/drizzle-kit/tests/validate-schema/pg.test.ts
@@ -689,6 +689,35 @@ test('foreign key mismatching data types #2', () => {
   expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
 });
 
+test('foreign key mismatching data types #3', () => {
+  const table1 = pgTable('test1', {
+    id: serial().primaryKey(),
+  });
+  const table2 = pgTable('test2', {
+    id: serial().primaryKey(),
+    table1Id: integer().notNull().references(() => table1.id),
+  });
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+});
+
 test('foreign key columns mixing tables #1', () => {
   const table1 = pgTable('test1', {
     id: serial().primaryKey(),

--- a/drizzle-kit/tests/validate-schema/pg.test.ts
+++ b/drizzle-kit/tests/validate-schema/pg.test.ts
@@ -1,0 +1,887 @@
+import { expect, test } from 'vitest';
+import { validatePgSchema } from 'src/validate-schema/validate';
+import { foreignKey, index, integer, pgEnum, pgSchema, pgSequence, pgTable, primaryKey, serial, text, unique, vector } from 'drizzle-orm/pg-core';
+import { prepareFromExports } from 'src/serializer/pgImports';
+import { SchemaValidationErrors as Err } from 'src/validate-schema/errors';
+import { sql } from 'drizzle-orm';
+
+test('schemas name collisions #1', () => {
+  const schema = {
+    test1Schema: pgSchema('test1'),
+    test2Schema: pgSchema('test1'),
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaNameCollisions);
+});
+
+test('schemas name collisions #2', () => {
+  const schema = {
+    test1Schema: pgSchema('test1'),
+    test2Schema: pgSchema('test1'),
+    test3Schema: pgSchema('test1'),
+    test4Schema: pgSchema('test2'),
+    test5Schema: pgSchema('test2'),
+    test6Schema: pgSchema('test3'),
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(2);
+  expect(codes).contains(Err.SchemaNameCollisions);
+});
+
+test('schema entity name collisions #1', () => {
+  const schema = {
+    table1: pgTable('test', {
+      id: serial().primaryKey()
+    }),
+    table2: pgTable('test', {
+      id: serial().primaryKey()
+    }),
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaEntityNameCollisions);
+});
+
+test('schema entity name collisions #2', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey()
+    }),
+    sequence: pgSequence('test')
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaEntityNameCollisions);
+});
+
+test('schema entity name collisions #3', () => {
+  const mySchema = pgSchema('my_schema');
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey()
+    }),
+    mySchemaTable: mySchema.table('test', {
+      id: serial().primaryKey()
+    })
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.SchemaEntityNameCollisions);
+});
+
+test('schema constraint name collisions #1', () => {
+  const schema = {
+    table1: pgTable('test1', {
+      id: serial().primaryKey(),
+      name: text('name').notNull()
+    }, (table) => ({
+      idx: index('name_idx').on(table.name),
+    })),
+    table2: pgTable('test2', {
+      id: serial().primaryKey(),
+      name: text('name').notNull()
+    }, (table) => ({
+      idx: index('name_idx').on(table.name),
+    })),
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaConstraintNameCollisions);
+});
+
+test('schema constraint name collisions #2', () => {
+  const schema = {
+    table1: pgTable('test1', {
+      id: serial().primaryKey(),
+      name: text('name').notNull()
+    }, (table) => ({
+      idx: index('name_idx').on(table.name),
+    })),
+    table2: pgTable('test2', {
+      id: serial().primaryKey(),
+      name: text('name').notNull()
+    }, (table) => ({
+      unique: unique('name_idx').on(table.name),
+    })),
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaConstraintNameCollisions);
+});
+
+test('enum value collisions #1', () => {
+  const schema = {
+    enum_: pgEnum('test', ['a', 'a', 'b', 'c', 'c'])
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(2);
+  expect(codes).contains(Err.EnumValueCollisions);
+});
+
+test('enum value collisions #2', () => {
+  const schema = {
+    enum_: pgEnum('test', ['a', 'A', 'b', 'c', 'C'])
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.EnumValueCollisions);
+});
+
+test('sequence incorrect values #1', () => {
+  const schema = {
+    sequence: pgSequence('test')
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.SequenceIncrementByZero);
+  expect(codes).not.contains(Err.SequenceInvalidMinMax);
+});
+
+test('sequence incorrect values #2', () => {
+  const schema = {
+    sequence: pgSequence('test', {
+      increment: 0
+    })
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SequenceIncrementByZero);
+  expect(codes).not.contains(Err.SequenceInvalidMinMax);
+});
+
+test('sequence incorrect values #3', () => {
+  const schema = {
+    sequence: pgSequence('test', {
+      increment: 2,
+      minValue: 1000,
+      maxValue: 100
+    })
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).not.contains(Err.SequenceIncrementByZero);
+  expect(codes).contains(Err.SequenceInvalidMinMax);
+});
+
+test('sequence incorrect values #4', () => {
+  const schema = {
+    sequence: pgSequence('test', {
+      increment: 0,
+      minValue: 2000,
+      maxValue: 300
+    })
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(2);
+  expect(codes).contains(Err.SequenceIncrementByZero);
+  expect(codes).contains(Err.SequenceInvalidMinMax);
+});
+
+test('table column name collisions #1', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey(),
+      firstName: text('first_name').notNull(),
+      lastName: text('last_name').notNull()
+    })
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #2', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey(),
+      firstName: text('first_name').notNull(),
+      lastName: text('first_name').notNull()
+    })
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #3', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey(),
+      firstName: text('last_name').notNull(),
+      lastName: text().notNull()
+    })
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #4', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey(),
+      firstName: text('last_name').notNull(),
+      lastName: text().notNull()
+    })
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    'snake_case',
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #5', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey(),
+      first_name: text('lastName').notNull(),
+      last_name: text().notNull()
+    })
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    'camelCase',
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.TableColumnNameCollisions);
+});
+
+test('index requires name #1', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey(),
+      firstName: text().notNull(),
+      lastName: text().notNull()
+    }, (table) => ({
+      idx: index().on(table.firstName, table.lastName)
+    }))
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.IndexRequiresName);
+});
+
+test('index requires name #2', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey(),
+      firstName: text().notNull(),
+      lastName: text().notNull()
+    }, (table) => ({
+      idx: index().on(table.firstName, sql`lower(${table.lastName})`)
+    }))
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.IndexRequiresName);
+});
+
+test('index vector column requires op #1', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey(),
+      vec: vector({
+        dimensions: 2
+      }).notNull()
+    }, (table) => ({
+      idx: index().on(table.vec.op('vector_cosine_ops'))
+    }))
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.IndexVectorColumnRequiresOp);
+});
+
+test('index vector column requires op #2', () => {
+  const schema = {
+    table: pgTable('test', {
+      id: serial().primaryKey(),
+      vec: vector({
+        dimensions: 2
+      }).notNull()
+    }, (table) => ({
+      idx: index().on(table.vec)
+    }))
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.IndexVectorColumnRequiresOp);
+});
+
+test('foreign key mismatching column count #2', () => {
+  const table1 = pgTable('test1', {
+    id: serial().primaryKey(),
+    c1: integer().notNull(),
+    c2: integer().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = pgTable('test2', {
+    c1: integer().notNull(),
+    c2: integer().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyMismatchingColumnCount);
+});
+
+test('foreign key mismatching data types #1', () => {
+  const table1 = pgTable('test1', {
+    id: serial().primaryKey(),
+    c1: integer().notNull(),
+    c2: integer().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = pgTable('test2', {
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.ForeignKeyMismatchingDataTypes);
+});
+
+test('foreign key mismatching data types #2', () => {
+  const table1 = pgTable('test1', {
+    id: serial().primaryKey(),
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = pgTable('test2', {
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+});
+
+test('foreign key columns mixing tables #1', () => {
+  const table1 = pgTable('test1', {
+    id: serial().primaryKey(),
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = pgTable('test2', {
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('foreign key columns mixing tables #2', () => {
+  const table1 = pgTable('test1', {
+    id: serial().primaryKey(),
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table2.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = pgTable('test2', {
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('foreign key columns mixing tables #3', () => {
+  const table1 = pgTable('test1', {
+    id: serial().primaryKey(),
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table.c2],
+    })
+  }));
+  const table2 = pgTable('test2', {
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('foreign key columns mixing tables #4', () => {
+  const table1 = pgTable('test1', {
+    id: serial().primaryKey(),
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table2.c2],
+      foreignColumns: [table2.c1, table.c2],
+    })
+  }));
+  const table2 = pgTable('test2', {
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(2);
+  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('primary key columns mixing tables #1', () => {
+  const table1 = pgTable('test1', {
+    c1: integer().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: primaryKey({
+      columns: [table2.c1, table.c2]
+    })
+  }));
+  const table2 = pgTable('test2', {
+    c1: integer().notNull(),
+  });
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+  const { messages, codes } = validatePgSchema(
+    undefined,
+    schemas,
+    tables,
+    views,
+    materializedViews,
+    enums,
+    sequences
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
+});

--- a/drizzle-kit/tests/validate-schema/pg.test.ts
+++ b/drizzle-kit/tests/validate-schema/pg.test.ts
@@ -1,918 +1,931 @@
-import { expect, test } from 'vitest';
-import { validatePgSchema } from 'src/validate-schema/validate';
-import { foreignKey, index, integer, pgEnum, pgSchema, pgSequence, pgTable, primaryKey, serial, text, unique, vector } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import {
+	foreignKey,
+	index,
+	integer,
+	pgEnum,
+	pgSchema,
+	pgSequence,
+	pgTable,
+	primaryKey,
+	serial,
+	text,
+	unique,
+	vector,
+} from 'drizzle-orm/pg-core';
 import { prepareFromExports } from 'src/serializer/pgImports';
 import { SchemaValidationErrors as Err } from 'src/validate-schema/errors';
-import { sql } from 'drizzle-orm';
+import { validatePgSchema } from 'src/validate-schema/validate';
+import { expect, test } from 'vitest';
 
 test('schemas name collisions #1', () => {
-  const schema = {
-    test1Schema: pgSchema('test1'),
-    test2Schema: pgSchema('test1'),
-  };
+	const schema = {
+		test1Schema: pgSchema('test1'),
+		test2Schema: pgSchema('test1'),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaNameCollisions);
 });
 
 test('schemas name collisions #2', () => {
-  const schema = {
-    test1Schema: pgSchema('test1'),
-    test2Schema: pgSchema('test1'),
-    test3Schema: pgSchema('test1'),
-    test4Schema: pgSchema('test2'),
-    test5Schema: pgSchema('test2'),
-    test6Schema: pgSchema('test3'),
-  };
+	const schema = {
+		test1Schema: pgSchema('test1'),
+		test2Schema: pgSchema('test1'),
+		test3Schema: pgSchema('test1'),
+		test4Schema: pgSchema('test2'),
+		test5Schema: pgSchema('test2'),
+		test6Schema: pgSchema('test3'),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(2);
-  expect(codes).contains(Err.SchemaNameCollisions);
+	expect(messages).length(2);
+	expect(codes).contains(Err.SchemaNameCollisions);
 });
 
 test('schema entity name collisions #1', () => {
-  const schema = {
-    table1: pgTable('test', {
-      id: serial().primaryKey()
-    }),
-    table2: pgTable('test', {
-      id: serial().primaryKey()
-    }),
-  };
+	const schema = {
+		table1: pgTable('test', {
+			id: serial().primaryKey(),
+		}),
+		table2: pgTable('test', {
+			id: serial().primaryKey(),
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaEntityNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaEntityNameCollisions);
 });
 
 test('schema entity name collisions #2', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey()
-    }),
-    sequence: pgSequence('test')
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+		}),
+		sequence: pgSequence('test'),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaEntityNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaEntityNameCollisions);
 });
 
 test('schema entity name collisions #3', () => {
-  const mySchema = pgSchema('my_schema');
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey()
-    }),
-    mySchemaTable: mySchema.table('test', {
-      id: serial().primaryKey()
-    })
-  };
+	const mySchema = pgSchema('my_schema');
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+		}),
+		mySchemaTable: mySchema.table('test', {
+			id: serial().primaryKey(),
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.SchemaEntityNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.SchemaEntityNameCollisions);
 });
 
 test('schema constraint name collisions #1', () => {
-  const schema = {
-    table1: pgTable('test1', {
-      id: serial().primaryKey(),
-      name: text('name').notNull()
-    }, (table) => ({
-      idx: index('name_idx').on(table.name),
-    })),
-    table2: pgTable('test2', {
-      id: serial().primaryKey(),
-      name: text('name').notNull()
-    }, (table) => ({
-      idx: index('name_idx').on(table.name),
-    })),
-  };
+	const schema = {
+		table1: pgTable('test1', {
+			id: serial().primaryKey(),
+			name: text('name').notNull(),
+		}, (table) => ({
+			idx: index('name_idx').on(table.name),
+		})),
+		table2: pgTable('test2', {
+			id: serial().primaryKey(),
+			name: text('name').notNull(),
+		}, (table) => ({
+			idx: index('name_idx').on(table.name),
+		})),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaConstraintNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaConstraintNameCollisions);
 });
 
 test('schema constraint name collisions #2', () => {
-  const schema = {
-    table1: pgTable('test1', {
-      id: serial().primaryKey(),
-      name: text('name').notNull()
-    }, (table) => ({
-      idx: index('test1_name_idx').on(table.name),
-    })),
-    table2: pgTable('test2', {
-      id: serial().primaryKey(),
-      name: text('name').notNull()
-    }, (table) => ({
-      unique: unique('test2_name_idx').on(table.name),
-    })),
-  };
+	const schema = {
+		table1: pgTable('test1', {
+			id: serial().primaryKey(),
+			name: text('name').notNull(),
+		}, (table) => ({
+			idx: index('test1_name_idx').on(table.name),
+		})),
+		table2: pgTable('test2', {
+			id: serial().primaryKey(),
+			name: text('name').notNull(),
+		}, (table) => ({
+			unique: unique('test2_name_idx').on(table.name),
+		})),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.SchemaConstraintNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.SchemaConstraintNameCollisions);
 });
 
 test('enum value collisions #1', () => {
-  const schema = {
-    enum_: pgEnum('test', ['a', 'a', 'b', 'c', 'c'])
-  };
+	const schema = {
+		enum_: pgEnum('test', ['a', 'a', 'b', 'c', 'c']),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(2);
-  expect(codes).contains(Err.EnumValueCollisions);
+	expect(messages).length(2);
+	expect(codes).contains(Err.EnumValueCollisions);
 });
 
 test('enum value collisions #2', () => {
-  const schema = {
-    enum_: pgEnum('test', ['a', 'A', 'b', 'c', 'C'])
-  };
+	const schema = {
+		enum_: pgEnum('test', ['a', 'A', 'b', 'c', 'C']),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.EnumValueCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.EnumValueCollisions);
 });
 
 test('sequence incorrect values #1', () => {
-  const schema = {
-    sequence: pgSequence('test')
-  };
+	const schema = {
+		sequence: pgSequence('test'),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.SequenceIncrementByZero);
-  expect(codes).not.contains(Err.SequenceInvalidMinMax);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.SequenceIncrementByZero);
+	expect(codes).not.contains(Err.SequenceInvalidMinMax);
 });
 
 test('sequence incorrect values #2', () => {
-  const schema = {
-    sequence: pgSequence('test', {
-      increment: 0
-    })
-  };
+	const schema = {
+		sequence: pgSequence('test', {
+			increment: 0,
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SequenceIncrementByZero);
-  expect(codes).not.contains(Err.SequenceInvalidMinMax);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SequenceIncrementByZero);
+	expect(codes).not.contains(Err.SequenceInvalidMinMax);
 });
 
 test('sequence incorrect values #3', () => {
-  const schema = {
-    sequence: pgSequence('test', {
-      increment: 2,
-      minValue: 1000,
-      maxValue: 100
-    })
-  };
+	const schema = {
+		sequence: pgSequence('test', {
+			increment: 2,
+			minValue: 1000,
+			maxValue: 100,
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).not.contains(Err.SequenceIncrementByZero);
-  expect(codes).contains(Err.SequenceInvalidMinMax);
+	expect(messages).length(1);
+	expect(codes).not.contains(Err.SequenceIncrementByZero);
+	expect(codes).contains(Err.SequenceInvalidMinMax);
 });
 
 test('sequence incorrect values #4', () => {
-  const schema = {
-    sequence: pgSequence('test', {
-      increment: 0,
-      minValue: 2000,
-      maxValue: 300
-    })
-  };
+	const schema = {
+		sequence: pgSequence('test', {
+			increment: 0,
+			minValue: 2000,
+			maxValue: 300,
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(2);
-  expect(codes).contains(Err.SequenceIncrementByZero);
-  expect(codes).contains(Err.SequenceInvalidMinMax);
+	expect(messages).length(2);
+	expect(codes).contains(Err.SequenceIncrementByZero);
+	expect(codes).contains(Err.SequenceInvalidMinMax);
 });
 
 test('table column name collisions #1', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey(),
-      firstName: text('first_name').notNull(),
-      lastName: text('last_name').notNull()
-    })
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+			firstName: text('first_name').notNull(),
+			lastName: text('last_name').notNull(),
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.TableColumnNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #2', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey(),
-      firstName: text('first_name').notNull(),
-      lastName: text('first_name').notNull()
-    })
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+			firstName: text('first_name').notNull(),
+			lastName: text('first_name').notNull(),
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.TableColumnNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #3', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey(),
-      firstName: text('last_name').notNull(),
-      lastName: text().notNull()
-    })
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+			firstName: text('last_name').notNull(),
+			lastName: text().notNull(),
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.TableColumnNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #4', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey(),
-      firstName: text('last_name').notNull(),
-      lastName: text().notNull()
-    })
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+			firstName: text('last_name').notNull(),
+			lastName: text().notNull(),
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    'snake_case',
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		'snake_case',
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.TableColumnNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #5', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey(),
-      first_name: text('lastName').notNull(),
-      last_name: text().notNull()
-    })
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+			first_name: text('lastName').notNull(),
+			last_name: text().notNull(),
+		}),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    'camelCase',
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		'camelCase',
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.TableColumnNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.TableColumnNameCollisions);
 });
 
 test('index requires name #1', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey(),
-      firstName: text().notNull(),
-      lastName: text().notNull()
-    }, (table) => ({
-      idx: index().on(table.firstName, table.lastName)
-    }))
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+			firstName: text().notNull(),
+			lastName: text().notNull(),
+		}, (table) => ({
+			idx: index().on(table.firstName, table.lastName),
+		})),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.IndexRequiresName);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.IndexRequiresName);
 });
 
 test('index requires name #2', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey(),
-      firstName: text().notNull(),
-      lastName: text().notNull()
-    }, (table) => ({
-      idx: index().on(table.firstName, sql`lower(${table.lastName})`)
-    }))
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+			firstName: text().notNull(),
+			lastName: text().notNull(),
+		}, (table) => ({
+			idx: index().on(table.firstName, sql`lower(${table.lastName})`),
+		})),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.IndexRequiresName);
+	expect(messages).length(1);
+	expect(codes).contains(Err.IndexRequiresName);
 });
 
 test('index vector column requires op #1', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey(),
-      vec: vector({
-        dimensions: 2
-      }).notNull()
-    }, (table) => ({
-      idx: index().on(table.vec.op('vector_cosine_ops'))
-    }))
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+			vec: vector({
+				dimensions: 2,
+			}).notNull(),
+		}, (table) => ({
+			idx: index().on(table.vec.op('vector_cosine_ops')),
+		})),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.IndexVectorColumnRequiresOp);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.IndexVectorColumnRequiresOp);
 });
 
 test('index vector column requires op #2', () => {
-  const schema = {
-    table: pgTable('test', {
-      id: serial().primaryKey(),
-      vec: vector({
-        dimensions: 2
-      }).notNull()
-    }, (table) => ({
-      idx: index().on(table.vec)
-    }))
-  };
+	const schema = {
+		table: pgTable('test', {
+			id: serial().primaryKey(),
+			vec: vector({
+				dimensions: 2,
+			}).notNull(),
+		}, (table) => ({
+			idx: index().on(table.vec),
+		})),
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.IndexVectorColumnRequiresOp);
+	expect(messages).length(1);
+	expect(codes).contains(Err.IndexVectorColumnRequiresOp);
 });
 
 test('foreign key mismatching column count #2', () => {
-  const table1 = pgTable('test1', {
-    id: serial().primaryKey(),
-    c1: integer().notNull(),
-    c2: integer().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = pgTable('test2', {
-    c1: integer().notNull(),
-    c2: integer().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = pgTable('test1', {
+		id: serial().primaryKey(),
+		c1: integer().notNull(),
+		c2: integer().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = pgTable('test2', {
+		c1: integer().notNull(),
+		c2: integer().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyMismatchingColumnCount);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyMismatchingColumnCount);
 });
 
 test('foreign key mismatching data types #1', () => {
-  const table1 = pgTable('test1', {
-    id: serial().primaryKey(),
-    c1: integer().notNull(),
-    c2: integer().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = pgTable('test2', {
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = pgTable('test1', {
+		id: serial().primaryKey(),
+		c1: integer().notNull(),
+		c2: integer().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = pgTable('test2', {
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.ForeignKeyMismatchingDataTypes);
+	expect(messages).length(1);
+	expect(codes).contains(Err.ForeignKeyMismatchingDataTypes);
 });
 
 test('foreign key mismatching data types #2', () => {
-  const table1 = pgTable('test1', {
-    id: serial().primaryKey(),
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = pgTable('test2', {
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = pgTable('test1', {
+		id: serial().primaryKey(),
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = pgTable('test2', {
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
 });
 
 test('foreign key mismatching data types #3', () => {
-  const table1 = pgTable('test1', {
-    id: serial().primaryKey(),
-  });
-  const table2 = pgTable('test2', {
-    id: serial().primaryKey(),
-    table1Id: integer().notNull().references(() => table1.id),
-  });
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = pgTable('test1', {
+		id: serial().primaryKey(),
+	});
+	const table2 = pgTable('test2', {
+		id: serial().primaryKey(),
+		table1Id: integer().notNull().references(() => table1.id),
+	});
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
 });
 
 test('foreign key columns mixing tables #1', () => {
-  const table1 = pgTable('test1', {
-    id: serial().primaryKey(),
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = pgTable('test2', {
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = pgTable('test1', {
+		id: serial().primaryKey(),
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = pgTable('test2', {
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('foreign key columns mixing tables #2', () => {
-  const table1 = pgTable('test1', {
-    id: serial().primaryKey(),
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table2.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = pgTable('test2', {
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = pgTable('test1', {
+		id: serial().primaryKey(),
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table2.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = pgTable('test2', {
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(1);
+	expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('foreign key columns mixing tables #3', () => {
-  const table1 = pgTable('test1', {
-    id: serial().primaryKey(),
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table.c2],
-    })
-  }));
-  const table2 = pgTable('test2', {
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = pgTable('test1', {
+		id: serial().primaryKey(),
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table.c2],
+		}),
+	}));
+	const table2 = pgTable('test2', {
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(1);
+	expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('foreign key columns mixing tables #4', () => {
-  const table1 = pgTable('test1', {
-    id: serial().primaryKey(),
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table2.c2],
-      foreignColumns: [table2.c1, table.c2],
-    })
-  }));
-  const table2 = pgTable('test2', {
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = pgTable('test1', {
+		id: serial().primaryKey(),
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table2.c2],
+			foreignColumns: [table2.c1, table.c2],
+		}),
+	}));
+	const table2 = pgTable('test2', {
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(2);
-  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(2);
+	expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('primary key columns mixing tables #1', () => {
-  const table1 = pgTable('test1', {
-    c1: integer().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: primaryKey({
-      columns: [table2.c1, table.c2]
-    })
-  }));
-  const table2 = pgTable('test2', {
-    c1: integer().notNull(),
-  });
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = pgTable('test1', {
+		c1: integer().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: primaryKey({
+			columns: [table2.c1, table.c2],
+		}),
+	}));
+	const table2 = pgTable('test2', {
+		c1: integer().notNull(),
+	});
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+	const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
 
-  const { messages, codes } = validatePgSchema(
-    undefined,
-    schemas,
-    tables,
-    views,
-    materializedViews,
-    enums,
-    sequences
-  );
+	const { messages, codes } = validatePgSchema(
+		undefined,
+		schemas,
+		tables,
+		views,
+		materializedViews,
+		enums,
+		sequences,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
+	expect(messages).length(1);
+	expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
 });
 
 // This is just for visualizing the formatted error messages

--- a/drizzle-kit/tests/validate-schema/pg.test.ts
+++ b/drizzle-kit/tests/validate-schema/pg.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { validatePgSchema } from 'src/validate-schema/validate';
+import { printValidationErrors, validatePgSchema } from 'src/validate-schema/validate';
 import { foreignKey, index, integer, pgEnum, pgSchema, pgSequence, pgTable, primaryKey, serial, text, unique, vector } from 'drizzle-orm/pg-core';
 import { prepareFromExports } from 'src/serializer/pgImports';
 import { SchemaValidationErrors as Err } from 'src/validate-schema/errors';
@@ -885,3 +885,49 @@ test('primary key columns mixing tables #1', () => {
   expect(messages).length(1);
   expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
 });
+
+// This is just for visualizing the formatted error messages
+// test('test', () => {
+//   const users = pgTable('users', {
+//     id: serial('id').primaryKey(),
+//     firstName: text('first_name').notNull(),
+//     lastName: text('first_name').notNull(),
+//     profileViews: integer('profile_views').notNull().default(0)
+//   }, (table) => ({
+//     profileViewsIdx: index('views_idx').on(table.profileViews),
+//   }))
+//   const posts = pgTable('posts', {
+//     id: serial('id').primaryKey(),
+//     userId: text('user_id').notNull(),
+//     title: text('title').notNull(),
+//     body: text('body').notNull(),
+//     views: integer('views').notNull().default(0),
+//     embedding: vector('embedding', { dimensions: 3 })
+//   }, (table) => ({
+//     viewsIdx: index('views_idx').on(table.views),
+//     embeddingIdx: index('embedding_idx').on(table.embedding),
+//     fk: foreignKey({
+//       columns: [table.userId],
+//       foreignColumns: [users.id],
+//     })
+//   }));
+//   const schema = {
+//     users,
+//     posts
+//   };
+
+//   const { schemas, enums, tables, sequences, views, materializedViews } = prepareFromExports(schema);
+
+//   const { messages } = validatePgSchema(
+//     'snake_case',
+//     schemas,
+//     tables,
+//     views,
+//     materializedViews,
+//     enums,
+//     sequences
+//   );
+
+//   printValidationErrors(messages, false);
+//   expect(true).toBeTruthy();
+// });

--- a/drizzle-kit/tests/validate-schema/pg.test.ts
+++ b/drizzle-kit/tests/validate-schema/pg.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { printValidationErrors, validatePgSchema } from 'src/validate-schema/validate';
+import { validatePgSchema } from 'src/validate-schema/validate';
 import { foreignKey, index, integer, pgEnum, pgSchema, pgSequence, pgTable, primaryKey, serial, text, unique, vector } from 'drizzle-orm/pg-core';
 import { prepareFromExports } from 'src/serializer/pgImports';
 import { SchemaValidationErrors as Err } from 'src/validate-schema/errors';
@@ -168,13 +168,13 @@ test('schema constraint name collisions #2', () => {
       id: serial().primaryKey(),
       name: text('name').notNull()
     }, (table) => ({
-      idx: index('name_idx').on(table.name),
+      idx: index('test1_name_idx').on(table.name),
     })),
     table2: pgTable('test2', {
       id: serial().primaryKey(),
       name: text('name').notNull()
     }, (table) => ({
-      unique: unique('name_idx').on(table.name),
+      unique: unique('test2_name_idx').on(table.name),
     })),
   };
 
@@ -190,8 +190,8 @@ test('schema constraint name collisions #2', () => {
     sequences
   );
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaConstraintNameCollisions);
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.SchemaConstraintNameCollisions);
 });
 
 test('enum value collisions #1', () => {

--- a/drizzle-kit/tests/validate-schema/sqlite.test.ts
+++ b/drizzle-kit/tests/validate-schema/sqlite.test.ts
@@ -1,496 +1,496 @@
-import { expect, test } from 'vitest';
-import { validateSQLiteSchema } from 'src/validate-schema/validate';
-import { foreignKey, index, int, sqliteTable, sqliteView, primaryKey, text, unique } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
+import { foreignKey, index, int, primaryKey, sqliteTable, sqliteView, text, unique } from 'drizzle-orm/sqlite-core';
 import { prepareFromExports } from 'src/serializer/sqliteImports';
 import { SchemaValidationErrors as Err } from 'src/validate-schema/errors';
-import { sql } from 'drizzle-orm';
+import { validateSQLiteSchema } from 'src/validate-schema/validate';
+import { expect, test } from 'vitest';
 
 test('schema entity name collisions #1', () => {
-  const schema = {
-    table1: sqliteTable('test', {
-      id: int().primaryKey({ autoIncrement: true }),
-    }),
-    table2: sqliteTable('test', {
-      id: int().primaryKey({ autoIncrement: true })
-    }),
-  };
+	const schema = {
+		table1: sqliteTable('test', {
+			id: int().primaryKey({ autoIncrement: true }),
+		}),
+		table2: sqliteTable('test', {
+			id: int().primaryKey({ autoIncrement: true }),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaEntityNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaEntityNameCollisions);
 });
 
 test('schema entity name collisions #2', () => {
-  const schema = {
-    table: sqliteTable('test', {
-      id: int().primaryKey({ autoIncrement: true })
-    }),
-    view: sqliteView('test', {
-      id: int().primaryKey({ autoIncrement: true })
-    }).as(sql``)
-  };
+	const schema = {
+		table: sqliteTable('test', {
+			id: int().primaryKey({ autoIncrement: true }),
+		}),
+		view: sqliteView('test', {
+			id: int().primaryKey({ autoIncrement: true }),
+		}).as(sql``),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaEntityNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaEntityNameCollisions);
 });
 
 test('schema constraint name collisions #1', () => {
-  const schema = {
-    table1: sqliteTable('test1', {
-      id: int().primaryKey({ autoIncrement: true }),
-      name: text('name').notNull()
-    }, (table) => ({
-      idx: index('name_idx').on(table.name),
-    })),
-    table2: sqliteTable('test2', {
-      id: int().primaryKey({ autoIncrement: true }),
-      name: text('name').notNull()
-    }, (table) => ({
-      idx: index('name_idx').on(table.name),
-    })),
-  };
+	const schema = {
+		table1: sqliteTable('test1', {
+			id: int().primaryKey({ autoIncrement: true }),
+			name: text('name').notNull(),
+		}, (table) => ({
+			idx: index('name_idx').on(table.name),
+		})),
+		table2: sqliteTable('test2', {
+			id: int().primaryKey({ autoIncrement: true }),
+			name: text('name').notNull(),
+		}, (table) => ({
+			idx: index('name_idx').on(table.name),
+		})),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.SchemaConstraintNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.SchemaConstraintNameCollisions);
 });
 
 test('schema constraint name collisions #2', () => {
-  const schema = {
-    table1: sqliteTable('test1', {
-      id: int().primaryKey({ autoIncrement: true }),
-      name: text('name').notNull()
-    }, (table) => ({
-      idx: index('test1_name_idx').on(table.name),
-    })),
-    table2: sqliteTable('test2', {
-      id: int().primaryKey({ autoIncrement: true }),
-      name: text('name').notNull()
-    }, (table) => ({
-      unique: unique('test2_name_idx').on(table.name),
-    })),
-  };
+	const schema = {
+		table1: sqliteTable('test1', {
+			id: int().primaryKey({ autoIncrement: true }),
+			name: text('name').notNull(),
+		}, (table) => ({
+			idx: index('test1_name_idx').on(table.name),
+		})),
+		table2: sqliteTable('test2', {
+			id: int().primaryKey({ autoIncrement: true }),
+			name: text('name').notNull(),
+		}, (table) => ({
+			unique: unique('test2_name_idx').on(table.name),
+		})),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.SchemaConstraintNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.SchemaConstraintNameCollisions);
 });
 
 test('table column name collisions #1', () => {
-  const schema = {
-    table: sqliteTable('test', {
-      id: int().primaryKey({ autoIncrement: true }),
-      firstName: text('first_name').notNull(),
-      lastName: text('last_name').notNull()
-    })
-  };
+	const schema = {
+		table: sqliteTable('test', {
+			id: int().primaryKey({ autoIncrement: true }),
+			firstName: text('first_name').notNull(),
+			lastName: text('last_name').notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.TableColumnNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #2', () => {
-  const schema = {
-    table: sqliteTable('test', {
-      id: int().primaryKey({ autoIncrement: true }),
-      firstName: text('first_name').notNull(),
-      lastName: text('first_name').notNull()
-    })
-  };
+	const schema = {
+		table: sqliteTable('test', {
+			id: int().primaryKey({ autoIncrement: true }),
+			firstName: text('first_name').notNull(),
+			lastName: text('first_name').notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.TableColumnNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #3', () => {
-  const schema = {
-    table: sqliteTable('test', {
-      id: int().primaryKey({ autoIncrement: true }),
-      firstName: text('last_name').notNull(),
-      lastName: text().notNull()
-    })
-  };
+	const schema = {
+		table: sqliteTable('test', {
+			id: int().primaryKey({ autoIncrement: true }),
+			firstName: text('last_name').notNull(),
+			lastName: text().notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.TableColumnNameCollisions);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #4', () => {
-  const schema = {
-    table: sqliteTable('test', {
-      id: int().primaryKey({ autoIncrement: true }),
-      firstName: text('last_name').notNull(),
-      lastName: text().notNull()
-    })
-  };
+	const schema = {
+		table: sqliteTable('test', {
+			id: int().primaryKey({ autoIncrement: true }),
+			firstName: text('last_name').notNull(),
+			lastName: text().notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    'snake_case',
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		'snake_case',
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.TableColumnNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.TableColumnNameCollisions);
 });
 
 test('table column name collisions #5', () => {
-  const schema = {
-    table: sqliteTable('test', {
-      id: int().primaryKey({ autoIncrement: true }),
-      first_name: text('lastName').notNull(),
-      last_name: text().notNull()
-    })
-  };
+	const schema = {
+		table: sqliteTable('test', {
+			id: int().primaryKey({ autoIncrement: true }),
+			first_name: text('lastName').notNull(),
+			last_name: text().notNull(),
+		}),
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    'camelCase',
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		'camelCase',
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.TableColumnNameCollisions);
+	expect(messages).length(1);
+	expect(codes).contains(Err.TableColumnNameCollisions);
 });
 
 test('foreign key mismatching column count #2', () => {
-  const table1 = sqliteTable('test1', {
-    id: int().primaryKey({ autoIncrement: true }),
-    c1: int().notNull(),
-    c2: int().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = sqliteTable('test2', {
-    c1: int().notNull(),
-    c2: int().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = sqliteTable('test1', {
+		id: int().primaryKey({ autoIncrement: true }),
+		c1: int().notNull(),
+		c2: int().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = sqliteTable('test2', {
+		c1: int().notNull(),
+		c2: int().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyMismatchingColumnCount);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyMismatchingColumnCount);
 });
 
 test('foreign key mismatching data types #1', () => {
-  const table1 = sqliteTable('test1', {
-    id: int().primaryKey({ autoIncrement: true }),
-    c1: int().notNull(),
-    c2: int().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = sqliteTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = sqliteTable('test1', {
+		id: int().primaryKey({ autoIncrement: true }),
+		c1: int().notNull(),
+		c2: int().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = sqliteTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.ForeignKeyMismatchingDataTypes);
+	expect(messages).length(1);
+	expect(codes).contains(Err.ForeignKeyMismatchingDataTypes);
 });
 
 test('foreign key mismatching data types #2', () => {
-  const table1 = sqliteTable('test1', {
-    id: int().primaryKey({ autoIncrement: true }),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = sqliteTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = sqliteTable('test1', {
+		id: int().primaryKey({ autoIncrement: true }),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = sqliteTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
 });
 
 test('foreign key columns mixing tables #1', () => {
-  const table1 = sqliteTable('test1', {
-    id: int().primaryKey({ autoIncrement: true }),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = sqliteTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = sqliteTable('test1', {
+		id: int().primaryKey({ autoIncrement: true }),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = sqliteTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(0);
-  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(0);
+	expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('foreign key columns mixing tables #2', () => {
-  const table1 = sqliteTable('test1', {
-    id: int().primaryKey({ autoIncrement: true }),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table2.c1, table.c2],
-      foreignColumns: [table2.c1, table2.c2],
-    })
-  }));
-  const table2 = sqliteTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = sqliteTable('test1', {
+		id: int().primaryKey({ autoIncrement: true }),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table2.c1, table.c2],
+			foreignColumns: [table2.c1, table2.c2],
+		}),
+	}));
+	const table2 = sqliteTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(1);
+	expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('foreign key columns mixing tables #3', () => {
-  const table1 = sqliteTable('test1', {
-    id: int().primaryKey({ autoIncrement: true }),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table.c2],
-      foreignColumns: [table2.c1, table.c2],
-    })
-  }));
-  const table2 = sqliteTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = sqliteTable('test1', {
+		id: int().primaryKey({ autoIncrement: true }),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table.c2],
+			foreignColumns: [table2.c1, table.c2],
+		}),
+	}));
+	const table2 = sqliteTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(1);
+	expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('foreign key columns mixing tables #4', () => {
-  const table1 = sqliteTable('test1', {
-    id: int().primaryKey({ autoIncrement: true }),
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: foreignKey({
-      columns: [table.c1, table2.c2],
-      foreignColumns: [table2.c1, table.c2],
-    })
-  }));
-  const table2 = sqliteTable('test2', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    pk: primaryKey({
-      columns: [table.c1, table.c2]
-    })
-  }));
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = sqliteTable('test1', {
+		id: int().primaryKey({ autoIncrement: true }),
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: foreignKey({
+			columns: [table.c1, table2.c2],
+			foreignColumns: [table2.c1, table.c2],
+		}),
+	}));
+	const table2 = sqliteTable('test2', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		pk: primaryKey({
+			columns: [table.c1, table.c2],
+		}),
+	}));
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(2);
-  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
-  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+	expect(messages).length(2);
+	expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+	expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
 });
 
 test('primary key columns mixing tables #1', () => {
-  const table1 = sqliteTable('test1', {
-    c1: int().notNull(),
-    c2: text().notNull()
-  }, (table) => ({
-    fk: primaryKey({
-      columns: [table2.c1, table.c2]
-    })
-  }));
-  const table2 = sqliteTable('test2', {
-    c1: int().notNull(),
-  });
-  const schema = {
-    table1,
-    table2
-  };
+	const table1 = sqliteTable('test1', {
+		c1: int().notNull(),
+		c2: text().notNull(),
+	}, (table) => ({
+		fk: primaryKey({
+			columns: [table2.c1, table.c2],
+		}),
+	}));
+	const table2 = sqliteTable('test2', {
+		c1: int().notNull(),
+	});
+	const schema = {
+		table1,
+		table2,
+	};
 
-  const { tables, views } = prepareFromExports(schema);
+	const { tables, views } = prepareFromExports(schema);
 
-  const { messages, codes } = validateSQLiteSchema(
-    undefined,
-    tables,
-    views,
-  );
+	const { messages, codes } = validateSQLiteSchema(
+		undefined,
+		tables,
+		views,
+	);
 
-  expect(messages).length(1);
-  expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
+	expect(messages).length(1);
+	expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
 });

--- a/drizzle-kit/tests/validate-schema/sqlite.test.ts
+++ b/drizzle-kit/tests/validate-schema/sqlite.test.ts
@@ -1,0 +1,496 @@
+import { expect, test } from 'vitest';
+import { validateSQLiteSchema } from 'src/validate-schema/validate';
+import { foreignKey, index, int, sqliteTable, sqliteView, primaryKey, text, unique } from 'drizzle-orm/sqlite-core';
+import { prepareFromExports } from 'src/serializer/sqliteImports';
+import { SchemaValidationErrors as Err } from 'src/validate-schema/errors';
+import { sql } from 'drizzle-orm';
+
+test('schema entity name collisions #1', () => {
+  const schema = {
+    table1: sqliteTable('test', {
+      id: int().primaryKey({ autoIncrement: true }),
+    }),
+    table2: sqliteTable('test', {
+      id: int().primaryKey({ autoIncrement: true })
+    }),
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaEntityNameCollisions);
+});
+
+test('schema entity name collisions #2', () => {
+  const schema = {
+    table: sqliteTable('test', {
+      id: int().primaryKey({ autoIncrement: true })
+    }),
+    view: sqliteView('test', {
+      id: int().primaryKey({ autoIncrement: true })
+    }).as(sql``)
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaEntityNameCollisions);
+});
+
+test('schema constraint name collisions #1', () => {
+  const schema = {
+    table1: sqliteTable('test1', {
+      id: int().primaryKey({ autoIncrement: true }),
+      name: text('name').notNull()
+    }, (table) => ({
+      idx: index('name_idx').on(table.name),
+    })),
+    table2: sqliteTable('test2', {
+      id: int().primaryKey({ autoIncrement: true }),
+      name: text('name').notNull()
+    }, (table) => ({
+      idx: index('name_idx').on(table.name),
+    })),
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.SchemaConstraintNameCollisions);
+});
+
+test('schema constraint name collisions #2', () => {
+  const schema = {
+    table1: sqliteTable('test1', {
+      id: int().primaryKey({ autoIncrement: true }),
+      name: text('name').notNull()
+    }, (table) => ({
+      idx: index('test1_name_idx').on(table.name),
+    })),
+    table2: sqliteTable('test2', {
+      id: int().primaryKey({ autoIncrement: true }),
+      name: text('name').notNull()
+    }, (table) => ({
+      unique: unique('test2_name_idx').on(table.name),
+    })),
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.SchemaConstraintNameCollisions);
+});
+
+test('table column name collisions #1', () => {
+  const schema = {
+    table: sqliteTable('test', {
+      id: int().primaryKey({ autoIncrement: true }),
+      firstName: text('first_name').notNull(),
+      lastName: text('last_name').notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #2', () => {
+  const schema = {
+    table: sqliteTable('test', {
+      id: int().primaryKey({ autoIncrement: true }),
+      firstName: text('first_name').notNull(),
+      lastName: text('first_name').notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #3', () => {
+  const schema = {
+    table: sqliteTable('test', {
+      id: int().primaryKey({ autoIncrement: true }),
+      firstName: text('last_name').notNull(),
+      lastName: text().notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #4', () => {
+  const schema = {
+    table: sqliteTable('test', {
+      id: int().primaryKey({ autoIncrement: true }),
+      firstName: text('last_name').notNull(),
+      lastName: text().notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    'snake_case',
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.TableColumnNameCollisions);
+});
+
+test('table column name collisions #5', () => {
+  const schema = {
+    table: sqliteTable('test', {
+      id: int().primaryKey({ autoIncrement: true }),
+      first_name: text('lastName').notNull(),
+      last_name: text().notNull()
+    })
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    'camelCase',
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.TableColumnNameCollisions);
+});
+
+test('foreign key mismatching column count #2', () => {
+  const table1 = sqliteTable('test1', {
+    id: int().primaryKey({ autoIncrement: true }),
+    c1: int().notNull(),
+    c2: int().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = sqliteTable('test2', {
+    c1: int().notNull(),
+    c2: int().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyMismatchingColumnCount);
+});
+
+test('foreign key mismatching data types #1', () => {
+  const table1 = sqliteTable('test1', {
+    id: int().primaryKey({ autoIncrement: true }),
+    c1: int().notNull(),
+    c2: int().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = sqliteTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.ForeignKeyMismatchingDataTypes);
+});
+
+test('foreign key mismatching data types #2', () => {
+  const table1 = sqliteTable('test1', {
+    id: int().primaryKey({ autoIncrement: true }),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = sqliteTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyMismatchingDataTypes);
+});
+
+test('foreign key columns mixing tables #1', () => {
+  const table1 = sqliteTable('test1', {
+    id: int().primaryKey({ autoIncrement: true }),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = sqliteTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(0);
+  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('foreign key columns mixing tables #2', () => {
+  const table1 = sqliteTable('test1', {
+    id: int().primaryKey({ autoIncrement: true }),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table2.c1, table.c2],
+      foreignColumns: [table2.c1, table2.c2],
+    })
+  }));
+  const table2 = sqliteTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).not.contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('foreign key columns mixing tables #3', () => {
+  const table1 = sqliteTable('test1', {
+    id: int().primaryKey({ autoIncrement: true }),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table.c2],
+      foreignColumns: [table2.c1, table.c2],
+    })
+  }));
+  const table2 = sqliteTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).not.contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('foreign key columns mixing tables #4', () => {
+  const table1 = sqliteTable('test1', {
+    id: int().primaryKey({ autoIncrement: true }),
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: foreignKey({
+      columns: [table.c1, table2.c2],
+      foreignColumns: [table2.c1, table.c2],
+    })
+  }));
+  const table2 = sqliteTable('test2', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    pk: primaryKey({
+      columns: [table.c1, table.c2]
+    })
+  }));
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(2);
+  expect(codes).contains(Err.ForeignKeyColumnsMixingTables);
+  expect(codes).contains(Err.ForeignKeyForeignColumnsMixingTables);
+});
+
+test('primary key columns mixing tables #1', () => {
+  const table1 = sqliteTable('test1', {
+    c1: int().notNull(),
+    c2: text().notNull()
+  }, (table) => ({
+    fk: primaryKey({
+      columns: [table2.c1, table.c2]
+    })
+  }));
+  const table2 = sqliteTable('test2', {
+    c1: int().notNull(),
+  });
+  const schema = {
+    table1,
+    table2
+  };
+
+  const { tables, views } = prepareFromExports(schema);
+
+  const { messages, codes } = validateSQLiteSchema(
+    undefined,
+    tables,
+    views,
+  );
+
+  expect(messages).length(1);
+  expect(codes).contains(Err.PrimaryKeyColumnsMixingTables);
+});

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -124,7 +124,7 @@ export abstract class PgColumnBuilder<
 	buildExtraConfigColumn<TTableName extends string>(
 		table: AnyPgTable<{ name: TTableName }>,
 	): ExtraConfigColumn {
-		return new ExtraConfigColumn(table, this.config);
+		return new ExtraConfigColumn(table, this.config, this.build(table));
 	}
 }
 
@@ -154,9 +154,16 @@ export class ExtraConfigColumn<
 > extends PgColumn<T, IndexedExtraConfigType> {
 	static readonly [entityKind]: string = 'ExtraConfigColumn';
 
-	override getSQLType(): string {
-		return this.getSQLType();
+	constructor(
+		override readonly table: PgTable,
+		config: ColumnBuilderRuntimeConfig<T['data'], IndexedExtraConfigType>,
+		builtColumn: PgColumn<T>,
+	) {
+		super(table, config);
+		this.getSQLType = builtColumn.getSQLType;
 	}
+
+	override getSQLType: () => string;
 
 	indexConfig: IndexedExtraConfigType = {
 		order: this.config.order ?? 'asc',


### PR DESCRIPTION
Addresses #272, #1031, #1766, #2667, #3325 and #2802.

This PR adds checks/validations for your Typescript schema for any dialect. This validation occurs during the `generate` and `push` commands in Drizzle Kit, giving detailed errors as to what went wrong and how you can fix them. If no errors were found, it will continue executing the respective command, otherwise it will stop execution and you'll have to fix those errors.

An example of what running a command that includes this validation looks like:
![Screenshot_2024-10-02_103934](https://github.com/user-attachments/assets/07c54040-b9cc-48b0-be1f-b5fafb788539)

The following checks are performed:
- Schema has a unique name (PG).
- Entity (entity = table, view, materialized view, enum, sequence) has a unique name within the schema.
- Constraint and index (primary key, foreign key, check, unique, index, unique index) has a unique name within the schema.
- Values in an enum are unique (PG).
- Sequence has valid values. This includes checking for an invalid increment, min and max value.
- Columns have a unique name within each table. This also takes into account implicit and explicit column aliases.
- Columns in a primary key belong to the same table.
- The amount of columns in a foreign key match the amount of columns that it references.
- Foreign key's columns and referenced columns have have the same data types.
- Columns in a foreign key belongs to the same table.
- Referenced columns in a foreign key belongs to the same table.
- Whether the index requires a manually defined name (PG).
- Vector type column in an index has an operator class (PG).

Misc. notes:
- Fixed an infinitely recursive method in the `ExtraConfigColumn` class located at `drizzle-orm/src/pg-core/columns/common.ts`.