### PR TITLE
Resolve aggregate functions to numbers when appropriate

### DIFF
--- a/drizzle-orm/src/sql/functions/aggregate.ts
+++ b/drizzle-orm/src/sql/functions/aggregate.ts
@@ -48,8 +48,8 @@ export function countDistinct(expression: SQLWrapper): SQL<number> {
  *
  * @see avgDistinct to get the average of all non-null and non-duplicate values in `expression`
  */
-export function avg(expression: SQLWrapper): SQL<string | null> {
-	return sql`avg(${expression})`.mapWith(String);
+export function avg(expression: SQLWrapper): SQL<number | null> {
+	return sql`avg(${expression})`.mapWith(Number);
 }
 
 /**
@@ -64,8 +64,8 @@ export function avg(expression: SQLWrapper): SQL<string | null> {
  *
  * @see avg to get the average of all non-null values in `expression`, including duplicates
  */
-export function avgDistinct(expression: SQLWrapper): SQL<string | null> {
-	return sql`avg(distinct ${expression})`.mapWith(String);
+export function avgDistinct(expression: SQLWrapper): SQL<number | null> {
+	return sql`avg(distinct ${expression})`.mapWith(Number);
 }
 
 /**
@@ -80,8 +80,8 @@ export function avgDistinct(expression: SQLWrapper): SQL<string | null> {
  *
  * @see sumDistinct to get the sum of all non-null and non-duplicate values in `expression`
  */
-export function sum(expression: SQLWrapper): SQL<string | null> {
-	return sql`sum(${expression})`.mapWith(String);
+export function sum(expression: SQLWrapper): SQL<number | null> {
+	return sql`sum(${expression})`.mapWith(Number);
 }
 
 /**
@@ -96,8 +96,8 @@ export function sum(expression: SQLWrapper): SQL<string | null> {
  *
  * @see sum to get the sum of all non-null values in `expression`, including duplicates
  */
-export function sumDistinct(expression: SQLWrapper): SQL<string | null> {
-	return sql`sum(distinct ${expression})`.mapWith(String);
+export function sumDistinct(expression: SQLWrapper): SQL<number | null> {
+	return sql`sum(distinct ${expression})`.mapWith(Number);
 }
 
 /**

--- a/integration-tests/tests/mysql/mysql-common.ts
+++ b/integration-tests/tests/mysql/mysql-common.ts
@@ -3086,9 +3086,9 @@ export function tests(driver?: string) {
 			const result2 = await db.select({ value: avg(table.nullOnly) }).from(table);
 			const result3 = await db.select({ value: avgDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).toBe('33.3333');
+			expect(result1[0]?.value).toBe(33.3333);
 			expect(result2[0]?.value).toBe(null);
-			expect(result3[0]?.value).toBe('42.5000');
+			expect(result3[0]?.value).toBe(42.5);
 		});
 
 		test('aggregate function: sum', async (ctx) => {
@@ -3100,9 +3100,9 @@ export function tests(driver?: string) {
 			const result2 = await db.select({ value: sum(table.nullOnly) }).from(table);
 			const result3 = await db.select({ value: sumDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).toBe('200');
+			expect(result1[0]?.value).toBe(200);
 			expect(result2[0]?.value).toBe(null);
-			expect(result3[0]?.value).toBe('170');
+			expect(result3[0]?.value).toBe(170);
 		});
 
 		test('aggregate function: max', async (ctx) => {

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -3702,9 +3702,9 @@ export function tests() {
 			const result2 = await db.select({ value: avg(table.nullOnly) }).from(table);
 			const result3 = await db.select({ value: avgDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).toBe('33.3333333333333333');
+			expect(result1[0]?.value).toBe(33.333333333333336);
 			expect(result2[0]?.value).toBeNull();
-			expect(result3[0]?.value).toBe('42.5000000000000000');
+			expect(result3[0]?.value).toBe(42.5);
 		});
 
 		test('aggregate function: sum', async (ctx) => {
@@ -3716,9 +3716,9 @@ export function tests() {
 			const result2 = await db.select({ value: sum(table.nullOnly) }).from(table);
 			const result3 = await db.select({ value: sumDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).toBe('200');
+			expect(result1[0]?.value).toBe(200);
 			expect(result2[0]?.value).toBeNull();
-			expect(result3[0]?.value).toBe('170');
+			expect(result3[0]?.value).toBe(170);
 		});
 
 		test('aggregate function: max', async (ctx) => {

--- a/integration-tests/tests/singlestore/singlestore-common.ts
+++ b/integration-tests/tests/singlestore/singlestore-common.ts
@@ -2864,9 +2864,9 @@ export function tests(driver?: string) {
 			const result2 = await db.select({ value: avg(table.nullOnly) }).from(table);
 			const result3 = await db.select({ value: avgDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).toBe('33.3333');
+			expect(result1[0]?.value).toBe(33.3333);
 			expect(result2[0]?.value).toBe(null);
-			expect(result3[0]?.value).toBe('42.5000');
+			expect(result3[0]?.value).toBe(42.5);
 		});
 
 		test('aggregate function: sum', async (ctx) => {
@@ -2878,9 +2878,9 @@ export function tests(driver?: string) {
 			const result2 = await db.select({ value: sum(table.nullOnly) }).from(table);
 			const result3 = await db.select({ value: sumDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).toBe('200');
+			expect(result1[0]?.value).toBe(200);
 			expect(result2[0]?.value).toBe(null);
-			expect(result3[0]?.value).toBe('170');
+			expect(result3[0]?.value).toBe(170);
 		});
 
 		test('aggregate function: max', async (ctx) => {

--- a/integration-tests/tests/sqlite/durable-objects/index.ts
+++ b/integration-tests/tests/sqlite/durable-objects/index.ts
@@ -3060,9 +3060,9 @@ export class MyDurableObject extends DurableObject {
 			const result2 = await this.db.select({ value: avg(table.nullOnly) }).from(table);
 			const result3 = await this.db.select({ value: avgDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).eq('24');
+			expect(result1[0]?.value).eq(24);
 			expect(result2[0]?.value).eq(null);
-			expect(result3[0]?.value).eq('42.5');
+			expect(result3[0]?.value).eq(42.5);
 		} catch (error: any) {
 			console.error(error);
 			throw new Error(`aggregatFunctionAvg error`);
@@ -3079,9 +3079,9 @@ export class MyDurableObject extends DurableObject {
 			const result2 = await this.db.select({ value: sum(table.nullOnly) }).from(table);
 			const result3 = await this.db.select({ value: sumDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).eq('200');
+			expect(result1[0]?.value).eq(200);
 			expect(result2[0]?.value).eq(null);
-			expect(result3[0]?.value).eq('170');
+			expect(result3[0]?.value).eq(170);
 		} catch (error: any) {
 			console.error(error);
 			throw new Error(`aggregateFunctionSum error`);

--- a/integration-tests/tests/sqlite/sqlite-common.ts
+++ b/integration-tests/tests/sqlite/sqlite-common.ts
@@ -2644,9 +2644,9 @@ export function tests() {
 			const result2 = await db.select({ value: avg(table.nullOnly) }).from(table);
 			const result3 = await db.select({ value: avgDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).toBe('24');
+			expect(result1[0]?.value).toBe(24);
 			expect(result2[0]?.value).toBeNull();
-			expect(result3[0]?.value).toBe('42.5');
+			expect(result3[0]?.value).toBe(42.5);
 		});
 
 		test('aggregate function: sum', async (ctx) => {
@@ -2658,9 +2658,9 @@ export function tests() {
 			const result2 = await db.select({ value: sum(table.nullOnly) }).from(table);
 			const result3 = await db.select({ value: sumDistinct(table.b) }).from(table);
 
-			expect(result1[0]?.value).toBe('200');
+			expect(result1[0]?.value).toBe(200);
 			expect(result2[0]?.value).toBeNull();
-			expect(result3[0]?.value).toBe('170');
+			expect(result3[0]?.value).toBe(170);
 		});
 
 		test('aggregate function: max', async (ctx) => {


### PR DESCRIPTION
The idea of this change is to improve ergonomics of the `avg` and `sum` aggregate functions (as well as their counterparts `avgDistinct` and `sumDistinct`) by mapping their results to numbers rather than strings.