### PR TITLE
[sql.js]: Fix Column name conversion not working when using `sql.js` (fix #3643)

### DIFF
--- a/drizzle-orm/src/sql-js/session.ts
+++ b/drizzle-orm/src/sql-js/session.ts
@@ -44,9 +44,18 @@ export class SQLJsSession<
 		fields: SelectedFieldsOrdered | undefined,
 		executeMethod: SQLiteExecuteMethod,
 		isResponseInArrayMode: boolean,
+		customResultMapper?: (rows: unknown[][]) => unknown,
 	): PreparedQuery<T> {
 		const stmt = this.client.prepare(query.sql);
-		return new PreparedQuery(stmt, query, this.logger, fields, executeMethod, isResponseInArrayMode);
+		return new PreparedQuery(
+			stmt,
+			query,
+			this.logger,
+			fields,
+			executeMethod,
+			isResponseInArrayMode,
+			customResultMapper,
+		);
 	}
 
 	override prepareOneTimeQuery<T extends Omit<PreparedQueryConfig, 'run'>>(


### PR DESCRIPTION
## Motivation

Fix #3642 

Fix Column name conversion not working when using `sql.js`

Example Code:

```
import initSqlJs from "sql.js";
import fs from "node:fs";
import { drizzle } from "drizzle-orm/sql-js";
import { numeric, sqliteTable, text } from "drizzle-orm/sqlite-core";

const testTable = sqliteTable("test", {
	id: numeric().primaryKey().notNull(),
	testSnakeName: text("test_snake_name").notNull(),
});

async function main() {
	const SQL = await initSqlJs();
        // // this a simple sqlite database, which is used to demonstrate this bug
	const dbFile = fs.readFileSync("./test.sqlite");
	const dbOrigin = new SQL.Database(dbFile);
	const db = drizzle(dbOrigin, {
		schema: { testTable },
		logger: true,
	});
	const result = await db.query.testTable.findFirst();
	console.log("result:", result);
	console.log("property:", result?.testSnakeName);
}

await main();

```

## Before Change:

```console
Query: select "id", "test_snake_name" from "test" "testTable" limit ? -- params: [1]
result: { id: 1, test_snake_name: 'test' }
property: undefined
```

## After change

```console
Query: select "id", "test_snake_name" from "test" "testTable" limit ? -- params: [1]
result: { id: 1, testSnakeName: 'test' }
property: test
```

Although we have excellent drivers for SQLite, such as `libsql` or `better-sqlite3`, we require `sql.js` for specific scenarios, particularly operating on an in-memory database in browser, which is crucial for certain static websites that display or allow users to control dates. I believe that robustly supporting `sql.js` will benefit `Drizzle` in adapting to various browser environments.

