### PR TITLE
[PG] Fix fk introspection ordering columns wrongly (critical failure)

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -62,10 +62,10 @@ function stringFromDatabaseIdentityProperty(field: any): string | undefined {
 	return typeof field === 'string'
 		? (field as string)
 		: typeof field === 'undefined'
-		? undefined
-		: typeof field === 'bigint'
-		? field.toString()
-		: String(field);
+			? undefined
+			: typeof field === 'bigint'
+				? field.toString()
+				: String(field);
 }
 
 export function buildArrayString(array: any[], sqlType: string): string {
@@ -182,8 +182,8 @@ export const generatePgSnapshot = (
 						as: is(generated.as, SQL)
 							? dialect.sqlToQuery(generated.as as SQL).sql
 							: typeof generated.as === 'function'
-							? dialect.sqlToQuery(generated.as() as SQL).sql
-							: (generated.as as any),
+								? dialect.sqlToQuery(generated.as() as SQL).sql
+								: (generated.as as any),
 						type: 'stored',
 					}
 					: undefined,
@@ -206,24 +206,19 @@ export const generatePgSnapshot = (
 				const existingUnique = uniqueConstraintObject[column.uniqueName!];
 				if (typeof existingUnique !== 'undefined') {
 					console.log(
-						`\n${
-							withStyle.errorWarning(`We\'ve found duplicated unique constraint names in ${
-								chalk.underline.blue(
-									tableName,
-								)
+						`\n${withStyle.errorWarning(`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(
+							tableName,
+						)
 							} table. 
-          The unique constraint ${
-								chalk.underline.blue(
-									column.uniqueName,
-								)
-							} on the ${
-								chalk.underline.blue(
-									name,
-								)
-							} column is conflicting with a unique constraint name already defined for ${
-								chalk.underline.blue(
-									existingUnique.columns.join(','),
-								)
+          The unique constraint ${chalk.underline.blue(
+								column.uniqueName,
+							)
+							} on the ${chalk.underline.blue(
+								name,
+							)
+							} column is conflicting with a unique constraint name already defined for ${chalk.underline.blue(
+								existingUnique.columns.join(','),
+							)
 							} columns\n`)
 						}`,
 					);
@@ -291,17 +286,14 @@ export const generatePgSnapshot = (
 			const existingUnique = uniqueConstraintObject[name];
 			if (typeof existingUnique !== 'undefined') {
 				console.log(
-					`\n${
-						withStyle.errorWarning(
-							`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(tableName)} table. 
-        The unique constraint ${chalk.underline.blue(name)} on the ${
-								chalk.underline.blue(
-									columnNames.join(','),
-								)
-							} columns is confilcting with a unique constraint name already defined for ${
-								chalk.underline.blue(existingUnique.columns.join(','))
-							} columns\n`,
+					`\n${withStyle.errorWarning(
+						`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(tableName)} table. 
+        The unique constraint ${chalk.underline.blue(name)} on the ${chalk.underline.blue(
+							columnNames.join(','),
 						)
+						} columns is confilcting with a unique constraint name already defined for ${chalk.underline.blue(existingUnique.columns.join(','))
+						} columns\n`,
+					)
 					}`,
 				);
 				process.exit(1);
@@ -364,12 +356,10 @@ export const generatePgSnapshot = (
 				if (is(it, SQL)) {
 					if (typeof value.config.name === 'undefined') {
 						console.log(
-							`\n${
-								withStyle.errorWarning(
-									`Please specify an index name in ${getTableName(value.config.table)} table that has "${
-										dialect.sqlToQuery(it).sql
-									}" expression. We can generate index names for indexes on columns only; for expressions in indexes, you need to specify the name yourself.`,
-								)
+							`\n${withStyle.errorWarning(
+								`Please specify an index name in ${getTableName(value.config.table)} table that has "${dialect.sqlToQuery(it).sql
+								}" expression. We can generate index names for indexes on columns only; for expressions in indexes, you need to specify the name yourself.`,
+							)
 							}`,
 						);
 						process.exit(1);
@@ -383,32 +373,25 @@ export const generatePgSnapshot = (
 					&& typeof it.indexConfig!.opClass === 'undefined'
 				) {
 					console.log(
-						`\n${
-							withStyle.errorWarning(
-								`You are specifying an index on the ${
-									chalk.blueBright(
-										name,
-									)
-								} column inside the ${
-									chalk.blueBright(
-										tableName,
-									)
-								} table with the ${
-									chalk.blueBright(
-										'vector',
-									)
-								} type without specifying an operator class. Vector extension doesn't have a default operator class, so you need to specify one of the available options. Here is a list of available op classes for the vector extension: [${
-									vectorOps
-										.map((it) => `${chalk.underline(`${it}`)}`)
-										.join(', ')
-								}].\n\nYou can specify it using current syntax: ${
-									chalk.underline(
-										`index("${value.config.name}").using("${value.config.method}", table.${name}.op("${
-											vectorOps[0]
-										}"))`,
-									)
-								}\n\nYou can check the "pg_vector" docs for more info: https://github.com/pgvector/pgvector?tab=readme-ov-file#indexing\n`,
+						`\n${withStyle.errorWarning(
+							`You are specifying an index on the ${chalk.blueBright(
+								name,
 							)
+							} column inside the ${chalk.blueBright(
+								tableName,
+							)
+							} table with the ${chalk.blueBright(
+								'vector',
+							)
+							} type without specifying an operator class. Vector extension doesn't have a default operator class, so you need to specify one of the available options. Here is a list of available op classes for the vector extension: [${vectorOps
+								.map((it) => `${chalk.underline(`${it}`)}`)
+								.join(', ')
+							}].\n\nYou can specify it using current syntax: ${chalk.underline(
+								`index("${value.config.name}").using("${value.config.method}", table.${name}.op("${vectorOps[0]
+								}"))`,
+							)
+							}\n\nYou can check the "pg_vector" docs for more info: https://github.com/pgvector/pgvector?tab=readme-ov-file#indexing\n`,
+						)
 						}`,
 					);
 					process.exit(1);
@@ -436,8 +419,8 @@ export const generatePgSnapshot = (
 							nulls: it.indexConfig?.nulls
 								? it.indexConfig?.nulls
 								: it.indexConfig?.order === 'desc'
-								? 'first'
-								: 'last',
+									? 'first'
+									: 'last',
 							opclass: it.indexConfig?.opClass,
 						};
 					}
@@ -448,16 +431,13 @@ export const generatePgSnapshot = (
 			if (typeof indexesInSchema[schema ?? 'public'] !== 'undefined') {
 				if (indexesInSchema[schema ?? 'public'].includes(name)) {
 					console.log(
-						`\n${
-							withStyle.errorWarning(
-								`We\'ve found duplicated index name across ${
-									chalk.underline.blue(schema ?? 'public')
-								} schema. Please rename your index in either the ${
-									chalk.underline.blue(
-										tableName,
-									)
-								} table or the table with the duplicated index name`,
+						`\n${withStyle.errorWarning(
+							`We\'ve found duplicated index name across ${chalk.underline.blue(schema ?? 'public')
+							} schema. Please rename your index in either the ${chalk.underline.blue(
+								tableName,
 							)
+							} table or the table with the duplicated index name`,
+						)
 						}`,
 					);
 					process.exit(1);
@@ -501,16 +481,13 @@ export const generatePgSnapshot = (
 
 			if (policiesObject[policy.name] !== undefined) {
 				console.log(
-					`\n${
-						withStyle.errorWarning(
-							`We\'ve found duplicated policy name across ${
-								chalk.underline.blue(tableKey)
-							} table. Please rename one of the policies with ${
-								chalk.underline.blue(
-									policy.name,
-								)
-							} name`,
+					`\n${withStyle.errorWarning(
+						`We\'ve found duplicated policy name across ${chalk.underline.blue(tableKey)
+						} table. Please rename one of the policies with ${chalk.underline.blue(
+							policy.name,
 						)
+						} name`,
+					)
 					}`,
 				);
 				process.exit(1);
@@ -532,22 +509,18 @@ export const generatePgSnapshot = (
 			if (typeof checksInTable[`"${schema ?? 'public'}"."${tableName}"`] !== 'undefined') {
 				if (checksInTable[`"${schema ?? 'public'}"."${tableName}"`].includes(check.name)) {
 					console.log(
-						`\n${
-							withStyle.errorWarning(
-								`We\'ve found duplicated check constraint name across ${
-									chalk.underline.blue(
-										schema ?? 'public',
-									)
-								} schema in ${
-									chalk.underline.blue(
-										tableName,
-									)
-								}. Please rename your check constraint in either the ${
-									chalk.underline.blue(
-										tableName,
-									)
-								} table or the table with the duplicated check contraint name`,
+						`\n${withStyle.errorWarning(
+							`We\'ve found duplicated check constraint name across ${chalk.underline.blue(
+								schema ?? 'public',
 							)
+							} schema in ${chalk.underline.blue(
+								tableName,
+							)
+							}. Please rename your check constraint in either the ${chalk.underline.blue(
+								tableName,
+							)
+							} table or the table with the duplicated check contraint name`,
+						)
 						}`,
 					);
 					process.exit(1);
@@ -583,10 +556,9 @@ export const generatePgSnapshot = (
 		// @ts-ignore
 		if (!policy._linkedTable) {
 			console.log(
-				`\n${
-					withStyle.errorWarning(
-						`"Policy ${policy.name} was skipped because it was not linked to any table. You should either include the policy in a table or use .link() on the policy to link it to any table you have. For more information, please check:`,
-					)
+				`\n${withStyle.errorWarning(
+					`"Policy ${policy.name} was skipped because it was not linked to any table. You should either include the policy in a table or use .link() on the policy to link it to any table you have. For more information, please check:`,
+				)
 				}`,
 			);
 			continue;
@@ -623,16 +595,13 @@ export const generatePgSnapshot = (
 
 		if (result[tableKey]?.policies[policy.name] !== undefined || policiesToReturn[policy.name] !== undefined) {
 			console.log(
-				`\n${
-					withStyle.errorWarning(
-						`We\'ve found duplicated policy name across ${
-							chalk.underline.blue(tableKey)
-						} table. Please rename one of the policies with ${
-							chalk.underline.blue(
-								policy.name,
-							)
-						} name`,
+				`\n${withStyle.errorWarning(
+					`We\'ve found duplicated policy name across ${chalk.underline.blue(tableKey)
+					} table. Please rename one of the policies with ${chalk.underline.blue(
+						policy.name,
 					)
+					} name`,
+				)
 				}`,
 			);
 			process.exit(1);
@@ -727,12 +696,10 @@ export const generatePgSnapshot = (
 		const existingView = resultViews[viewKey];
 		if (typeof existingView !== 'undefined') {
 			console.log(
-				`\n${
-					withStyle.errorWarning(
-						`We\'ve found duplicated view name across ${
-							chalk.underline.blue(schema ?? 'public')
-						} schema. Please rename your view`,
-					)
+				`\n${withStyle.errorWarning(
+					`We\'ve found duplicated view name across ${chalk.underline.blue(schema ?? 'public')
+					} schema. Please rename your view`,
+				)
 				}`,
 			);
 			process.exit(1);
@@ -770,8 +737,8 @@ export const generatePgSnapshot = (
 							as: is(generated.as, SQL)
 								? dialect.sqlToQuery(generated.as as SQL).sql
 								: typeof generated.as === 'function'
-								? dialect.sqlToQuery(generated.as() as SQL).sql
-								: (generated.as as any),
+									? dialect.sqlToQuery(generated.as() as SQL).sql
+									: (generated.as as any),
 							type: 'stored',
 						}
 						: undefined,
@@ -794,17 +761,14 @@ export const generatePgSnapshot = (
 					const existingUnique = uniqueConstraintObject[column.uniqueName!];
 					if (typeof existingUnique !== 'undefined') {
 						console.log(
-							`\n${
-								withStyle.errorWarning(
-									`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(viewName)} table. 
-          The unique constraint ${chalk.underline.blue(column.uniqueName)} on the ${
-										chalk.underline.blue(
-											column.name,
-										)
-									} column is confilcting with a unique constraint name already defined for ${
-										chalk.underline.blue(existingUnique.columns.join(','))
-									} columns\n`,
+							`\n${withStyle.errorWarning(
+								`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(viewName)} table. 
+          The unique constraint ${chalk.underline.blue(column.uniqueName)} on the ${chalk.underline.blue(
+									column.name,
 								)
+								} column is confilcting with a unique constraint name already defined for ${chalk.underline.blue(existingUnique.columns.join(','))
+								} columns\n`,
+							)
 							}`,
 						);
 						process.exit(1);
@@ -1032,8 +996,7 @@ WHERE
 	const seqWhere = schemaFilters.map((t) => `schemaname = '${t}'`).join(' or ');
 
 	const allSequences = await db.query(
-		`select schemaname, sequencename, start_value, min_value, max_value, increment_by, cycle, cache_size from pg_sequences as seq${
-			seqWhere === '' ? '' : ` WHERE ${seqWhere}`
+		`select schemaname, sequencename, start_value, min_value, max_value, increment_by, cycle, cache_size from pg_sequences as seq${seqWhere === '' ? '' : ` WHERE ${seqWhere}`
 		};`,
 	);
 
@@ -1156,9 +1119,8 @@ WHERE
 			using: string;
 			withCheck: string;
 		}
-	>(`SELECT schemaname, tablename, policyname as name, permissive as "as", roles as to, cmd as for, qual as using, with_check as "withCheck" FROM pg_policies${
-		wherePolicies === '' ? '' : ` WHERE ${wherePolicies}`
-	};`);
+	>(`SELECT schemaname, tablename, policyname as name, permissive as "as", roles as to, cmd as for, qual as using, with_check as "withCheck" FROM pg_policies${wherePolicies === '' ? '' : ` WHERE ${wherePolicies}`
+		};`);
 
 	for (const dbPolicy of allPolicies) {
 		const { tablename, schemaname, to, withCheck, using, ...rest } = dbPolicy;
@@ -1258,43 +1220,53 @@ WHERE
 
 					const tableForeignKeys = await db.query(
 						`SELECT
-            con.contype AS constraint_type,
-            nsp.nspname AS constraint_schema,
-            con.conname AS constraint_name,
-            rel.relname AS table_name,
-            att.attname AS column_name,
-            fnsp.nspname AS foreign_table_schema,
-            frel.relname AS foreign_table_name,
-            fatt.attname AS foreign_column_name,
-            CASE con.confupdtype
-              WHEN 'a' THEN 'NO ACTION'
-              WHEN 'r' THEN 'RESTRICT'
-              WHEN 'n' THEN 'SET NULL'
-              WHEN 'c' THEN 'CASCADE'
-              WHEN 'd' THEN 'SET DEFAULT'
-            END AS update_rule,
-            CASE con.confdeltype
-              WHEN 'a' THEN 'NO ACTION'
-              WHEN 'r' THEN 'RESTRICT'
-              WHEN 'n' THEN 'SET NULL'
-              WHEN 'c' THEN 'CASCADE'
-              WHEN 'd' THEN 'SET DEFAULT'
-            END AS delete_rule
-          FROM
-            pg_catalog.pg_constraint con
-            JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
-            JOIN pg_catalog.pg_namespace nsp ON nsp.oid = con.connamespace
-            LEFT JOIN pg_catalog.pg_attribute att ON att.attnum = ANY (con.conkey)
-              AND att.attrelid = con.conrelid
-            LEFT JOIN pg_catalog.pg_class frel ON frel.oid = con.confrelid
-            LEFT JOIN pg_catalog.pg_namespace fnsp ON fnsp.oid = frel.relnamespace
-            LEFT JOIN pg_catalog.pg_attribute fatt ON fatt.attnum = ANY (con.confkey)
-              AND fatt.attrelid = con.confrelid
-          WHERE
-            nsp.nspname = '${tableSchema}'
-            AND rel.relname = '${tableName}'
-            AND con.contype IN ('f');`,
-					);
+						con.contype AS constraint_type,
+						nsp.nspname AS constraint_schema,
+						con.conname AS constraint_name,
+						rel.relname AS table_name,
+						att.attname AS column_name,
+						fnsp.nspname AS foreign_table_schema,
+						frel.relname AS foreign_table_name,
+						fatt.attname AS foreign_column_name,
+						CASE con.confupdtype
+							WHEN 'a' THEN 'NO ACTION'
+							WHEN 'r' THEN 'RESTRICT'
+							WHEN 'n' THEN 'SET NULL'
+							WHEN 'c' THEN 'CASCADE'
+							WHEN 'd' THEN 'SET DEFAULT'
+						END AS update_rule,
+						CASE con.confdeltype
+							WHEN 'a' THEN 'NO ACTION'
+							WHEN 'r' THEN 'RESTRICT'
+							WHEN 'n' THEN 'SET NULL'
+							WHEN 'c' THEN 'CASCADE'
+							WHEN 'd' THEN 'SET DEFAULT'
+						END AS delete_rule
+				FROM pg_catalog.pg_constraint con
+				JOIN pg_catalog.pg_class rel 
+					ON rel.oid = con.conrelid
+				JOIN pg_catalog.pg_namespace nsp 
+					ON nsp.oid = con.connamespace
+
+				CROSS JOIN generate_subscripts(con.conkey, 1) AS s(i)
+
+				LEFT JOIN pg_catalog.pg_attribute att
+					ON att.attrelid  = con.conrelid
+					AND att.attnum   = con.conkey[s.i]
+
+				LEFT JOIN pg_catalog.pg_class frel
+					ON frel.oid = con.confrelid
+
+				LEFT JOIN pg_catalog.pg_namespace fnsp
+					ON fnsp.oid = frel.relnamespace
+
+				LEFT JOIN pg_catalog.pg_attribute fatt
+					ON fatt.attrelid = con.confrelid
+					AND fatt.attnum   = con.confkey[s.i]
+
+				WHERE nsp.nspname = '${tableSchema}' 
+					AND rel.relname = '${tableName}' 
+					AND con.contype IN ('f')`);
 
 					foreignKeysCount += tableForeignKeys.length;
 					if (progressCallback) {
@@ -1507,8 +1479,8 @@ WHERE
 									cache: sequencesToReturn[identityName]?.cache
 										? sequencesToReturn[identityName]?.cache
 										: sequencesToReturn[`${tableSchema}.${identityName}`]?.cache
-										? sequencesToReturn[`${tableSchema}.${identityName}`]?.cache
-										: undefined,
+											? sequencesToReturn[`${tableSchema}.${identityName}`]?.cache
+											: undefined,
 									cycle: identityCycle,
 									schema: tableSchema,
 								}
@@ -1518,8 +1490,7 @@ WHERE
 						if (identityName && typeof identityName === 'string') {
 							// remove "" from sequence name
 							delete sequencesToReturn[
-								`${tableSchema}.${
-									identityName.startsWith('"') && identityName.endsWith('"') ? identityName.slice(1, -1) : identityName
+								`${tableSchema}.${identityName.startsWith('"') && identityName.endsWith('"') ? identityName.slice(1, -1) : identityName
 								}`
 							];
 							delete sequencesToReturn[identityName];
@@ -1805,8 +1776,8 @@ WHERE
 									cache: sequencesToReturn[identityName]?.cache
 										? sequencesToReturn[identityName]?.cache
 										: sequencesToReturn[`${viewSchema}.${identityName}`]?.cache
-										? sequencesToReturn[`${viewSchema}.${identityName}`]?.cache
-										: undefined,
+											? sequencesToReturn[`${viewSchema}.${identityName}`]?.cache
+											: undefined,
 									cycle: identityCycle,
 									schema: viewSchema,
 								}
@@ -1816,8 +1787,7 @@ WHERE
 						if (identityName) {
 							// remove "" from sequence name
 							delete sequencesToReturn[
-								`${viewSchema}.${
-									identityName.startsWith('"') && identityName.endsWith('"') ? identityName.slice(1, -1) : identityName
+								`${viewSchema}.${identityName.startsWith('"') && identityName.endsWith('"') ? identityName.slice(1, -1) : identityName
 								}`
 							];
 							delete sequencesToReturn[identityName];
@@ -1960,27 +1930,26 @@ const defaultForColumn = (column: any, internals: PgKitInternals, tableName: str
 	const columnDefaultAsString: string = column.column_default.toString();
 
 	if (isArray) {
-		return `'{${
-			columnDefaultAsString
-				.slice(2, -2)
-				.split(/\s*,\s*/g)
-				.map((value) => {
-					if (['integer', 'smallint', 'bigint', 'double precision', 'real'].includes(column.data_type.slice(0, -2))) {
-						return value;
-					} else if (column.data_type.startsWith('timestamp')) {
-						return `${value}`;
-					} else if (column.data_type.slice(0, -2) === 'interval') {
-						return value.replaceAll('"', `\"`);
-					} else if (column.data_type.slice(0, -2) === 'boolean') {
-						return value === 't' ? 'true' : 'false';
-					} else if (['json', 'jsonb'].includes(column.data_type.slice(0, -2))) {
-						return JSON.stringify(JSON.stringify(JSON.parse(JSON.parse(value)), null, 0));
-					} else {
-						return `\"${value}\"`;
-					}
-				})
-				.join(',')
-		}}'`;
+		return `'{${columnDefaultAsString
+			.slice(2, -2)
+			.split(/\s*,\s*/g)
+			.map((value) => {
+				if (['integer', 'smallint', 'bigint', 'double precision', 'real'].includes(column.data_type.slice(0, -2))) {
+					return value;
+				} else if (column.data_type.startsWith('timestamp')) {
+					return `${value}`;
+				} else if (column.data_type.slice(0, -2) === 'interval') {
+					return value.replaceAll('"', `\"`);
+				} else if (column.data_type.slice(0, -2) === 'boolean') {
+					return value === 't' ? 'true' : 'false';
+				} else if (['json', 'jsonb'].includes(column.data_type.slice(0, -2))) {
+					return JSON.stringify(JSON.stringify(JSON.parse(JSON.parse(value)), null, 0));
+				} else {
+					return `\"${value}\"`;
+				}
+			})
+			.join(',')
+			}}'`;
 	}
 
 	if (['integer', 'smallint', 'bigint', 'double precision', 'real'].includes(column.data_type)) {

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -62,10 +62,10 @@ function stringFromDatabaseIdentityProperty(field: any): string | undefined {
 	return typeof field === 'string'
 		? (field as string)
 		: typeof field === 'undefined'
-			? undefined
-			: typeof field === 'bigint'
-				? field.toString()
-				: String(field);
+		? undefined
+		: typeof field === 'bigint'
+		? field.toString()
+		: String(field);
 }
 
 export function buildArrayString(array: any[], sqlType: string): string {
@@ -182,8 +182,8 @@ export const generatePgSnapshot = (
 						as: is(generated.as, SQL)
 							? dialect.sqlToQuery(generated.as as SQL).sql
 							: typeof generated.as === 'function'
-								? dialect.sqlToQuery(generated.as() as SQL).sql
-								: (generated.as as any),
+							? dialect.sqlToQuery(generated.as() as SQL).sql
+							: (generated.as as any),
 						type: 'stored',
 					}
 					: undefined,
@@ -206,19 +206,24 @@ export const generatePgSnapshot = (
 				const existingUnique = uniqueConstraintObject[column.uniqueName!];
 				if (typeof existingUnique !== 'undefined') {
 					console.log(
-						`\n${withStyle.errorWarning(`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(
-							tableName,
-						)
+						`\n${
+							withStyle.errorWarning(`We\'ve found duplicated unique constraint names in ${
+								chalk.underline.blue(
+									tableName,
+								)
 							} table. 
-          The unique constraint ${chalk.underline.blue(
-								column.uniqueName,
-							)
-							} on the ${chalk.underline.blue(
-								name,
-							)
-							} column is conflicting with a unique constraint name already defined for ${chalk.underline.blue(
-								existingUnique.columns.join(','),
-							)
+          The unique constraint ${
+								chalk.underline.blue(
+									column.uniqueName,
+								)
+							} on the ${
+								chalk.underline.blue(
+									name,
+								)
+							} column is conflicting with a unique constraint name already defined for ${
+								chalk.underline.blue(
+									existingUnique.columns.join(','),
+								)
 							} columns\n`)
 						}`,
 					);
@@ -286,14 +291,17 @@ export const generatePgSnapshot = (
 			const existingUnique = uniqueConstraintObject[name];
 			if (typeof existingUnique !== 'undefined') {
 				console.log(
-					`\n${withStyle.errorWarning(
-						`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(tableName)} table. 
-        The unique constraint ${chalk.underline.blue(name)} on the ${chalk.underline.blue(
-							columnNames.join(','),
+					`\n${
+						withStyle.errorWarning(
+							`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(tableName)} table. 
+        The unique constraint ${chalk.underline.blue(name)} on the ${
+								chalk.underline.blue(
+									columnNames.join(','),
+								)
+							} columns is confilcting with a unique constraint name already defined for ${
+								chalk.underline.blue(existingUnique.columns.join(','))
+							} columns\n`,
 						)
-						} columns is confilcting with a unique constraint name already defined for ${chalk.underline.blue(existingUnique.columns.join(','))
-						} columns\n`,
-					)
 					}`,
 				);
 				process.exit(1);
@@ -356,10 +364,12 @@ export const generatePgSnapshot = (
 				if (is(it, SQL)) {
 					if (typeof value.config.name === 'undefined') {
 						console.log(
-							`\n${withStyle.errorWarning(
-								`Please specify an index name in ${getTableName(value.config.table)} table that has "${dialect.sqlToQuery(it).sql
-								}" expression. We can generate index names for indexes on columns only; for expressions in indexes, you need to specify the name yourself.`,
-							)
+							`\n${
+								withStyle.errorWarning(
+									`Please specify an index name in ${getTableName(value.config.table)} table that has "${
+										dialect.sqlToQuery(it).sql
+									}" expression. We can generate index names for indexes on columns only; for expressions in indexes, you need to specify the name yourself.`,
+								)
 							}`,
 						);
 						process.exit(1);
@@ -373,25 +383,32 @@ export const generatePgSnapshot = (
 					&& typeof it.indexConfig!.opClass === 'undefined'
 				) {
 					console.log(
-						`\n${withStyle.errorWarning(
-							`You are specifying an index on the ${chalk.blueBright(
-								name,
+						`\n${
+							withStyle.errorWarning(
+								`You are specifying an index on the ${
+									chalk.blueBright(
+										name,
+									)
+								} column inside the ${
+									chalk.blueBright(
+										tableName,
+									)
+								} table with the ${
+									chalk.blueBright(
+										'vector',
+									)
+								} type without specifying an operator class. Vector extension doesn't have a default operator class, so you need to specify one of the available options. Here is a list of available op classes for the vector extension: [${
+									vectorOps
+										.map((it) => `${chalk.underline(`${it}`)}`)
+										.join(', ')
+								}].\n\nYou can specify it using current syntax: ${
+									chalk.underline(
+										`index("${value.config.name}").using("${value.config.method}", table.${name}.op("${
+											vectorOps[0]
+										}"))`,
+									)
+								}\n\nYou can check the "pg_vector" docs for more info: https://github.com/pgvector/pgvector?tab=readme-ov-file#indexing\n`,
 							)
-							} column inside the ${chalk.blueBright(
-								tableName,
-							)
-							} table with the ${chalk.blueBright(
-								'vector',
-							)
-							} type without specifying an operator class. Vector extension doesn't have a default operator class, so you need to specify one of the available options. Here is a list of available op classes for the vector extension: [${vectorOps
-								.map((it) => `${chalk.underline(`${it}`)}`)
-								.join(', ')
-							}].\n\nYou can specify it using current syntax: ${chalk.underline(
-								`index("${value.config.name}").using("${value.config.method}", table.${name}.op("${vectorOps[0]
-								}"))`,
-							)
-							}\n\nYou can check the "pg_vector" docs for more info: https://github.com/pgvector/pgvector?tab=readme-ov-file#indexing\n`,
-						)
 						}`,
 					);
 					process.exit(1);
@@ -419,8 +436,8 @@ export const generatePgSnapshot = (
 							nulls: it.indexConfig?.nulls
 								? it.indexConfig?.nulls
 								: it.indexConfig?.order === 'desc'
-									? 'first'
-									: 'last',
+								? 'first'
+								: 'last',
 							opclass: it.indexConfig?.opClass,
 						};
 					}
@@ -431,13 +448,16 @@ export const generatePgSnapshot = (
 			if (typeof indexesInSchema[schema ?? 'public'] !== 'undefined') {
 				if (indexesInSchema[schema ?? 'public'].includes(name)) {
 					console.log(
-						`\n${withStyle.errorWarning(
-							`We\'ve found duplicated index name across ${chalk.underline.blue(schema ?? 'public')
-							} schema. Please rename your index in either the ${chalk.underline.blue(
-								tableName,
+						`\n${
+							withStyle.errorWarning(
+								`We\'ve found duplicated index name across ${
+									chalk.underline.blue(schema ?? 'public')
+								} schema. Please rename your index in either the ${
+									chalk.underline.blue(
+										tableName,
+									)
+								} table or the table with the duplicated index name`,
 							)
-							} table or the table with the duplicated index name`,
-						)
 						}`,
 					);
 					process.exit(1);
@@ -481,13 +501,16 @@ export const generatePgSnapshot = (
 
 			if (policiesObject[policy.name] !== undefined) {
 				console.log(
-					`\n${withStyle.errorWarning(
-						`We\'ve found duplicated policy name across ${chalk.underline.blue(tableKey)
-						} table. Please rename one of the policies with ${chalk.underline.blue(
-							policy.name,
+					`\n${
+						withStyle.errorWarning(
+							`We\'ve found duplicated policy name across ${
+								chalk.underline.blue(tableKey)
+							} table. Please rename one of the policies with ${
+								chalk.underline.blue(
+									policy.name,
+								)
+							} name`,
 						)
-						} name`,
-					)
 					}`,
 				);
 				process.exit(1);
@@ -509,18 +532,22 @@ export const generatePgSnapshot = (
 			if (typeof checksInTable[`"${schema ?? 'public'}"."${tableName}"`] !== 'undefined') {
 				if (checksInTable[`"${schema ?? 'public'}"."${tableName}"`].includes(check.name)) {
 					console.log(
-						`\n${withStyle.errorWarning(
-							`We\'ve found duplicated check constraint name across ${chalk.underline.blue(
-								schema ?? 'public',
+						`\n${
+							withStyle.errorWarning(
+								`We\'ve found duplicated check constraint name across ${
+									chalk.underline.blue(
+										schema ?? 'public',
+									)
+								} schema in ${
+									chalk.underline.blue(
+										tableName,
+									)
+								}. Please rename your check constraint in either the ${
+									chalk.underline.blue(
+										tableName,
+									)
+								} table or the table with the duplicated check contraint name`,
 							)
-							} schema in ${chalk.underline.blue(
-								tableName,
-							)
-							}. Please rename your check constraint in either the ${chalk.underline.blue(
-								tableName,
-							)
-							} table or the table with the duplicated check contraint name`,
-						)
 						}`,
 					);
 					process.exit(1);
@@ -556,9 +583,10 @@ export const generatePgSnapshot = (
 		// @ts-ignore
 		if (!policy._linkedTable) {
 			console.log(
-				`\n${withStyle.errorWarning(
-					`"Policy ${policy.name} was skipped because it was not linked to any table. You should either include the policy in a table or use .link() on the policy to link it to any table you have. For more information, please check:`,
-				)
+				`\n${
+					withStyle.errorWarning(
+						`"Policy ${policy.name} was skipped because it was not linked to any table. You should either include the policy in a table or use .link() on the policy to link it to any table you have. For more information, please check:`,
+					)
 				}`,
 			);
 			continue;
@@ -595,13 +623,16 @@ export const generatePgSnapshot = (
 
 		if (result[tableKey]?.policies[policy.name] !== undefined || policiesToReturn[policy.name] !== undefined) {
 			console.log(
-				`\n${withStyle.errorWarning(
-					`We\'ve found duplicated policy name across ${chalk.underline.blue(tableKey)
-					} table. Please rename one of the policies with ${chalk.underline.blue(
-						policy.name,
+				`\n${
+					withStyle.errorWarning(
+						`We\'ve found duplicated policy name across ${
+							chalk.underline.blue(tableKey)
+						} table. Please rename one of the policies with ${
+							chalk.underline.blue(
+								policy.name,
+							)
+						} name`,
 					)
-					} name`,
-				)
 				}`,
 			);
 			process.exit(1);
@@ -696,10 +727,12 @@ export const generatePgSnapshot = (
 		const existingView = resultViews[viewKey];
 		if (typeof existingView !== 'undefined') {
 			console.log(
-				`\n${withStyle.errorWarning(
-					`We\'ve found duplicated view name across ${chalk.underline.blue(schema ?? 'public')
-					} schema. Please rename your view`,
-				)
+				`\n${
+					withStyle.errorWarning(
+						`We\'ve found duplicated view name across ${
+							chalk.underline.blue(schema ?? 'public')
+						} schema. Please rename your view`,
+					)
 				}`,
 			);
 			process.exit(1);
@@ -737,8 +770,8 @@ export const generatePgSnapshot = (
 							as: is(generated.as, SQL)
 								? dialect.sqlToQuery(generated.as as SQL).sql
 								: typeof generated.as === 'function'
-									? dialect.sqlToQuery(generated.as() as SQL).sql
-									: (generated.as as any),
+								? dialect.sqlToQuery(generated.as() as SQL).sql
+								: (generated.as as any),
 							type: 'stored',
 						}
 						: undefined,
@@ -761,14 +794,17 @@ export const generatePgSnapshot = (
 					const existingUnique = uniqueConstraintObject[column.uniqueName!];
 					if (typeof existingUnique !== 'undefined') {
 						console.log(
-							`\n${withStyle.errorWarning(
-								`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(viewName)} table. 
-          The unique constraint ${chalk.underline.blue(column.uniqueName)} on the ${chalk.underline.blue(
-									column.name,
+							`\n${
+								withStyle.errorWarning(
+									`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(viewName)} table. 
+          The unique constraint ${chalk.underline.blue(column.uniqueName)} on the ${
+										chalk.underline.blue(
+											column.name,
+										)
+									} column is confilcting with a unique constraint name already defined for ${
+										chalk.underline.blue(existingUnique.columns.join(','))
+									} columns\n`,
 								)
-								} column is confilcting with a unique constraint name already defined for ${chalk.underline.blue(existingUnique.columns.join(','))
-								} columns\n`,
-							)
 							}`,
 						);
 						process.exit(1);
@@ -996,7 +1032,8 @@ WHERE
 	const seqWhere = schemaFilters.map((t) => `schemaname = '${t}'`).join(' or ');
 
 	const allSequences = await db.query(
-		`select schemaname, sequencename, start_value, min_value, max_value, increment_by, cycle, cache_size from pg_sequences as seq${seqWhere === '' ? '' : ` WHERE ${seqWhere}`
+		`select schemaname, sequencename, start_value, min_value, max_value, increment_by, cycle, cache_size from pg_sequences as seq${
+			seqWhere === '' ? '' : ` WHERE ${seqWhere}`
 		};`,
 	);
 
@@ -1119,8 +1156,9 @@ WHERE
 			using: string;
 			withCheck: string;
 		}
-	>(`SELECT schemaname, tablename, policyname as name, permissive as "as", roles as to, cmd as for, qual as using, with_check as "withCheck" FROM pg_policies${wherePolicies === '' ? '' : ` WHERE ${wherePolicies}`
-		};`);
+	>(`SELECT schemaname, tablename, policyname as name, permissive as "as", roles as to, cmd as for, qual as using, with_check as "withCheck" FROM pg_policies${
+		wherePolicies === '' ? '' : ` WHERE ${wherePolicies}`
+	};`);
 
 	for (const dbPolicy of allPolicies) {
 		const { tablename, schemaname, to, withCheck, using, ...rest } = dbPolicy;
@@ -1479,8 +1517,8 @@ WHERE
 									cache: sequencesToReturn[identityName]?.cache
 										? sequencesToReturn[identityName]?.cache
 										: sequencesToReturn[`${tableSchema}.${identityName}`]?.cache
-											? sequencesToReturn[`${tableSchema}.${identityName}`]?.cache
-											: undefined,
+										? sequencesToReturn[`${tableSchema}.${identityName}`]?.cache
+										: undefined,
 									cycle: identityCycle,
 									schema: tableSchema,
 								}
@@ -1490,7 +1528,8 @@ WHERE
 						if (identityName && typeof identityName === 'string') {
 							// remove "" from sequence name
 							delete sequencesToReturn[
-								`${tableSchema}.${identityName.startsWith('"') && identityName.endsWith('"') ? identityName.slice(1, -1) : identityName
+								`${tableSchema}.${
+									identityName.startsWith('"') && identityName.endsWith('"') ? identityName.slice(1, -1) : identityName
 								}`
 							];
 							delete sequencesToReturn[identityName];
@@ -1776,8 +1815,8 @@ WHERE
 									cache: sequencesToReturn[identityName]?.cache
 										? sequencesToReturn[identityName]?.cache
 										: sequencesToReturn[`${viewSchema}.${identityName}`]?.cache
-											? sequencesToReturn[`${viewSchema}.${identityName}`]?.cache
-											: undefined,
+										? sequencesToReturn[`${viewSchema}.${identityName}`]?.cache
+										: undefined,
 									cycle: identityCycle,
 									schema: viewSchema,
 								}
@@ -1787,7 +1826,8 @@ WHERE
 						if (identityName) {
 							// remove "" from sequence name
 							delete sequencesToReturn[
-								`${viewSchema}.${identityName.startsWith('"') && identityName.endsWith('"') ? identityName.slice(1, -1) : identityName
+								`${viewSchema}.${
+									identityName.startsWith('"') && identityName.endsWith('"') ? identityName.slice(1, -1) : identityName
 								}`
 							];
 							delete sequencesToReturn[identityName];
@@ -1930,26 +1970,27 @@ const defaultForColumn = (column: any, internals: PgKitInternals, tableName: str
 	const columnDefaultAsString: string = column.column_default.toString();
 
 	if (isArray) {
-		return `'{${columnDefaultAsString
-			.slice(2, -2)
-			.split(/\s*,\s*/g)
-			.map((value) => {
-				if (['integer', 'smallint', 'bigint', 'double precision', 'real'].includes(column.data_type.slice(0, -2))) {
-					return value;
-				} else if (column.data_type.startsWith('timestamp')) {
-					return `${value}`;
-				} else if (column.data_type.slice(0, -2) === 'interval') {
-					return value.replaceAll('"', `\"`);
-				} else if (column.data_type.slice(0, -2) === 'boolean') {
-					return value === 't' ? 'true' : 'false';
-				} else if (['json', 'jsonb'].includes(column.data_type.slice(0, -2))) {
-					return JSON.stringify(JSON.stringify(JSON.parse(JSON.parse(value)), null, 0));
-				} else {
-					return `\"${value}\"`;
-				}
-			})
-			.join(',')
-			}}'`;
+		return `'{${
+			columnDefaultAsString
+				.slice(2, -2)
+				.split(/\s*,\s*/g)
+				.map((value) => {
+					if (['integer', 'smallint', 'bigint', 'double precision', 'real'].includes(column.data_type.slice(0, -2))) {
+						return value;
+					} else if (column.data_type.startsWith('timestamp')) {
+						return `${value}`;
+					} else if (column.data_type.slice(0, -2) === 'interval') {
+						return value.replaceAll('"', `\"`);
+					} else if (column.data_type.slice(0, -2) === 'boolean') {
+						return value === 't' ? 'true' : 'false';
+					} else if (['json', 'jsonb'].includes(column.data_type.slice(0, -2))) {
+						return JSON.stringify(JSON.stringify(JSON.parse(JSON.parse(value)), null, 0));
+					} else {
+						return `\"${value}\"`;
+					}
+				})
+				.join(',')
+		}}'`;
 	}
 
 	if (['integer', 'smallint', 'bigint', 'double precision', 'real'].includes(column.data_type)) {


### PR DESCRIPTION
Fixes https://github.com/drizzle-team/drizzle-orm/issues/3993

No idea how to contrib to this, someone can tidy this up if it's wrong.

tl;dr the old implementation was not sympathetic to the order of the columns in the fk relationshops, so when introspecting it would, in some cases, cause the generated SQL to be completely wrong - mismatched columns.