### PR TITLE
Add AbortSignal to NodePgPreparedQuery

### DIFF
--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -39,6 +39,7 @@ export class NodePgPreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 		name: string | undefined,
 		private _isResponseInArrayMode: boolean,
 		private customResultMapper?: (rows: unknown[][]) => T['execute'],
+		private signal?: AbortSignal,
 	) {
 		super({ sql: queryString, params }, cache, queryMetadata, cacheConfig);
 		this.rawQueryConfig = {
@@ -132,6 +133,13 @@ export class NodePgPreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 
 	async execute(placeholderValues: Record<string, unknown> | undefined = {}): Promise<T['execute']> {
 		return tracer.startActiveSpan('drizzle.execute', async () => {
+			try {
+				this.signal?.throwIfAborted();
+			} catch (e) {
+				// Create new error to capture stack trace
+				throw new Error('PostgreSQL connection experienced an error or has been closed', { cause: e });
+			}
+
 			const params = fillPlaceholders(this.params, placeholderValues);
 
 			this.logger.logQuery(this.rawQueryConfig.text, params);
@@ -204,6 +212,11 @@ export class NodePgSession<
 > extends PgSession<NodePgQueryResultHKT, TFullSchema, TSchema> {
 	static override readonly [entityKind]: string = 'NodePgSession';
 
+	private abortController = new AbortController();
+	private errorCallback = (err: unknown) => {
+		this.abortController.abort(err);
+	};
+
 	private logger: Logger;
 	private cache: Cache;
 
@@ -216,6 +229,7 @@ export class NodePgSession<
 		super(dialect);
 		this.logger = options.logger ?? new NoopLogger();
 		this.cache = options.cache ?? new NoopCache();
+		this.client.on('error', this.errorCallback);
 	}
 
 	prepareQuery<T extends PreparedQueryConfig = PreparedQueryConfig>(
@@ -242,6 +256,7 @@ export class NodePgSession<
 			name,
 			isResponseInArrayMode,
 			customResultMapper,
+			this.abortController.signal,
 		);
 	}
 
@@ -263,7 +278,10 @@ export class NodePgSession<
 			await tx.execute(sql`rollback`);
 			throw error;
 		} finally {
-			if (isPool) (session.client as PoolClient).release();
+			if (isPool) {
+				session.end();
+				(session.client as PoolClient).release();
+			}
 		}
 	}
 
@@ -272,6 +290,11 @@ export class NodePgSession<
 		return Number(
 			res['rows'][0]['count'],
 		);
+	}
+
+	end(): void {
+		this.client.off('error', this.errorCallback);
+		this.abortController.abort();
 	}
 }
 


### PR DESCRIPTION
This signal is aborted from the NodePgSession object when an error event occurs on the underlying node-postgres client object. By default, there is no handler for such errors, meaning they will crash the Node.js process.
The AbortSignal acts as a "buffer" for the error event, storing it and turning it into a promise rejection that will then travel up the call stack, allowing the code that invoked Drizzle to decide what to do with it.

Closes #3908.

This is a minimal reproducer for the error case this addresses:

```ts
import { setTimeout } from "node:timers/promises";

import { sql } from "drizzle-orm";
import { drizzle } from "drizzle-orm/node-postgres";

const db = drizzle("postgres://postgres:asdf@localhost:5432/postgres");

try {
  await db.transaction(async (tx) => {
    const {
      rows: [{ pid }],
    } = await tx.execute("select pg_backend_pid() as pid");

    Promise.resolve(db.execute(sql`select pg_terminate_backend(${pid})`));

    await setTimeout(5000);
  });
} finally {
  console.log("Finally");
}
```

Before this patch, this results in an uncaught error terminating the process. Notably, the print in the `finally` block is never executed.

```
node:events:502
      throw er; // Unhandled 'error' event
      ^

error: terminating connection due to administrator command
    at Parser.parseErrorMessage (/home/user/Scratchpad/drizzle-repro-pgerror/node_modules/.pnpm/pg-protocol@1.7.0/node_modules/pg-protocol/src/parser.ts:368:69)
    at Parser.handlePacket (/home/user/Scratchpad/drizzle-repro-pgerror/node_modules/.pnpm/pg-protocol@1.7.0/node_modules/pg-protocol/src/parser.ts:187:21)
    at Parser.parse (/home/user/Scratchpad/drizzle-repro-pgerror/node_modules/.pnpm/pg-protocol@1.7.0/node_modules/pg-protocol/src/parser.ts:102:30)
    at Socket.<anonymous> (/home/user/Scratchpad/drizzle-repro-pgerror/node_modules/.pnpm/pg-protocol@1.7.0/node_modules/pg-protocol/src/index.ts:7:48)
    at Socket.emit (node:events:524:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:189:23)
Emitted 'error' event on Client instance at:
    at Client._handleErrorEvent (/home/user/Scratchpad/drizzle-repro-pgerror/node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/client.js:340:10)
    at Client._handleErrorMessage (/home/user/Scratchpad/drizzle-repro-pgerror/node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/client.js:351:12)
    at Connection.emit (node:events:524:28)
    at /home/user/Scratchpad/drizzle-repro-pgerror/node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/connection.js:116:12
    at Parser.parse (/home/user/Scratchpad/drizzle-repro-pgerror/node_modules/.pnpm/pg-protocol@1.7.0/node_modules/pg-protocol/src/parser.ts:103:9)
    at Socket.<anonymous> (/home/user/Scratchpad/drizzle-repro-pgerror/node_modules/.pnpm/pg-protocol@1.7.0/node_modules/pg-protocol/src/index.ts:7:48)
    [... lines matching original stack trace ...]
    at Readable.push (node:internal/streams/readable:392:5) {
  length: 116,
  severity: 'FATAL',
  code: '57P01',
  detail: undefined,
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'postgres.c',
  line: '3246',
  routine: 'ProcessInterrupts'
}

Node.js v22.13.0
```

With this patch, such errors are now caught by the session and rethrown on next attempted use. As you can see, the `finally` block executes as expected; the process doesn't just crash. Also, the stack trace, while not complete due to a [v8 bug](https://issues.chromium.org/issues/332083029) with custom thenables, now clearly leads into Drizzle code at the location that tried to use the connection next.

```
Finally
/home/user/Code/drizzle-team/drizzle-orm/drizzle-orm/src/node-postgres/session.ts:91
                                throw new Error('PostgreSQL connection experienced an error or has been closed', {cause: e});
                                      ^


Error: PostgreSQL connection experienced an error or has been closed
    at <anonymous> (/home/user/Code/drizzle-team/drizzle-orm/drizzle-orm/src/node-postgres/session.ts:91:11)
    at Object.startActiveSpan (/home/user/Code/drizzle-team/drizzle-orm/drizzle-orm/src/tracing.ts:27:11)
    at NodePgPreparedQuery.execute (/home/user/Code/drizzle-team/drizzle-orm/drizzle-orm/src/node-postgres/session.ts:87:17)
    at QueryPromise.execute (/home/user/Code/drizzle-team/drizzle-orm/drizzle-orm/src/pg-core/db.ts:616:19)
    at QueryPromise.then (/home/user/Code/drizzle-team/drizzle-orm/drizzle-orm/src/query-promise.ts:32:15) {
  [cause]: error: terminating connection due to administrator command
      at Parser.parseErrorMessage (/home/user/Code/drizzle-team/drizzle-orm/node_modules/.pnpm/pg-protocol@1.6.1/node_modules/pg-protocol/src/parser.ts:369:69)
      at Parser.handlePacket (/home/user/Code/drizzle-team/drizzle-orm/node_modules/.pnpm/pg-protocol@1.6.1/node_modules/pg-protocol/src/parser.ts:188:21)
      at Parser.parse (/home/user/Code/drizzle-team/drizzle-orm/node_modules/.pnpm/pg-protocol@1.6.1/node_modules/pg-protocol/src/parser.ts:103:30)
      at Socket.<anonymous> (/home/user/Code/drizzle-team/drizzle-orm/node_modules/.pnpm/pg-protocol@1.6.1/node_modules/pg-protocol/src/index.ts:7:48)
      at Socket.emit (node:events:524:28)
      at addChunk (node:internal/streams/readable:561:12)
      at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
      at Readable.push (node:internal/streams/readable:392:5)
      at TCP.onStreamRead (node:internal/stream_base_commons:189:23) {
    length: 116,
    severity: 'FATAL',
    code: '57P01',
    detail: undefined,
    hint: undefined,
    position: undefined,
    internalPosition: undefined,
    internalQuery: undefined,
    where: undefined,
    schema: undefined,
    table: undefined,
    column: undefined,
    dataType: undefined,
    constraint: undefined,
    file: 'postgres.c',
    line: '3246',
    routine: 'ProcessInterrupts'
  }
}

Node.js v22.13.0
```

Due to the aforementioned stack trace issue, I wasn't quite sure where to place the re-throw in `NodePgPreparedQuery.execute`. For now, I placed it at the start of the method, but I was wondering if it might be better to put it after the `logQuery` invocation or even inside the `drizzle.driver.execute` spans, to ensure observability tools can fill the gap.