### PR TITLE
DROP INDEX does not include PG Schema prefix

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -3557,8 +3557,12 @@ class PgDropIndexConvertor extends Convertor {
 	}
 
 	convert(statement: JsonDropIndexStatement): string {
+		const { schema } = statement;
 		const { name } = PgSquasher.unsquashIdx(statement.data);
-		return `DROP INDEX "${name}";`;
+
+		const indexNameWithSchema = schema ? `"${schema}"."${name}"` : `"${name}"`;
+
+		return `DROP INDEX ${indexNameWithSchema};`;
 	}
 }
 


### PR DESCRIPTION
In PostgreSQL created indexes will belong to the same schema, as the table, to which the index belongs to. When generating SQL for migration an index name does not currently contain the schema prefix. This is incorrect, since there is no guarantee that the selected schema of the connection, during the SQL migration, is the same as the schema of the index, causing the SQL migration to fail. Therefore, all index names needs to be prefixed with the schema name.

Fixes #3703 