### PR TITLE
Add .idea folder to Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .vscode
+.idea
 dist
 dist.new
 *.tsbuildinfo


### PR DESCRIPTION
This change lets contributors use Jetbrains IDE-s like WebStorm. VSCode files were already ignored (`.vscode`), but Jetbrains IDE-s use the `.idea` folder so whenever a contributor opened the project, a lot of extra IDE-specific files appeared in Git because they weren't ignored as VSCode files are ignored