### PR TITLE
Fixed vercel session's lack of `count` override (fixes #3710)

### DIFF
--- a/drizzle-orm/src/vercel-postgres/session.ts
+++ b/drizzle-orm/src/vercel-postgres/session.ts
@@ -15,7 +15,7 @@ import type { SelectedFieldsOrdered } from '~/pg-core/query-builders/select.type
 import type { PgQueryResultHKT, PgTransactionConfig, PreparedQueryConfig } from '~/pg-core/session.ts';
 import { PgPreparedQuery, PgSession } from '~/pg-core/session.ts';
 import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
-import { fillPlaceholders, type Query, sql } from '~/sql/sql.ts';
+import { fillPlaceholders, type Query, type SQL, sql } from '~/sql/sql.ts';
 import { type Assume, mapResultRow } from '~/utils.ts';
 
 export type VercelPgClient = VercelPool | VercelClient | VercelPoolClient;
@@ -179,6 +179,12 @@ export class VercelPgSession<
 		params: unknown[],
 	): Promise<QueryResult<T>> {
 		return this.client.query<T>(query, params);
+	}
+
+	override async count(sql: SQL): Promise<number> {
+		const result = await this.execute(sql);
+
+		return Number((result as any)['rows'][0]['count']);
 	}
 
 	override async transaction<T>(


### PR DESCRIPTION
- Fixed vercel session's lack of `count` override (fixes #3710)