### PR TITLE
fix(drizzle-orm): fix configuration validation correct property checks for schema and casing

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -278,14 +278,14 @@ export function isConfig(data: any): boolean {
 	}
 
 	if ('schema' in data) {
-		const type = typeof data['logger'];
+		const type = typeof data['schema'];
 		if (type !== 'object' && type !== 'undefined') return false;
 
 		return true;
 	}
 
 	if ('casing' in data) {
-		const type = typeof data['logger'];
+		const type = typeof data['casing'];
 		if (type !== 'string' && type !== 'undefined') return false;
 
 		return true;


### PR DESCRIPTION
🚨 Important❗️❗️❗️
**Change Summary:**  
I fixed two **typo bugs** in the configuration validation logic where the `'schema'` and `'casing'` configuration properties were being incorrectly validated by checking the wrong property (`data['logger']` instead of `data['schema']` and `data['casing']`).

**Why This Matters:**  
1. **Schema Validation Fix:**  
   - **Before:** The code mistakenly checked `typeof data['logger']` when validating the `'schema'` property.  
   - **After:** Correctly checks `typeof data['schema']` to validate the schema configuration.  

2. **Casing Validation Fix:**  
   - **Before:** The code checked `typeof data['logger']` when validating the `'casing'` property.  
   - **After:** Properly checks `typeof data['casing']` to validate the casing configuration.  

**Impact:**  
- Ensures the configuration validator works as intended for `schema` and `casing` settings.  
- Prevents false negatives/positives where valid configurations might have been rejected or invalid ones accepted due to incorrect property checks.  
 
This change addresses a subtle but critical validation oversight, ensuring the configuration checker accurately reflects the intended structure of the configuration object. It improves code correctness and reliability for schema and casing configuration handling.