### PR TITLE
Fix Enum Array Column Types for PostgreSQL Migrations

### DIFF
--- a/drizzle-kit/tests/pg-array.test.ts
+++ b/drizzle-kit/tests/pg-array.test.ts
@@ -329,6 +329,7 @@ test('array #11: enum array default', async (t) => {
 			primaryKey: false,
 			notNull: false,
 			default: '\'{"a","b","c"}\'',
+			typeSchema: 'public',
 		},
 	});
 });
@@ -363,6 +364,7 @@ test('array #12: enum empty array default', async (t) => {
 			primaryKey: false,
 			notNull: false,
 			default: "'{}'",
+			typeSchema: 'public',
 		},
 	});
 });

--- a/drizzle-kit/tests/pg-enums.test.ts
+++ b/drizzle-kit/tests/pg-enums.test.ts
@@ -577,6 +577,31 @@ test('enums #21', async () => {
 	]);
 });
 
+test('enums #22 - enum array in schema', async () => {
+	const schema = pgSchema('custom_schema');
+	const myEnum = schema.enum('my_enum', ['one', 'two', 'three']);
+
+	const from = {
+		myEnum,
+		table: schema.table('table', {
+			id: serial('id').primaryKey(),
+		}),
+	};
+
+	const to = {
+		myEnum,
+		table: schema.table('table', {
+			id: serial('id').primaryKey(),
+			col1: myEnum('col1').array(),
+		}),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements.length).toBe(1);
+	expect(sqlStatements[0]).toBe('ALTER TABLE "custom_schema"."table" ADD COLUMN "col1" "custom_schema"."my_enum"[];');
+});
+
 test('drop enum value', async () => {
 	const enum1 = pgEnum('enum', ['value1', 'value2', 'value3']);
 


### PR DESCRIPTION
Fix an issue specific to PostgreSQL migrations, where enum array column types are generated without the schema prefix. This omission leads to invalid SQL statements that cannot be executed properly.

### Current Behavior:
Generated migrations for enum array columns omit the schema prefix. For example:

```sql
"completedOnboardingItems" "onboardingChecklistItem"[] DEFAULT '{}'
```

### Expected Behavior (Post-Fix):
Enum array columns correctly include the schema prefix, ensuring valid SQL generation:

```sql
"completedOnboardingItems" "app"."onboardingChecklistItem"[] DEFAULT '{}'
```

### Schema Structure:
Below is a simplified version of the schema used for generating the migrations:

```javascript
import { integer, pgEnum, pgSchema, serial, text } from "drizzle-orm/pg-core";

const appSchema = pgSchema("app");

export const onboardingChecklistItem = appSchema.enum(
  "onboardingChecklistItem",
  [
    "A",
    "B",
    "C"
  ]
);

export const user = appSchema.table("user", {
  id: serial("id").primaryKey(),
  completedOnboardingItems: onboardingChecklistItem("completedOnboardingItems")
    .array()
    .default([]),
});
```

Related to: https://github.com/drizzle-team/drizzle-orm/issues/3278