### PR TITLE
BREAKING CHANGE: drop support for executing raw SQL strings in `execute()` methods for all dialects

### DIFF
--- a/drizzle-orm/src/aws-data-api/pg/driver.ts
+++ b/drizzle-orm/src/aws-data-api/pg/driver.ts
@@ -41,7 +41,7 @@ export class AwsDataApiPgDatabase<
 
 	override execute<
 		TRow extends Record<string, unknown> = Record<string, unknown>,
-	>(query: SQLWrapper | string): PgRaw<AwsDataApiPgQueryResult<TRow>> {
+	>(query: SQLWrapper): PgRaw<AwsDataApiPgQueryResult<TRow>> {
 		return super.execute(query);
 	}
 }

--- a/drizzle-orm/src/mysql-core/db.ts
+++ b/drizzle-orm/src/mysql-core/db.ts
@@ -461,9 +461,9 @@ export class MySqlDatabase<
 	}
 
 	execute<T extends { [column: string]: any } = ResultSetHeader>(
-		query: SQLWrapper | string,
+		query: SQLWrapper,
 	): Promise<MySqlQueryResultKind<TQueryResult, T>> {
-		return this.session.execute(typeof query === 'string' ? sql.raw(query) : query.getSQL());
+		return this.session.execute(query.getSQL());
 	}
 
 	transaction<T>(

--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -600,9 +600,9 @@ export class PgDatabase<
 	protected authToken?: NeonAuthToken;
 
 	execute<TRow extends Record<string, unknown> = Record<string, unknown>>(
-		query: SQLWrapper | string,
+		query: SQLWrapper,
 	): PgRaw<PgQueryResultKind<TQueryResult, TRow>> {
-		const sequel = typeof query === 'string' ? sql.raw(query) : query.getSQL();
+		const sequel = query.getSQL();
 		const builtQuery = this.dialect.sqlToQuery(sequel);
 		const prepared = this.session.prepareQuery<
 			PreparedQueryConfig & { execute: PgQueryResultKind<TQueryResult, TRow> }

--- a/drizzle-orm/src/singlestore-core/db.ts
+++ b/drizzle-orm/src/singlestore-core/db.ts
@@ -463,9 +463,9 @@ export class SingleStoreDatabase<
 	}
 
 	execute<T extends { [column: string]: any } = ResultSetHeader>(
-		query: SQLWrapper | string,
+		query: SQLWrapper,
 	): Promise<SingleStoreQueryResultKind<TQueryResult, T>> {
-		return this.session.execute(typeof query === 'string' ? sql.raw(query) : query.getSQL());
+		return this.session.execute(query.getSQL());
 	}
 
 	transaction<T>(

--- a/drizzle-orm/src/sqlite-core/db.ts
+++ b/drizzle-orm/src/sqlite-core/db.ts
@@ -519,8 +519,8 @@ export class BaseSQLiteDatabase<
 		return new SQLiteDeleteBase(from, this.session, this.dialect);
 	}
 
-	run(query: SQLWrapper | string): DBResult<TResultKind, TRunResult> {
-		const sequel = typeof query === 'string' ? sql.raw(query) : query.getSQL();
+	run(query: SQLWrapper): DBResult<TResultKind, TRunResult> {
+		const sequel = query.getSQL();
 		if (this.resultKind === 'async') {
 			return new SQLiteRaw(
 				async () => this.session.run(sequel),
@@ -533,8 +533,8 @@ export class BaseSQLiteDatabase<
 		return this.session.run(sequel) as DBResult<TResultKind, TRunResult>;
 	}
 
-	all<T = unknown>(query: SQLWrapper | string): DBResult<TResultKind, T[]> {
-		const sequel = typeof query === 'string' ? sql.raw(query) : query.getSQL();
+	all<T = unknown>(query: SQLWrapper): DBResult<TResultKind, T[]> {
+		const sequel = query.getSQL();
 		if (this.resultKind === 'async') {
 			return new SQLiteRaw(
 				async () => this.session.all(sequel),
@@ -547,8 +547,8 @@ export class BaseSQLiteDatabase<
 		return this.session.all(sequel) as DBResult<TResultKind, T[]>;
 	}
 
-	get<T = unknown>(query: SQLWrapper | string): DBResult<TResultKind, T> {
-		const sequel = typeof query === 'string' ? sql.raw(query) : query.getSQL();
+	get<T = unknown>(query: SQLWrapper): DBResult<TResultKind, T> {
+		const sequel = query.getSQL();
 		if (this.resultKind === 'async') {
 			return new SQLiteRaw(
 				async () => this.session.get(sequel),
@@ -561,8 +561,8 @@ export class BaseSQLiteDatabase<
 		return this.session.get(sequel) as DBResult<TResultKind, T>;
 	}
 
-	values<T extends unknown[] = unknown[]>(query: SQLWrapper | string): DBResult<TResultKind, T[]> {
-		const sequel = typeof query === 'string' ? sql.raw(query) : query.getSQL();
+	values<T extends unknown[] = unknown[]>(query: SQLWrapper): DBResult<TResultKind, T[]> {
+		const sequel = query.getSQL();
 		if (this.resultKind === 'async') {
 			return new SQLiteRaw(
 				async () => this.session.values(sequel),

--- a/integration-tests/tests/pg/neon-http.test.ts
+++ b/integration-tests/tests/pg/neon-http.test.ts
@@ -560,7 +560,7 @@ describe('$withAuth tests', (it) => {
 	});
 
 	it('exec', async () => {
-		await db.$withAuth('exec').execute(`SELECT 1`).catch(() => null);
+		await db.$withAuth('exec').execute(sql.raw('SELECT 1')).catch(() => null);
 
 		expect(client.mock.lastCall?.[2]).toStrictEqual({ arrayMode: false, fullResults: true, authToken: 'exec' });
 	});
@@ -659,7 +659,7 @@ describe('$withAuth callback tests', (it) => {
 	});
 
 	it('exec', async () => {
-		await db.$withAuth(auth('exec')).execute(`SELECT 1`).catch(() => null);
+		await db.$withAuth(auth('exec')).execute(sql.raw('SELECT 1')).catch(() => null);
 
 		expect(client.mock.lastCall?.[2]['authToken']()).toStrictEqual('exec');
 	});
@@ -763,7 +763,7 @@ describe('$withAuth async callback tests', (it) => {
 	});
 
 	it('exec', async () => {
-		await db.$withAuth(auth('exec')).execute(`SELECT 1`).catch(() => null);
+		await db.$withAuth(auth('exec')).execute(sql.raw('SELECT 1')).catch(() => null);
 
 		expect(client.mock.lastCall?.[2]['authToken']()).toBeInstanceOf(Promise);
 		expect(await client.mock.lastCall?.[2]['authToken']()).toStrictEqual('exec');


### PR DESCRIPTION
Issue reference: https://github.com/drizzle-team/drizzle-orm/issues/3598

**Description of changes**

Support for execution of raw SQL strings is removed.

With this change, one needs to wrap an SQL string in `sql` tagged function (i.e. sql\`\<string\>\`) or in `sql.raw(string)` (in case the SQL string isn't static) before passing it to `.execute()`.

**Why?**

Unlike raw strings, `sql` tagged templates are by design safe from SQL injections.
In case one cannot use a tagged template, then wrapping an SQL string in `sql.raw()` still makes the intent more clear and visible (e.g. for code reviewers) that one needs to pay extra attention to what is being executed.

Currently, accidentally missing/removing `sql` when using `.execute()` method, could lead to an SQL injection vulnerability. For example, these 2 snippets look similar:

```sql
await db.execute(sql`select * from users where id = ${id}`);
```
vs
```sql
await db.execute(`select * from users where id = ${id}`);
```