### PR TITLE
[drizzle-kit] fix: exclude _cf_KV table

### DIFF
--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -864,7 +864,7 @@ WHERE
 	const checkConstraints: Record<string, CheckConstraint> = {};
 	const checks = await db.query<{ tableName: string; sql: string }>(`SELECT name as "tableName", sql as "sql"
 		FROM sqlite_master 
-		WHERE type = 'table' AND name != 'sqlite_sequence';`);
+		WHERE type = 'table' AND name != 'sqlite_sequence' and name != '_cf_KV';`);
 	for (const check of checks) {
 		if (!tablesFilter(check.tableName)) continue;
 


### PR DESCRIPTION
Exclude the _cf_KV table from the results when searching for check constraints.

This PR solves the following problems
https://github.com/drizzle-team/drizzle-orm/issues/3728

Push to d1 can be executed successfully with this PR and #2941.

