### PR TITLE
[pg] fix int8 precision loss in relations (bigint, bigserial and custom int8)

### DIFF
--- a/drizzle-orm/src/pg-core/columns/bigint.ts
+++ b/drizzle-orm/src/pg-core/columns/bigint.ts
@@ -86,6 +86,11 @@ export class PgBigInt64<T extends ColumnBaseConfig<'bigint', 'PgBigInt64'>> exte
 
 	// eslint-disable-next-line unicorn/prefer-native-coercion-functions
 	override mapFromDriverValue(value: string): bigint {
+		if (typeof value === 'number') {
+			throw new Error(
+				`PgBigInt64:mapFromDriverValue(value: string) received number instead of string, meaning precision was lost.`,
+			);
+		}
 		return BigInt(value);
 	}
 }

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -195,6 +195,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional cast when selected in a relation (`with: { ... }``).
+	 * This is mostly useful to force int8 (bigint) to be casted as string, instead of
+	 * getting converted to a number and losing precision.
+	 * @example
+	 * For example, when custom type expects to receive a stringified bigint :
+	 * ```
+	 * castInRelation: 'text'
+	 * ```
+	 */
+	castInRelation?: 'text';
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -5,6 +5,9 @@ import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
 import {
+	CustomTypeParams,
+	PgBigInt64,
+	PgBigSerial64,
 	PgColumn,
 	PgDate,
 	PgDateString,
@@ -1342,6 +1345,10 @@ export class PgDialect {
 							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
 							: is(field, SQL.Aliased)
 							? field.sql
+							: (is(field, PgBigSerial64) || is(field, PgBigInt64)
+									|| (field as (typeof field & { config?: { customTypeParams?: CustomTypeParams<any> } }))?.config
+											?.customTypeParams?.castInRelation === 'text')
+							? sql`CAST(${field} AS TEXT)`
 							: field
 					),
 					sql`, `,

--- a/integration-tests/tests/relational/issues-schemas/bigint/pg.schema.ts
+++ b/integration-tests/tests/relational/issues-schemas/bigint/pg.schema.ts
@@ -1,0 +1,90 @@
+import { relations } from 'drizzle-orm';
+import { bigint, bigserial, customType, pgTable } from 'drizzle-orm/pg-core';
+
+export const TestBigint = pgTable('test_bigint', {
+	serialBigintId: bigserial({ mode: 'bigint' }).notNull(),
+	nonSerialBigint: bigint({ mode: 'bigint' }).notNull(),
+});
+
+export const TestBigintChild = pgTable('test_bigint_child', {
+	childSerialBigintId: bigserial({ mode: 'bigint' }).notNull(),
+	childNonSerialBigint: bigint({ mode: 'bigint' }).notNull(),
+	parentBigintId: bigint({ mode: 'bigint' }).notNull(),
+});
+
+export const TestBigintRelations = relations(TestBigint, ({ many }) => ({
+	children: many(TestBigintChild),
+}));
+
+export const TestBigintChildRelations = relations(
+	TestBigintChild,
+	({ one }) => ({
+		parent: one(TestBigint, {
+			fields: [TestBigintChild.parentBigintId],
+			references: [TestBigint.serialBigintId],
+		}),
+	}),
+);
+
+export const CustomBigint = customType<{
+	data: bigint;
+	driverData: string;
+	default: false;
+}>({
+	castInRelation: 'text',
+	dataType() {
+		return 'bigint not null';
+	},
+	fromDriver(value: string): bigint {
+		if (typeof value === 'number') {
+			throw new Error(
+				`CustomBigint:fromDriver(value: string) received number instead of string, meaning precision was lost.`,
+			);
+		}
+		return BigInt(value);
+	},
+});
+
+export const CustomBigserial = customType<{
+	data: bigint;
+	driverData: string;
+	default: false;
+}>({
+	castInRelation: 'text',
+	dataType() {
+		return 'bigserial not null';
+	},
+	fromDriver(value: string): bigint {
+		if (typeof value === 'number') {
+			throw new Error(
+				`CustomBigserial:fromDriver(value: string) received number instead of string, meaning precision was lost.`,
+			);
+		}
+		return BigInt(value);
+	},
+});
+
+export const TestCustomBigint = pgTable('test_custom_bigint', {
+	serialBigintId: CustomBigserial().notNull(),
+	customBigint: CustomBigint().notNull(),
+});
+
+export const TestCustomBigintChild = pgTable('test_custom_bigint_child', {
+	childSerialBigintId: CustomBigserial().notNull(),
+	childCustomBigint: CustomBigint().notNull(),
+	parentBigintId: CustomBigint().notNull(),
+});
+
+export const TestCustomBigintRelations = relations(TestCustomBigint, ({ many }) => ({
+	children: many(TestCustomBigintChild),
+}));
+
+export const TestCustomBigintChildRelations = relations(
+	TestCustomBigintChild,
+	({ one }) => ({
+		parent: one(TestCustomBigint, {
+			fields: [TestCustomBigintChild.parentBigintId],
+			references: [TestCustomBigint.serialBigintId],
+		}),
+	}),
+);

--- a/integration-tests/tests/relational/issues-schemas/bigint/pg.test.ts
+++ b/integration-tests/tests/relational/issues-schemas/bigint/pg.test.ts
@@ -1,0 +1,218 @@
+import 'dotenv/config';
+import Docker from 'dockerode';
+import { desc, sql } from 'drizzle-orm';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import getPort from 'get-port';
+import pg from 'pg';
+import { v4 as uuid } from 'uuid';
+import { afterAll, beforeAll, beforeEach, expect, expectTypeOf, test } from 'vitest';
+import * as schema from './pg.schema.ts';
+
+const { Client } = pg;
+
+const ENABLE_LOGGING = false;
+
+const VALUE_STRING = '130237967670177794';
+const VALUE_BIGINT = 130237967670177794n;
+
+/*
+	Test cases:
+	- querying with relation containing bigint values, with no precision loss
+*/
+
+let pgContainer: Docker.Container;
+let db: NodePgDatabase<typeof schema>;
+let client: pg.Client;
+
+async function createDockerDB(): Promise<string> {
+	const docker = new Docker();
+	const port = await getPort({ port: 5432 });
+	const image = 'postgres:14';
+
+	const pullStream = await docker.pull(image);
+	await new Promise((resolve, reject) =>
+		docker.modem.followProgress(pullStream, (err) => err ? reject(err) : resolve(err))
+	);
+
+	pgContainer = await docker.createContainer({
+		Image: image,
+		Env: [
+			'POSTGRES_PASSWORD=postgres',
+			'POSTGRES_USER=postgres',
+			'POSTGRES_DB=postgres',
+		],
+		name: `drizzle-integration-tests-${uuid()}`,
+		HostConfig: {
+			AutoRemove: true,
+			PortBindings: {
+				'5432/tcp': [{ HostPort: `${port}` }],
+			},
+		},
+	});
+
+	await pgContainer.start();
+
+	return `postgres://postgres:postgres@localhost:${port}/postgres`;
+}
+
+beforeAll(async () => {
+	const connectionString = process.env['PG_CONNECTION_STRING'] ?? (await createDockerDB());
+
+	const sleep = 250;
+	let timeLeft = 5000;
+	let connected = false;
+	let lastError: unknown | undefined;
+	do {
+		try {
+			client = new Client(connectionString);
+			await client.connect();
+			connected = true;
+			break;
+		} catch (e) {
+			lastError = e;
+			await new Promise((resolve) => setTimeout(resolve, sleep));
+			timeLeft -= sleep;
+		}
+	} while (timeLeft > 0);
+	if (!connected) {
+		console.error('Cannot connect to Postgres');
+		await client?.end().catch(console.error);
+		await pgContainer?.stop().catch(console.error);
+		throw lastError;
+	}
+	db = drizzle(client, { schema, logger: ENABLE_LOGGING, casing: 'snake_case' });
+});
+
+afterAll(async () => {
+	await client?.end().catch(console.error);
+	await pgContainer?.stop().catch(console.error);
+});
+
+beforeEach(async () => {
+	await db.execute(sql`drop schema public cascade`);
+	await db.execute(sql`create schema public`);
+
+	await db.execute(
+		sql`
+			CREATE TABLE public.test_bigint (
+        serial_bigint_id bigserial NOT NULL,
+        non_serial_bigint int8 NOT NULL,
+        CONSTRAINT test_bigint_pkey PRIMARY KEY (serial_bigint_id)
+      );
+
+			CREATE TABLE public.test_bigint_child (
+        child_serial_bigint_id bigserial NOT NULL,
+        child_non_serial_bigint int8 NOT NULL,
+        parent_bigint_id int8 NOT NULL,
+        CONSTRAINT test_bigint_child_pkey PRIMARY KEY (child_serial_bigint_id)
+      );
+
+      CREATE TABLE public.test_custom_bigint (
+        serial_bigint_id bigserial NOT NULL,
+        custom_bigint int8 NOT NULL,
+        CONSTRAINT test_custom_bigint_pkey PRIMARY KEY (serial_bigint_id)
+      );
+
+			CREATE TABLE public.test_custom_bigint_child (
+        child_serial_bigint_id bigserial NOT NULL,
+        child_custom_bigint int8 NOT NULL,
+        parent_bigint_id int8 NOT NULL,
+        CONSTRAINT test_custom_bigint_child_pkey PRIMARY KEY (child_serial_bigint_id)
+      );
+		`,
+	);
+});
+
+test('bigint and bigserial should not loose precisision even in relation', async () => {
+	await db.insert(schema.TestBigint).values({
+		serialBigintId: VALUE_BIGINT,
+		nonSerialBigint: VALUE_BIGINT,
+	});
+
+	await db.insert(schema.TestBigintChild).values({
+		childSerialBigintId: VALUE_BIGINT,
+		childNonSerialBigint: VALUE_BIGINT,
+		parentBigintId: VALUE_BIGINT,
+	});
+
+	const query = db.query.TestBigint.findFirst({
+		with: {
+			children: {
+				with: {
+					parent: true,
+				},
+			},
+		},
+	});
+
+	const querySql = query.toSQL();
+
+	console.log(querySql);
+
+	const res = await query;
+
+	if (!res) throw new Error('Type guard');
+
+	expect(res.serialBigintId).toEqual(VALUE_BIGINT);
+	expect(res.nonSerialBigint).toEqual(VALUE_BIGINT);
+
+	const child = res.children[0];
+
+	if (!child) throw new Error('Type guard');
+
+	expect(child.childSerialBigintId).toEqual(VALUE_BIGINT);
+	expect(child.childNonSerialBigint).toEqual(VALUE_BIGINT);
+	expect(child.parentBigintId).toEqual(VALUE_BIGINT);
+
+	if (!child.parent) throw new Error('Type guard');
+
+	expect(child.parent.serialBigintId).toEqual(VALUE_BIGINT);
+	expect(child.parent.nonSerialBigint).toEqual(VALUE_BIGINT);
+});
+
+test('custom bigint and bigserial should not loose precisision even in relation', async () => {
+	await db.insert(schema.TestCustomBigint).values({
+		serialBigintId: VALUE_BIGINT,
+		customBigint: VALUE_BIGINT,
+	});
+
+	await db.insert(schema.TestCustomBigintChild).values({
+		childSerialBigintId: VALUE_BIGINT,
+		childCustomBigint: VALUE_BIGINT,
+		parentBigintId: VALUE_BIGINT,
+	});
+
+	const query = db.query.TestCustomBigint.findFirst({
+		with: {
+			children: {
+				with: {
+					parent: true,
+				},
+			},
+		},
+	});
+
+	const querySql = query.toSQL();
+
+	console.log(querySql);
+
+	const res = await query;
+
+	if (!res) throw new Error('Type guard');
+
+	expect(res.serialBigintId).toEqual(VALUE_BIGINT);
+	expect(res.customBigint).toEqual(VALUE_BIGINT);
+
+	const child = res.children[0];
+
+	if (!child) throw new Error('Type guard');
+
+	expect(child.childSerialBigintId).toEqual(VALUE_BIGINT);
+	expect(child.childCustomBigint).toEqual(VALUE_BIGINT);
+	expect(child.parentBigintId).toEqual(VALUE_BIGINT);
+
+	if (!child.parent) throw new Error('Type guard');
+
+	expect(child.parent.serialBigintId).toEqual(VALUE_BIGINT);
+	expect(child.parent.customBigint).toEqual(VALUE_BIGINT);
+});


### PR DESCRIPTION
- Fixes a bug where `bigint` was serialized as `number` in relation, losing precision.
- Native `bigserial` and `bigint` types are automatically casted to `text`.
- Allows custom types to also be casted via `castInRelation: 'text'`.
- Added tests for native and custom types, with `one` and `many` relations.

There are probably edge cases not covered, my understanding of drizzle's internals being limited.

Related (pg) : #3267, #813
Related (other dialect) : #1688
