### PR TITLE
Use schema from enum wrapped in array

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -159,14 +159,15 @@ export const generatePgSnapshot = (
 			const primaryKey: boolean = column.primary;
 			const sqlTypeLowered = column.getSQLType().toLowerCase();
 
-			const getEnumSchema = (column: PgColumn) => {
+			const getEnumSchema = (column: PgColumn): string | undefined => {
 				while (is(column, PgArray)) {
 					column = column.baseColumn;
 				}
-				return is(column, PgEnumColumn) ? column.enum.schema || 'public' : undefined;
-			};
-			const typeSchema: string | undefined = getEnumSchema(column);
 
+				return is(column, PgEnumColumn) ? column.enum.schema ?? 'public' : undefined;
+			};
+
+			const typeSchema = getEnumSchema(column);
 			const generated = column.generated;
 			const identity = column.generatedIdentity;
 
@@ -754,7 +755,15 @@ export const generatePgSnapshot = (
 				const primaryKey: boolean = column.primary;
 				const sqlTypeLowered = column.getSQLType().toLowerCase();
 
-				const typeSchema = is(column, PgEnumColumn) ? column.enum.schema || 'public' : undefined;
+				const getEnumSchema = (column: PgColumn): string | undefined => {
+					while (is(column, PgArray)) {
+						column = column.baseColumn;
+					}
+
+					return is(column, PgEnumColumn) ? column.enum.schema ?? 'public' : undefined;
+				};
+
+				const typeSchema = getEnumSchema(column);
 				const generated = column.generated;
 				const identity = column.generatedIdentity;
 


### PR DESCRIPTION
When enum arrays are used, the generated migrations (and likely other things) ignore the specified schema. This change checks for enums wrapped in arrays, in addition to non-array enums.

Should fix #1564, #3278, #3514 (and possibly other I havn't found).