### PR TITLE
fix: Inconsistent SQL Migration Files Processing Across Different Operating Systems

### DIFF
--- a/drizzle-orm/src/migrator.ts
+++ b/drizzle-orm/src/migrator.ts
@@ -39,7 +39,7 @@ export function readMigrationFiles(config: MigrationConfig): MigrationMeta[] {
 		const migrationPath = `${migrationFolderTo}/${journalEntry.tag}.sql`;
 
 		try {
-			const query = fs.readFileSync(`${migrationFolderTo}/${journalEntry.tag}.sql`).toString();
+			const query = fs.readFileSync(`${migrationFolderTo}/${journalEntry.tag}.sql`).toString().replace(/\r\n/g, '\n'); // Normalize all line endings to LF;
 
 			const result = query.split('--> statement-breakpoint').map((it) => {
 				return it;


### PR DESCRIPTION
## Description

When using the `readMigrationFiles` function, the generated SQL arrays differ between Windows and macOS/Linux environments due to different line ending conventions.

## Current Behavior

The `readMigrationFiles` function reads SQL files and splits them at statement breakpoints. However, it preserves the native line endings:

- On Windows: Lines end with `\r\n` (CRLF)
- On macOS/Linux: Lines end with `\n` (LF)

This causes inconsistency in the resulting SQL arrays:

**On macOS:**
```json
"sql": [
  "ALTER TABLE \"messages\" ADD COLUMN \"client_id\" text;",
  "\nALTER TABLE \"session_groups\" ADD COLUMN \"client_id\" text;",
  // ...more statements with \n line breaks
]
```

**On Windows:**
```json
"sql": [
  "ALTER TABLE \"messages\" ADD COLUMN \"client_id\" text;",
  "\r\nALTER TABLE \"session_groups\" ADD COLUMN \"client_id\" text;",
  // ...more statements with \r\n line breaks
]
```

## Expected Behavior

The function should produce consistent SQL arrays regardless of the operating system where it runs.

## Proposed Solution

Normalize line endings when reading SQL files:

```typescript
const query = fs.readFileSync(`${migrationFolderTo}/${journalEntry.tag}.sql`)
  .toString()
  .replace(/\r\n/g, '\n'); // Normalize all line endings to LF
```

This simple change ensures consistent behavior across all platforms.

---

- refs: https://github.com/drizzle-team/drizzle-orm/issues/4329