### PR TITLE
[MySQL] Remove AUTO_INCREMENT from MySQL serial type

### DIFF
--- a/drizzle-kit/tests/mysql-checks.test.ts
+++ b/drizzle-kit/tests/mysql-checks.test.ts
@@ -50,7 +50,7 @@ test('create table with check', async (t) => {
 
 	expect(sqlStatements.length).toBe(1);
 	expect(sqlStatements[0]).toBe(`CREATE TABLE \`users\` (
-\t\`id\` serial AUTO_INCREMENT NOT NULL,
+\t\`id\` serial NOT NULL,
 \t\`age\` int,
 \tCONSTRAINT \`users_id\` PRIMARY KEY(\`id\`),
 \tCONSTRAINT \`some_check_name\` CHECK(\`users\`.\`age\` > 21)

--- a/drizzle-kit/tests/mysql.test.ts
+++ b/drizzle-kit/tests/mysql.test.ts
@@ -595,7 +595,7 @@ test('add table with indexes', async () => {
 	const { sqlStatements } = await diffTestSchemasMysql(from, to, []);
 	expect(sqlStatements.length).toBe(6);
 	expect(sqlStatements).toStrictEqual([
-		`CREATE TABLE \`users\` (\n\t\`id\` serial AUTO_INCREMENT NOT NULL,\n\t\`name\` text,\n\t\`email\` text,\n\tCONSTRAINT \`users_id\` PRIMARY KEY(\`id\`),\n\tCONSTRAINT \`uniqueExpr\` UNIQUE((lower(\`email\`))),\n\tCONSTRAINT \`uniqueCol\` UNIQUE(\`email\`)
+		`CREATE TABLE \`users\` (\n\t\`id\` serial NOT NULL,\n\t\`name\` text,\n\t\`email\` text,\n\tCONSTRAINT \`users_id\` PRIMARY KEY(\`id\`),\n\tCONSTRAINT \`uniqueExpr\` UNIQUE((lower(\`email\`))),\n\tCONSTRAINT \`uniqueCol\` UNIQUE(\`email\`)
 );
 `,
 		'CREATE INDEX `indexExpr` ON `users` ((lower(`email`)));',
@@ -748,7 +748,7 @@ test('optional db aliases (snake case)', async () => {
 `;
 
 	const st2 = `CREATE TABLE \`t2\` (
-	\`t2_id\` serial AUTO_INCREMENT NOT NULL,
+	\`t2_id\` serial NOT NULL,
 	CONSTRAINT \`t2_t2_id\` PRIMARY KEY(\`t2_id\`)
 );
 `;
@@ -839,7 +839,7 @@ test('optional db aliases (camel case)', async () => {
 `;
 
 	const st2 = `CREATE TABLE \`t2\` (
-	\`t2Id\` serial AUTO_INCREMENT NOT NULL,
+	\`t2Id\` serial NOT NULL,
 	CONSTRAINT \`t2_t2Id\` PRIMARY KEY(\`t2Id\`)
 );
 `;

--- a/drizzle-kit/tests/singlestore.test.ts
+++ b/drizzle-kit/tests/singlestore.test.ts
@@ -569,7 +569,7 @@ test('add table with indexes', async () => {
 	const { sqlStatements } = await diffTestSchemasSingleStore(from, to, []);
 	expect(sqlStatements.length).toBe(6);
 	expect(sqlStatements).toStrictEqual([
-		`CREATE TABLE \`users\` (\n\t\`id\` serial AUTO_INCREMENT NOT NULL,\n\t\`name\` text,\n\t\`email\` text,\n\tCONSTRAINT \`users_id\` PRIMARY KEY(\`id\`),\n\tCONSTRAINT \`uniqueExpr\` UNIQUE((lower(\`email\`))),\n\tCONSTRAINT \`uniqueCol\` UNIQUE(\`email\`)
+		`CREATE TABLE \`users\` (\n\t\`id\` serial NOT NULL,\n\t\`name\` text,\n\t\`email\` text,\n\tCONSTRAINT \`users_id\` PRIMARY KEY(\`id\`),\n\tCONSTRAINT \`uniqueExpr\` UNIQUE((lower(\`email\`))),\n\tCONSTRAINT \`uniqueCol\` UNIQUE(\`email\`)
 );
 `,
 		'CREATE INDEX `indexExpr` ON `users` ((lower(`email`)));',

--- a/drizzle-orm/src/mysql-core/columns/serial.ts
+++ b/drizzle-orm/src/mysql-core/columns/serial.ts
@@ -10,7 +10,7 @@ import type {
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { MySqlColumnBuilderWithAutoIncrement, MySqlColumnWithAutoIncrement } from './common.ts';
+import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlSerialBuilderInitial<TName extends string> = IsAutoincrement<
 	IsPrimaryKey<
@@ -30,14 +30,13 @@ export type MySqlSerialBuilderInitial<TName extends string> = IsAutoincrement<
 >;
 
 export class MySqlSerialBuilder<T extends ColumnBuilderBaseConfig<'number', 'MySqlSerial'>>
-	extends MySqlColumnBuilderWithAutoIncrement<T>
+	extends MySqlColumnBuilder<T>
 {
 	static override readonly [entityKind]: string = 'MySqlSerialBuilder';
 
 	constructor(name: T['name']) {
 		super(name, 'number', 'MySqlSerial');
 		this.config.hasDefault = true;
-		this.config.autoIncrement = true;
 	}
 
 	/** @internal */
@@ -50,7 +49,7 @@ export class MySqlSerialBuilder<T extends ColumnBuilderBaseConfig<'number', 'MyS
 
 export class MySqlSerial<
 	T extends ColumnBaseConfig<'number', 'MySqlSerial'>,
-> extends MySqlColumnWithAutoIncrement<T> {
+> extends MySqlColumn<T> {
 	static override readonly [entityKind]: string = 'MySqlSerial';
 
 	getSQLType(): string {

--- a/drizzle-seed/tests/mysql/allDataTypesTest/mysql_all_data_types.test.ts
+++ b/drizzle-seed/tests/mysql/allDataTypesTest/mysql_all_data_types.test.ts
@@ -82,7 +82,7 @@ beforeAll(async () => {
 				\`decimal\` decimal,
 				\`double\` double,
 				\`float\` float,
-				\`serial\` serial AUTO_INCREMENT,
+				\`serial\` serial,
 				\`binary\` binary(255),
 				\`varbinary\` varbinary(256),
 				\`char\` char(255),

--- a/integration-tests/tests/relational/issues-schemas/duplicates/mysql/mysql.duplicates.test.ts
+++ b/integration-tests/tests/relational/issues-schemas/duplicates/mysql/mysql.duplicates.test.ts
@@ -88,7 +88,7 @@ beforeEach(async () => {
 	await db.execute(
 		sql`
 			CREATE TABLE \`members\` (
-			    \`id\` serial AUTO_INCREMENT PRIMARY KEY NOT NULL,
+			    \`id\` serial PRIMARY KEY NOT NULL,
 			    \`created_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			    \`updated_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			    \`name_en\` varchar(50) NOT NULL,
@@ -102,7 +102,7 @@ beforeEach(async () => {
 	await db.execute(
 		sql`
 			CREATE TABLE \`artist_to_member\` (
-			    \`id\` serial AUTO_INCREMENT PRIMARY KEY NOT NULL,
+			    \`id\` serial PRIMARY KEY NOT NULL,
 			    \`member_id\` int NOT NULL,
 			    \`artist_id\` int NOT NULL);
 		`,
@@ -110,7 +110,7 @@ beforeEach(async () => {
 	await db.execute(
 		sql`
 			CREATE TABLE \`artists\` (
-			    \`id\` serial AUTO_INCREMENT PRIMARY KEY NOT NULL,
+			    \`id\` serial PRIMARY KEY NOT NULL,
 			    \`created_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			    \`updated_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			    \`name_en\` varchar(50) NOT NULL,
@@ -129,7 +129,7 @@ beforeEach(async () => {
 	await db.execute(
 		sql`
 			CREATE TABLE \`albums\` (
-			    \`id\` serial AUTO_INCREMENT PRIMARY KEY NOT NULL,
+			    \`id\` serial PRIMARY KEY NOT NULL,
 			    \`created_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			    \`updated_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			    \`artist_id\` int NOT NULL,

--- a/integration-tests/tests/seeder/mysql.test.ts
+++ b/integration-tests/tests/seeder/mysql.test.ts
@@ -205,7 +205,7 @@ const createAllDataTypesTable = async () => {
 				\`decimal\` decimal,
 				\`double\` double,
 				\`float\` float,
-				\`serial\` serial AUTO_INCREMENT,
+				\`serial\` serial,
 				\`binary\` binary(255),
 				\`varbinary\` varbinary(256),
 				\`char\` char(255),


### PR DESCRIPTION
As reported on issue #3333, the AUTO_INCREMENT along side the serial type causes an error on MariaDB instances. This commit removes AUTO_INCREMENT clause from the serial type and from the integration tests.