### PR TITLE
[drizzle-kit]: fix postgresjs returns array not rows in object

### DIFF
--- a/drizzle-kit/src/api.ts
+++ b/drizzle-kit/src/api.ts
@@ -114,7 +114,7 @@ export const pushSchema = async (
 	const db: DB = {
 		query: async (query: string, params?: any[]) => {
 			const res = await drizzleInstance.execute(sql.raw(query));
-			return res.rows;
+			return "rows" in res ? res.rows : res;
 		},
 	};
 


### PR DESCRIPTION
`drizzleInstance.execute` returns `T[]` instead of `{ rows: T[] }` when using postgresjs