### PR TITLE
[Bug fix] TypeError: Cannot destructure property 'resourceArn' of 'connection' as it is undefined.

### DIFF
--- a/drizzle-orm/src/aws-data-api/pg/driver.ts
+++ b/drizzle-orm/src/aws-data-api/pg/driver.ts
@@ -151,7 +151,6 @@ export function drizzle<
 ): AwsDataApiPgDatabase<TSchema> & {
 	$client: TClient;
 } {
-	// eslint-disable-next-line no-instanceof/no-instanceof
 	if (params[0].constructor.name === "RDSDataClient") {
 		return construct(params[0] as TClient, params[1] as DrizzleAwsDataApiPgConfig<TSchema>) as any;
 	}

--- a/drizzle-orm/src/aws-data-api/pg/driver.ts
+++ b/drizzle-orm/src/aws-data-api/pg/driver.ts
@@ -152,7 +152,7 @@ export function drizzle<
 	$client: TClient;
 } {
 	// eslint-disable-next-line no-instanceof/no-instanceof
-	if (params[0] instanceof RDSDataClient) {
+	if (params[0].constructor.name === "RDSDataClient") {
 		return construct(params[0] as TClient, params[1] as DrizzleAwsDataApiPgConfig<TSchema>) as any;
 	}
 


### PR DESCRIPTION
Discussed here:
https://github.com/drizzle-team/drizzle-orm/issues/3224 
kudos to @NikolaRusakov for gist

I think what we see here is that drizzle-kit imports the CommonJS version of a package (`@aws-sdk/client-rds-data`) and driver imports ESM version of same package, and somehow it confuses `instanceof` 

I was not able to replicate this use-case in vitest but I can provide debug screenshot
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/d65fe9ef-5105-431f-8acf-69abf1ed9fc8">
<img width="1235" alt="image" src="https://github.com/user-attachments/assets/962ea430-f1d9-45c8-80c4-436a6003091e">


