### PR TITLE
[drizzle-kit] Change to create the drizzle studio directory on studio command execution instead of on import

### DIFF
--- a/drizzle-kit/src/utils/certs.ts
+++ b/drizzle-kit/src/utils/certs.ts
@@ -1,6 +1,5 @@
 import envPaths from 'env-paths';
-import { mkdirSync } from 'fs';
-import { access, readFile } from 'fs/promises';
+import { access, mkdir, readFile } from 'fs/promises';
 import { join } from 'path';
 import { $ } from 'zx';
 
@@ -10,9 +9,10 @@ const p = envPaths('drizzle-studio', {
 
 $.verbose = false;
 $.cwd = p.data;
-mkdirSync(p.data, { recursive: true });
 
 export const certs = async () => {
+	await mkdir(p.data, { recursive: true });
+
 	const res = await $`mkcert --help`.nothrow();
 
 	// ~/.local/share/drizzle-studio
@@ -33,5 +33,3 @@ export const certs = async () => {
 	}
 	return null;
 };
-
-certs();


### PR DESCRIPTION
Change to create the drizzle studio directory on studio command execution instead of on import.

### Background
Regarding application operation in k8s:
- For web applications, setting `securityContext.readOnlyRootFilesystem` to `true` is a common security recommendation
- It's a common workflow to perform database migrations through k8s jobs using the app's docker image during deployment
- Despite only needing to call the migrate command, drizzle-kit forcibly creates a drizzle studio directory
- Due to this write operation by drizzle-kit, we cannot set `securityContext.readOnlyRootFilesystem` to `true`

Currently, we work around this issue by including the directory in the docker image beforehand. However, this workaround is undesirable.