### PR TITLE
chore: remove unused `SQLiteSchema` import

### DIFF
--- a/drizzle-kit/src/introspect-sqlite.ts
+++ b/drizzle-kit/src/introspect-sqlite.ts
@@ -9,7 +9,6 @@ import type {
 	ForeignKey,
 	Index,
 	PrimaryKey,
-	SQLiteSchema,
 	SQLiteSchemaInternal,
 	UniqueConstraint,
 } from './serializer/sqliteSchema';


### PR DESCRIPTION
I came across this issue while reading the code and have fixed it.
I believe this can be prevented by configuring ESLint. Shall we set it up?