### PR TITLE
Enable tracing

### DIFF
--- a/drizzle-orm/src/tracing.ts
+++ b/drizzle-orm/src/tracing.ts
@@ -1,16 +1,19 @@
-import type { Span, Tracer } from '@opentelemetry/api';
+import type { Exception, Span, Tracer } from '@opentelemetry/api';
 import { iife } from '~/tracing-utils.ts';
 import { npmVersion } from '~/version.ts';
 
 let otel: typeof import('@opentelemetry/api') | undefined;
 let rawTracer: Tracer | undefined;
-// try {
-// 	otel = await import('@opentelemetry/api');
-// } catch (err: any) {
-// 	if (err.code !== 'MODULE_NOT_FOUND' && err.code !== 'ERR_MODULE_NOT_FOUND') {
-// 		throw err;
-// 	}
-// }
+
+(async () => {
+	try {
+		otel = await import('@opentelemetry/api');
+	} catch (err: any) {
+		if (err.code !== 'MODULE_NOT_FOUND' && err.code !== 'ERR_MODULE_NOT_FOUND') {
+			throw err;
+		}
+	}
+})();
 
 type SpanName =
 	| 'drizzle.operation'
@@ -35,10 +38,11 @@ export const tracer = {
 			(otel, rawTracer) =>
 				rawTracer.startActiveSpan(
 					name,
-					((span: Span) => {
+					(async (span: Span) => {
 						try {
-							return fn(span);
+							return await fn(span);
 						} catch (e) {
+							span.recordException(e as Exception);
 							span.setStatus({
 								code: otel.SpanStatusCode.ERROR,
 								message: e instanceof Error ? e.message : 'Unknown error', // eslint-disable-line no-instanceof/no-instanceof


### PR DESCRIPTION
This PR enables otel tracing, which is already implemented.

The tracing seems to have been disabled due to incompatibility with top-level await for certain bundlers. This issue was resolved with an IIFE.

Additionaly, a bug was fixed where the finally clause runs before the promise resolves due to the wrapper retuning early. Hence the async/await wrapping on the span.

We've run this code as a patch in production for a few weeks and it works well. Though only tested for `postgres-js`.

Let me know if any tests are needed, or how I can help to get this feature enabled.
