### PR TITLE
[drizzle-kit] Fix loading a schema in a typescript project

### DIFF
--- a/drizzle-kit/src/serializer/sqliteImports.ts
+++ b/drizzle-kit/src/serializer/sqliteImports.ts
@@ -1,5 +1,9 @@
+import chalk from 'chalk';
 import { is } from 'drizzle-orm';
 import { AnySQLiteTable, SQLiteTable, SQLiteView } from 'drizzle-orm/sqlite-core';
+import * as esbuild from 'esbuild';
+import { mkdtemp, rm } from 'fs/promises';
+import { join, resolve } from 'path';
 import { safeRegister } from '../cli/commands/utils';
 
 export const prepareFromExports = (exports: Record<string, unknown>) => {
@@ -25,15 +29,23 @@ export const prepareFromSqliteImports = async (imports: string[]) => {
 	const views: SQLiteView[] = [];
 
 	const { unregister } = await safeRegister();
-	for (let i = 0; i < imports.length; i++) {
-		const it = imports[i];
 
-		const i0: Record<string, unknown> = require(`${it}`);
-		const prepared = prepareFromExports(i0);
+	const outDir = await mkdtemp('.drizzle-kit.sqlite-imports-');
+	let outFile = resolve(join(outDir, 'schema.js'));
+	console.log(chalk.grey(`Reading schema files '${JSON.stringify(imports)}'`));
+	const res = esbuild.buildSync({
+		entryPoints: imports,
+		bundle: true,
+		format: 'cjs',
+		outfile: outFile,
+	});
+	const i0: Record<string, unknown> = require(outFile);
+	const prepared = prepareFromExports(i0);
 
-		tables.push(...prepared.tables);
-		views.push(...prepared.views);
-	}
+	await rm(outDir, { recursive: true });
+
+	tables.push(...prepared.tables);
+	views.push(...prepared.views);
 
 	unregister();
 

--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -1,7 +1,7 @@
 import type { RunResult } from 'better-sqlite3';
 import chalk from 'chalk';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { parse } from 'url';
 import type { NamedWithSchema } from './cli/commands/migrate';
 import { info } from './cli/views';
@@ -309,10 +309,18 @@ export const kloudMeta = () => {
 	};
 };
 
+const mkdirSQLiteUrl = (it: string) => {
+	if (it.startsWith('file:')) {
+		it = it.substring(5);
+	}
+	mkdirSync(dirname(it), { recursive: true });
+};
+
 export const normaliseSQLiteUrl = (
 	it: string,
 	type: 'libsql' | 'better-sqlite',
 ) => {
+	mkdirSQLiteUrl(it);
 	if (type === 'libsql') {
 		if (it.startsWith('file:')) {
 			return it;


### PR DESCRIPTION
Hi,

if you have a typescript project with a schema file in typescript, there is a good chance that the load of
the schema could fail due to the use of the node resolver, which can not resolve suffixes .js to .ts.

To solve this, I use build to bundle the loaded schema before it's loaded.

I think this should be generalized for all schema in all flavors.

If this PR is liked, I'll be happy to try it for all flavors. 

thx 

meno