### PR TITLE
[Validators] Export `BuildSchema` type and simplify JSON schema

### DIFF
--- a/drizzle-typebox/src/column.ts
+++ b/drizzle-typebox/src/column.ts
@@ -60,9 +60,7 @@ import { isColumnType, isWithEnum } from './utils.ts';
 import type { BufferSchema, JsonSchema } from './utils.ts';
 
 export const literalSchema = t.Union([t.String(), t.Number(), t.Boolean(), t.Null()]);
-export const jsonSchema: JsonSchema = t.Recursive((self) =>
-	t.Union([literalSchema, t.Array(self), t.Record(t.String(), self)])
-) as any;
+export const jsonSchema: JsonSchema = t.Union([literalSchema, t.Array(t.Any()), t.Record(t.String(), t.Any())]) as any;
 TypeRegistry.Set('Buffer', (_, value) => value instanceof Buffer); // eslint-disable-line no-instanceof/no-instanceof
 export const bufferSchema: BufferSchema = { [Kind]: 'Buffer', type: 'buffer' } as any;
 

--- a/drizzle-typebox/src/index.ts
+++ b/drizzle-typebox/src/index.ts
@@ -1,2 +1,3 @@
 export * from './schema.ts';
+export type { BuildSchema } from './schema.types.internal.ts';
 export * from './schema.types.ts';

--- a/drizzle-typebox/src/utils.ts
+++ b/drizzle-typebox/src/utils.ts
@@ -14,7 +14,7 @@ export function isWithEnum(column: Column): column is typeof column & { enumValu
 export const isPgEnum: (entity: any) => entity is PgEnum<[string, ...string[]]> = isWithEnum as any;
 
 type Literal = Static<typeof literalSchema>;
-export type Json = Literal | { [key: string]: Json } | Json[];
+export type Json = Literal | { [key: string]: any } | any[];
 export interface JsonSchema extends TSchema {
 	[Kind]: 'Union';
 	static: Json;

--- a/drizzle-valibot/src/column.ts
+++ b/drizzle-valibot/src/column.ts
@@ -61,8 +61,8 @@ import type { Json } from './utils.ts';
 export const literalSchema = v.union([v.string(), v.number(), v.boolean(), v.null()]);
 export const jsonSchema: v.GenericSchema<Json> = v.union([
 	literalSchema,
-	v.array(v.lazy(() => jsonSchema)),
-	v.record(v.string(), v.lazy(() => jsonSchema)),
+	v.array(v.any()),
+	v.record(v.string(), v.any()),
 ]);
 export const bufferSchema: v.GenericSchema<Buffer> = v.custom<Buffer>((v) => v instanceof Buffer); // eslint-disable-line no-instanceof/no-instanceof
 

--- a/drizzle-valibot/src/index.ts
+++ b/drizzle-valibot/src/index.ts
@@ -1,2 +1,3 @@
 export * from './schema.ts';
+export type { BuildSchema } from './schema.types.internal.ts';
 export * from './schema.types.ts';

--- a/drizzle-valibot/src/utils.ts
+++ b/drizzle-valibot/src/utils.ts
@@ -14,7 +14,7 @@ export function isWithEnum(column: Column): column is typeof column & { enumValu
 export const isPgEnum: (entity: any) => entity is PgEnum<[string, ...string[]]> = isWithEnum as any;
 
 type Literal = v.InferOutput<typeof literalSchema>;
-export type Json = Literal | { [key: string]: Json } | Json[];
+export type Json = Literal | { [key: string]: any } | any[];
 
 export type IsNever<T> = [T] extends [never] ? true : false;
 

--- a/drizzle-zod/src/column.ts
+++ b/drizzle-zod/src/column.ts
@@ -61,9 +61,7 @@ import { isColumnType, isWithEnum } from './utils.ts';
 import type { Json } from './utils.ts';
 
 export const literalSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
-export const jsonSchema: z.ZodType<Json> = z.lazy(() =>
-	z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)])
-);
+export const jsonSchema: z.ZodType<Json> = z.union([literalSchema, z.record(z.any()), z.array(z.any())]);
 export const bufferSchema: z.ZodType<Buffer> = z.custom<Buffer>((v) => v instanceof Buffer); // eslint-disable-line no-instanceof/no-instanceof
 
 export function columnToSchema(column: Column, factory: CreateSchemaFactoryOptions | undefined): z.ZodTypeAny {

--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -1,2 +1,3 @@
 export * from './schema.ts';
+export type { BuildSchema } from './schema.types.internal.ts';
 export * from './schema.types.ts';

--- a/drizzle-zod/src/utils.ts
+++ b/drizzle-zod/src/utils.ts
@@ -14,7 +14,7 @@ export function isWithEnum(column: Column): column is typeof column & { enumValu
 export const isPgEnum: (entity: any) => entity is PgEnum<[string, ...string[]]> = isWithEnum as any;
 
 type Literal = z.infer<typeof literalSchema>;
-export type Json = Literal | { [key: string]: Json } | Json[];
+export type Json = Literal | { [key: string]: any } | any[];
 
 export type IsNever<T> = [T] extends [never] ? true : false;
 


### PR DESCRIPTION
Addresses #3732 & #3869.
Branched off of #3852.

Fixed the `The inferred type of X cannot be named without a reference to ../../../../../node_modules/drizzle-zod/schema.types.internal.mjs` error for all validator packages. Using @slimshreydy's reproduction repo, I managed to fix it by going into `node_modules` and exporting `BuildSchema` type. This PR exports this so you don't have to manually do what was described prior.

**Breaking for some users**
Depending on the tsconfig.json, it seems that recursive types causes some issues. The only recursive type in these packages is the default JSON schema. I've simplified the definition to make it more accessible. Most developers override this field anyways, but it is important to note this change.