### PR TITLE
Fixed `.mock` in postgres-js

### DIFF
--- a/drizzle-orm/src/postgres-js/driver.ts
+++ b/drizzle-orm/src/postgres-js/driver.ts
@@ -119,6 +119,11 @@ export namespace drizzle {
 	): PostgresJsDatabase<TSchema> & {
 		$client: '$client is not available on drizzle.mock()';
 	} {
-		return construct({} as any, config) as any;
+		return construct({
+			options: {
+				parsers: {},
+				serializers: {},
+			},
+		} as any, config) as any;
 	}
 }


### PR DESCRIPTION
- Fixed `.mock()` crashing in postgres-js driver due to client accessing client fields