### PR TITLE
[postgres-kit] Pass ssl and max connection options to postgres

### DIFF
--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -222,9 +222,7 @@ export const preparePostgresDB = async (
 		const { drizzle } = await import('drizzle-orm/postgres-js');
 		const { migrate } = await import('drizzle-orm/postgres-js/migrator');
 
-		const client = 'url' in credentials
-			? postgres.default(credentials.url, { max: 1 })
-			: postgres.default({ ...credentials, max: 1 });
+		const client = postgres.default({ max: 1, ...credentials });
 
 		const transparentParser = (val: any) => val;
 

--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -222,7 +222,9 @@ export const preparePostgresDB = async (
 		const { drizzle } = await import('drizzle-orm/postgres-js');
 		const { migrate } = await import('drizzle-orm/postgres-js/migrator');
 
-		const client = postgres.default({ max: 1, ...credentials });
+		const client = 'url' in credentials
+			? postgres.default(credentials.url, { max: 1, ...credentials })
+			: postgres.default({ max: 1, ...credentials });
 
 		const transparentParser = (val: any) => val;
 

--- a/drizzle-kit/src/cli/validations/postgres.ts
+++ b/drizzle-kit/src/cli/validations/postgres.ts
@@ -18,6 +18,7 @@ export const postgresCredentials = union([
 			boolean(),
 			object({}).passthrough(),
 		]).optional(),
+		max: coerce.number().min(1).optional(),
 	}).transform((o) => {
 		delete o.driver;
 		return o as Omit<typeof o, 'driver'>;

--- a/drizzle-kit/src/cli/validations/postgres.ts
+++ b/drizzle-kit/src/cli/validations/postgres.ts
@@ -2,6 +2,18 @@ import { boolean, coerce, literal, object, string, TypeOf, undefined, union } fr
 import { error } from '../views';
 import { wrapParam } from './common';
 
+const postgresConnectionOptions = {
+	ssl: union([
+		literal('require'),
+		literal('allow'),
+		literal('prefer'),
+		literal('verify-full'),
+		boolean(),
+		object({}).passthrough(),
+	]).optional(),
+	max: coerce.number().min(1).optional(),
+}
+
 export const postgresCredentials = union([
 	object({
 		driver: undefined(),
@@ -10,15 +22,7 @@ export const postgresCredentials = union([
 		user: string().min(1).optional(),
 		password: string().min(1).optional(),
 		database: string().min(1),
-		ssl: union([
-			literal('require'),
-			literal('allow'),
-			literal('prefer'),
-			literal('verify-full'),
-			boolean(),
-			object({}).passthrough(),
-		]).optional(),
-		max: coerce.number().min(1).optional(),
+		...postgresConnectionOptions
 	}).transform((o) => {
 		delete o.driver;
 		return o as Omit<typeof o, 'driver'>;
@@ -26,7 +30,8 @@ export const postgresCredentials = union([
 	object({
 		driver: undefined(),
 		url: string().min(1),
-	}).transform<{ url: string }>((o) => {
+		...postgresConnectionOptions
+	}).transform((o) => {
 		delete o.driver;
 		return o;
 	}),


### PR DESCRIPTION
Pass ssl and max connection options to postgres.

`ssl` - Needed if using Drizzle with a server that enforces ssl. This PR allows using url & ssl, instead of having to split url into host, port, username, password, database just to be able to pass ssl as a parameter to postgres.

`max` - Don't know what the story behind `max: 1` here is, but I had to set max to 2, otherwise `drizzle-kit push` would get stuck pulling database schema from Supabase pooler (with enforce ssl enabled). Having max: 1 first and ...credentials afterwards allows overriding max from drizzle.config.ts which solved that issue.


There would be plenty more options to add, see https://www.npmjs.com/package/postgres#connection-details

Might be worth it changing the other pg connections in connections.ts to use the same pattern. I couldn't test those so didn't touch them. Also unsure if those other packages would support the same set of connection options.