### PR TITLE
Allow custom casing in schema push operations

### DIFF
--- a/drizzle-kit/src/api.ts
+++ b/drizzle-kit/src/api.ts
@@ -112,6 +112,7 @@ export const pushSchema = async (
 	schemaFilters?: string[],
 	tablesFilter?: string[],
 	extensionsFilters?: Config['extensionsFilters'],
+	casing?: CasingType,
 ) => {
 	const { applyPgSnapshotsDiff } = await import('./snapshotsDiffer');
 	const { sql } = await import('drizzle-orm');
@@ -126,7 +127,7 @@ export const pushSchema = async (
 		},
 	};
 
-	const cur = generateDrizzleJson(imports);
+	const cur = generateDrizzleJson(imports, undefined, schemaFilters, casing);
 	const { schema: prev } = await pgPushIntrospect(
 		db,
 		filters,


### PR DESCRIPTION
## Problem
When using `drizzle` with custom casing options (e.g., `casing: 'snake_case'`), the `pushSchema` operation doesn't respect the configured casing. This leads to mismatches between the runtime configuration and schema synchronization.

### Example of the issue:
```typescript
// Database configuration using snake_case
export const db = drizzle({ 
  client: pgPool, 
  casing: 'snake_case', 
  schema: dbSchema 
});

// Auto-sync function that previously didn't respect casing
export const autoSynchronize = async () => {
  // This would generate schema with default casing, causing mismatch
  const result = await pushSchema(dbSchema, db as any);
  if (result.hasDataLoss) {
    log.fatal('executing database synchronisation would lead to data loss, aborting');
    return;
  }

  await result.apply();
};
```

## Solution
Added a new optional `casing` parameter to `pushSchema` that gets passed through to `generateDrizzleJson`. This ensures the schema generation respects the same casing rules that are used in the database connection configuration.

### Updated Usage
```typescript
// Schema push with matching casing
const result = await pushSchema(
  dbSchema, 
  db as any, 
  undefined, 
  undefined, 
  undefined, 
  'snake_case'
);
```