### PR TITLE
fix(3554) Emit valid SQL for `noWait` flag

### DIFF
--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -359,7 +359,7 @@ export class MySqlDialect {
 			const { config, strength } = lockingClause;
 			lockingClausesSql = sql` for ${sql.raw(strength)}`;
 			if (config.noWait) {
-				lockingClausesSql.append(sql` no wait`);
+				lockingClausesSql.append(sql` nowait`);
 			} else if (config.skipLocked) {
 				lockingClausesSql.append(sql` skip locked`);
 			}

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -389,7 +389,7 @@ export class PgDialect {
 				);
 			}
 			if (lockingClause.config.noWait) {
-				clauseSql.append(sql` no wait`);
+				clauseSql.append(sql` nowait`);
 			} else if (lockingClause.config.skipLocked) {
 				clauseSql.append(sql` skip locked`);
 			}

--- a/integration-tests/tests/mysql/mysql-common.ts
+++ b/integration-tests/tests/mysql/mysql-common.ts
@@ -1846,7 +1846,7 @@ export function tests(driver?: string) {
 			}
 			{
 				const query = db.select().from(users2Table).for('update', { noWait: true }).toSQL();
-				expect(query.sql).toMatch(/ for update no wait$/);
+				expect(query.sql).toMatch(/ for update nowait$/);
 			}
 		});
 

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -2035,7 +2035,7 @@ export function tests() {
 					.for('share', { of: users2Table, noWait: true })
 					.toSQL();
 
-				expect(query.sql).toMatch(/for share of "users2" no wait$/);
+				expect(query.sql).toMatch(/for share of "users2" nowait$/);
 			}
 		});
 


### PR DESCRIPTION
Fixes #3554 for PostgreSQL and MySQL. Both databases seem to have chosen to spell "no wait" and "skip locked" flags as one word and two words respectively. 

https://dev.mysql.com/doc/refman/8.4/en/innodb-locking-reads.html

https://www.postgresql.org/docs/16/sql-select.html#:~:text=The%20locking%20clause%20has,%5B%2C%20...%5D%20%5D%20%5B%20NOWAIT%20%7C%20SKIP%20LOCKED%20%5D