### PR TITLE
[WIP] fix: handle empty string and array on pg introspect

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1975,8 +1975,10 @@ const defaultForColumn = (column: any, internals: PgKitInternals, tableName: str
 						return value === 't' ? 'true' : 'false';
 					} else if (['json', 'jsonb'].includes(column.data_type.slice(0, -2))) {
 						return JSON.stringify(JSON.stringify(JSON.parse(JSON.parse(value)), null, 0));
-					} else {
+					} else if (value) {
 						return `\"${value}\"`;
+					} else {
+            return ``; 
 					}
 				})
 				.join(',')

--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -366,6 +366,7 @@ export function escapeSingleQuotes(str: string) {
 }
 
 export function unescapeSingleQuotes(str: string, ignoreFirstAndLastChar: boolean) {
+  if (ignoreFirstAndLastChar && str === `''`) return str;
 	const regex = ignoreFirstAndLastChar ? /(?<!^)'(?!$)/g : /'/g;
 	return str.replace(/''/g, "'").replace(regex, "\\'");
 }

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -35,7 +35,7 @@ import {
 	varchar,
 } from 'drizzle-orm/pg-core';
 import fs from 'fs';
-import { introspectPgToFile } from 'tests/schemaDiffer';
+import { introspectPgToFile, introspectAfterSqlStatements } from 'tests/schemaDiffer';
 import { expect, test } from 'vitest';
 
 if (!fs.existsSync('tests/introspect/postgres')) {
@@ -891,4 +891,14 @@ test('multiple policies with roles from schema', async () => {
 
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
+});
+
+test('default empty array', async () => {
+  const client = new PGlite();
+  const defaultVal = `'{}'`;
+  const statements = [
+    `CREATE TABLE "users" ("names" text[] default ${defaultVal});`,
+  ];
+  const { tables } = await introspectAfterSqlStatements(client, statements);
+  expect(tables['public.users']?.columns.names?.default).toBe(defaultVal);
 });

--- a/drizzle-kit/tests/push/pg.test.ts
+++ b/drizzle-kit/tests/push/pg.test.ts
@@ -2008,6 +2008,35 @@ test('add array column - empty array default', async () => {
 	expect(sqlStatements).toStrictEqual(['ALTER TABLE "test" ADD COLUMN "values" integer[] DEFAULT \'{}\';']);
 });
 
+
+test('add text array column - empty array default', async () => {
+	const client = new PGlite();
+
+	const schema1 = {
+		test: pgTable('test', {
+			id: serial('id').primaryKey(),
+		}),
+	};
+	const schema2 = {
+		test: pgTable('test', {
+			id: serial('id').primaryKey(),
+			values: text('values').array().notNull().default([]),
+		}),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasPush(client, schema1, schema2, [], false, ['public']);
+
+	expect(statements).toStrictEqual([
+		{
+			type: 'alter_table_add_column',
+			tableName: 'test',
+			schema: '',
+			column: { name: 'values', type: 'text[]', primaryKey: false, notNull: true, default: "'{}'" },
+		},
+	]);
+	expect(sqlStatements).toStrictEqual(['ALTER TABLE "test" ADD COLUMN "values" text[] DEFAULT \'{}\' NOT NULL;']);
+});
+
 test('add array column - default', async () => {
 	const client = new PGlite();
 

--- a/drizzle-kit/tests/schemaDiffer.ts
+++ b/drizzle-kit/tests/schemaDiffer.ts
@@ -2240,6 +2240,41 @@ export const diffTestSchemasLibSQL = async (
 	return { sqlStatements, statements };
 };
 
+export const introspectAfterSqlStatements = async (
+	client: PGlite,
+	sqlStatements: string[],
+	schemas: string[] = ['public'],
+	entities?: Entities,
+) => {
+	for (const st of sqlStatements) {
+		await client.query(st);
+	}
+	// introspect to schema
+	const introspectedSchema = await fromDatabase(
+		{
+			query: async (query: string, values?: any[] | undefined) => {
+				const res = await client.query(query, values);
+				return res.rows as any[];
+			},
+		},
+		undefined,
+		schemas,
+		entities,
+	);
+
+	const { version: _initV, dialect: _initD, ...initRest } = introspectedSchema;
+
+	const initSch = {
+		version: '7',
+		dialect: 'postgresql',
+		id: '0',
+		prevId: '0',
+		...initRest,
+	} as const;
+	
+	return pgSchema.parse(initSch);
+};
+
 // --- Introspect to file helpers ---
 
 export const introspectPgToFile = async (


### PR DESCRIPTION

Addresses [#3549](https://github.com/drizzle-team/drizzle-orm/issues/3549) and [#3559](https://github.com/drizzle-team/drizzle-orm/issues/3559)