### PR TITLE
Fix Durable Object Migrator

### DIFF
--- a/drizzle-orm/src/durable-sqlite/migrator.ts
+++ b/drizzle-orm/src/durable-sqlite/migrator.ts
@@ -13,10 +13,11 @@ function readMigrationFiles({ journal, migrations }: MigrationConfig): Migration
 	const migrationQueries: MigrationMeta[] = [];
 
 	for (const journalEntry of journal.entries) {
-		const query = migrations[`m${journalEntry.idx.toString().padStart(4, '0')}`];
+		const key = journalEntry.tag;
+		const query = migrations[key];
 
 		if (!query) {
-			throw new Error(`Missing migration: ${journalEntry.tag}`);
+			throw new Error(`Missing migration: ${key}`);
 		}
 
 		try {

--- a/drizzle-orm/src/durable-sqlite/migrator.ts
+++ b/drizzle-orm/src/durable-sqlite/migrator.ts
@@ -13,7 +13,8 @@ function readMigrationFiles({ journal, migrations }: MigrationConfig): Migration
 	const migrationQueries: MigrationMeta[] = [];
 
 	for (const journalEntry of journal.entries) {
-		const query = migrations[`m${journalEntry.idx.toString().padStart(4, '0')}`];
+		const key = journalEntry.tag;
+		const query = migrations[key];
 
 		if (!query) {
 			throw new Error(`Missing migration: ${journalEntry.tag}`);


### PR DESCRIPTION
Ran into an error where the durable object function was not parsing the migrations.json file produced

```ts
export class DrizzleDurableObject extends DurableObject {
	storage: DurableObjectStorage
	db: DrizzleSqliteDODatabase<typeof schema>

	constructor(ctx: DurableObjectState, env: Env) {
		super(ctx, env)
		this.storage = ctx.storage
		this.db = drizzle(this.storage, { logger: true })
		ctx.blockConcurrencyWhile(async () => {
			console.log('Migrations object:', JSON.stringify(migrations, null, 2))

			await migrate(this.db, migrations)
		})
	}
}
```

```ts
Migrations object: { 
  "journal": {
    "entries": [
      {
        "idx": 0,
        "version": "6",
        "when": 1738537506661,
        "tag": "0000_open_crystal",
        "breakpoints": true
      }
    ]
  },
  "migrations": {
    "0000_open_crystal": "CREATE TABLE `messages` (\n\t`id` text PRIMARY KEY NOT NULL,\n\t`content` text NOT NULL\n);\n--> statement-breakpoint\nCREATE TABLE `users` (\n\t`id` text PRIMARY KEY NOT NULL,\n\t`name` text NOT NULL\n);\n"
  }
}
Entering migrate function
Migration config: {
  journal: { entries: [ [Object] ] },
  migrations: {
    '0000_open_crystal': 'CREATE TABLE `messages` (\n' +
      '\t`id` text PRIMARY KEY NOT NULL,\n' +
      '\t`content` text NOT NULL\n' +
      ');\n' +
      '--> statement-breakpoint\n' +
      'CREATE TABLE `users` (\n' +
      '\t`id` text PRIMARY KEY NOT NULL,\n' +
      '\t`name` text NOT NULL\n' +
      ');\n'
  }
}
Entering readMigrationFiles
Journal: {
  entries: [
    {
      idx: 0,
      version: '6',
      when: 1738537506661,
      tag: '0000_open_crystal',
      breakpoints: true
    }
  ]
}
Migrations: {
  '0000_open_crystal': 'CREATE TABLE `messages` (\n' +
    '\t`id` text PRIMARY KEY NOT NULL,\n' +
    '\t`content` text NOT NULL\n' +
    ');\n' +
    '--> statement-breakpoint\n' +
    'CREATE TABLE `users` (\n' +
    '\t`id` text PRIMARY KEY NOT NULL,\n' +
    '\t`name` text NOT NULL\n' +
    ');\n'
}
Processing journal entry: {
  idx: 0,
  version: '6',
  when: 1738537506661,
  tag: '0000_open_crystal',
  breakpoints: true
}
Migration key: m0000
✘ [ERROR] Error: Missing migration for key: m0000


✘ [ERROR] Uncaught (in promise) Error: Missing migration: 0000_open_crystal
```