### PR TITLE
[PG, MySQL, SQLite, SingleStore] Fix withReplica `$count`

### DIFF
--- a/drizzle-orm/src/mysql-core/db.ts
+++ b/drizzle-orm/src/mysql-core/db.ts
@@ -497,6 +497,7 @@ export const withReplicas = <
 ): MySQLWithReplicas<Q> => {
 	const select: Q['select'] = (...args: []) => getReplica(replicas).select(...args);
 	const selectDistinct: Q['selectDistinct'] = (...args: []) => getReplica(replicas).selectDistinct(...args);
+	const $count: Q['$count'] = (...args: [any]) => getReplica(replicas).$count(...args);
 	const $with: Q['with'] = (...args: []) => getReplica(replicas).with(...args);
 
 	const update: Q['update'] = (...args: [any]) => primary.update(...args);
@@ -515,6 +516,7 @@ export const withReplicas = <
 		$primary: primary,
 		select,
 		selectDistinct,
+		$count,
 		with: $with,
 		get query() {
 			return getReplica(replicas).query;

--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -647,6 +647,7 @@ export const withReplicas = <
 	const select: Q['select'] = (...args: []) => getReplica(replicas).select(...args);
 	const selectDistinct: Q['selectDistinct'] = (...args: []) => getReplica(replicas).selectDistinct(...args);
 	const selectDistinctOn: Q['selectDistinctOn'] = (...args: [any]) => getReplica(replicas).selectDistinctOn(...args);
+	const $count: Q['$count'] = (...args: [any]) => getReplica(replicas).$count(...args);
 	const _with: Q['with'] = (...args: any) => getReplica(replicas).with(...args);
 	const $with: Q['$with'] = (arg: any) => getReplica(replicas).$with(arg);
 
@@ -670,6 +671,7 @@ export const withReplicas = <
 		select,
 		selectDistinct,
 		selectDistinctOn,
+		$count,
 		$with,
 		with: _with,
 		get query() {

--- a/drizzle-orm/src/singlestore-core/db.ts
+++ b/drizzle-orm/src/singlestore-core/db.ts
@@ -490,6 +490,7 @@ export const withReplicas = <
 ): SingleStoreWithReplicas<Q> => {
 	const select: Q['select'] = (...args: []) => getReplica(replicas).select(...args);
 	const selectDistinct: Q['selectDistinct'] = (...args: []) => getReplica(replicas).selectDistinct(...args);
+	const $count: Q['$count'] = (...args: [any]) => getReplica(replicas).$count(...args);
 	const $with: Q['with'] = (...args: []) => getReplica(replicas).with(...args);
 
 	const update: Q['update'] = (...args: [any]) => primary.update(...args);
@@ -508,6 +509,7 @@ export const withReplicas = <
 		$primary: primary,
 		select,
 		selectDistinct,
+		$count,
 		with: $with,
 		get query() {
 			return getReplica(replicas).query;

--- a/drizzle-orm/src/sqlite-core/db.ts
+++ b/drizzle-orm/src/sqlite-core/db.ts
@@ -603,6 +603,7 @@ export const withReplicas = <
 ): SQLiteWithReplicas<Q> => {
 	const select: Q['select'] = (...args: []) => getReplica(replicas).select(...args);
 	const selectDistinct: Q['selectDistinct'] = (...args: []) => getReplica(replicas).selectDistinct(...args);
+	const $count: Q['$count'] = (...args: [any]) => getReplica(replicas).$count(...args);
 	const $with: Q['with'] = (...args: []) => getReplica(replicas).with(...args);
 
 	const update: Q['update'] = (...args: [any]) => primary.update(...args);
@@ -627,6 +628,7 @@ export const withReplicas = <
 		$primary: primary,
 		select,
 		selectDistinct,
+		$count,
 		with: $with,
 		get query() {
 			return getReplica(replicas).query;

--- a/integration-tests/tests/replicas/mysql.test.ts
+++ b/integration-tests/tests/replicas/mysql.test.ts
@@ -803,3 +803,111 @@ describe('[findMany] read replicas mysql', () => {
 		expect(query2.toSQL().sql).toEqual('select `id`, `name`, `verified` from `users` `usersTable`');
 	});
 });
+
+describe('[$count] read replicas postgres', () => {
+	it('primary $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$primary.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(0);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+	});
+
+	it('random replica $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const randomMockReplica = vi.fn().mockReturnValueOnce(read1).mockReturnValueOnce(read2);
+
+		const db = withReplicas(primaryDb, [read1, read2], () => {
+			return randomMockReplica();
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+
+		db.select().from(users);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(1);
+	});
+
+	it('single read replica $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+
+		db.$count(users);
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+	});
+
+	it('single read replica $count + primary $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+
+		db.$primary.$count(users);
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+	});
+
+	it('always first read $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2], (replicas) => {
+			return replicas[0]!;
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+
+		db.$count(users);
+
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+	});
+});

--- a/integration-tests/tests/replicas/postgres.test.ts
+++ b/integration-tests/tests/replicas/postgres.test.ts
@@ -825,3 +825,111 @@ describe('[findMany] read replicas postgres', () => {
 		);
 	});
 });
+
+describe('[$count] read replicas postgres', () => {
+	it('primary $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$primary.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(0);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+	});
+
+	it('random replica $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const randomMockReplica = vi.fn().mockReturnValueOnce(read1).mockReturnValueOnce(read2);
+
+		const db = withReplicas(primaryDb, [read1, read2], () => {
+			return randomMockReplica();
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+
+		db.select().from(users);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(1);
+	});
+
+	it('single read replica $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+
+		db.$count(users);
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+	});
+
+	it('single read replica $count + primary $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+
+		db.$primary.$count(users);
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+	});
+
+	it('always first read $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2], (replicas) => {
+			return replicas[0]!;
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+
+		db.$count(users);
+
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+	});
+});

--- a/integration-tests/tests/replicas/singlestore.test.ts
+++ b/integration-tests/tests/replicas/singlestore.test.ts
@@ -812,3 +812,112 @@ describe('[transaction] replicas singlestore', () => {
 // 	// 	expect(query2.toSQL().sql).toEqual('select `id`, `name`, `verified` from `users` `usersTable`');
 // 	// });
 // });
+
+
+describe('[$count] read replicas postgres', () => {
+	it('primary $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$primary.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(0);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+	});
+
+	it('random replica $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const randomMockReplica = vi.fn().mockReturnValueOnce(read1).mockReturnValueOnce(read2);
+
+		const db = withReplicas(primaryDb, [read1, read2], () => {
+			return randomMockReplica();
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+
+		db.select().from(users);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(1);
+	});
+
+	it('single read replica $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+
+		db.$count(users);
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+	});
+
+	it('single read replica $count + primary $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+
+		db.$primary.$count(users);
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+	});
+
+	it('always first read $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2], (replicas) => {
+			return replicas[0]!;
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+
+		db.$count(users);
+
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+	});
+});

--- a/integration-tests/tests/replicas/sqlite.test.ts
+++ b/integration-tests/tests/replicas/sqlite.test.ts
@@ -799,3 +799,112 @@ describe('[findMany] read replicas sqlite', () => {
 		expect(query2.toSQL().sql).toEqual('select "id", "name", "verified" from "users" "usersTable"');
 	});
 });
+
+
+describe('[$count] read replicas postgres', () => {
+	it('primary $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$primary.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(0);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+	});
+
+	it('random replica $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const randomMockReplica = vi.fn().mockReturnValueOnce(read1).mockReturnValueOnce(read2);
+
+		const db = withReplicas(primaryDb, [read1, read2], () => {
+			return randomMockReplica();
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+
+		db.select().from(users);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(1);
+	});
+
+	it('single read replica $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+
+		db.$count(users);
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+	});
+
+	it('single read replica $count + primary $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+
+		db.$primary.$count(users);
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+	});
+
+	it('always first read $count', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2], (replicas) => {
+			return replicas[0]!;
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$count');
+		const spyRead1 = vi.spyOn(read1, '$count');
+		const spyRead2 = vi.spyOn(read2, '$count');
+
+		db.$count(users);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+
+		db.$count(users);
+
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+	});
+});


### PR DESCRIPTION
Fixes #3951

This bug is present in all dialects supported by Drizzle. Tests have been updated to ensure there are no regressions when using `$count` with an instance returned by `withReplicas` function.