### PR TITLE
fix: changed the meaningless `concat` to `push`.

### DIFF
--- a/drizzle-kit/src/snapshotsDiffer.ts
+++ b/drizzle-kit/src/snapshotsDiffer.ts
@@ -1785,15 +1785,15 @@ export const applyPgSnapshotsDiff = async (
 		return preparePgCreateTableJson(it, curFull);
 	});
 
-	jsonCreatePoliciesStatements.push(...([] as JsonCreatePolicyStatement[]).concat(
-		...(createdTables.map((it) =>
-			prepareCreatePolicyJsons(
+	jsonCreatePoliciesStatements.push(
+		...(createdTables.flatMap((it) => {
+			return prepareCreatePolicyJsons(
 				it.name,
 				it.schema,
 				Object.values(it.policies).map(action === 'push' ? PgSquasher.unsquashPolicyPush : PgSquasher.unsquashPolicy),
-			)
+			)}
 		)),
-	));
+	);
 	const createViews: JsonCreatePgViewStatement[] = [];
 	const dropViews: JsonDropViewStatement[] = [];
 	const renameViews: JsonRenameViewStatement[] = [];


### PR DESCRIPTION
In https://github.com/drizzle-team/drizzle-orm/pull/3193, elements were being added to an array using concat, but the result was not assigned to any variable, making the operation meaningless. This PR updates it to a meaningful operation.

Is it correct? @AndriiSherman