### PR TITLE
[drizzle-kit] Make studio compatible with Bun (#3595)

### DIFF
--- a/drizzle-kit/src/serializer/studio.ts
+++ b/drizzle-kit/src/serializer/studio.ts
@@ -18,7 +18,6 @@ import { AnyPgTable, getTableConfig as pgTableConfig, PgTable } from 'drizzle-or
 import { AnySQLiteTable, getTableConfig as sqliteTableConfig, SQLiteTable } from 'drizzle-orm/sqlite-core';
 import fs from 'fs';
 import { Hono } from 'hono';
-import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
 import { createServer } from 'node:https';
 import { LibSQLCredentials } from 'src/cli/validations/libsql';
@@ -493,7 +492,6 @@ export const prepareServer = async (
 ): Promise<Server> => {
 	app = app !== undefined ? app : new Hono();
 
-	app.use(compress());
 	app.use(async (ctx, next) => {
 		await next();
 		// * https://wicg.github.io/private-network-access/#headers


### PR DESCRIPTION
After [PR 2866](https://github.com/drizzle-team/drizzle-orm/pull/2866) was merged, adding `hono/compress` to the studio.ts file, studio is no longer able to run on Bun.

This PR removes that middleware from studio.

I checked the PR/commit and some issues that could be related to this but couldn't find any information on why is was added to begin with.