### PR TITLE
examples: use `defineConfig` instead of `Config`

### DIFF
--- a/examples/better-sqlite3/drizzle.config.ts
+++ b/examples/better-sqlite3/drizzle.config.ts
@@ -1,10 +1,10 @@
-import type { Config } from 'drizzle-kit';
+import { defineConfig } from 'drizzle-kit';
 
-export default {
+export default defineConfig({
 	schema: './src/schema.ts',
 	out: './drizzle',
 	driver: 'better-sqlite',
 	dbCredentials: {
 		url: './sqlite.db',
 	},
-} satisfies Config;
+});

--- a/examples/libsql/drizzle.config.ts
+++ b/examples/libsql/drizzle.config.ts
@@ -1,7 +1,7 @@
-import { type Config } from 'drizzle-kit';
+import { defineConfig } from 'drizzle-kit';
 
-export default {
+export default defineConfig({
 	out: './migrations',
 	schema: './src/schema.ts',
 	breakpoints: true,
-} satisfies Config;
+});

--- a/examples/postgresjs/drizzle.config.ts
+++ b/examples/postgresjs/drizzle.config.ts
@@ -1,6 +1,6 @@
-import type { Config } from 'drizzle-kit';
+import { defineConfig } from 'drizzle-kit';
 
-export default {
+export default defineConfig({
 	schema: 'src/schema.ts',
 	out: 'drizzle',
-} satisfies Config;
+});


### PR DESCRIPTION
## Before

```ts
import type { Config } from 'drizzle-kit';

export default {
  // ...
} satisfies Config;
```

## After

```ts
import { defineConfig } from 'drizzle-kit';

export default defineConfig({
  // ...
});
```

## Why?

To match the content of [the document](https://orm.drizzle.team/docs/drizzle-config-file).