### PR TITLE
[pg-kit] Fix invalid javascript syntax for `default()` values in generated schema.

### DIFF
--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -369,5 +369,5 @@ export function escapeSingleQuotes(str: string) {
 
 export function unescapeSingleQuotes(str: string, ignoreFirstAndLastChar: boolean) {
 	const regex = ignoreFirstAndLastChar ? /(?<!^)'(?!$)/g : /'/g;
-	return str.replace(/''/g, "'").replace(regex, "\\'");
+	return str.replace(/(?<!^)''(?!$)/g, "'").replace(regex, "\\'");
 }

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -432,6 +432,10 @@ test('instrospect strings with single quotes', async () => {
 			enum: myEnum('my_enum').default('escape\'s quotes " '),
 			text: text('text').default('escape\'s quotes " '),
 			varchar: varchar('varchar').default('escape\'s quotes " '),
+			varcharEmpty: varchar('varchar_empty').default(''),
+			/* dprint-ignore-start */
+			varcharSingleQuotes: varchar('varchar_single_quotes').default("I love two '' adjacent single quotes \'\' :)"),
+			/* dprint-ignore-end */
 		}),
 	};
 


### PR DESCRIPTION
Fixes #4121

Fix invalid javascript syntax for `default()` values in generated schema.

* Modify `unescapeSingleQuotes()` function in `drizzle-kit/src/utils.ts` to correctly process two adjacent single quotes.
* Add new test cases for `varcharEmpty` and `varcharSingleQuotes` in `drizzle-kit/tests/introspect/pg.test.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/drizzle-team/drizzle-orm/pull/4328?shareId=7379fbb8-cc2d-4a18-8284-71e9cca1dfe1).