### PR TITLE
fix(1113): timestamp mode 'date' returns value.toISOString is not a function for parameterized inserts

### DIFF
--- a/drizzle-orm/src/pg-core/columns/timestamp.ts
+++ b/drizzle-orm/src/pg-core/columns/timestamp.ts
@@ -63,8 +63,8 @@ export class PgTimestamp<T extends ColumnBaseConfig<'date', 'PgTimestamp'>> exte
 		return new Date(this.withTimezone ? value : value + '+0000');
 	};
 
-	override mapToDriverValue = (value: Date): string => {
-		return value.toISOString();
+	override mapToDriverValue = (value: Date | string): string => {
+		return new Date(value).toISOString();
 	};
 }
 


### PR DESCRIPTION
Fixed for #1113