### PR TITLE
[turso] Allows authToken to be empty string

### DIFF
--- a/drizzle-kit/src/cli/validations/libsql.ts
+++ b/drizzle-kit/src/cli/validations/libsql.ts
@@ -5,7 +5,7 @@ import { wrapParam } from './common';
 
 export const libSQLCredentials = object({
 	url: string().min(1),
-	authToken: string().min(1).optional(),
+	authToken: string().min(0).optional(),
 });
 
 export type LibSQLCredentials = {

--- a/drizzle-kit/src/cli/validations/sqlite.ts
+++ b/drizzle-kit/src/cli/validations/sqlite.ts
@@ -7,7 +7,7 @@ export const sqliteCredentials = union([
 	object({
 		driver: literal('turso'),
 		url: string().min(1),
-		authToken: string().min(1).optional(),
+		authToken: string().min(0).optional(),
 	}),
 	object({
 		driver: literal('d1-http'),


### PR DESCRIPTION
`authToken` especially provided by env variable could be an empty string, relaxing the validation would allow it to pass instead of forcing developer to create a branching case for providing credentials

Currently, when `authToken` is provided as an empty string, validation message is outputted though is not exactly clear.
<img width="364" alt="Screenshot 2025-01-11 at 18 23 03" src="https://github.com/user-attachments/assets/07e75209-89b6-4f3e-85e7-3059231f37b3" />

Without relaxing the validation, developer would need to use a branch case.
<img width="509" alt="Screenshot 2025-01-11 at 18 24 42" src="https://github.com/user-attachments/assets/aa137155-2031-4ef2-ad01-be1a964e1888" />
