### PR TITLE
[Drizzle-Kit]: ignore column type casing when finding alternations

### DIFF
--- a/drizzle-kit/src/jsonDiffer.js
+++ b/drizzle-kit/src/jsonDiffer.js
@@ -576,7 +576,7 @@ const alternationsInColumn = (column) => {
 
 	const result = altered
 		.filter((it) => {
-			if ('type' in it && it.type.__old.replace(' (', '(') === it.type.__new.replace(' (', '(')) {
+			if ('type' in it && it.type.__old.toLowerCase().replace(' (', '(') === it.type.__new.toLowerCase().replace(' (', '(')) {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
Fixes this issue with the `pushSchema` API, it looks like the database automatically formats `geometry(point)` to `geometry(Point)`, and although it's the same type, Drizzle-Kit thinks it's changed and prints the alter column type prompt:


![image](https://github.com/user-attachments/assets/ea059477-1a1b-409e-ae17-2d0836fef773)

Now we ignore the casing when checking whether the column type was changed.

