### PR TITLE
"schemaFilters" option was ignored when pass from cli due to inconsistently naming 

### DIFF
--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -494,7 +494,7 @@ export const preparePullConfig = async (
 		}
 	}
 
-	const schemasFilterConfig = config.schemaFilter; // TODO: consistent naming
+	const schemasFilterConfig = config.schemaFilter;
 	const schemasFilter = schemasFilterConfig
 		? typeof schemasFilterConfig === 'string'
 			? [schemasFilterConfig]

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -208,7 +208,7 @@ export const migrate = command({
 
 const optionsFilters = {
 	tablesFilter: string().desc('Table name filters'),
-	schemaFilters: string().desc('Schema name filters'),
+	schemaFilter: string().desc('Schema name filters'),
 	extensionsFilters: string().desc(
 		'`Database extensions internal database filters',
 	),
@@ -264,7 +264,7 @@ export const push = command({
 				'database',
 				'ssl',
 				'authToken',
-				'schemaFilters',
+				'schemaFilter',
 				'extensionsFilters',
 				'tablesFilter',
 				'casing',
@@ -466,7 +466,7 @@ export const pull = command({
 				'casing',
 				'breakpoints',
 				'tablesFilter',
-				'schemaFilters',
+				'schemaFilter',
 				'extensionsFilters',
 			],
 		);


### PR DESCRIPTION
close #3626 

In `drizzle.config.ts`, the option name `schemaFilter` is specified, but the CLI side requires the option name `schemaFilters`.

This caused the value passed when specifying the `schemaFilters` option from the CLI side to be ignored, so we have fixed this.