### PR TITLE
Update README.md to fix links to specific DB docs and make the bundle size up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 ### What's Drizzle?
 Drizzle is a modern TypeScript ORM developers [wanna use in their next project](https://stateofdb.com/tools/drizzle). 
-It is [lightweight](https://bundlephobia.com/package/drizzle-orm) at only ~7.4kb minified+gzipped, and it's tree shakeable with exactly 0 dependencies. 
+It is [lightweight](https://bundlephobia.com/package/drizzle-orm) at only ~11.8kB minified+gzipped, and it's tree shakeable with exactly 0 dependencies. 
 
-**Drizzle supports every PostgreSQL, MySQL and SQLite database**, including serverless ones like [Turso](https://orm.drizzle.team/docs/get-started-sqlite#turso), [Neon](https://orm.drizzle.team/docs/get-started-postgresql#neon), [Xata](xata.io), [PlanetScale](https://orm.drizzle.team/docs/get-started-mysql#planetscale), [Cloudflare D1](https://orm.drizzle.team/docs/get-started-sqlite#cloudflare-d1), [FlyIO LiteFS](https://fly.io/docs/litefs/), [Vercel Postgres](https://orm.drizzle.team/docs/get-started-postgresql#vercel-postgres), [Supabase](https://orm.drizzle.team/docs/get-started-postgresql#supabase) and [AWS Data API](https://orm.drizzle.team/docs/get-started-postgresql#aws-data-api). No bells and whistles, no Rust binaries, no serverless adapters, everything just works out of the box.
+**Drizzle supports every PostgreSQL, MySQL and SQLite database**, including serverless ones like [Turso](https://orm.drizzle.team/docs/connect-turso), [Neon](https://orm.drizzle.team/docs/connect-neon), [Xata](xata.io), [PlanetScale](https://orm.drizzle.team/docs/connect-planetscale), [Cloudflare D1](https://orm.drizzle.team/docs/connect-cloudflare-d1), [FlyIO LiteFS](https://fly.io/docs/litefs/), [Vercel Postgres](https://orm.drizzle.team/docs/connect-vercel-postgres), [Supabase](https://orm.drizzle.team/docs/connect-supabase) and [AWS Data API](https://orm.drizzle.team/docs/connect-aws-data-api-pg). No bells and whistles, no Rust binaries, no serverless adapters, everything just works out of the box.
 
 **Drizzle is serverless-ready by design**. It works in every major JavaScript runtime like NodeJS, Bun, Deno, Cloudflare Workers, Supabase functions, any Edge runtime, and even in browsers.  
 With Drizzle you can be [**fast out of the box**](https://orm.drizzle.team/benchmarks) and save time and costs while never introducing any data proxies into your infrastructure. 


### PR DESCRIPTION
just updated the README to fix the links, then noticed that the reported bundle size was out-of-date and used the kilobit (not kiloByte) unit notation, so i updated that also