### PR TITLE
chore: remove unused import from `drizzle-kit/src/cli/commands/migrate.ts`

### DIFF
--- a/drizzle-kit/src/cli/commands/migrate.ts
+++ b/drizzle-kit/src/cli/commands/migrate.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import {
 	prepareMySqlDbPushSnapshot,
 	prepareMySqlMigrationSnapshot,
-	preparePgDbPushSnapshot,
 	preparePgMigrationSnapshot,
 	prepareSingleStoreDbPushSnapshot,
 	prepareSingleStoreMigrationSnapshot,


### PR DESCRIPTION
Related: https://github.com/drizzle-team/drizzle-orm/pull/3811