### PR TITLE
[SQLite, Turso]: Avoid wrapping SQL expressions in backticks for index generation

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -3535,15 +3535,13 @@ export class CreateSqliteIndexConvertor extends Convertor {
 		const { name, columns, isUnique, where } = SQLiteSquasher.unsquashIdx(
 			statement.data,
 		);
-		// // since postgresql 9.5
+
 		const indexPart = isUnique ? 'UNIQUE INDEX' : 'INDEX';
 		const whereStatement = where ? ` WHERE ${where}` : '';
 		const uniqueString = columns
 			.map((it) => {
-				return statement.internal?.indexes
-					? statement.internal?.indexes[name]?.columns[it]?.isExpression
-						? it
-						: `\`${it}\``
+				return statement.internal?.indexes?.[name]?.columns?.[it]?.isExpression
+					? it
 					: `\`${it}\``;
 			})
 			.join(',');


### PR DESCRIPTION
This PR addresses an issue in the `CreateSqliteIndexConvertor` where the code incorrectly treated all columns as plain identifiers, wrapping them in backticks.

The fix checks the isExpression property in the internal.indexes object and ensures that:

- SQL expressions are left untouched.
- Plain column names are still correctly escaped with backticks.

Fixes https://github.com/drizzle-team/drizzle-orm/issues/3350 (which should not have been closed yet).