### PR TITLE
SQLite onConflict chaining fix

### DIFF
--- a/drizzle-orm/src/alias.ts
+++ b/drizzle-orm/src/alias.ts
@@ -1,9 +1,14 @@
 import type { AnyColumn } from './column.ts';
 import { Column } from './column.ts';
 import { entityKind, is } from './entity.ts';
+import type { AnyMySqlTable, BuildAliasTable as BuildAliasMySqlTable, MySqlView } from './mysql-core/index.ts';
+import type { AnyPgTable, BuildAliasTable as BuildAliasPgTable, PgView } from './pg-core/index.ts';
 import type { Relation } from './relations.ts';
 import type { View } from './sql/sql.ts';
 import { SQL, sql } from './sql/sql.ts';
+import type { BuildAliasTable as BuildAliasSQLiteTable } from './sqlite-core/index.ts';
+import type { AnySQLiteTable } from './sqlite-core/table.ts';
+import type { SQLiteView } from './sqlite-core/view.ts';
 import { Table } from './table.ts';
 import { ViewBaseConfig } from './view-common.ts';
 
@@ -88,8 +93,15 @@ export class RelationTableAliasProxyHandler<T extends Relation> implements Proxy
 	}
 }
 
-export function aliasedTable<T extends Table>(table: T, tableAlias: string): T {
-	return new Proxy(table, new TableAliasProxyHandler(tableAlias, false));
+export function aliasedTable<T extends Table | View, TAlias extends string>(
+	table: T,
+	tableAlias: TAlias,
+): T extends AnyPgTable | PgView ? BuildAliasPgTable<T, TAlias>
+	: T extends AnySQLiteTable | SQLiteView ? BuildAliasSQLiteTable<T, TAlias>
+	: T extends AnyMySqlTable | MySqlView ? BuildAliasMySqlTable<T, TAlias>
+	: never
+{
+	return new Proxy(table, new TableAliasProxyHandler(tableAlias, false)) as any;
 }
 
 export function aliasedRelation<T extends Relation>(relation: T, tableAlias: string): T {

--- a/drizzle-orm/src/alias.ts
+++ b/drizzle-orm/src/alias.ts
@@ -1,14 +1,9 @@
 import type { AnyColumn } from './column.ts';
 import { Column } from './column.ts';
 import { entityKind, is } from './entity.ts';
-import type { AnyMySqlTable, BuildAliasTable as BuildAliasMySqlTable, MySqlView } from './mysql-core/index.ts';
-import type { AnyPgTable, BuildAliasTable as BuildAliasPgTable, PgView } from './pg-core/index.ts';
 import type { Relation } from './relations.ts';
 import type { View } from './sql/sql.ts';
 import { SQL, sql } from './sql/sql.ts';
-import type { BuildAliasTable as BuildAliasSQLiteTable } from './sqlite-core/index.ts';
-import type { AnySQLiteTable } from './sqlite-core/table.ts';
-import type { SQLiteView } from './sqlite-core/view.ts';
 import { Table } from './table.ts';
 import { ViewBaseConfig } from './view-common.ts';
 
@@ -93,14 +88,10 @@ export class RelationTableAliasProxyHandler<T extends Relation> implements Proxy
 	}
 }
 
-export function aliasedTable<T extends Table | View, TAlias extends string>(
+export function aliasedTable<T extends Table | View>(
 	table: T,
-	tableAlias: TAlias,
-): T extends AnyPgTable | PgView ? BuildAliasPgTable<T, TAlias>
-	: T extends AnySQLiteTable | SQLiteView ? BuildAliasSQLiteTable<T, TAlias>
-	: T extends AnyMySqlTable | MySqlView ? BuildAliasMySqlTable<T, TAlias>
-	: never
-{
+	tableAlias: string,
+): T {
 	return new Proxy(table, new TableAliasProxyHandler(tableAlias, false)) as any;
 }
 

--- a/drizzle-orm/src/mysql-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.types.ts
@@ -97,7 +97,7 @@ export type MySqlJoin<
 				T['_']['selection'],
 				TJoinedName,
 				TJoinedTable extends MySqlTable ? TJoinedTable['_']['columns']
-					: TJoinedTable extends Subquery ? Assume<TJoinedTable['_']['selectedFields'], SelectedFields>
+					: TJoinedTable extends Subquery | View ? Assume<TJoinedTable['_']['selectedFields'], SelectedFields>
 					: never,
 				T['_']['selectMode']
 			>,

--- a/drizzle-orm/src/pg-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/pg-core/query-builders/select.types.ts
@@ -98,7 +98,7 @@ export type PgSelectJoin<
 				T['_']['selection'],
 				TJoinedName,
 				TJoinedTable extends Table ? TJoinedTable['_']['columns']
-					: TJoinedTable extends Subquery ? Assume<TJoinedTable['_']['selectedFields'], SelectedFields>
+					: TJoinedTable extends Subquery | View ? Assume<TJoinedTable['_']['selectedFields'], SelectedFields>
 					: never,
 				T['_']['selectMode']
 			>,

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -181,7 +181,7 @@ export class SQL<T = unknown> implements SQLWrapper {
 				const schemaName = chunk[Table.Symbol.Schema];
 				const tableName = chunk[Table.Symbol.Name];
 				return {
-					sql: schemaName === undefined
+					sql: schemaName === undefined || chunk[IsAlias]
 						? escapeName(tableName)
 						: escapeName(schemaName) + '.' + escapeName(tableName),
 					params: [],
@@ -208,7 +208,7 @@ export class SQL<T = unknown> implements SQLWrapper {
 				const schemaName = chunk[ViewBaseConfig].schema;
 				const viewName = chunk[ViewBaseConfig].name;
 				return {
-					sql: schemaName === undefined
+					sql: schemaName === undefined || chunk[ViewBaseConfig].isAlias
 						? escapeName(viewName)
 						: escapeName(schemaName) + '.' + escapeName(viewName),
 					params: [],

--- a/drizzle-orm/src/sqlite-core/db.ts
+++ b/drizzle-orm/src/sqlite-core/db.ts
@@ -25,7 +25,7 @@ import { SQLiteCountBuilder } from './query-builders/count.ts';
 import { RelationalQueryBuilder } from './query-builders/query.ts';
 import { SQLiteRaw } from './query-builders/raw.ts';
 import type { SelectedFields } from './query-builders/select.types.ts';
-import type { WithBuilder, WithSubqueryWithSelection } from './subquery.ts';
+import type { WithBuilder } from './subquery.ts';
 import type { SQLiteViewBase } from './view-base.ts';
 
 export class BaseSQLiteDatabase<

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -487,7 +487,9 @@ export abstract class SQLiteDialect {
 			? sql` returning ${this.buildSelection(returning, { isSingleTable: true })}`
 			: undefined;
 
-		const onConflictSql = onConflict ? sql` on conflict ${onConflict}` : undefined;
+		const onConflictSql = onConflict?.length
+			? sql.join(onConflict)
+			: undefined;
 
 		// if (isSingleValue && valuesSqlList.length === 0){
 		// 	return sql`insert into ${table} default values ${onConflictSql}${returningSql}`;

--- a/drizzle-orm/type-tests/common/aliased-table.ts
+++ b/drizzle-orm/type-tests/common/aliased-table.ts
@@ -1,0 +1,229 @@
+import { type Equal, Expect } from 'type-tests/utils.ts';
+import { aliasedTable, eq } from '~/index.ts';
+import { drizzle as sqlited } from '~/libsql/index.ts';
+import { mysqlView } from '~/mysql-core/view.ts';
+import { drizzle as mysqld } from '~/mysql2/index.ts';
+import { pgView } from '~/pg-core/view.ts';
+import { drizzle as pgd } from '~/postgres-js/index.ts';
+import { sqliteView } from '~/sqlite-core/view.ts';
+import { users as mysqlUsers } from '../mysql/tables.ts';
+import { users as pgUsers } from '../pg/tables.ts';
+import { users as sqliteUsers } from '../sqlite/tables.ts';
+
+const pg = pgd.mock();
+const sqlite = sqlited.mock();
+const mysql = mysqld.mock();
+
+const pgvUsers = pgView('users_view').as((qb) => qb.select().from(pgUsers));
+const sqlitevUsers = sqliteView('users_view').as((qb) => qb.select().from(sqliteUsers));
+const mysqlvUsers = mysqlView('users_view').as((qb) => qb.select().from(mysqlUsers));
+
+const pgAlias = aliasedTable(pgUsers, 'usersAlias');
+const sqliteAlias = aliasedTable(sqliteUsers, 'usersAlias');
+const mysqlAlias = aliasedTable(mysqlUsers, 'usersAlias');
+
+const pgvAlias = aliasedTable(pgvUsers, 'usersvAlias');
+const sqlitevAlias = aliasedTable(sqlitevUsers, 'usersvAlias');
+const mysqlvAlias = aliasedTable(mysqlvUsers, 'usersvAlias');
+
+const pgRes = await pg.select().from(pgUsers).leftJoin(pgAlias, eq(pgAlias.id, pgUsers.id));
+const sqliteRes = await sqlite.select().from(sqliteUsers).leftJoin(sqliteAlias, eq(sqliteAlias.id, sqliteUsers.id));
+const mysqlRes = await mysql.select().from(mysqlUsers).leftJoin(mysqlAlias, eq(mysqlAlias.id, mysqlUsers.id));
+
+const pgvRes = await pg.select().from(pgUsers).leftJoin(pgvAlias, eq(pgvAlias.id, pgUsers.id));
+const sqlitevRes = await sqlite.select().from(sqliteUsers).leftJoin(sqlitevAlias, eq(sqlitevAlias.id, sqliteUsers.id));
+const mysqlvRes = await mysql.select().from(mysqlUsers).leftJoin(mysqlvAlias, eq(mysqlvAlias.id, mysqlUsers.id));
+
+Expect<
+	Equal<typeof pgRes, {
+		users_table: {
+			id: number;
+			uuid: string;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			text: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+			arrayCol: string[];
+		};
+		usersAlias: {
+			id: number;
+			uuid: string;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			text: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+			arrayCol: string[];
+		} | null;
+	}[]>
+>;
+
+Expect<
+	Equal<typeof sqliteRes, {
+		users_table: {
+			id: number;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number | null;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			name: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+		};
+		usersAlias: {
+			id: number;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number | null;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			name: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+		} | null;
+	}[]>
+>;
+
+Expect<
+	Equal<typeof mysqlRes, {
+		users_table: {
+			id: number;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			text: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+		};
+		usersAlias: {
+			id: number;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			text: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+		} | null;
+	}[]>
+>;
+
+Expect<
+	Equal<typeof pgvRes, {
+		users_table: {
+			id: number;
+			uuid: string;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			text: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+			arrayCol: string[];
+		};
+		usersvAlias: {
+			id: number;
+			uuid: string;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			text: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+			arrayCol: string[];
+		} | null;
+	}[]>
+>;
+
+Expect<
+	Equal<typeof sqlitevRes, {
+		users_table: {
+			id: number;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number | null;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			name: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+		};
+		usersvAlias: {
+			id: number;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number | null;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			name: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+		} | null;
+	}[]>
+>;
+
+Expect<
+	Equal<typeof mysqlvRes, {
+		users_table: {
+			id: number;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			text: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+		};
+		usersvAlias: {
+			id: number;
+			homeCity: number;
+			currentCity: number | null;
+			serialNullable: number;
+			serialNotNull: number;
+			class: 'A' | 'C';
+			subClass: 'B' | 'D' | null;
+			text: string | null;
+			age1: number;
+			createdAt: Date;
+			enumCol: 'a' | 'b' | 'c';
+		} | null;
+	}[]>
+>;

--- a/drizzle-orm/type-tests/common/aliased-table.ts
+++ b/drizzle-orm/type-tests/common/aliased-table.ts
@@ -1,10 +1,13 @@
 import { type Equal, Expect } from 'type-tests/utils.ts';
-import { aliasedTable, eq } from '~/index.ts';
+import { eq } from '~/index.ts';
 import { drizzle as sqlited } from '~/libsql/index.ts';
+import { alias as mysqlAliasFn } from '~/mysql-core/alias.ts';
 import { mysqlView } from '~/mysql-core/view.ts';
 import { drizzle as mysqld } from '~/mysql2/index.ts';
+import { alias as pgAliasFn } from '~/pg-core/alias.ts';
 import { pgView } from '~/pg-core/view.ts';
 import { drizzle as pgd } from '~/postgres-js/index.ts';
+import { alias as sqliteAliasFn } from '~/sqlite-core/alias.ts';
 import { sqliteView } from '~/sqlite-core/view.ts';
 import { users as mysqlUsers } from '../mysql/tables.ts';
 import { users as pgUsers } from '../pg/tables.ts';
@@ -18,13 +21,13 @@ const pgvUsers = pgView('users_view').as((qb) => qb.select().from(pgUsers));
 const sqlitevUsers = sqliteView('users_view').as((qb) => qb.select().from(sqliteUsers));
 const mysqlvUsers = mysqlView('users_view').as((qb) => qb.select().from(mysqlUsers));
 
-const pgAlias = aliasedTable(pgUsers, 'usersAlias');
-const sqliteAlias = aliasedTable(sqliteUsers, 'usersAlias');
-const mysqlAlias = aliasedTable(mysqlUsers, 'usersAlias');
+const pgAlias = pgAliasFn(pgUsers, 'usersAlias');
+const sqliteAlias = sqliteAliasFn(sqliteUsers, 'usersAlias');
+const mysqlAlias = mysqlAliasFn(mysqlUsers, 'usersAlias');
 
-const pgvAlias = aliasedTable(pgvUsers, 'usersvAlias');
-const sqlitevAlias = aliasedTable(sqlitevUsers, 'usersvAlias');
-const mysqlvAlias = aliasedTable(mysqlvUsers, 'usersvAlias');
+const pgvAlias = pgAliasFn(pgvUsers, 'usersvAlias');
+const sqlitevAlias = sqliteAliasFn(sqlitevUsers, 'usersvAlias');
+const mysqlvAlias = mysqlAliasFn(mysqlvUsers, 'usersvAlias');
 
 const pgRes = await pg.select().from(pgUsers).leftJoin(pgAlias, eq(pgAlias.id, pgUsers.id));
 const sqliteRes = await sqlite.select().from(sqliteUsers).leftJoin(sqliteAlias, eq(sqliteAlias.id, sqliteUsers.id));

--- a/integration-tests/tests/sqlite/better-sqlite.test.ts
+++ b/integration-tests/tests/sqlite/better-sqlite.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
 import { skipTests } from '~/common';
 import { anotherUsersMigratorTable, tests, usersMigratorTable } from './sqlite-common';
 
-const ENABLE_LOGGING = false;
+const ENABLE_LOGGING = true;
 
 let db: BetterSQLite3Database;
 let client: Database.Database;

--- a/integration-tests/tests/sqlite/better-sqlite.test.ts
+++ b/integration-tests/tests/sqlite/better-sqlite.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
 import { skipTests } from '~/common';
 import { anotherUsersMigratorTable, tests, usersMigratorTable } from './sqlite-common';
 
-const ENABLE_LOGGING = true;
+const ENABLE_LOGGING = false;
 
 let db: BetterSQLite3Database;
 let client: Database.Database;


### PR DESCRIPTION
- Fixed SQLite `onConflict` clauses being overwritten instead of stacked (fixes #2276)
- Added related tests
- Removed unused import
- Fixed joined views not generating proper types in MySQL and PostgreSQL
- Added view support to `aliasedTable()` function (requested in #3491)
- ~~Made `aliasedTable()` function same as `alias()` functions on type-level (fixes `aliasedTable()` not aliasing tables on type level)~~ - removed in favor of dialect-specific `alias()` functions
- Fixed sql builder prefixing aliased views and tables with their schema   