### PR TITLE
[PG, Neon] Rename Neon Auth schema

### DIFF
--- a/changelogs/drizzle-orm/0.39.2.md
+++ b/changelogs/drizzle-orm/0.39.2.md
@@ -1,0 +1,1 @@
+- To be compatible with latest Neon Auth feature we renamed the pre-defined schema internally, from `neon_identity` to `neon_auth` - thanks @pffigueiredo

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drizzle-orm",
-	"version": "0.39.1",
+	"version": "0.39.2",
 	"description": "Drizzle ORM package for SQL databases",
 	"type": "module",
 	"scripts": {

--- a/drizzle-orm/src/neon/neon-identity.ts
+++ b/drizzle-orm/src/neon/neon-identity.ts
@@ -1,15 +1,15 @@
 import { jsonb, pgSchema, text, timestamp } from '~/pg-core/index.ts';
 
-const neonIdentitySchema = pgSchema('neon_identity');
+const neonAuthSchema = pgSchema('neon_auth');
 
 /**
- * Table schema of the `users_sync` table used by Neon Identity.
+ * Table schema of the `users_sync` table used by Neon Auth.
  * This table automatically synchronizes and stores user data from external authentication providers.
  *
- * @schema neon_identity
+ * @schema neon_auth
  * @table users_sync
  */
-export const usersSync = neonIdentitySchema.table('users_sync', {
+export const usersSync = neonAuthSchema.table('users_sync', {
 	rawJson: jsonb('raw_json').notNull(),
 	id: text().primaryKey().notNull(),
 	name: text(),

--- a/integration-tests/tests/bun/bun-sql.test.ts
+++ b/integration-tests/tests/bun/bun-sql.test.ts
@@ -4761,13 +4761,13 @@ test('neon: policy', () => {
 	}
 });
 
-test('neon: neon_identity', () => {
+test('neon: neon_auth', () => {
 	const usersSyncTable = usersSync;
 
 	const { columns, schema, name } = getTableConfig(usersSyncTable);
 
 	expect(name).toBe('users_sync');
-	expect(schema).toBe('neon_identity');
+	expect(schema).toBe('neon_auth');
 	expect(columns).toHaveLength(6);
 });
 

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -5139,13 +5139,13 @@ export function tests() {
 			}
 		});
 
-		test('neon: neon_identity', () => {
+		test('neon: neon_auth', () => {
 			const usersSyncTable = usersSync;
 
 			const { columns, schema, name } = getTableConfig(usersSyncTable);
 
 			expect(name).toBe('users_sync');
-			expect(schema).toBe('neon_identity');
+			expect(schema).toBe('neon_auth');
 			expect(columns).toHaveLength(6);
 		});
 


### PR DESCRIPTION
## Description

This PR aims to fix an issue caused by Neon renaming the internal schema `neon_identity` to `neon_auth`.

**FIX**

- Renamed the pre-defined schema internally, from `neon_identity` to `neon_auth`.

**NOTES**

- Neon will be launching the Neon Auth feature in the upcoming days, so it would be nice if we could publish a patch with this in the next couple of days 🙏 

## Test Plan

Adapted existing tests to use `neon_auth`.

## Subscribers

cc @davidgomes 

## Issue

Closes #4063
