### PR TITLE
[PG, Neon] Add neon_identity integration

### DIFF
--- a/drizzle-orm/src/neon/index.ts
+++ b/drizzle-orm/src/neon/index.ts
@@ -1,1 +1,2 @@
+export * from './neon-identity.ts';
 export * from './rls.ts';

--- a/drizzle-orm/src/neon/neon-identity.ts
+++ b/drizzle-orm/src/neon/neon-identity.ts
@@ -1,0 +1,19 @@
+import { jsonb, pgSchema, text, timestamp } from '~/pg-core/index.ts';
+
+const neonIdentitySchema = pgSchema('neon_identity');
+
+/**
+ * Table schema of the `users_sync` table used by Neon Identity.
+ * This table automatically synchronizes and stores user data from external authentication providers.
+ *
+ * @schema neon_identity
+ * @table users_sync
+ */
+export const usersSync = neonIdentitySchema.table('users_sync', {
+	rawJson: jsonb('raw_json').notNull(),
+	id: text().primaryKey().notNull(),
+	name: text(),
+	email: text(),
+	createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }),
+	deletedAt: timestamp('deleted_at', { withTimezone: true, mode: 'string' }),
+});

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -31,7 +31,7 @@ import {
 	sumDistinct,
 	TransactionRollbackError,
 } from 'drizzle-orm';
-import { authenticatedRole, crudPolicy } from 'drizzle-orm/neon';
+import { authenticatedRole, crudPolicy, usersSync } from 'drizzle-orm/neon';
 import type { NeonHttpDatabase } from 'drizzle-orm/neon-http';
 import type { PgColumn, PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import {
@@ -5128,6 +5128,16 @@ export function tests() {
 				expect(policies[0]?.name === 'crud-custom-policy-modify');
 				expect(policies[1]?.name === 'crud-custom-policy-read');
 			}
+		});
+
+		test('neon: neon_identity', () => {
+			const usersSyncTable = usersSync;
+
+			const { columns, schema, name } = getTableConfig(usersSyncTable);
+
+			expect(name).toBe('users_sync');
+			expect(schema).toBe('neon_identity');
+			expect(columns).toHaveLength(6);
 		});
 
 		test('Enable RLS function', () => {


### PR DESCRIPTION
## Description

This PR aims to add Neon Identity related databased objects to the `drizzle-orm` sdk, so that Neon users that want to use Neon Identity with Drizzle, can simply import the pre-defined schemas and don't need to define them by hand everytime.

**FEATURES**

- define `neon_identity` schema
- define and export `users_sync` table

## Test Plan

Added a small test that asserts the schema, table name and columns included.
Also installed the local `drizlzle-orm` version and used to `usersSync` export to make sure everything worked fine.

![image](https://github.com/user-attachments/assets/2b00d454-52bf-4ce6-9a62-f66e5be3f5a6)


## Subscribers

cc @davidgomes 

## Issue

Relates to #3959 