### PR TITLE
fix(mysql): parse json data

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/json.ts
+++ b/drizzle-orm/src/mysql-core/columns/json.ts
@@ -38,6 +38,17 @@ export class MySqlJson<T extends ColumnBaseConfig<'json', 'MySqlJson'>> extends 
 	override mapToDriverValue(value: T['data']): string {
 		return JSON.stringify(value);
 	}
+
+	override mapFromDriverValue(value: T['data'] | string): T['data'] {
+		if (typeof value === 'string') {
+			try {
+				return JSON.parse(value);
+			} catch {
+				return value as T['data'];
+			}
+		}
+		return value;
+	}
 }
 
 export function json(): MySqlJsonBuilderInitial<''>;


### PR DESCRIPTION
Currently json fields will return string values instead of parsed data.
The same logic was used for Postges: https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-orm/src/pg-core/columns/json.ts#L48