### PR TITLE
[SingleStore] Add Connection Attributes and Fix Options

### DIFF
--- a/drizzle-orm/src/singlestore/driver.ts
+++ b/drizzle-orm/src/singlestore/driver.ts
@@ -11,8 +11,8 @@ import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { SingleStoreDatabase } from '~/singlestore-core/db.ts';
 import { SingleStoreDialect } from '~/singlestore-core/dialect.ts';
-import { type DrizzleConfig, type IfNotImported, type ImportTypeError, isConfig } from '~/utils.ts';
-import { version } from '../../package.json';
+import { type DrizzleConfig, isConfig } from '~/utils.ts';
+import { npmVersion } from '~/version.ts';
 import type {
 	SingleStoreDriverClient,
 	SingleStoreDriverPreparedQueryHKT,
@@ -105,32 +105,28 @@ export type AnySingleStoreDriverConnection = Pool | Connection | CallbackPool | 
 
 const CONNECTION_ATTRS: PoolOptions['connectAttributes'] = {
 	_connector_name: 'SingleStore Drizzle ORM Driver',
-	_connector_version: version,
+	_connector_version: npmVersion,
 };
 
 export function drizzle<
 	TSchema extends Record<string, unknown> = Record<string, never>,
 	TClient extends AnySingleStoreDriverConnection = CallbackPool,
 >(
-	...params: IfNotImported<
-		CallbackPool,
-		[ImportTypeError<'singlestore'>],
-		[
-			TClient | string,
-		] | [
-			TClient | string,
-			SingleStoreDriverDrizzleConfig<TSchema>,
-		] | [
-			(
-				& SingleStoreDriverDrizzleConfig<TSchema>
-				& ({
-					connection: string | PoolOptions;
-				} | {
-					client: TClient;
-				})
-			),
-		]
-	>
+	...params: [
+		TClient | string,
+	] | [
+		TClient | string,
+		SingleStoreDriverDrizzleConfig<TSchema>,
+	] | [
+		(
+			& SingleStoreDriverDrizzleConfig<TSchema>
+			& ({
+				connection: string | PoolOptions;
+			} | {
+				client: TClient;
+			})
+		),
+	]
 ): SingleStoreDriverDatabase<TSchema> & {
 	$client: TClient;
 } {


### PR DESCRIPTION
Adds some connection attributes to help the SingleStore team know which traffic is coming from Drizzle :)

Also fixes an issue where there was a type error when attempting to create a Drizzle instance with a connection string or options rather than providing your own connection pool.

Tested on `mysql2@2.0.0` as well as latest with both a connection string and connection options, and all seems to be working as expected.