### PR TITLE
[WIP] "ignore" a column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ rollup.config-*.mjs
 *.log
 .DS_Store
 drizzle-seed/src/dev
+.idea/

--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -111,6 +111,26 @@ export const generateMySqlSnapshot = (
 				};
 			}
 
+			if(column.isIgnored && column.notNull) {
+				// For notNull to false if a given column is ignored
+				console.log(
+					`\n${
+						withStyle.errorWarning(`There is a misconfigred ignored column in ${
+							chalk.underline.blue(
+								tableName,
+							)
+						} table. 
+          The ignored column ${
+							chalk.underline.blue(
+								name,
+							)
+						} column also is registered as .notNull(). Ignored columns must be nullable\n`)
+					}`,
+				);
+
+				process.exit(1);
+			}
+
 			if (column.isUnique) {
 				const existingUnique = uniqueConstraintObject[column.uniqueName!];
 				if (typeof existingUnique !== 'undefined') {

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -202,6 +202,26 @@ export const generatePgSnapshot = (
 					: undefined,
 			};
 
+			if(column.isIgnored && column.notNull) {
+				// For notNull to false if a given column is ignored
+				console.log(
+					`\n${
+						withStyle.errorWarning(`There is a misconfigred ignored column in ${
+							chalk.underline.blue(
+								tableName,
+							)
+						} table. 
+          The ignored column ${ 
+							chalk.underline.blue(
+								name,
+							)
+						} column also is registered as .notNull(). Ignored columns must be nullable\n`)
+					}`,
+				);
+
+				process.exit(1);
+			}
+
 			if (column.isUnique) {
 				const existingUnique = uniqueConstraintObject[column.uniqueName!];
 				if (typeof existingUnique !== 'undefined') {

--- a/drizzle-kit/src/serializer/singlestoreSerializer.ts
+++ b/drizzle-kit/src/serializer/singlestoreSerializer.ts
@@ -90,6 +90,26 @@ export const generateSingleStoreSnapshot = (
 				};
 			}
 
+			if(column.isIgnored && column.notNull) {
+				// For notNull to false if a given column is ignored
+				console.log(
+					`\n${
+						withStyle.errorWarning(`There is a misconfigred ignored column in ${
+							chalk.underline.blue(
+								tableName,
+							)
+						} table. 
+          The ignored column ${
+							chalk.underline.blue(
+								name,
+							)
+						} column also is registered as .notNull(). Ignored columns must be nullable\n`)
+					}`,
+				);
+
+				process.exit(1);
+			}
+
 			if (column.isUnique) {
 				const existingUnique = uniqueConstraintObject[column.uniqueName!];
 				if (typeof existingUnique !== 'undefined') {

--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -99,6 +99,26 @@ export const generateSqliteSnapshot = (
 			}
 			columnsObject[name] = columnToSet;
 
+			if(column.isIgnored && column.notNull) {
+				// For notNull to false if a given column is ignored
+				console.log(
+					`\n${
+						withStyle.errorWarning(`There is a misconfigred ignored column in ${
+							chalk.underline.blue(
+								tableName,
+							)
+						} table. 
+          The ignored column ${
+							chalk.underline.blue(
+								name,
+							)
+						} column also is registered as .notNull(). Ignored columns must be nullable\n`)
+					}`,
+				);
+
+				process.exit(1);
+			}
+
 			if (column.isUnique) {
 				const existingUnique = indexesObject[column.uniqueName!];
 				if (typeof existingUnique !== 'undefined') {

--- a/drizzle-kit/tests/pg-generated.test.ts
+++ b/drizzle-kit/tests/pg-generated.test.ts
@@ -266,6 +266,48 @@ test('generated as sql: add generated constraint to an exisiting column', async 
 	]);
 });
 
+test('generated as sql: dont drop ignored column', async () => {
+	const from = {
+		users: pgTable('users', {
+			id: integer('id').notNull(),
+			id2: integer('id2'),
+			name: text('name').notNull(),
+		}),
+	};
+
+	const to = {
+		users: pgTable('users', {
+			id: integer('id').notNull(),
+			id2: integer('id2').$ignore(),
+			name: text('name').notNull(),
+		}),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements).toStrictEqual([]);
+});
+
+test('generated as sql: throws error if column is notNull and $ignored', async () => {
+	const from = {
+		users: pgTable('users', {
+			id: integer('id').notNull(),
+			id2: integer('id2'),
+			name: text('name').notNull(),
+		}),
+	};
+
+	const to = {
+		users: pgTable('users', {
+			id: integer('id').notNull(),
+			id2: integer('id2'),
+			name: text('name').notNull().$ignore(),
+		}),
+	};
+
+	await expect(diffTestSchemas(from, to, [])).rejects.toThrowError();
+});
+
 test('generated as sql: drop generated constraint', async () => {
 	const from = {
 		users: pgTable('users', {

--- a/drizzle-orm/src/column-builder.ts
+++ b/drizzle-orm/src/column-builder.ts
@@ -149,7 +149,6 @@ export type HasRuntimeDefault<T extends ColumnBuilderBase> = T & {
 export type IsIgnored<T extends ColumnBuilderBase> = T & {
   _: {
     isIgnored: true;
-    notNull: false;
   };
 };
 

--- a/drizzle-orm/src/column-builder.ts
+++ b/drizzle-orm/src/column-builder.ts
@@ -59,6 +59,7 @@ export type MakeColumnConfig<
 	notNull: T extends { notNull: true } ? true : false;
 	hasDefault: T extends { hasDefault: true } ? true : false;
 	isPrimaryKey: T extends { isPrimaryKey: true } ? true : false;
+	isIgnored: T extends { isIgnored: true } ? true : false;
 	isAutoincrement: T extends { isAutoincrement: true } ? true : false;
 	hasRuntimeDefault: T extends { hasRuntimeDefault: true } ? true : false;
 	enumValues: T['enumValues'];
@@ -102,6 +103,7 @@ export type ColumnBuilderRuntimeConfig<TData, TRuntimeConfig extends object = ob
 	hasDefault: boolean;
 	primaryKey: boolean;
 	isUnique: boolean;
+	isIgnored: boolean;
 	uniqueName: string | undefined;
 	uniqueType: string | undefined;
 	dataType: string;
@@ -142,6 +144,13 @@ export type HasRuntimeDefault<T extends ColumnBuilderBase> = T & {
 	_: {
 		hasRuntimeDefault: true;
 	};
+};
+
+export type IsIgnored<T extends ColumnBuilderBase> = T & {
+  _: {
+    isIgnored: true;
+    notNull: false;
+  };
 };
 
 export type $Type<T extends ColumnBuilderBase, TType> = T & {
@@ -196,6 +205,7 @@ export abstract class ColumnBuilder<
 			hasDefault: false,
 			primaryKey: false,
 			isUnique: false,
+			isIgnored: false,
 			uniqueName: undefined,
 			uniqueType: undefined,
 			dataType,
@@ -254,6 +264,15 @@ export abstract class ColumnBuilder<
 		this.config.defaultFn = fn;
 		this.config.hasDefault = true;
 		return this as HasRuntimeDefault<HasDefault<this>>;
+	}
+
+	/**
+	 * Ignores this column from being selected in queries.
+	 * Cannot be combined with notNull().
+	 */
+	$ignore(): IsIgnored<this> {
+		this.config.isIgnored = true;
+		return this as IsIgnored<this>;
 	}
 
 	/**

--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -18,6 +18,7 @@ export interface ColumnBaseConfig<
 	notNull: boolean;
 	hasDefault: boolean;
 	isPrimaryKey: boolean;
+	isIgnored: boolean;
 	isAutoincrement: boolean;
 	hasRuntimeDefault: boolean;
 }
@@ -32,6 +33,7 @@ export type ColumnTypeConfig<T extends ColumnBaseConfig<ColumnDataType, string>,
 	driverParam: T['driverParam'];
 	notNull: T['notNull'];
 	hasDefault: T['hasDefault'];
+	isIgnored: T["isIgnored"];
 	isPrimaryKey: T['isPrimaryKey'];
 	isAutoincrement: T['isAutoincrement'];
 	hasRuntimeDefault: T['hasRuntimeDefault'];
@@ -78,6 +80,7 @@ export abstract class Column<
 	readonly onUpdateFn: (() => T['data'] | SQL) | undefined;
 	readonly hasDefault: boolean;
 	readonly isUnique: boolean;
+	readonly isIgnored: boolean;
 	readonly uniqueName: string | undefined;
 	readonly uniqueType: string | undefined;
 	readonly dataType: T['dataType'];
@@ -102,6 +105,7 @@ export abstract class Column<
 		this.hasDefault = config.hasDefault;
 		this.primary = config.primaryKey;
 		this.isUnique = config.isUnique;
+		this.isIgnored = config.isIgnored;
 		this.uniqueName = config.uniqueName;
 		this.uniqueType = config.uniqueType;
 		this.dataType = config.dataType as T['dataType'];

--- a/drizzle-orm/src/pg-core/query-builders/insert.ts
+++ b/drizzle-orm/src/pg-core/query-builders/insert.ts
@@ -37,12 +37,15 @@ export interface PgInsertConfig<TTable extends PgTable = PgTable> {
 	overridingSystemValue_?: boolean;
 }
 
+type InsertModel<TTable extends PgTable<TableConfig>, OverrideT extends boolean> =
+	InferInsertModel<TTable, { dbColumnNames: false; override: OverrideT }>;
+
 export type PgInsertValue<TTable extends PgTable<TableConfig>, OverrideT extends boolean = false> =
 	& {
-		[Key in keyof InferInsertModel<TTable, { dbColumnNames: false; override: OverrideT }>]:
-			| InferInsertModel<TTable, { dbColumnNames: false; override: OverrideT }>[Key]
-			| SQL
-			| Placeholder;
+		[Key in keyof InsertModel<TTable, OverrideT>]:
+		| InsertModel<TTable, OverrideT>[Key]
+		| SQL
+		| Placeholder;
 	}
 	& {};
 

--- a/drizzle-orm/src/query-builders/select.types.ts
+++ b/drizzle-orm/src/query-builders/select.types.ts
@@ -152,10 +152,20 @@ export type GetSelectTableName<TTable extends TableLike> = TTable extends Table 
 	: TTable extends SQL ? undefined
 	: never;
 
-export type GetSelectTableSelection<TTable extends TableLike> = TTable extends Table ? TTable['_']['columns']
-	: TTable extends Subquery | View ? Assume<TTable['_']['selectedFields'], ColumnsSelection>
-	: TTable extends SQL ? {}
-	: never;
+export type GetSelectTableSelection<TTable extends TableLike> =
+	TTable extends Table
+		? {
+			[
+			Key in keyof TTable['_']['columns'] & string as TTable['_']['columns'][Key]['_']['isIgnored'] extends true
+				? never
+				: Key
+			]: TTable['_']['columns'][Key];
+		}
+		: TTable extends Subquery | View
+			? Assume<TTable['_']['selectedFields'], ColumnsSelection>
+			: TTable extends SQL
+				? {}
+				: never;
 
 export type SelectResultField<T, TDeep extends boolean = true> = T extends DrizzleTypeError<any> ? T
 	: T extends Table ? Equal<TDeep, true> extends true ? SelectResultField<T['_']['columns'], false> : never

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -686,7 +686,9 @@ export function getViewName<T extends View>(view: T): T['_']['name'] {
 export type InferSelectViewModel<TView extends View> =
 	Equal<TView['_']['selectedFields'], { [x: string]: unknown }> extends true ? { [x: string]: unknown }
 		: SelectResult<
-			TView['_']['selectedFields'],
+			{
+				[K in keyof TView['_']['selectedFields'] as TView['_']['selectedFields'][K] extends { isIgnored: true } ? never : K]: TView['_']['selectedFields'][K]
+			},
 			'single',
 			Record<TView['_']['name'], 'not-null'>
 		>;

--- a/drizzle-orm/src/table.ts
+++ b/drizzle-orm/src/table.ts
@@ -159,33 +159,34 @@ export type InferModelFromColumns<
 	TConfig extends { dbColumnNames: boolean; override?: boolean } = { dbColumnNames: false; override: false },
 > = Simplify<
 	TInferMode extends 'insert' ?
-			& {
-				[
-					Key in keyof TColumns & string as RequiredKeyOnly<
-						MapColumnName<Key, TColumns[Key], TConfig['dbColumnNames']>,
-						TColumns[Key]
-					>
-				]: GetColumnData<TColumns[Key], 'query'>;
-			}
-			& {
-				[
-					Key in keyof TColumns & string as OptionalKeyOnly<
-						MapColumnName<Key, TColumns[Key], TConfig['dbColumnNames']>,
-						TColumns[Key],
-						TConfig['override']
-					>
-				]?: GetColumnData<TColumns[Key], 'query'> | undefined;
-			}
+		& {
+			[
+			Key in keyof TColumns & string as TColumns[Key]['_']['isIgnored'] extends true ? never : RequiredKeyOnly<
+				MapColumnName<Key, TColumns[Key], TConfig['dbColumnNames']>,
+				TColumns[Key]
+			>
+			]: GetColumnData<TColumns[Key], 'query'>;
+		}
+		& {
+		[
+		Key in keyof TColumns & string as TColumns[Key]['_']['isIgnored'] extends true ? never : OptionalKeyOnly<
+			MapColumnName<Key, TColumns[Key], TConfig['dbColumnNames']>,
+			TColumns[Key],
+			TConfig['override']
+		>
+		]?: GetColumnData<TColumns[Key], 'query'> | undefined;
+	}
 		: {
 			[
-				Key in keyof TColumns & string as MapColumnName<
-					Key,
-					TColumns[Key],
-					TConfig['dbColumnNames']
-				>
+			Key in keyof TColumns & string as TColumns[Key]['_']['isIgnored'] extends true ? never : MapColumnName<
+				Key,
+				TColumns[Key],
+				TConfig['dbColumnNames']
+			>
 			]: GetColumnData<TColumns[Key], 'query'>;
 		}
 >;
+
 
 /** @deprecated Use one of the alternatives: {@link InferSelectModel} / {@link InferInsertModel}, or `table.$inferSelect` / `table.$inferInsert`
  */

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -185,7 +185,14 @@ export type Writable<T> = {
 };
 
 export function getTableColumns<T extends Table>(table: T): T['_']['columns'] {
-	return table[Table.Symbol.Columns];
+	const columns = table[Table.Symbol.Columns];
+	for (const [name, column] of Object.entries(columns)) {
+		if (column.isIgnored) {
+			delete columns[name];
+		}
+	}
+
+	return columns;
 }
 
 export function getViewSelectedFields<T extends View>(view: T): T['_']['selectedFields'] {

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+import { getTableColumns } from "~/index.ts";
+import { pgTable, serial, text } from "~/pg-core/index.ts";
+
+const pgExampleTable = pgTable("test", {
+  id: serial("d").primaryKey(),
+  exists: text("exists").notNull(),
+  ignored: text("ignored").$ignore(),
+});
+
+test("getTableColumns excludes ignored columns", () => {
+  const columns = getTableColumns(pgExampleTable);
+
+  expect(Object.keys(columns)).toHaveLength(2);
+  expect(Object.keys(columns)).toEqual(["id", "exists"]);
+});

--- a/drizzle-orm/type-tests/pg/generated-columns.ts
+++ b/drizzle-orm/type-tests/pg/generated-columns.ts
@@ -1,222 +1,250 @@
-import { type Equal, Expect } from 'type-tests/utils';
-import { type InferInsertModel, type InferSelectModel, sql } from '~/index';
-import { drizzle } from '~/node-postgres';
-import { integer, pgTable, serial, text, varchar } from '~/pg-core';
-import { db } from './db';
+import { type Equal, Expect } from "type-tests/utils";
+import { type InferInsertModel, type InferSelectModel, sql } from "~/index";
+import { drizzle } from "~/node-postgres";
+import { integer, pgTable, serial, text, varchar } from "~/pg-core";
+import { db } from "./db";
 
-const users = pgTable(
-	'users',
-	{
-		id: serial('id').primaryKey(),
-		firstName: varchar('first_name', { length: 255 }),
-		lastName: varchar('last_name', { length: 255 }),
-		email: text('email').notNull(),
-		fullName: text('full_name').generatedAlwaysAs(sql`concat_ws(first_name, ' ', last_name)`).notNull(),
-		upperName: text('upper_name').generatedAlwaysAs(
-			sql` case when first_name is null then null else upper(first_name) end `,
-		),
-	},
-);
+const users = pgTable("users", {
+  id: serial("id").primaryKey(),
+  firstName: varchar("first_name", { length: 255 }),
+  lastName: varchar("last_name", { length: 255 }),
+  email: text("email").notNull(),
+  fullName: text("full_name")
+    .generatedAlwaysAs(sql`concat_ws(first_name, ' ', last_name)`)
+    .notNull(),
+  upperName: text("upper_name").generatedAlwaysAs(
+    sql` case when first_name is null then null else upper(first_name) end `,
+  ),
+});
 {
-	type User = typeof users.$inferSelect;
-	type NewUser = typeof users.$inferInsert;
+  type User = typeof users.$inferSelect;
+  type NewUser = typeof users.$inferInsert;
 
-	Expect<
-		Equal<
-			{
-				id: number;
-				firstName: string | null;
-				lastName: string | null;
-				email: string;
-				fullName: string;
-				upperName: string | null;
-			},
-			User
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        id: number;
+        firstName: string | null;
+        lastName: string | null;
+        email: string;
+        fullName: string;
+        upperName: string | null;
+      },
+      User
+    >
+  >();
 
-	Expect<
-		Equal<
-			{
-				email: string;
-				id?: number | undefined;
-				firstName?: string | null | undefined;
-				lastName?: string | null | undefined;
-			},
-			NewUser
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        email: string;
+        id?: number | undefined;
+        firstName?: string | null | undefined;
+        lastName?: string | null | undefined;
+      },
+      NewUser
+    >
+  >();
 }
 
 {
-	type User = InferSelectModel<typeof users>;
-	type NewUser = InferInsertModel<typeof users>;
+  type User = InferSelectModel<typeof users>;
+  type NewUser = InferInsertModel<typeof users>;
 
-	Expect<
-		Equal<
-			{
-				id: number;
-				firstName: string | null;
-				lastName: string | null;
-				email: string;
-				fullName: string;
-				upperName: string | null;
-			},
-			User
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        id: number;
+        firstName: string | null;
+        lastName: string | null;
+        email: string;
+        fullName: string;
+        upperName: string | null;
+      },
+      User
+    >
+  >();
 
-	Expect<
-		Equal<
-			{
-				email: string;
-				id?: number | undefined;
-				firstName?: string | null | undefined;
-				lastName?: string | null | undefined;
-			},
-			NewUser
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        email: string;
+        id?: number | undefined;
+        firstName?: string | null | undefined;
+        lastName?: string | null | undefined;
+      },
+      NewUser
+    >
+  >();
 }
 
 {
-	const dbUsers = await db.select().from(users);
+  const dbUsers = await db.select().from(users);
 
-	Expect<
-		Equal<
-			{
-				id: number;
-				firstName: string | null;
-				lastName: string | null;
-				email: string;
-				fullName: string;
-				upperName: string | null;
-			}[],
-			typeof dbUsers
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        id: number;
+        firstName: string | null;
+        lastName: string | null;
+        email: string;
+        fullName: string;
+        upperName: string | null;
+      }[],
+      typeof dbUsers
+    >
+  >();
 }
 
 {
-	const db = drizzle({} as any, { schema: { users } });
+  const db = drizzle({} as any, { schema: { users } });
 
-	const dbUser = await db.query.users.findFirst();
+  const dbUser = await db.query.users.findFirst();
 
-	Expect<
-		Equal<
-			{
-				id: number;
-				firstName: string | null;
-				lastName: string | null;
-				email: string;
-				fullName: string;
-				upperName: string | null;
-			} | undefined,
-			typeof dbUser
-		>
-	>();
+  Expect<
+    Equal<
+      | {
+          id: number;
+          firstName: string | null;
+          lastName: string | null;
+          email: string;
+          fullName: string;
+          upperName: string | null;
+        }
+      | undefined,
+      typeof dbUser
+    >
+  >();
 }
 
 {
-	const db = drizzle({} as any, { schema: { users } });
+  const db = drizzle({} as any, { schema: { users } });
 
-	const dbUser = await db.query.users.findMany();
+  const dbUser = await db.query.users.findMany();
 
-	Expect<
-		Equal<
-			{
-				id: number;
-				firstName: string | null;
-				lastName: string | null;
-				email: string;
-				fullName: string;
-				upperName: string | null;
-			}[],
-			typeof dbUser
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        id: number;
+        firstName: string | null;
+        lastName: string | null;
+        email: string;
+        fullName: string;
+        upperName: string | null;
+      }[],
+      typeof dbUser
+    >
+  >();
 }
 
 {
-	// @ts-expect-error - Can't use the fullName because it's a generated column
-	await db.insert(users).values({
-		firstName: 'test',
-		lastName: 'test',
-		email: 'test',
-		fullName: 'test',
-	});
+  // @ts-expect-error - Can't use the fullName because it's a generated column
+  await db.insert(users).values({
+    firstName: "test",
+    lastName: "test",
+    email: "test",
+    fullName: "test",
+  });
 }
 
 {
-	await db.update(users).set({
-		firstName: 'test',
-		lastName: 'test',
-		email: 'test',
-		// @ts-expect-error - Can't use the fullName because it's a generated column
-		fullName: 'test',
-	});
+  await db.update(users).set({
+    firstName: "test",
+    lastName: "test",
+    email: "test",
+    // @ts-expect-error - Can't use the fullName because it's a generated column
+    fullName: "test",
+  });
 }
 
-const users2 = pgTable(
-	'users',
-	{
-		id: integer('id').generatedByDefaultAsIdentity(),
-		id2: integer('id').generatedAlwaysAsIdentity(),
-	},
-);
+const users2 = pgTable("users", {
+  id: integer("id").generatedByDefaultAsIdentity(),
+  id2: integer("id").generatedAlwaysAsIdentity(),
+});
 
 {
-	type User = typeof users2.$inferSelect;
-	type NewUser = typeof users2.$inferInsert;
+  type User = typeof users2.$inferSelect;
+  type NewUser = typeof users2.$inferInsert;
 
-	Expect<
-		Equal<
-			{
-				id: number;
-				id2: number;
-			},
-			User
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        id: number;
+        id2: number;
+      },
+      User
+    >
+  >();
 
-	Expect<
-		Equal<
-			{
-				id?: number | undefined;
-			},
-			NewUser
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        id?: number | undefined;
+      },
+      NewUser
+    >
+  >();
 }
 
-const usersSeq = pgTable(
-	'users',
-	{
-		id: integer('id').generatedByDefaultAsIdentity(),
-		id2: integer('id').generatedAlwaysAsIdentity(),
-	},
-);
+const usersSeq = pgTable("users", {
+  id: integer("id").generatedByDefaultAsIdentity(),
+  id2: integer("id").generatedAlwaysAsIdentity(),
+});
 
 {
-	type User = typeof usersSeq.$inferSelect;
-	type NewUser = typeof usersSeq.$inferInsert;
+  type User = typeof usersSeq.$inferSelect;
+  type NewUser = typeof usersSeq.$inferInsert;
 
-	Expect<
-		Equal<
-			{
-				id: number;
-				id2: number;
-			},
-			User
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        id: number;
+        id2: number;
+      },
+      User
+    >
+  >();
 
-	Expect<
-		Equal<
-			{
-				id?: number | undefined;
-			},
-			NewUser
-		>
-	>();
+  Expect<
+    Equal<
+      {
+        id?: number | undefined;
+      },
+      NewUser
+    >
+  >();
+}
+
+const usersWithIgnored = pgTable("users", {
+  id: serial("id").primaryKey(),
+  firstName: varchar("first_name", { length: 255 }),
+  email: text("email").notNull(),
+  ignored: text("ignored").$ignore(),
+});
+
+{
+  type User = typeof usersWithIgnored.$inferSelect;
+  type NewUser = typeof usersWithIgnored.$inferInsert;
+
+  Expect<
+    Equal<
+      {
+        id: number;
+        firstName: string | null;
+        email: string;
+      },
+      User
+    >
+  >();
+
+  Expect<
+    Equal<
+      {
+        id?: number | undefined;
+        email: string;
+        firstName?: string | null | undefined;
+      },
+      NewUser
+    >
+  >();
 }

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -172,6 +172,7 @@ export const usersMigratorTable = pgTable('users12', {
 	id: serial('id').primaryKey(),
 	name: text('name').notNull(),
 	email: text('email').notNull(),
+	test: text('test').$ignore(),
 });
 
 // To test aggregate functions


### PR DESCRIPTION
# _**CURRENTLY A WORK IN PROGRESS**_

The general idea here is to be able to "ignore" a column similar to Prisma. The goal is that when `.$ignored()` is added to a given column, that column will be left out of the default columns that are selected by Drizzle. 

## Motivation
The idea with this would to create a way to safely be able to drop columns from a given table. As it stands today, if you remove the column from a schema, migrations will attempt to drop the column. But... it's not safe to drop columns until all applications that talk to your Database have migrated to the new schema, at which point it would be safe to drop the column.


Adding `.$ignored()` will also remove the column from from the `$inferedSelect` and `$inferedInsert` for the table as well.

TODO List:
- [ ] Make sure `.$ignored()` columns are not dropped when migrations are generated
- [ ] Make sure adding `.$ignored()` on an already `.notNull()` column would generate a migration to make the column `NULLABLE`
- [ ] Ideally... Drizzle types would prevent adding `.notNull()` and `.$ignored()` to the same column
- [ ] Granted this is something Drizzle wants to move forward with... I would want to add `.$ignored()` for tables as well.