### PR TITLE
Wrap postgresjs client calls to capture stack traces

### DIFF
--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -17,3 +17,12 @@ export class TransactionRollbackError extends DrizzleError {
 		super({ message: 'Rollback' });
 	}
 }
+
+export async function wrapPromiseCaptureStacktrace<R>(promise: PromiseLike<R>): Promise<R> {
+	try {
+		return await promise;
+	} catch (e) {
+		Error.captureStackTrace(e as any, wrapPromiseCaptureStacktrace);
+		throw e;
+	}
+}


### PR DESCRIPTION
Resolves #1827