### PR TITLE
[drizzle-kit] move @esbuild-kit/esm-loader to devDependencies

### DIFF
--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -44,7 +44,6 @@
 	},
 	"dependencies": {
 		"@drizzle-team/brocli": "^0.10.2",
-		"@esbuild-kit/esm-loader": "^2.5.5",
 		"esbuild": "^0.19.7",
 		"esbuild-register": "^3.5.0",
 		"gel": "^2.0.0"
@@ -54,6 +53,7 @@
 		"@aws-sdk/client-rds-data": "^3.556.0",
 		"@cloudflare/workers-types": "^4.20230518.0",
 		"@electric-sql/pglite": "^0.2.12",
+		"@esbuild-kit/esm-loader": "^2.5.5",
 		"@hono/node-server": "^1.9.0",
 		"@hono/zod-validator": "^0.2.1",
 		"@libsql/client": "^0.10.0",


### PR DESCRIPTION
@esbuild-kit/esm-loader package (recently marked depracated) is only required in development, not used in end-user environments.

Moving it to devDepencies removes the following installation warnings:
> 2 deprecated subdependencies found: @esbuild-kit/core-utils@3.3.2, @esbuild-kit/esm-loader@2.6.5

Fixes #3067