### PR TITLE
exactOptionalPropertyTypes improvements (issue #2742)

### DIFF
--- a/drizzle-orm/src/mysql-core/query-builders/update.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/update.ts
@@ -34,7 +34,8 @@ export type MySqlUpdateSetSource<TTable extends MySqlTable> =
 	& {
 		[Key in keyof TTable['$inferInsert']]?:
 			| GetColumnData<TTable['_']['columns'][Key], 'query'>
-			| SQL;
+			| SQL
+			| undefined;
 	}
 	& {};
 

--- a/drizzle-orm/src/pg-core/query-builders/update.ts
+++ b/drizzle-orm/src/pg-core/query-builders/update.ts
@@ -53,7 +53,8 @@ export type PgUpdateSetSource<TTable extends PgTable> =
 		[Key in keyof TTable['$inferInsert']]?:
 			| GetColumnData<TTable['_']['columns'][Key]>
 			| SQL
-			| PgColumn;
+			| PgColumn
+			| undefined;
 	}
 	& {};
 

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -214,22 +214,27 @@ export type DBQueryConfig<
 	TTableConfig extends TableRelationalConfig = TableRelationalConfig,
 > =
 	& {
-		columns?: {
-			[K in keyof TTableConfig['columns']]?: boolean;
-		};
-		with?: {
-			[K in keyof TTableConfig['relations']]?:
-				| true
-				| DBQueryConfig<
-					TTableConfig['relations'][K] extends One ? 'one' : 'many',
-					false,
-					TSchema,
-					FindTableByDBName<
+		columns?:
+			| {
+				[K in keyof TTableConfig['columns']]?: boolean;
+			}
+			| undefined;
+		with?:
+			| {
+				[K in keyof TTableConfig['relations']]?:
+					| true
+					| DBQueryConfig<
+						TTableConfig['relations'][K] extends One ? 'one' : 'many',
+						false,
 						TSchema,
-						TTableConfig['relations'][K]['referencedTableName']
+						FindTableByDBName<
+							TSchema,
+							TTableConfig['relations'][K]['referencedTableName']
+						>
 					>
-				>;
-		};
+					| undefined;
+			}
+			| undefined;
 		extras?:
 			| Record<string, SQL.Aliased>
 			| ((
@@ -238,7 +243,8 @@ export type DBQueryConfig<
 						: TTableConfig['columns']
 				>,
 				operators: { sql: Operators['sql'] },
-			) => Record<string, SQL.Aliased>);
+			) => Record<string, SQL.Aliased>)
+			| undefined;
 	}
 	& (TRelationType extends 'many' ?
 			& {
@@ -260,11 +266,12 @@ export type DBQueryConfig<
 								: TTableConfig['columns']
 						>,
 						operators: OrderByOperators,
-					) => ValueOrArray<AnyColumn | SQL>);
-				limit?: number | Placeholder;
+					) => ValueOrArray<AnyColumn | SQL>)
+					| undefined;
+				limit?: number | Placeholder | undefined;
 			}
 			& (TIsRoot extends true ? {
-					offset?: number | Placeholder;
+					offset?: number | Placeholder | undefined;
 				}
 				: {})
 		: {});

--- a/drizzle-orm/src/singlestore-core/query-builders/update.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/update.ts
@@ -34,7 +34,8 @@ export type SingleStoreUpdateSetSource<TTable extends SingleStoreTable> =
 	& {
 		[Key in keyof TTable['$inferInsert']]?:
 			| GetColumnData<TTable['_']['columns'][Key], 'query'>
-			| SQL;
+			| SQL
+			| undefined;
 	}
 	& {};
 

--- a/drizzle-orm/src/sqlite-core/query-builders/update.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/update.ts
@@ -40,7 +40,8 @@ export type SQLiteUpdateSetSource<TTable extends SQLiteTable> =
 		[Key in keyof TTable['$inferInsert']]?:
 			| GetColumnData<TTable['_']['columns'][Key], 'query'>
 			| SQL
-			| SQLiteColumn;
+			| SQLiteColumn
+			| undefined;
 	}
 	& {};
 

--- a/drizzle-orm/src/table.ts
+++ b/drizzle-orm/src/table.ts
@@ -174,7 +174,7 @@ export type InferModelFromColumns<
 						TColumns[Key],
 						TConfig['override']
 					>
-				]?: GetColumnData<TColumns[Key], 'query'>;
+				]?: GetColumnData<TColumns[Key], 'query'> | undefined;
 			}
 		: {
 			[


### PR DESCRIPTION
 - Added `| undefined` to optional fields in `insertModel`, `db.update().set()` args & rqb config to allow `undefined` to still be passed to optional fields with `exactOptionalPropertyTypes` typescript flag set to `true`