### PR TITLE
[Pg] Added support for postgres CTE Materialization options

### DIFF
--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -124,6 +124,7 @@ export class PgDatabase<
 	 */
 	$with: WithBuilder = (alias: string, selection?: ColumnsSelection) => {
 		const self = this;
+		let isMaterialized: boolean | undefined;
 		const as = (
 			qb:
 				| TypedQueryBuilder<ColumnsSelection | undefined>
@@ -140,11 +141,17 @@ export class PgDatabase<
 					selection ?? ('getSelectedFields' in qb ? qb.getSelectedFields() ?? {} : {}) as SelectedFields,
 					alias,
 					true,
+					undefined,
+					isMaterialized,
 				),
 				new SelectionProxyHandler({ alias, sqlAliasedBehavior: 'alias', sqlBehavior: 'error' }),
 			);
 		};
-		return { as };
+		const materialized = (shouldBeMaterialized: boolean) => {
+			isMaterialized = shouldBeMaterialized;
+			return { as };
+		};
+		return { as, materialized };
 	};
 
 	$count(

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -128,7 +128,11 @@ export class PgDialect {
 
 		const withSqlChunks = [sql`with `];
 		for (const [i, w] of queries.entries()) {
-			withSqlChunks.push(sql`${sql.identifier(w._.alias)} as (${w._.sql})`);
+			let asKeyword = sql`as`;
+			if (w._.isMaterialized !== undefined) {
+				asKeyword = w._.isMaterialized ? sql`as materialized` : sql`as not materialized`;
+			}
+			withSqlChunks.push(sql`${sql.identifier(w._.alias)} ${asKeyword} (${w._.sql})`);
 			if (i < queries.length - 1) {
 				withSqlChunks.push(sql`, `);
 			}

--- a/drizzle-orm/src/pg-core/query-builders/query-builder.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query-builder.ts
@@ -23,6 +23,7 @@ export class QueryBuilder {
 
 	$with: WithBuilder = (alias: string, selection?: ColumnsSelection) => {
 		const queryBuilder = this;
+		let isMaterialized: boolean | undefined;
 		const as = (
 			qb:
 				| TypedQueryBuilder<ColumnsSelection | undefined>
@@ -39,11 +40,17 @@ export class QueryBuilder {
 					selection ?? ('getSelectedFields' in qb ? qb.getSelectedFields() ?? {} : {}) as SelectedFields,
 					alias,
 					true,
+					undefined,
+					isMaterialized,
 				),
 				new SelectionProxyHandler({ alias, sqlAliasedBehavior: 'alias', sqlBehavior: 'error' }),
 			) as any;
 		};
-		return { as };
+		const materialized = (shouldBeMaterialized: boolean) => {
+			isMaterialized = shouldBeMaterialized;
+			return { as };
+		};
+		return { as, materialized };
 	};
 
 	with(...queries: WithSubquery[]) {

--- a/drizzle-orm/src/pg-core/subquery.ts
+++ b/drizzle-orm/src/pg-core/subquery.ts
@@ -14,16 +14,24 @@ export type WithSubqueryWithSelection<TSelection extends ColumnsSelection, TAlia
 
 export interface WithBuilder {
 	<TAlias extends string>(alias: TAlias): {
-		as: {
-			<TSelection extends ColumnsSelection>(
-				qb: TypedQueryBuilder<TSelection> | ((qb: QueryBuilder) => TypedQueryBuilder<TSelection>),
-			): WithSubqueryWithSelection<TSelection, TAlias>;
-			(
-				qb: TypedQueryBuilder<undefined> | ((qb: QueryBuilder) => TypedQueryBuilder<undefined>),
-			): WithSubqueryWithoutSelection<TAlias>;
-		};
+		as: WithBuilderAs<TAlias>;
+		materialized: (shouldBeMaterialized: boolean) => { as: WithBuilderAs<TAlias> };
 	};
 	<TAlias extends string, TSelection extends ColumnsSelection>(alias: TAlias, selection: TSelection): {
-		as: (qb: SQL | ((qb: QueryBuilder) => SQL)) => WithSubqueryWithSelection<TSelection, TAlias>;
+		as: WithBuilderAsSelection<TAlias, TSelection>;
+		materialized: (shouldBeMaterialized: boolean) => { as: WithBuilderAsSelection<TAlias, TSelection> };
 	};
 }
+
+interface WithBuilderAs<TAlias extends string> {
+	<TSelection extends ColumnsSelection>(
+		qb: TypedQueryBuilder<TSelection> | ((qb: QueryBuilder) => TypedQueryBuilder<TSelection>),
+	): WithSubqueryWithSelection<TSelection, TAlias>;
+	(
+		qb: TypedQueryBuilder<undefined> | ((qb: QueryBuilder) => TypedQueryBuilder<undefined>),
+	): WithSubqueryWithoutSelection<TAlias>;
+}
+
+type WithBuilderAsSelection<TAlias extends string, TSelection extends ColumnsSelection> = (
+	qb: SQL | ((qb: QueryBuilder) => SQL),
+) => WithSubqueryWithSelection<TSelection, TAlias>;

--- a/drizzle-orm/src/subquery.ts
+++ b/drizzle-orm/src/subquery.ts
@@ -22,9 +22,17 @@ export class Subquery<
 		alias: TAlias;
 		isWith: boolean;
 		usedTables?: string[];
+		isMaterialized?: boolean;
 	};
 
-	constructor(sql: SQL, fields: TSelectedFields, alias: string, isWith = false, usedTables: string[] = []) {
+	constructor(
+		sql: SQL,
+		fields: TSelectedFields,
+		alias: string,
+		isWith = false,
+		usedTables: string[] = [],
+		isMaterialized?: boolean,
+	) {
 		this._ = {
 			brand: 'Subquery',
 			sql,
@@ -32,6 +40,7 @@ export class Subquery<
 			alias: alias as TAlias,
 			isWith,
 			usedTables,
+			isMaterialized,
 		};
 	}
 

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -2554,6 +2554,49 @@ export function tests() {
 			]);
 		});
 
+		test('join on materialized aliased sql from with clause', async (ctx) => {
+			const { db } = ctx.pg;
+
+			const users = db.$with('users').materialized(true).as(
+				db.select({
+					id: sql<number>`id`.as('userId'),
+					name: sql<string>`name`.as('userName'),
+					city: sql<string>`city`.as('city'),
+				}).from(
+					sql`(select 1 as id, 'John' as name, 'New York' as city) as users`,
+				),
+			);
+
+			const cities = db.$with('cities').materialized(false).as(
+				db.select({
+					id: sql<number>`id`.as('cityId'),
+					name: sql<string>`name`.as('cityName'),
+				}).from(
+					sql`(select 1 as id, 'Paris' as name) as cities`,
+				),
+			);
+
+			const result = await db
+				.with(users, cities)
+				.select({
+					userId: users.id,
+					name: users.name,
+					userCity: users.city,
+					cityId: cities.id,
+					cityName: cities.name,
+				})
+				.from(users)
+				.leftJoin(cities, (cols) => eq(cols.cityId, cols.userId));
+
+			Expect<
+				Equal<{ userId: number; name: string; userCity: string; cityId: number; cityName: string }[], typeof result>
+			>;
+
+			expect(result).toEqual([
+				{ userId: 1, name: 'John', userCity: 'New York', cityId: 1, cityName: 'Paris' },
+			]);
+		});
+
 		test('prefixed table', async (ctx) => {
 			const { db } = ctx.pg;
 


### PR DESCRIPTION
This PR adds support for forcefully enabling or disabling [materialized CTEs (postgres docs)](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CTE-MATERIALIZATION).
Materialized CTEs can impact query performance, and having explicit control allows for better optimization.

This feature was requested in issue #2318

### Usage
I added an optional chainable function  `materialized(shouldBeMaterialized: boolean)` after `$with`, allowing queries to specify materialization behavior like this:

```typescript
/* If the CTE is referenced more than once in the main query,
this will make sure that is executed only one time */
const sq = db.$with('sq').materialized(true).as(/*sub query*/);
```

```typescript
/* When only a small part of the CTE output is needed and computing
the full subquery is expensive, it might be cheaper to force postgres
to duplicate the computation by inlining the CTE */
const sq = db.$with('sq').materialized(false).as(/*sub query*/);
```
### Notes
If the PR is approved, this option will need to be documented. I’m unsure of the specific guidelines for documentation, so any pointers would be appreciated.