### PR TITLE
[Driggle kit] fix driggle-kit push  to cockrouch

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -2038,7 +2038,7 @@ const getColumnsInfoQuery = ({ schema, table, db }: { schema: string; table: str
     END AS is_nullable,  -- NULL or NOT NULL constraint
     a.attndims AS array_dimensions,  -- Array dimensions
     CASE 
-        WHEN a.atttypid = ANY ('{int,int8,int2}'::regtype[]) 
+        WHEN a.atttypid = 'int'::regtype OR a.atttypid = 'int2'::regtype OR a.atttypid = 'int8'::regtype
         AND EXISTS (
             SELECT FROM pg_attrdef ad
             WHERE ad.adrelid = a.attrelid 

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1658,7 +1658,7 @@ WHERE
 						uniqueConstraints: uniqueConstrains,
 						checkConstraints: checkConstraints,
 						policies: policiesByTable[`${tableSchema}.${tableName}`] ?? {},
-						isRLSEnabled: row.rls_enabled,
+						isRLSEnabled: row.rls_enabled ?? false,
 					};
 				} catch (e) {
 					rej(e);


### PR DESCRIPTION
I tried using Driggle with CockroachDB, but I encountered some errors with driggle-kit push, so I fixed them.

and 

driggle-studio not woking.
this Query is not support. need where trace_id = ... .
UNION ALL SELECT 'cluster_inflight_traces' AS table_name, count(*) AS count FROM "crdb_internal"."cluster_inflight_traces"