### PR TITLE
fix: prevent Maximum call stack size exceeded

### DIFF
--- a/drizzle-kit/src/cli/commands/libSqlPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/libSqlPushUtils.ts
@@ -11,6 +11,7 @@ import {
 	SQLiteDropTableConvertor,
 	SqliteRenameTableConvertor,
 } from '../../sqlgenerator';
+import { push_array } from '../../utils';
 
 export const getOldTableName = (
 	tableName: string,
@@ -299,11 +300,11 @@ export const libSqlLogSuggestionsAndReturn = async (
 					.filter((t) => SQLiteSquasher.unsquashPushFK(t).tableTo === tableName)
 					.map((it) => SQLiteSquasher.unsquashPushFK(it).tableFrom);
 
-				tablesReferencingCurrent.push(...tablesRefs);
+				push_array(tablesReferencingCurrent, tablesRefs);
 			}
 
 			if (!tablesReferencingCurrent.length) {
-				statementsToExecute.push(..._moveDataStatements(tableName, json2, dataLoss));
+				push_array(statementsToExecute, _moveDataStatements(tableName, json2, dataLoss));
 				continue;
 			}
 

--- a/drizzle-kit/src/cli/commands/migrate.ts
+++ b/drizzle-kit/src/cli/commands/migrate.ts
@@ -55,6 +55,7 @@ import {
 	schema,
 } from '../views';
 import { ExportConfig, GenerateConfig } from './utils';
+import { push_array } from '../../utils';
 
 export type Named = {
 	name: string;
@@ -1126,7 +1127,7 @@ export const promptColumnsConflicts = async <T extends Named>(
 		chalk.gray(`--- all columns conflicts in ${tableName} table resolved ---\n`),
 	);
 
-	result.deleted.push(...leftMissing);
+	push_array(result.deleted, leftMissing);
 	return result;
 };
 
@@ -1198,7 +1199,7 @@ export const promptNamedConflict = async <T extends Named>(
 		index += 1;
 	} while (index < newItems.length);
 	console.log(chalk.gray(`--- all ${entity} conflicts resolved ---\n`));
-	result.deleted.push(...leftMissing);
+	push_array(result.deleted, leftMissing);
 	return result;
 };
 
@@ -1288,7 +1289,7 @@ export const promptNamedWithSchemasConflict = async <T extends NamedWithSchema>(
 		index += 1;
 	} while (index < newItems.length);
 	console.log(chalk.gray(`--- all ${entity} conflicts resolved ---\n`));
-	result.deleted.push(...leftMissing);
+	push_array(result.deleted, leftMissing);
 	return result;
 };
 
@@ -1347,7 +1348,7 @@ export const promptSchemasConflict = async <T extends Named>(
 		index += 1;
 	} while (index < newSchemas.length);
 	console.log(chalk.gray('--- all schemas conflicts resolved ---\n'));
-	result.deleted.push(...leftMissing);
+	push_array(result.deleted, leftMissing);
 	return result;
 };
 

--- a/drizzle-kit/src/cli/commands/pgPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/pgPushUtils.ts
@@ -5,6 +5,7 @@ import { PgSquasher } from '../../serializer/pgSchema';
 import { fromJson } from '../../sqlgenerator';
 import type { DB } from '../../utils';
 import { Select } from '../selector-ui';
+import { push_array } from '../../utils';
 
 // export const filterStatements = (statements: JsonStatement[]) => {
 //   return statements.filter((statement) => {
@@ -252,7 +253,7 @@ export const pgSuggestions = async (db: DB, statements: JsonStatement[]) => {
 		}
 		const stmnt = fromJson([statement], 'postgresql', 'push');
 		if (typeof stmnt !== 'undefined') {
-			statementsToExecute.push(...stmnt);
+			push_array(statementsToExecute, stmnt);
 		}
 	}
 

--- a/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
+++ b/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
@@ -10,7 +10,7 @@ import {
 } from '../../sqlgenerator';
 
 import type { JsonStatement } from '../../jsonStatements';
-import { findAddedAndRemoved, type SQLiteDB } from '../../utils';
+import { findAddedAndRemoved, push_array, type SQLiteDB } from '../../utils';
 
 export const _moveDataStatements = (
 	tableName: string,
@@ -283,11 +283,11 @@ export const logSuggestionsAndReturn = async (
 					.filter((t) => SQLiteSquasher.unsquashPushFK(t).tableTo === tableName)
 					.map((it) => SQLiteSquasher.unsquashPushFK(it).tableFrom);
 
-				tablesReferencingCurrent.push(...tablesRefs);
+				push_array(tablesReferencingCurrent, tablesRefs);
 			}
 
 			if (!tablesReferencingCurrent.length) {
-				statementsToExecute.push(..._moveDataStatements(tableName, json2, dataLoss));
+				push_array(statementsToExecute, _moveDataStatements(tableName, json2, dataLoss));
 				continue;
 			}
 
@@ -298,7 +298,7 @@ export const logSuggestionsAndReturn = async (
 			if (pragmaState) {
 				statementsToExecute.push(`PRAGMA foreign_keys=OFF;`);
 			}
-			statementsToExecute.push(..._moveDataStatements(tableName, json2, dataLoss));
+			push_array(statementsToExecute, _moveDataStatements(tableName, json2, dataLoss));
 			if (pragmaState) {
 				statementsToExecute.push(`PRAGMA foreign_keys=ON;`);
 			}

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -43,6 +43,7 @@ import {
 } from '../validations/sqlite';
 import { studioCliParams, studioConfig } from '../validations/studio';
 import { error, grey } from '../views';
+import { push_array } from '../../utils';
 
 // NextJs default config is target: es5, which esbuild-register can't consume
 const assertES5 = async (unregister: () => void) => {
@@ -323,7 +324,7 @@ export const preparePushConfig = async (
 			: schemasFilterConfig
 		: [];
 
-	tablesFilter.push(...getTablesFilterByExtensions(config));
+	push_array(tablesFilter, getTablesFilterByExtensions(config));
 
 	if (config.dialect === 'postgresql') {
 		const parsed = postgresCredentials.safeParse(config);

--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -15,6 +15,7 @@ import {
 } from './serializer/mysqlSchema';
 import { indexName } from './serializer/mysqlSerializer';
 import { unescapeSingleQuotes } from './utils';
+import { push_array } from './utils';
 
 const mysqlImportsList = new Set([
 	'mysqlTable',
@@ -158,11 +159,11 @@ export const schemaToTypeScript = (
 				(it) => 'check',
 			);
 
-			res.mysql.push(...idxImports);
-			res.mysql.push(...fkImpots);
-			res.mysql.push(...pkImports);
-			res.mysql.push(...uniqueImports);
-			res.mysql.push(...checkImports);
+			push_array(res.mysql, idxImports);
+			push_array(res.mysql, fkImpots);
+			push_array(res.mysql, pkImports);
+			push_array(res.mysql, uniqueImports);
+			push_array(res.mysql, checkImports);
 
 			const columnImports = Object.values(it.columns)
 				.map((col) => {
@@ -189,7 +190,7 @@ export const schemaToTypeScript = (
 					return mysqlImportsList.has(type);
 				});
 
-			res.mysql.push(...columnImports);
+			push_array(res.mysql, columnImports);
 			return res;
 		},
 		{ mysql: [] as string[] },
@@ -223,7 +224,7 @@ export const schemaToTypeScript = (
 				return mysqlImportsList.has(type);
 			});
 
-		imports.mysql.push(...columnImports);
+		push_array(imports.mysql, columnImports);
 	});
 
 	const tableStatements = Object.values(schema.tables).map((table) => {

--- a/drizzle-kit/src/introspect-pg.ts
+++ b/drizzle-kit/src/introspect-pg.ts
@@ -24,7 +24,7 @@ import {
 	UniqueConstraint,
 } from './serializer/pgSchema';
 import { indexName } from './serializer/pgSerializer';
-import { unescapeSingleQuotes } from './utils';
+import { unescapeSingleQuotes, push_array } from './utils';
 
 const pgImportsList = new Set([
 	'pgTable',
@@ -348,12 +348,12 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 				res.pg.push('pgSchema');
 			}
 
-			res.pg.push(...idxImports);
-			res.pg.push(...fkImpots);
-			res.pg.push(...pkImports);
-			res.pg.push(...uniqueImports);
-			res.pg.push(...policiesImports);
-			res.pg.push(...checkImports);
+			push_array(res.pg, idxImports);
+			push_array(res.pg, fkImpots);
+			push_array(res.pg, pkImports);
+			push_array(res.pg, uniqueImports);
+			push_array(res.pg, policiesImports);
+			push_array(res.pg, checkImports);
 
 			const columnImports = Object.values(it.columns)
 				.map((col) => {
@@ -372,7 +372,7 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 					return pgImportsList.has(type);
 				});
 
-			res.pg.push(...columnImports);
+			push_array(res.pg, columnImports);
 			return res;
 		},
 		{ pg: [] as string[] },
@@ -403,7 +403,7 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 					return pgImportsList.has(type);
 				});
 
-			imports.pg.push(...columnImports);
+			push_array(imports.pg, columnImports);
 		});
 	});
 

--- a/drizzle-kit/src/introspect-singlestore.ts
+++ b/drizzle-kit/src/introspect-singlestore.ts
@@ -12,6 +12,7 @@ import {
 	UniqueConstraint,
 } from './serializer/singlestoreSchema';
 import { indexName } from './serializer/singlestoreSerializer';
+import { push_array } from './utils';
 
 // time precision to fsp
 // {mode: "string"} for timestamp by default
@@ -151,9 +152,9 @@ export const schemaToTypeScript = (
 				(it) => 'unique',
 			);
 
-			res.singlestore.push(...idxImports);
-			res.singlestore.push(...pkImports);
-			res.singlestore.push(...uniqueImports);
+			push_array(res.singlestore, idxImports);
+			push_array(res.singlestore, pkImports);
+			push_array(res.singlestore, uniqueImports);
 
 			const columnImports = Object.values(it.columns)
 				.map((col) => {
@@ -183,7 +184,7 @@ export const schemaToTypeScript = (
 					return singlestoreImportsList.has(type);
 				});
 
-			res.singlestore.push(...columnImports);
+			push_array(res.singlestore, columnImports);
 			return res;
 		},
 		{ singlestore: [] as string[] },
@@ -220,7 +221,7 @@ export const schemaToTypeScript = (
 				return singlestoreImportsList.has(type);
 			});
 
-		imports.singlestore.push(...columnImports);
+		push_array(imports.singlestore, columnImports);
 	}); */
 
 	const tableStatements = Object.values(schema.tables).map((table) => {

--- a/drizzle-kit/src/introspect-sqlite.ts
+++ b/drizzle-kit/src/introspect-sqlite.ts
@@ -13,6 +13,7 @@ import type {
 	SQLiteSchemaInternal,
 	UniqueConstraint,
 } from './serializer/sqliteSchema';
+import { push_array } from './utils';
 
 const sqliteImportsList = new Set([
 	'sqliteTable',
@@ -96,11 +97,11 @@ export const schemaToTypeScript = (
 				(it) => 'check',
 			);
 
-			res.sqlite.push(...idxImports);
-			res.sqlite.push(...fkImpots);
-			res.sqlite.push(...pkImports);
-			res.sqlite.push(...uniqueImports);
-			res.sqlite.push(...checkImports);
+			push_array(res.sqlite, idxImports);
+			push_array(res.sqlite, fkImpots);
+			push_array(res.sqlite, pkImports);
+			push_array(res.sqlite, uniqueImports);
+			push_array(res.sqlite, checkImports);
 
 			const columnImports = Object.values(it.columns)
 				.map((col) => {
@@ -110,7 +111,7 @@ export const schemaToTypeScript = (
 					return sqliteImportsList.has(type);
 				});
 
-			res.sqlite.push(...columnImports);
+			push_array(res.sqlite, columnImports);
 			return res;
 		},
 		{ sqlite: [] as string[] },
@@ -127,7 +128,7 @@ export const schemaToTypeScript = (
 				return sqliteImportsList.has(type);
 			});
 
-		imports.sqlite.push(...columnImports);
+		push_array(imports.sqlite, columnImports);
 	});
 
 	const tableStatements = Object.values(schema.tables).map((table) => {

--- a/drizzle-kit/src/serializer/mysqlImports.ts
+++ b/drizzle-kit/src/serializer/mysqlImports.ts
@@ -1,6 +1,7 @@
 import { is } from 'drizzle-orm';
 import { AnyMySqlTable, MySqlTable, MySqlView } from 'drizzle-orm/mysql-core';
 import { safeRegister } from '../cli/commands/utils';
+import { push_array } from '../utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnyMySqlTable[] = [];
@@ -30,8 +31,8 @@ export const prepareFromMySqlImports = async (imports: string[]) => {
 		const i0: Record<string, unknown> = require(`${it}`);
 		const prepared = prepareFromExports(i0);
 
-		tables.push(...prepared.tables);
-		views.push(...prepared.views);
+		push_array(tables, prepared.tables);
+		push_array(views, prepared.views);
 	}
 	unregister();
 	return { tables: Array.from(new Set(tables)), views };

--- a/drizzle-kit/src/serializer/pgImports.ts
+++ b/drizzle-kit/src/serializer/pgImports.ts
@@ -15,6 +15,7 @@ import {
 	PgView,
 } from 'drizzle-orm/pg-core';
 import { safeRegister } from '../cli/commands/utils';
+import { push_array } from '../utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnyPgTable[] = [];
@@ -81,14 +82,14 @@ export const prepareFromPgImports = async (imports: string[]) => {
 		const i0: Record<string, unknown> = require(`${it}`);
 		const prepared = prepareFromExports(i0);
 
-		tables.push(...prepared.tables);
-		enums.push(...prepared.enums);
-		schemas.push(...prepared.schemas);
-		sequences.push(...prepared.sequences);
-		views.push(...prepared.views);
-		matViews.push(...prepared.matViews);
-		roles.push(...prepared.roles);
-		policies.push(...prepared.policies);
+		push_array(tables, prepared.tables);
+		push_array(enums, prepared.enums);
+		push_array(schemas, prepared.schemas);
+		push_array(sequences, prepared.sequences);
+		push_array(views, prepared.views);
+		push_array(matViews, prepared.matViews);
+		push_array(roles, prepared.roles);
+		push_array(policies, prepared.policies);
 	}
 	unregister();
 

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -41,6 +41,7 @@ import type {
 } from '../serializer/pgSchema';
 import { type DB, escapeSingleQuotes, isPgArrayType } from '../utils';
 import { getColumnCasing, sqlToStr } from './utils';
+import { push_array } from '../utils';
 
 export const indexName = (tableName: string, columns: string[]) => {
 	return `${tableName}_${columns.join('_')}_index`;
@@ -930,7 +931,7 @@ function prepareRoles(entities?: {
 		if (typeof entities.roles === 'object') {
 			if (entities.roles.provider) {
 				if (entities.roles.provider === 'supabase') {
-					excludeRoles.push(...[
+					push_array(excludeRoles, [
 						'anon',
 						'authenticator',
 						'authenticated',
@@ -941,14 +942,14 @@ function prepareRoles(entities?: {
 						'supabase_admin',
 					]);
 				} else if (entities.roles.provider === 'neon') {
-					excludeRoles.push(...['authenticated', 'anonymous']);
+					push_array(excludeRoles, ['authenticated', 'anonymous']);
 				}
 			}
 			if (entities.roles.include) {
-				includeRoles.push(...entities.roles.include);
+				push_array(includeRoles, entities.roles.include);
 			}
 			if (entities.roles.exclude) {
-				excludeRoles.push(...entities.roles.exclude);
+				push_array(excludeRoles, entities.roles.exclude);
 			}
 		} else {
 			useRoles = entities.roles;

--- a/drizzle-kit/src/serializer/singlestoreImports.ts
+++ b/drizzle-kit/src/serializer/singlestoreImports.ts
@@ -1,6 +1,7 @@
 import { is } from 'drizzle-orm';
 import { AnySingleStoreTable, SingleStoreTable } from 'drizzle-orm/singlestore-core';
 import { safeRegister } from '../cli/commands/utils';
+import { push_array } from '../utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnySingleStoreTable[] = [];
@@ -30,8 +31,8 @@ export const prepareFromSingleStoreImports = async (imports: string[]) => {
 		const i0: Record<string, unknown> = require(`${it}`);
 		const prepared = prepareFromExports(i0);
 
-		tables.push(...prepared.tables);
-		/* views.push(...prepared.views); */
+		push_array(tables, prepared.tables);
+		/* push_array(views, prepared.views); */
 	}
 	unregister();
 	return { tables: Array.from(new Set(tables)) /* , views */ };

--- a/drizzle-kit/src/serializer/sqliteImports.ts
+++ b/drizzle-kit/src/serializer/sqliteImports.ts
@@ -1,6 +1,7 @@
 import { is } from 'drizzle-orm';
 import { AnySQLiteTable, SQLiteTable, SQLiteView } from 'drizzle-orm/sqlite-core';
 import { safeRegister } from '../cli/commands/utils';
+import { push_array } from '../utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
 	const tables: AnySQLiteTable[] = [];
@@ -31,8 +32,8 @@ export const prepareFromSqliteImports = async (imports: string[]) => {
 		const i0: Record<string, unknown> = require(`${it}`);
 		const prepared = prepareFromExports(i0);
 
-		tables.push(...prepared.tables);
-		views.push(...prepared.views);
+		push_array(tables, prepared.tables);
+		push_array(views, prepared.views);
 	}
 
 	unregister();

--- a/drizzle-kit/src/statementCombiner.ts
+++ b/drizzle-kit/src/statementCombiner.ts
@@ -5,6 +5,7 @@ import {
 	prepareCreateIndexesJson,
 } from './jsonStatements';
 import { SQLiteSchemaSquashed, SQLiteSquasher } from './serializer/sqliteSchema';
+import { push_array } from './utils';
 
 export const prepareLibSQLRecreateTable = (
 	table: SQLiteSchemaSquashed['tables'][keyof SQLiteSchemaSquashed['tables']],
@@ -34,7 +35,7 @@ export const prepareLibSQLRecreateTable = (
 	];
 
 	if (Object.keys(indexes).length) {
-		statements.push(...prepareCreateIndexesJson(name, '', indexes));
+		push_array(statements, prepareCreateIndexesJson(name, '', indexes));
 	}
 	return statements;
 };
@@ -67,7 +68,7 @@ export const prepareSQLiteRecreateTable = (
 	];
 
 	if (Object.keys(indexes).length) {
-		statements.push(...prepareCreateIndexesJson(name, '', indexes));
+		push_array(statements, prepareCreateIndexesJson(name, '', indexes));
 	}
 	return statements;
 };
@@ -106,7 +107,7 @@ export const libSQLCombineStatements = (
 				const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
 
 				if (wasRename) {
-					newStatements[tableName].push(...preparedStatements);
+					push_array(newStatements[tableName], preparedStatements);
 				} else {
 					newStatements[tableName] = preparedStatements;
 				}
@@ -153,7 +154,7 @@ export const libSQLCombineStatements = (
 					const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
 
 					if (wasRename) {
-						newStatements[tableName].push(...preparedStatements);
+						push_array(newStatements[tableName], preparedStatements);
 					} else {
 						newStatements[tableName] = preparedStatements;
 					}
@@ -207,7 +208,7 @@ export const libSQLCombineStatements = (
 					const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
 
 					if (wasRename) {
-						newStatements[tableName].push(...preparedStatements);
+						push_array(newStatements[tableName], preparedStatements);
 					} else {
 						newStatements[tableName] = preparedStatements;
 					}
@@ -240,7 +241,7 @@ export const libSQLCombineStatements = (
 				const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
 
 				if (wasRename) {
-					newStatements[tableName].push(...preparedStatements);
+					push_array(newStatements[tableName], preparedStatements);
 				} else {
 					newStatements[tableName] = preparedStatements;
 				}
@@ -266,7 +267,7 @@ export const libSQLCombineStatements = (
 				const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
 
 				if (wasRename) {
-					newStatements[tableName].push(...preparedStatements);
+					push_array(newStatements[tableName], preparedStatements);
 				} else {
 					newStatements[tableName] = preparedStatements;
 				}
@@ -343,7 +344,7 @@ export const sqliteCombineStatements = (
 				const preparedStatements = prepareSQLiteRecreateTable(json2.tables[tableName], action);
 
 				if (wasRename) {
-					newStatements[tableName].push(...preparedStatements);
+					push_array(newStatements[tableName], preparedStatements);
 				} else {
 					newStatements[tableName] = preparedStatements;
 				}
@@ -369,7 +370,7 @@ export const sqliteCombineStatements = (
 				const preparedStatements = prepareSQLiteRecreateTable(json2.tables[tableName], action);
 
 				if (wasRename) {
-					newStatements[tableName].push(...preparedStatements);
+					push_array(newStatements[tableName], preparedStatements);
 				} else {
 					newStatements[tableName] = preparedStatements;
 				}
@@ -408,7 +409,7 @@ export const sqliteCombineStatements = (
 				const preparedStatements = prepareSQLiteRecreateTable(json2.tables[tableName], action);
 
 				if (wasRename) {
-					newStatements[tableName].push(...preparedStatements);
+					push_array(newStatements[tableName], preparedStatements);
 				} else {
 					newStatements[tableName] = preparedStatements;
 				}

--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -369,3 +369,14 @@ export function unescapeSingleQuotes(str: string, ignoreFirstAndLastChar: boolea
 	const regex = ignoreFirstAndLastChar ? /(?<!^)'(?!$)/g : /'/g;
 	return str.replace(/''/g, "'").replace(regex, "\\'");
 }
+
+/**
+ * To avoid a potential `Maximum call stack size exceeded` error with `Array.push(...items)`, we use push one element at a time.
+ * Please note that there is a same function in `drizzle-orm/src/utils.ts`, `drizzle-seed/src/utils.ts`.
+ */
+export function push_array<T>(array: T[], items: T[]): void {
+  // eslint-disable-next-line unicorn/no-for-loop -- for is faster than for of
+  for (let i = 0; i < items.length; i++) {
+    array.push(items[i]!);
+  }
+}

--- a/drizzle-orm/src/mysql-core/query-builders/select.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.ts
@@ -22,7 +22,7 @@ import { SQL, View } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { Table } from '~/table.ts';
 import type { ValueOrArray } from '~/utils.ts';
-import { applyMixins, getTableColumns, getTableLikeName, haveSameKeys, orderSelectedFields } from '~/utils.ts';
+import { applyMixins, getTableColumns, getTableLikeName, haveSameKeys, orderSelectedFields, push_array } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type { IndexBuilder } from '../indexes.ts';
 import { convertIndexToString, toArray } from '../utils.ts';
@@ -703,7 +703,7 @@ export abstract class MySqlSelectQueryBuilderBase<
 		MySqlSetOperatorExcludedMethods,
 		true
 	> {
-		this.config.setOperators.push(...setOperators);
+		push_array(this.config.setOperators, setOperators);
 		return this as any;
 	}
 

--- a/drizzle-orm/src/mysql-core/table.ts
+++ b/drizzle-orm/src/mysql-core/table.ts
@@ -8,6 +8,7 @@ import type { ForeignKey, ForeignKeyBuilder } from './foreign-keys.ts';
 import type { AnyIndexBuilder } from './indexes.ts';
 import type { PrimaryKeyBuilder } from './primary-keys.ts';
 import type { UniqueConstraintBuilder } from './unique-constraint.ts';
+import { push_array } from '../utils.ts';
 
 export type MySqlTableExtraConfigValue =
 	| AnyIndexBuilder
@@ -92,7 +93,7 @@ export function mysqlTableWithSchema<
 			const colBuilder = colBuilderBase as MySqlColumnBuilder;
 			colBuilder.setName(name);
 			const column = colBuilder.build(rawTable);
-			rawTable[InlineForeignKeys].push(...colBuilder.buildForeignKeys(column, rawTable));
+			push_array(rawTable[InlineForeignKeys], colBuilder.buildForeignKeys(column, rawTable));
 			return [name, column];
 		}),
 	) as unknown as BuildColumns<TTableName, TColumnsMap, 'mysql'>;

--- a/drizzle-orm/src/pg-core/query-builders/select.ts
+++ b/drizzle-orm/src/pg-core/query-builders/select.ts
@@ -32,7 +32,7 @@ import {
 	type NeonAuthToken,
 	type ValueOrArray,
 } from '~/utils.ts';
-import { orderSelectedFields } from '~/utils.ts';
+import { orderSelectedFields, push_array } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type {
 	AnyPgSelect,
@@ -630,7 +630,7 @@ export abstract class PgSelectQueryBuilderBase<
 		PgSetOperatorExcludedMethods,
 		true
 	> {
-		this.config.setOperators.push(...setOperators);
+		push_array(this.config.setOperators, setOperators);
 		return this as any;
 	}
 

--- a/drizzle-orm/src/pg-core/table.ts
+++ b/drizzle-orm/src/pg-core/table.ts
@@ -9,6 +9,7 @@ import type { AnyIndexBuilder } from './indexes.ts';
 import type { PgPolicy } from './policies.ts';
 import type { PrimaryKeyBuilder } from './primary-keys.ts';
 import type { UniqueConstraintBuilder } from './unique-constraint.ts';
+import { push_array } from '../utils.ts';
 
 export type PgTableExtraConfigValue =
 	| AnyIndexBuilder
@@ -97,7 +98,7 @@ export function pgTableWithSchema<
 			const colBuilder = colBuilderBase as PgColumnBuilder;
 			colBuilder.setName(name);
 			const column = colBuilder.build(rawTable);
-			rawTable[InlineForeignKeys].push(...colBuilder.buildForeignKeys(column, rawTable));
+			push_array(rawTable[InlineForeignKeys], colBuilder.buildForeignKeys(column, rawTable));
 			return [name, column];
 		}),
 	) as unknown as BuildColumns<TTableName, TColumnsMap, 'pg'>;

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -29,6 +29,7 @@ import {
 } from './sql/expressions/index.ts';
 import { type Placeholder, SQL, sql } from './sql/sql.ts';
 import type { Assume, ColumnsWithTable, Equal, Simplify, ValueOrArray } from './utils.ts';
+import { push_array } from './utils.ts';
 
 export abstract class Relation<TTableName extends string = string> {
 	static readonly [entityKind]: string = 'Relation';
@@ -464,7 +465,7 @@ export function extractTablesRelationalConfig<
 			if (extraConfig) {
 				for (const configEntry of Object.values(extraConfig)) {
 					if (is(configEntry, PrimaryKeyBuilder)) {
-						tablesConfig[key]!.primaryKey.push(...configEntry.columns);
+						push_array(tablesConfig[key]!.primaryKey, configEntry.columns);
 					}
 				}
 			}
@@ -481,7 +482,7 @@ export function extractTablesRelationalConfig<
 					const tableConfig = tablesConfig[tableName]!;
 					tableConfig.relations[relationName] = relation;
 					if (primaryKey) {
-						tableConfig.primaryKey.push(...primaryKey);
+						push_array(tableConfig.primaryKey, primaryKey);
 					}
 				} else {
 					if (!(dbName in relationsBuffer)) {

--- a/drizzle-orm/src/singlestore-core/query-builders/select.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/select.ts
@@ -31,6 +31,7 @@ import {
 	getTableLikeName,
 	haveSameKeys,
 	orderSelectedFields,
+	push_array,
 	type ValueOrArray,
 } from '~/utils.ts';
 import type {
@@ -557,7 +558,7 @@ export abstract class SingleStoreSelectQueryBuilderBase<
 		SingleStoreSetOperatorExcludedMethods,
 		true
 	> {
-		this.config.setOperators.push(...setOperators);
+		push_array(this.config.setOperators, setOperators);
 		return this as any;
 	}
 

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -9,6 +9,7 @@ import { ViewBaseConfig } from '~/view-common.ts';
 import type { AnyColumn } from '../column.ts';
 import { Column } from '../column.ts';
 import { IsAlias, Table } from '../table.ts';
+import { push_array } from '~/utils.ts';
 
 /**
  * This class is used to indicate a primitive param value that is used in `sql` tag.
@@ -75,12 +76,12 @@ function mergeQueries(queries: QueryWithTypings[]): QueryWithTypings {
 	const result: QueryWithTypings = { sql: '', params: [] };
 	for (const query of queries) {
 		result.sql += query.sql;
-		result.params.push(...query.params);
+		push_array(result.params, query.params);
 		if (query.typings?.length) {
 			if (!result.typings) {
 				result.typings = [];
 			}
-			result.typings.push(...query.typings);
+			push_array(result.typings, query.typings);
 		}
 	}
 	return result;
@@ -115,7 +116,7 @@ export class SQL<T = unknown> implements SQLWrapper {
 	constructor(readonly queryChunks: SQLChunk[]) {}
 
 	append(query: SQL): this {
-		this.queryChunks.push(...query.queryChunks);
+		push_array(this.queryChunks, query.queryChunks);
 		return this;
 	}
 

--- a/drizzle-orm/src/sqlite-core/query-builders/select.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/select.ts
@@ -28,6 +28,7 @@ import {
 	getTableLikeName,
 	haveSameKeys,
 	orderSelectedFields,
+	push_array,
 	type ValueOrArray,
 } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
@@ -530,7 +531,7 @@ export abstract class SQLiteSelectQueryBuilderBase<
 		SQLiteSetOperatorExcludedMethods,
 		true
 	> {
-		this.config.setOperators.push(...setOperators);
+		push_array(this.config.setOperators, setOperators);
 		return this as any;
 	}
 

--- a/drizzle-orm/src/sqlite-core/table.ts
+++ b/drizzle-orm/src/sqlite-core/table.ts
@@ -8,6 +8,7 @@ import type { ForeignKey, ForeignKeyBuilder } from './foreign-keys.ts';
 import type { IndexBuilder } from './indexes.ts';
 import type { PrimaryKeyBuilder } from './primary-keys.ts';
 import type { UniqueConstraintBuilder } from './unique-constraint.ts';
+import { push_array } from '~/utils.ts';
 
 export type SQLiteTableExtraConfigValue =
 	| IndexBuilder
@@ -193,7 +194,7 @@ function sqliteTableBase<
 			const colBuilder = colBuilderBase as SQLiteColumnBuilder;
 			colBuilder.setName(name);
 			const column = colBuilder.build(rawTable);
-			rawTable[InlineForeignKeys].push(...colBuilder.buildForeignKeys(column, rawTable));
+			push_array(rawTable[InlineForeignKeys], colBuilder.buildForeignKeys(column, rawTable));
 			return [name, column];
 		}),
 	) as unknown as BuildColumns<TTableName, TColumnsMap, 'sqlite'>;

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -83,9 +83,9 @@ export function orderSelectedFields<TColumn extends AnyColumn>(
 		if (is(field, Column) || is(field, SQL) || is(field, SQL.Aliased)) {
 			result.push({ path: newPath, field });
 		} else if (is(field, Table)) {
-			result.push(...orderSelectedFields(field[Table.Symbol.Columns], newPath));
+			push_array(result, orderSelectedFields(field[Table.Symbol.Columns], newPath));
 		} else {
-			result.push(...orderSelectedFields(field as Record<string, unknown>, newPath));
+			push_array(result, orderSelectedFields(field as Record<string, unknown>, newPath));
 		}
 		return result;
 	}, []) as SelectedFieldsOrdered<TColumn>;
@@ -317,3 +317,15 @@ export function isConfig(data: any): boolean {
 }
 
 export type NeonAuthToken = string | (() => string | Promise<string>);
+
+/**
+ * To avoid a potential `Maximum call stack size exceeded` error with `Array.push(...items)`, we use push one element at a time.
+ * Please note that there is a same function in `drizzle-kit/src/utils.ts#push_array`, `drizzle-seed/src/utils.ts`.
+ */
+export function push_array<T>(array: T[], items: T[]): void {
+  // eslint-disable-next-line unicorn/no-for-loop -- for is faster than for of
+  for (let i = 0; i < items.length; i++) {
+    array.push(items[i]!);
+  }
+}
+

--- a/drizzle-seed/src/index.ts
+++ b/drizzle-seed/src/index.ts
@@ -16,6 +16,7 @@ import { SeedService } from './services/SeedService.ts';
 import type { DrizzleStudioObjectType, DrizzleStudioRelationType } from './types/drizzleStudio.ts';
 import type { RefinementsType } from './types/seedService.ts';
 import type { Column, Relation, RelationWithReferences, Table } from './types/tables.ts';
+import { push_array } from './utils.ts';
 
 type InferCallbackType<
 	DB extends
@@ -617,7 +618,7 @@ const getPostgresInfo = (schema: { [key: string]: PgTable }) => {
 		if (tableRelations[dbToTsTableNamesMap[tableConfig.name] as string] === undefined) {
 			tableRelations[dbToTsTableNamesMap[tableConfig.name] as string] = [];
 		}
-		tableRelations[dbToTsTableNamesMap[tableConfig.name] as string]!.push(...newRelations);
+		push_array(tableRelations[dbToTsTableNamesMap[tableConfig.name] as string]!, newRelations);
 
 		const getAllBaseColumns = (
 			baseColumn: PgArray<any, any>['baseColumn'] & { baseColumn?: PgArray<any, any>['baseColumn'] },
@@ -909,7 +910,7 @@ const getMySqlInfo = (schema: { [key: string]: MySqlTable }) => {
 		if (tableRelations[dbToTsTableNamesMap[tableConfig.name] as string] === undefined) {
 			tableRelations[dbToTsTableNamesMap[tableConfig.name] as string] = [];
 		}
-		tableRelations[dbToTsTableNamesMap[tableConfig.name] as string]!.push(...newRelations);
+		push_array(tableRelations[dbToTsTableNamesMap[tableConfig.name] as string]!, newRelations);
 
 		const getTypeParams = (sqlType: string) => {
 			// get type params and set only type
@@ -1128,7 +1129,7 @@ const getSqliteInfo = (schema: { [key: string]: SQLiteTable }) => {
 		if (tableRelations[dbToTsTableNamesMap[tableConfig.name] as string] === undefined) {
 			tableRelations[dbToTsTableNamesMap[tableConfig.name] as string] = [];
 		}
-		tableRelations[dbToTsTableNamesMap[tableConfig.name] as string]!.push(...newRelations);
+		push_array(tableRelations[dbToTsTableNamesMap[tableConfig.name] as string]!, newRelations);
 
 		const getTypeParams = (sqlType: string) => {
 			// get type params and set only type

--- a/drizzle-seed/src/services/Generators.ts
+++ b/drizzle-seed/src/services/Generators.ts
@@ -13,6 +13,7 @@ import phonesInfo from '../datasets/phonesInfo.ts';
 import states, { maxStringLength as maxStateLength } from '../datasets/states.ts';
 import streetSuffix, { maxStringLength as maxStreetSuffixLength } from '../datasets/streetSuffix.ts';
 import { fastCartesianProduct, fillTemplate, getWeightedIndices, isObject } from './utils.ts';
+import { push_array } from '../utils.ts';
 
 export abstract class AbstractGenerator<T = {}> {
 	static readonly entityKind: string = 'AbstractGenerator';
@@ -775,7 +776,7 @@ export class GenerateUniqueInt extends AbstractGenerator<{
 			this.state!.intervals[intervalIdx] = this.state!.intervals[this.state!.intervals.length - 1]!;
 			this.state?.intervals.pop();
 			this.timeSpent += (Date.now() - t0.getTime()) / 1000;
-			this.state!.intervals.push(...intervalsToAdd);
+			push_array(this.state!.intervals, intervalsToAdd);
 		}
 
 		return numb;
@@ -805,7 +806,7 @@ export class GenerateUniqueInt extends AbstractGenerator<{
 
 			this.state!.intervals[intervalIdx] = this.state!.intervals[this.state!.intervals.length - 1]!;
 			this.state?.intervals.pop();
-			this.state!.intervals.push(...intervalsToAdd);
+			push_array(this.state!.intervals, intervalsToAdd);
 		}
 
 		return numb;

--- a/drizzle-seed/src/services/SeedService.ts
+++ b/drizzle-seed/src/services/SeedService.ts
@@ -18,6 +18,7 @@ import type { AbstractGenerator, GenerateArray, GenerateInterval, GenerateWeight
 
 import { latestVersion } from './apiVersion.ts';
 import { equalSets, generateHashFromString } from './utils.ts';
+import { push_array } from '../utils.ts';
 
 export class SeedService {
 	static readonly entityKind: string = 'SeedService';
@@ -397,7 +398,7 @@ export class SeedService {
 			}
 
 			children = [...tablesInOutRelations[parent]!.dependantTableNames];
-			leafTablesNames.push(...children);
+			push_array(leafTablesNames, children);
 		}
 		return orderedTablesNames;
 	};

--- a/drizzle-seed/src/services/utils.ts
+++ b/drizzle-seed/src/services/utils.ts
@@ -1,3 +1,5 @@
+import { push_array } from '../utils';
+
 export const fastCartesianProduct = (sets: (number | string | boolean | object)[][], index: number) => {
 	const resultList = [];
 	let currSet: (typeof sets)[number];
@@ -36,7 +38,7 @@ export const getWeightedIndices = (weights: number[], accuracy = 100) => {
 	const weightedIndices: number[] = [];
 	for (const [index, weight] of weights.entries()) {
 		const ticketsNumb = Math.floor(weight * accuracy);
-		weightedIndices.push(...Array.from<number>({ length: ticketsNumb }).fill(index));
+		push_array(weightedIndices, Array.from<number>({ length: ticketsNumb }).fill(index));
 	}
 
 	return weightedIndices;

--- a/drizzle-seed/src/utils.ts
+++ b/drizzle-seed/src/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * To avoid a potential `Maximum call stack size exceeded` error with `Array.push(...items)`, we use push one element at a time.
+ * Please note that there is a same function in `drizzle-orm/src/utils.ts`, `drizzle-kit/src/utils.ts#push_array`.
+ */
+export function push_array<T>(array: T[], items: T[]): void {
+  // eslint-disable-next-line unicorn/no-for-loop -- for is faster than for of
+  for (let i = 0; i < items.length; i++) {
+    array.push(items[i]!);
+  }
+}


### PR DESCRIPTION
close: https://github.com/drizzle-team/drizzle-orm/issues/1740

Attempting to INSERT a large amount of data at once causes a Maximum call stack size exceeded error.
In my case, it occurred with the following: https://github.com/drizzle-team/drizzle-orm/blob/10d22305b062dd0f4b0ff1594a6ae722487b7886/drizzle-orm/src/sql/sql.ts#L78

The minimal code to reproduce this issue is as follows:
```ts
const array = [];
const items = Array.from({ length: 110088 }, (_, i) => i + 1);
array.push(...items)
```

To address this issue, I added a `push_array` utility to prevent the error.
Regarding performance, I believe the impact is negligible, but is there any benchmark data available to confirm this?

I’d like to add an ESLint rule to inspect the use of `array.push(...items)` in the future. What do you think? If you agree, I will create a separate PR for it.
