### PR TITLE
fix new issue link for drizzle studio

### DIFF
--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -703,7 +703,7 @@ export const studio = command({
 			console.log();
 			console.log(
 				withStyle.fullWarning(
-					'Drizzle Studio is currently in Beta. If you find anything that is not working as expected or should be improved, feel free to create an issue on GitHub: https://github.com/drizzle-team/drizzle-kit-mirror/issues/new or write to us on Discord: https://discord.gg/WcRKz2FFxN',
+					'Drizzle Studio is currently in Beta. If you find anything that is not working as expected or should be improved, feel free to create an issue on GitHub: https://github.com/drizzle-team/drizzle-orm/issues/new/choose or write to us on Discord: https://discord.gg/WcRKz2FFxN',
 				),
 			);
 


### PR DESCRIPTION
The warning that appears when running Drizzle Studio mentions the wrong repository for issues.

The old message that I am referring to:
` Warning  Drizzle Studio is currently in Beta. If you find anything that is not working as expected or should be improved, feel free to create an issue on GitHub: https://github.com/drizzle-team/drizzle-kit-mirror/issues/new or write to us on Discord: https://discord.gg/WcRKz2FFxN`