### PR TITLE
[drizzle-kit] Test function calls as default value for PG

### DIFF
--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -892,3 +892,22 @@ test('multiple policies with roles from schema', async () => {
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
 });
+
+test('default-function-call', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		foo: pgTable('foo', {
+			bar: text('bar').default(sql`md5('baz')`),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'default-functions-call',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});


### PR DESCRIPTION
In specific case, `drizzle-kit pull` is not able to generate a valid schema. This test checks if drizzle is able to generate the default value for `md5('str')`.

Relates to #3593 