### PR TITLE
[Pg]: add array keyword support

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1951,6 +1951,10 @@ const defaultForColumn = (column: any, internals: PgKitInternals, tableName: str
 		column.column_default = column.column_default.slice(0, -2);
 	}
 
+	if (isArray && column.column_default.includes("ARRAY")) {
+		return `\"${column.column_default}\"`
+	}
+
 	// if (
 	// 	!['integer', 'smallint', 'bigint', 'double precision', 'real'].includes(column.data_type)
 	// ) {

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -302,6 +302,7 @@ test('instrospect all column array types', async () => {
 			real: real('real').array().default([100, 200]),
 			json: json('json').$type<{ attr: string }>().array().default([{ attr: 'value1' }, { attr: 'value2' }]),
 			jsonb: jsonb('jsonb').$type<{ attr: string }>().array().default([{ attr: 'value1' }, { attr: 'value2' }]),
+			jsonb_array: jsonb('jsonb_array').$type<{ attr: string }>().array().default(sql`array['{ "attr": "value1" }', '{ "attr": "value2" }']::jsonb[]`),
 			time: time('time').array().default(['00:00:00', '01:00:00']),
 			timestamp: timestamp('timestamp', { withTimezone: true, precision: 6 })
 				.array()


### PR DESCRIPTION
Resolves https://github.com/drizzle-team/drizzle-orm/issues/2861 and https://github.com/drizzle-team/drizzle-orm/issues/2904

Previously if a raw sql string was used with the ARRAY keyword definition the `defaultForColumn` function would not know how to parse it.  Now the `defaultForColumn` function will return early if the ARRAY definition is used.

I chose jsonb column type in the test as it was a slightly more complicated scenario than just text or other column type.

