### PR TITLE
fix: allows crudPolicy to skip generating policies, adds TSDoc to crudPolicy function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ To understand how test should be created and run - please check [Run tests](#-ru
 
 📂 extensions/ - all the extension helpers for databases
 
-📂 serialaizer/ - all the necessary logic to read from the Drizzle ORM schema and convert it to a common JSON format, as well as the logic to introspect all tables, types, and other database elements and convert them to a common JSON format
+📂 serializer/ - all the necessary logic to read from the Drizzle ORM schema and convert it to a common JSON format, as well as the logic to introspect all tables, types, and other database elements and convert them to a common JSON format
 
 📄 introspect-pg.ts, introspect-mysql.ts, introspect-sqlite.ts - these files are responsible for mapping JSON snapshots to TypeScript files during introspect commands
 

--- a/drizzle-orm/src/neon/rls.ts
+++ b/drizzle-orm/src/neon/rls.ts
@@ -1,65 +1,98 @@
-import { is } from '~/entity.ts';
-import { type AnyPgColumn, pgPolicy, type PgPolicyToOption } from '~/pg-core/index.ts';
-import { PgRole, pgRole } from '~/pg-core/roles.ts';
-import { type SQL, sql } from '~/sql/sql.ts';
+import { is } from "~/entity.ts";
+import {
+  type AnyPgColumn,
+  pgPolicy,
+  type PgPolicyToOption,
+} from "~/pg-core/index.ts";
+import { PgRole, pgRole } from "~/pg-core/roles.ts";
+import { type SQL, sql } from "~/sql/sql.ts";
 
+/**
+ * Generates a set of PostgreSQL row-level security (RLS) policies for CRUD operations based on the provided options.
+ *
+ * @param options - An object containing the policy configuration.
+ * @param options.role - The PostgreSQL role(s) to apply the policy to. Can be a single `PgRole` instance or an array of `PgRole` instances or role names.
+ * @param options.read - The SQL expression or boolean value that defines the read policy. Set to `true` to allow all reads, `false` to deny all reads, or provide a custom SQL expression. Set to `null` to prevent the policy from being generated.
+ * @param options.modify - The SQL expression or boolean value that defines the modify (insert, update, delete) policies. Set to `true` to allow all modifications, `false` to deny all modifications, or provide a custom SQL expression. Set to `null` to prevent policies from being generated.
+ * @returns An array of PostgreSQL policy definitions, one for each CRUD operation.
+ */
 export const crudPolicy = (options: {
-	role: PgPolicyToOption;
-	read?: SQL | boolean;
-	modify?: SQL | boolean;
+  role: PgPolicyToOption;
+  read: SQL | boolean | null;
+  modify: SQL | boolean | null;
 }) => {
-	const read: SQL = options.read === true
-		? sql`true`
-		: options.read === false || options.read === undefined
-		? sql`false`
-		: options.read;
+  if (options.read === undefined) {
+    throw new Error("crudPolicy requires a read policy");
+  }
 
-	const modify: SQL = options.modify === true
-		? sql`true`
-		: options.modify === false || options.modify === undefined
-		? sql`false`
-		: options.modify;
+  if (options.modify === undefined) {
+    throw new Error("crudPolicy requires a modify policy");
+  }
 
-	let rolesName = '';
-	if (Array.isArray(options.role)) {
-		rolesName = options.role
-			.map((it) => {
-				return is(it, PgRole) ? it.name : (it as string);
-			})
-			.join('-');
-	} else {
-		rolesName = is(options.role, PgRole)
-			? options.role.name
-			: (options.role as string);
-	}
+  let read: SQL | undefined;
+  if (options.read === true) {
+    read = sql`true`;
+  } else if (options.read === false) {
+    read = sql`false`;
+  } else if (options.read !== null) {
+    read = options.read;
+  }
 
-	return [
-		pgPolicy(`crud-${rolesName}-policy-insert`, {
-			for: 'insert',
-			to: options.role,
-			withCheck: modify,
-		}),
-		pgPolicy(`crud-${rolesName}-policy-update`, {
-			for: 'update',
-			to: options.role,
-			using: modify,
-			withCheck: modify,
-		}),
-		pgPolicy(`crud-${rolesName}-policy-delete`, {
-			for: 'delete',
-			to: options.role,
-			using: modify,
-		}),
-		pgPolicy(`crud-${rolesName}-policy-select`, {
-			for: 'select',
-			to: options.role,
-			using: read,
-		}),
-	];
+  let modify: SQL | undefined;
+  if (options.modify === true) {
+    modify = sql`true`;
+  } else if (options.modify === false) {
+    modify = sql`false`;
+  } else if (options.modify !== null) {
+    modify = options.modify;
+  }
+
+  let rolesName = "";
+  if (Array.isArray(options.role)) {
+    rolesName = options.role
+      .map((it) => {
+        return is(it, PgRole) ? it.name : (it as string);
+      })
+      .join("-");
+  } else {
+    rolesName = is(options.role, PgRole)
+      ? options.role.name
+      : (options.role as string);
+  }
+
+  return [
+    read &&
+      pgPolicy(`crud-${rolesName}-policy-select`, {
+        for: "select",
+        to: options.role,
+        using: read,
+      }),
+
+    modify &&
+      pgPolicy(`crud-${rolesName}-policy-insert`, {
+        for: "insert",
+        to: options.role,
+        withCheck: modify,
+      }),
+    modify &&
+      pgPolicy(`crud-${rolesName}-policy-update`, {
+        for: "update",
+        to: options.role,
+        using: modify,
+        withCheck: modify,
+      }),
+    modify &&
+      pgPolicy(`crud-${rolesName}-policy-delete`, {
+        for: "delete",
+        to: options.role,
+        using: modify,
+      }),
+  ].filter(Boolean);
 };
 
 // These are default roles that Neon will set up.
-export const authenticatedRole = pgRole('authenticated').existing();
-export const anonymousRole = pgRole('anonymous').existing();
+export const authenticatedRole = pgRole("authenticated").existing();
+export const anonymousRole = pgRole("anonymous").existing();
 
-export const authUid = (userIdColumn: AnyPgColumn) => sql`(select auth.user_id() = ${userIdColumn})`;
+export const authUid = (userIdColumn: AnyPgColumn) =>
+  sql`(select auth.user_id() = ${userIdColumn})`;


### PR DESCRIPTION
* Adds support for `crudPolicy` to **skip** generating policies if `read` or `write` are `null`
* Adds TSDoc documentation to the `crudPolicy` function
* Fixes typo in `CONTRIBUTING.md`