### PR TITLE
Add .vscode with recommended configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-.vscode
 dist
 dist.new
 *.tsbuildinfo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "dprint.dprint",
+        "dbaeumer.vscode-eslint",
+        "bradlc.vscode-tailwindcss",
+        "vercel.turbo-vsc"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+	"editor.defaultFormatter": "dprint.dprint",
+	"editor.formatOnSave": true,
+	"[typescript]": {
+		"editor.defaultFormatter": "dprint.dprint"
+	}
+}


### PR DESCRIPTION
At the moment, it's really inconvenient to start working on PR with an absence `.vscode` of the folder. It can specify which formatter will be used in this project and which extensions are recommended. This simplifies onboarding at times