### PR TITLE
[SQL] Add extract aggregate function

### DIFF
--- a/drizzle-orm/src/sql/functions/aggregate.ts
+++ b/drizzle-orm/src/sql/functions/aggregate.ts
@@ -127,3 +127,23 @@ export function max<T extends SQLWrapper>(expression: T): SQL<(T extends AnyColu
 export function min<T extends SQLWrapper>(expression: T): SQL<(T extends AnyColumn ? T['_']['data'] : string) | null> {
 	return sql`min(${expression})`.mapWith(is(expression, Column) ? expression : String) as any;
 }
+
+/**
+ * Returns subfields such as year or hour from date/time values.
+ * 
+ * ## NOTE
+ * The `field` parameter will vary depending on the SQL dialect used.
+ *
+ * ## Examples
+ *
+ * ```ts
+ * // Get the month from the `employedAt` column
+ * db.select({ month: extract('MONTH', employees.employedAt) }).from(employees)
+ *
+ * // Get all employees that were employed in January
+ * db.select().from(employees).where(eq(extract('MONTH', employees.employedAt), 1))
+ * ```
+ */
+export function extract(field: string, expression: SQLWrapper): SQL<number> {
+	return sql`extract(${field} from ${expression})`.mapWith(Number);
+}


### PR DESCRIPTION
This pull request introduces a new `extract` aggregate fuction used for returning subfields such as year or hour from date/time values.

I did not add anything other than the function.

Build, tests and lint are still OK.

I am not sure on how to test the new feature since I could not find examples on how the other aggregate functions have been tested.

Closes: #3610