### PR TITLE
Extended Neon HTTP `$withAuth` token variants

### DIFF
--- a/drizzle-orm/src/neon-http/driver.ts
+++ b/drizzle-orm/src/neon-http/driver.ts
@@ -8,7 +8,7 @@ import { PgDatabase } from '~/pg-core/db.ts';
 import { PgDialect } from '~/pg-core/dialect.ts';
 import { createTableRelationsHelpers, extractTablesRelationalConfig } from '~/relations.ts';
 import type { ExtractTablesWithRelations, RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
-import { type DrizzleConfig, isConfig, type NeonAuthToken } from '~/utils.ts';
+import { type DrizzleConfig, isConfig } from '~/utils.ts';
 import { type NeonHttpClient, type NeonHttpQueryResultHKT, NeonHttpSession } from './session.ts';
 
 export interface NeonDriverOptions {
@@ -42,7 +42,7 @@ export class NeonHttpDriver {
 
 function wrap<T extends object>(
 	target: T,
-	token: NeonAuthToken,
+	token: Exclude<HTTPQueryOptions<true, true>['authToken'], undefined>,
 	cb: (target: any, p: string | symbol, res: any) => any,
 	deep?: boolean,
 ) {

--- a/drizzle-orm/src/neon-http/driver.ts
+++ b/drizzle-orm/src/neon-http/driver.ts
@@ -1,4 +1,4 @@
-import type { HTTPTransactionOptions, NeonQueryFunction } from '@neondatabase/serverless';
+import type { HTTPQueryOptions, HTTPTransactionOptions, NeonQueryFunction } from '@neondatabase/serverless';
 import { neon, types } from '@neondatabase/serverless';
 import type { BatchItem, BatchResponse } from '~/batch.ts';
 import { entityKind } from '~/entity.ts';
@@ -73,7 +73,7 @@ export class NeonHttpDatabase<
 	static override readonly [entityKind]: string = 'NeonHttpDatabase';
 
 	$withAuth(
-		token: NeonAuthToken,
+		token: Exclude<HTTPQueryOptions<true, true>['authToken'], undefined>,
 	): Omit<
 		this,
 		Exclude<

--- a/drizzle-orm/src/neon-http/session.ts
+++ b/drizzle-orm/src/neon-http/session.ts
@@ -11,7 +11,7 @@ import { PgPreparedQuery as PgPreparedQuery, PgSession } from '~/pg-core/session
 import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
 import { fillPlaceholders, type Query, type SQL } from '~/sql/sql.ts';
-import { mapResultRow } from '~/utils.ts';
+import { mapResultRow, type NeonAuthToken } from '~/utils.ts';
 
 export type NeonHttpClient = NeonQueryFunction<any, any>;
 
@@ -40,11 +40,11 @@ export class NeonHttpPreparedQuery<T extends PreparedQueryConfig> extends PgPrep
 
 	async execute(placeholderValues: Record<string, unknown> | undefined): Promise<T['execute']>;
 	/** @internal */
-	async execute(placeholderValues: Record<string, unknown> | undefined, token?: string): Promise<T['execute']>;
+	async execute(placeholderValues: Record<string, unknown> | undefined, token?: NeonAuthToken): Promise<T['execute']>;
 	/** @internal */
 	async execute(
 		placeholderValues: Record<string, unknown> | undefined = {},
-		token: string | undefined = this.authToken,
+		token: NeonAuthToken | undefined = this.authToken,
 	): Promise<T['execute']> {
 		const params = fillPlaceholders(this.query.params, placeholderValues);
 
@@ -108,9 +108,9 @@ export class NeonHttpPreparedQuery<T extends PreparedQueryConfig> extends PgPrep
 
 	values(placeholderValues: Record<string, unknown> | undefined): Promise<T['values']>;
 	/** @internal */
-	values(placeholderValues: Record<string, unknown> | undefined, token?: string): Promise<T['values']>;
+	values(placeholderValues: Record<string, unknown> | undefined, token?: NeonAuthToken): Promise<T['values']>;
 	/** @internal */
-	values(placeholderValues: Record<string, unknown> | undefined = {}, token?: string): Promise<T['values']> {
+	values(placeholderValues: Record<string, unknown> | undefined = {}, token?: NeonAuthToken): Promise<T['values']> {
 		const params = fillPlaceholders(this.query.params, placeholderValues);
 		this.logger.logQuery(this.query.sql, params);
 		return this.client(this.query.sql, params, { arrayMode: true, fullResults: true, authToken: token }).then((
@@ -203,9 +203,9 @@ export class NeonHttpSession<
 
 	override async count(sql: SQL): Promise<number>;
 	/** @internal */
-	override async count(sql: SQL, token?: string): Promise<number>;
+	override async count(sql: SQL, token?: NeonAuthToken): Promise<number>;
 	/** @internal */
-	override async count(sql: SQL, token?: string): Promise<number> {
+	override async count(sql: SQL, token?: NeonAuthToken): Promise<number> {
 		const res = await this.execute<{ rows: [{ count: string }] }>(sql, token);
 
 		return Number(

--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -21,7 +21,7 @@ import type { ExtractTablesWithRelations, RelationalSchemaConfig, TablesRelation
 import { SelectionProxyHandler } from '~/selection-proxy.ts';
 import { type ColumnsSelection, type SQL, sql, type SQLWrapper } from '~/sql/sql.ts';
 import { WithSubquery } from '~/subquery.ts';
-import type { DrizzleTypeError } from '~/utils.ts';
+import type { DrizzleTypeError, NeonAuthToken } from '~/utils.ts';
 import type { PgColumn } from './columns/index.ts';
 import { PgCountBuilder } from './query-builders/count.ts';
 import { RelationalQueryBuilder } from './query-builders/query.ts';
@@ -597,7 +597,7 @@ export class PgDatabase<
 		return new PgRefreshMaterializedView(view, this.session, this.dialect);
 	}
 
-	protected authToken?: string;
+	protected authToken?: NeonAuthToken;
 
 	execute<TRow extends Record<string, unknown> = Record<string, unknown>>(
 		query: SQLWrapper | string,

--- a/drizzle-orm/src/pg-core/query-builders/count.ts
+++ b/drizzle-orm/src/pg-core/query-builders/count.ts
@@ -51,6 +51,7 @@ export class PgCountBuilder<
 	/** @intrnal */
 	setToken(token?: NeonAuthToken) {
 		this.token = token;
+		return this;
 	}
 
 	then<TResult1 = number, TResult2 = never>(

--- a/drizzle-orm/src/pg-core/query-builders/count.ts
+++ b/drizzle-orm/src/pg-core/query-builders/count.ts
@@ -1,5 +1,6 @@
 import { entityKind } from '~/entity.ts';
 import { SQL, sql, type SQLWrapper } from '~/sql/sql.ts';
+import type { NeonAuthToken } from '~/utils.ts';
 import type { PgSession } from '../session.ts';
 import type { PgTable } from '../table.ts';
 
@@ -7,7 +8,7 @@ export class PgCountBuilder<
 	TSession extends PgSession<any, any, any>,
 > extends SQL<number> implements Promise<number>, SQLWrapper {
 	private sql: SQL<number>;
-	private token?: string;
+	private token?: NeonAuthToken;
 
 	static override readonly [entityKind] = 'PgCountBuilder';
 	[Symbol.toStringTag] = 'PgCountBuilder';
@@ -48,7 +49,7 @@ export class PgCountBuilder<
 	}
 
 	/** @intrnal */
-	setToken(token: string) {
+	setToken(token?: NeonAuthToken) {
 		this.token = token;
 	}
 

--- a/drizzle-orm/src/pg-core/query-builders/delete.ts
+++ b/drizzle-orm/src/pg-core/query-builders/delete.ts
@@ -15,7 +15,7 @@ import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
 import type { Subquery } from '~/subquery.ts';
 import { Table } from '~/table.ts';
 import { tracer } from '~/tracing.ts';
-import { orderSelectedFields } from '~/utils.ts';
+import { type NeonAuthToken, orderSelectedFields } from '~/utils.ts';
 import type { PgColumn } from '../columns/common.ts';
 import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
 
@@ -232,9 +232,9 @@ export class PgDeleteBase<
 		return this._prepare(name);
 	}
 
-	private authToken?: string;
+	private authToken?: NeonAuthToken;
 	/** @internal */
-	setToken(token: string) {
+	setToken(token?: NeonAuthToken) {
 		this.authToken = token;
 		return this;
 	}

--- a/drizzle-orm/src/pg-core/query-builders/insert.ts
+++ b/drizzle-orm/src/pg-core/query-builders/insert.ts
@@ -19,7 +19,7 @@ import type { Subquery } from '~/subquery.ts';
 import type { InferInsertModel } from '~/table.ts';
 import { Columns, Table } from '~/table.ts';
 import { tracer } from '~/tracing.ts';
-import { haveSameKeys, mapUpdateSet, orderSelectedFields } from '~/utils.ts';
+import { haveSameKeys, mapUpdateSet, type NeonAuthToken, orderSelectedFields } from '~/utils.ts';
 import type { AnyPgColumn, PgColumn } from '../columns/common.ts';
 import { QueryBuilder } from './query-builder.ts';
 import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
@@ -63,9 +63,9 @@ export class PgInsertBuilder<
 		private overridingSystemValue_?: boolean,
 	) {}
 
-	private authToken?: string;
+	private authToken?: NeonAuthToken;
 	/** @internal */
-	setToken(token: string) {
+	setToken(token?: NeonAuthToken) {
 		this.authToken = token;
 		return this;
 	}
@@ -94,25 +94,15 @@ export class PgInsertBuilder<
 			return result;
 		});
 
-		return this.authToken === undefined
-			? new PgInsertBase(
-				this.table,
-				mappedValues,
-				this.session,
-				this.dialect,
-				this.withList,
-				false,
-				this.overridingSystemValue_,
-			)
-			: new PgInsertBase(
-				this.table,
-				mappedValues,
-				this.session,
-				this.dialect,
-				this.withList,
-				false,
-				this.overridingSystemValue_,
-			).setToken(this.authToken) as any;
+		return new PgInsertBase(
+			this.table,
+			mappedValues,
+			this.session,
+			this.dialect,
+			this.withList,
+			false,
+			this.overridingSystemValue_,
+		).setToken(this.authToken) as any;
 	}
 
 	select(selectQuery: (qb: QueryBuilder) => PgInsertSelectQueryBuilder<TTable>): PgInsertBase<TTable, TQueryResult>;
@@ -402,9 +392,9 @@ export class PgInsertBase<
 		return this._prepare(name);
 	}
 
-	private authToken?: string;
+	private authToken?: NeonAuthToken;
 	/** @internal */
-	setToken(token: string) {
+	setToken(token?: NeonAuthToken) {
 		this.authToken = token;
 		return this;
 	}

--- a/drizzle-orm/src/pg-core/query-builders/query.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query.ts
@@ -11,7 +11,7 @@ import {
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, QueryWithTypings, SQL, SQLWrapper } from '~/sql/sql.ts';
 import { tracer } from '~/tracing.ts';
-import type { KnownKeysOnly } from '~/utils.ts';
+import type { KnownKeysOnly, NeonAuthToken } from '~/utils.ts';
 import type { PgDialect } from '../dialect.ts';
 import type { PgPreparedQuery, PgSession, PreparedQueryConfig } from '../session.ts';
 import type { PgTable } from '../table.ts';
@@ -142,9 +142,9 @@ export class PgRelationalQuery<TResult> extends QueryPromise<TResult>
 		return this._toSQL().builtQuery;
 	}
 
-	private authToken?: string;
+	private authToken?: NeonAuthToken;
 	/** @internal */
-	setToken(token: string) {
+	setToken(token?: NeonAuthToken) {
 		this.authToken = token;
 		return this;
 	}

--- a/drizzle-orm/src/pg-core/query-builders/refresh-materialized-view.ts
+++ b/drizzle-orm/src/pg-core/query-builders/refresh-materialized-view.ts
@@ -12,6 +12,7 @@ import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
 import { tracer } from '~/tracing.ts';
+import type { NeonAuthToken } from '~/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface PgRefreshMaterializedView<TQueryResult extends PgQueryResultHKT>
@@ -92,9 +93,9 @@ export class PgRefreshMaterializedView<TQueryResult extends PgQueryResultHKT>
 		return this._prepare(name);
 	}
 
-	private authToken?: string;
+	private authToken?: NeonAuthToken;
 	/** @internal */
-	setToken(token: string) {
+	setToken(token: NeonAuthToken) {
 		this.authToken = token;
 		return this;
 	}

--- a/drizzle-orm/src/pg-core/query-builders/update.ts
+++ b/drizzle-orm/src/pg-core/query-builders/update.ts
@@ -25,7 +25,14 @@ import { SelectionProxyHandler } from '~/selection-proxy.ts';
 import { type ColumnsSelection, type Query, SQL, type SQLWrapper } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { Table } from '~/table.ts';
-import { type Assume, getTableLikeName, mapUpdateSet, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import {
+	type Assume,
+	getTableLikeName,
+	mapUpdateSet,
+	type NeonAuthToken,
+	orderSelectedFields,
+	type UpdateSet,
+} from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type { PgColumn } from '../columns/common.ts';
 import type { PgViewBase } from '../view-base.ts';
@@ -64,8 +71,8 @@ export class PgUpdateBuilder<TTable extends PgTable, TQueryResult extends PgQuer
 		private withList?: Subquery[],
 	) {}
 
-	private authToken?: string;
-	setToken(token: string) {
+	private authToken?: NeonAuthToken;
+	setToken(token: NeonAuthToken) {
 		this.authToken = token;
 		return this;
 	}
@@ -73,21 +80,13 @@ export class PgUpdateBuilder<TTable extends PgTable, TQueryResult extends PgQuer
 	set(
 		values: PgUpdateSetSource<TTable>,
 	): PgUpdateWithout<PgUpdateBase<TTable, TQueryResult>, false, 'leftJoin' | 'rightJoin' | 'innerJoin' | 'fullJoin'> {
-		return this.authToken === undefined
-			? new PgUpdateBase<TTable, TQueryResult>(
-				this.table,
-				mapUpdateSet(this.table, values),
-				this.session,
-				this.dialect,
-				this.withList,
-			)
-			: new PgUpdateBase<TTable, TQueryResult>(
-				this.table,
-				mapUpdateSet(this.table, values),
-				this.session,
-				this.dialect,
-				this.withList,
-			).setToken(this.authToken);
+		return new PgUpdateBase<TTable, TQueryResult>(
+			this.table,
+			mapUpdateSet(this.table, values),
+			this.session,
+			this.dialect,
+			this.withList,
+		).setToken(this.authToken);
 	}
 }
 
@@ -548,9 +547,9 @@ export class PgUpdateBase<
 		return this._prepare(name);
 	}
 
-	private authToken?: string;
+	private authToken?: NeonAuthToken;
 	/** @internal */
-	setToken(token: string) {
+	setToken(token?: NeonAuthToken) {
 		this.authToken = token;
 		return this;
 	}

--- a/drizzle-orm/src/pg-core/session.ts
+++ b/drizzle-orm/src/pg-core/session.ts
@@ -4,6 +4,7 @@ import type { TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
 import { type Query, type SQL, sql } from '~/sql/index.ts';
 import { tracer } from '~/tracing.ts';
+import type { NeonAuthToken } from '~/utils.ts';
 import { PgDatabase } from './db.ts';
 import type { PgDialect } from './dialect.ts';
 import type { SelectedFieldsOrdered } from './query-builders/select.types.ts';
@@ -17,7 +18,7 @@ export interface PreparedQueryConfig {
 export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements PreparedQuery {
 	constructor(protected query: Query) {}
 
-	protected authToken?: string;
+	protected authToken?: NeonAuthToken;
 
 	getQuery(): Query {
 		return this.query;
@@ -28,7 +29,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 	}
 
 	/** @internal */
-	setToken(token?: string) {
+	setToken(token?: NeonAuthToken) {
 		this.authToken = token;
 		return this;
 	}
@@ -40,9 +41,9 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 
 	abstract execute(placeholderValues?: Record<string, unknown>): Promise<T['execute']>;
 	/** @internal */
-	abstract execute(placeholderValues?: Record<string, unknown>, token?: string): Promise<T['execute']>;
+	abstract execute(placeholderValues?: Record<string, unknown>, token?: NeonAuthToken): Promise<T['execute']>;
 	/** @internal */
-	abstract execute(placeholderValues?: Record<string, unknown>, token?: string): Promise<T['execute']>;
+	abstract execute(placeholderValues?: Record<string, unknown>, token?: NeonAuthToken): Promise<T['execute']>;
 
 	/** @internal */
 	abstract all(placeholderValues?: Record<string, unknown>): Promise<T['all']>;
@@ -76,9 +77,9 @@ export abstract class PgSession<
 
 	execute<T>(query: SQL): Promise<T>;
 	/** @internal */
-	execute<T>(query: SQL, token?: string): Promise<T>;
+	execute<T>(query: SQL, token?: NeonAuthToken): Promise<T>;
 	/** @internal */
-	execute<T>(query: SQL, token?: string): Promise<T> {
+	execute<T>(query: SQL, token?: NeonAuthToken): Promise<T> {
 		return tracer.startActiveSpan('drizzle.operation', () => {
 			const prepared = tracer.startActiveSpan('drizzle.prepareQuery', () => {
 				return this.prepareQuery<PreparedQueryConfig & { execute: T }>(
@@ -104,9 +105,9 @@ export abstract class PgSession<
 
 	async count(sql: SQL): Promise<number>;
 	/** @internal */
-	async count(sql: SQL, token?: string): Promise<number>;
+	async count(sql: SQL, token?: NeonAuthToken): Promise<number>;
 	/** @internal */
-	async count(sql: SQL, token?: string): Promise<number> {
+	async count(sql: SQL, token?: NeonAuthToken): Promise<number> {
 		const res = await this.execute<[{ count: string }]>(sql, token);
 
 		return Number(

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -311,3 +311,5 @@ export function isConfig(data: any): boolean {
 
 	return false;
 }
+
+export type NeonAuthToken = string | (() => string | Promise<string>);

--- a/drizzle-orm/type-tests/utils/neon-auth-token.ts
+++ b/drizzle-orm/type-tests/utils/neon-auth-token.ts
@@ -1,0 +1,5 @@
+import type { HTTPQueryOptions } from '@neondatabase/serverless';
+import { type Equal, Expect } from 'type-tests/utils.ts';
+import type { NeonAuthToken } from '~/utils';
+
+Expect<Equal<Exclude<HTTPQueryOptions<true, true>['authToken'], undefined>, NeonAuthToken>>;

--- a/integration-tests/tests/pg/neon-http.test.ts
+++ b/integration-tests/tests/pg/neon-http.test.ts
@@ -586,3 +586,205 @@ describe('$withAuth tests', (it) => {
 		});
 	});
 });
+
+describe('$withAuth callback tests', (it) => {
+	const client = vi.fn();
+	const db = drizzle({
+		client: client as any as NeonQueryFunction<any, any>,
+		schema: {
+			usersTable,
+		},
+	});
+	const auth = (token: string) => () => token;
+
+	it('$count', async () => {
+		await db.$withAuth(auth('$count')).$count(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('$count');
+	});
+
+	it('delete', async () => {
+		await db.$withAuth(auth('delete')).delete(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('delete');
+	});
+
+	it('select', async () => {
+		await db.$withAuth(auth('select')).select().from(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('select');
+	});
+
+	it('selectDistinct', async () => {
+		await db.$withAuth(auth('selectDistinct')).selectDistinct().from(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('selectDistinct');
+	});
+
+	it('selectDistinctOn', async () => {
+		await db.$withAuth(auth('selectDistinctOn')).selectDistinctOn([usersTable.name]).from(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('selectDistinctOn');
+	});
+
+	it('update', async () => {
+		await db.$withAuth(auth('update')).update(usersTable).set({
+			name: 'CHANGED',
+		}).where(eq(usersTable.name, 'TARGET')).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('update');
+	});
+
+	it('insert', async () => {
+		await db.$withAuth(auth('insert')).insert(usersTable).values({
+			name: 'WITHAUTHUSER',
+		}).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('insert');
+	});
+
+	it('with', async () => {
+		await db.$withAuth(auth('with')).with(db.$with('WITH').as((qb) => qb.select().from(usersTable))).select().from(
+			usersTable,
+		)
+			.catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('with');
+	});
+
+	it('rqb', async () => {
+		await db.$withAuth(auth('rqb')).query.usersTable.findFirst().catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('rqb');
+	});
+
+	it('exec', async () => {
+		await db.$withAuth(auth('exec')).execute(`SELECT 1`).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('exec');
+	});
+
+	it('prepared', async () => {
+		const prep = db.$withAuth(auth('prepared')).select().from(usersTable).prepare('withAuthPrepared');
+
+		await prep.execute().catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('prepared');
+	});
+
+	it('refreshMaterializedView', async () => {
+		const johns = pgMaterializedView('johns')
+			.as((qb) => qb.select().from(usersTable).where(eq(usersTable.name, 'John')));
+
+		await db.$withAuth(auth('refreshMaterializedView')).refreshMaterializedView(johns);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('refreshMaterializedView');
+	});
+});
+
+describe('$withAuth async callback tests', (it) => {
+	const client = vi.fn();
+	const db = drizzle({
+		client: client as any as NeonQueryFunction<any, any>,
+		schema: {
+			usersTable,
+		},
+	});
+	const auth = (token: string) => async () => token;
+
+	it('$count', async () => {
+		await db.$withAuth(auth('$count')).$count(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('$count');
+	});
+
+	it('delete', async () => {
+		await db.$withAuth(auth('delete')).delete(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('delete');
+	});
+
+	it('select', async () => {
+		await db.$withAuth(auth('select')).select().from(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('select');
+	});
+
+	it('selectDistinct', async () => {
+		await db.$withAuth(auth('selectDistinct')).selectDistinct().from(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('selectDistinct');
+	});
+
+	it('selectDistinctOn', async () => {
+		await db.$withAuth(auth('selectDistinctOn')).selectDistinctOn([usersTable.name]).from(usersTable).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('selectDistinctOn');
+	});
+
+	it('update', async () => {
+		await db.$withAuth(auth('update')).update(usersTable).set({
+			name: 'CHANGED',
+		}).where(eq(usersTable.name, 'TARGET')).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('update');
+	});
+
+	it('insert', async () => {
+		await db.$withAuth(auth('insert')).insert(usersTable).values({
+			name: 'WITHAUTHUSER',
+		}).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('insert');
+	});
+
+	it('with', async () => {
+		await db.$withAuth(auth('with')).with(db.$with('WITH').as((qb) => qb.select().from(usersTable))).select().from(
+			usersTable,
+		)
+			.catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('with');
+	});
+
+	it('rqb', async () => {
+		await db.$withAuth(auth('rqb')).query.usersTable.findFirst().catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('rqb');
+	});
+
+	it('exec', async () => {
+		await db.$withAuth(auth('exec')).execute(`SELECT 1`).catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('exec');
+	});
+
+	it('prepared', async () => {
+		const prep = db.$withAuth(auth('prepared')).select().from(usersTable).prepare('withAuthPrepared');
+
+		await prep.execute().catch(() => null);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('prepared');
+	});
+
+	it('refreshMaterializedView', async () => {
+		const johns = pgMaterializedView('johns')
+			.as((qb) => qb.select().from(usersTable).where(eq(usersTable.name, 'John')));
+
+		await db.$withAuth(auth('refreshMaterializedView')).refreshMaterializedView(johns);
+
+		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
+		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('refreshMaterializedView');
+	});
+});


### PR DESCRIPTION
 - Added callback & async callback variants for `neon-http` auth tokens (fixes #3597)
 - Safer typecheck on token applying proxy