### PR TITLE
[mysql-kit]: handle lowercase information_schema_table_constraints columns

### DIFF
--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -968,9 +968,9 @@ AND
 		progressCallback('checks', checksCount, 'fetching');
 	}
 	for (const checkConstraintRow of checkConstraints) {
-		const constraintName = checkConstraintRow['CONSTRAINT_NAME'];
-		const constraintValue = checkConstraintRow['CHECK_CLAUSE'];
-		const tableName = checkConstraintRow['TABLE_NAME'];
+		const constraintName = checkConstraintRow['CONSTRAINT_NAME'] ?? checkConstraintRow['constraint_name'];
+		const constraintValue = checkConstraintRow['CHECK_CLAUSE'] ?? checkConstraintRow['check_clause'];
+		const tableName = checkConstraintRow['TABLE_NAME'] ?? checkConstraintRow['table_name'];
 
 		const tableInResult = result[tableName];
 		// if (typeof tableInResult === 'undefined') continue;


### PR DESCRIPTION
In certain circumstances the information_schema columns are lowercased from the db. This updates the mysqlSerializer to handle this case.

Fixes https://github.com/drizzle-team/drizzle-orm/issues/3884

I suspect this may be a MariaDB vs MySQL difference, but I haven't confirmed it.

In my case (mariadb:10.11 docker) only the `table_constraints` and `check_constraints` tables' columns are lowercased, so I haven't updated the code for eg. `INFORMATION_SCHEMA.STATISTICS` or `information_schema.referential_constraints`.