### PR TITLE
Expanded custom type functionality for RQBv2, JSON aggregations

### DIFF
--- a/drizzle-orm/src/gel-core/columns/common.ts
+++ b/drizzle-orm/src/gel-core/columns/common.ts
@@ -326,6 +326,19 @@ export class GelArray<
 		this.size = config.size;
 	}
 
+	override mapFromDriverValue(value: unknown[]): T['data'] {
+		return value.map((v) => this.baseColumn.mapFromDriverValue(v));
+	}
+
+	// Needed for arrays of custom types
+	mapFromJsonValue(value: unknown[]): T['data'] {
+		const base = this.baseColumn;
+
+		return 'mapFromJsonValue' in base
+			? value.map((v) => (<(value: unknown) => unknown> base.mapFromJsonValue)(v))
+			: value.map((v) => base.mapFromDriverValue(v));
+	}
+
 	getSQLType(): string {
 		return `${this.baseColumn.getSQLType()}[${typeof this.size === 'number' ? this.size : ''}]`;
 	}

--- a/drizzle-orm/src/gel-core/columns/custom.ts
+++ b/drizzle-orm/src/gel-core/columns/custom.ts
@@ -101,7 +101,7 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 	}
 }
 
-export type CustomTypeValues = {
+export interface CustomTypeValues {
 	/**
 	 * Required type for custom column, that will infer proper type model
 	 *
@@ -118,8 +118,7 @@ export type CustomTypeValues = {
 	 *
 	 * Needed only in case driver's output and input for type differ
 	 *
-	 * @default
-	 * Defaults to `driverData`
+	 * Defaults to {@link driverData}
 	 */
 	driverOutput?: unknown;
 
@@ -167,7 +166,7 @@ export type CustomTypeValues = {
 	 * });
 	 */
 	default?: boolean;
-};
+}
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
@@ -241,9 +240,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 *
+	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying bigint column via RQB or JSON funcitons, the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
@@ -263,17 +264,15 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * 	customField: 5044565289845416380n;
 	 * }
 	 * ```
-	 * @default
-	 * Defaults to {@link fromDriver} function
 	 */
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside JSON functions
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
 	 * @example
 	 * For example, when using bigint we need to cast field to text to preserve data integrity
 	 * ```

--- a/drizzle-orm/src/gel-core/columns/custom.ts
+++ b/drizzle-orm/src/gel-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyGelTable } from '~/gel-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { SQL, SQLGenerator } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { GelColumn, GelColumnBuilder } from './common.ts';
 
@@ -63,6 +63,8 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private mapJson?: (value: unknown) => T['data'];
+	private wrapName?: (name: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
 
 	constructor(
 		table: AnyGelTable<{ name: T['tableName'] }>,
@@ -72,6 +74,8 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.mapJson = config.customTypeParams.fromJson;
+		this.wrapName = config.customTypeParams.jsonWrap;
 	}
 
 	getSQLType(): string {
@@ -80,6 +84,16 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
 		return typeof this.mapFrom === 'function' ? this.mapFrom(value) : value as T['data'];
+	}
+
+	mapFromJsonValue(value: unknown): T['data'] {
+		return typeof this.mapJson === 'function' ? this.mapJson(value) : this.mapFromDriverValue(value) as T['data'];
+	}
+
+	jsonWrapName(name: SQL, sql: SQLGenerator, arrayDimensions?: number): SQL {
+		if (typeof this.wrapName === 'function') return this.wrapName(name, sql, arrayDimensions);
+
+		return name;
 	}
 
 	override mapToDriverValue(value: T['data']): T['driverParam'] {
@@ -103,6 +117,11 @@ export type CustomTypeValues = {
 	 * Type helper, that represents what type database driver is accepting for specific database data type
 	 */
 	driverData?: unknown;
+
+	/**
+	 * Type helper, that represents what type field returns after being aggregated to JSON
+	 */
+	jsonData?: unknown;
 
 	/**
 	 * What config type should be used for {@link CustomTypeParams} `dataType` generation
@@ -195,6 +214,37 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional mapping function, that is responsible for data mapping from database's JSON format to JS/TS code
+	 *
+	 * Used by Relational Queries V2
+	 * @example
+	 * For example, when using bigint we need to map it's string representation to JS bigint
+	 * ```
+	 * fromJson(value: string): bigint {
+	 * 	return BigInt(value);
+	 * },
+	 * ```
+	 *
+	 * @default
+	 * Defaults to `fromDriver` function
+	 */
+	fromJson?: (value: T['jsonData']) => T['data'];
+
+	/**
+	 * Optional name wrapper function, that is responsible for modifying field in selection before it's casted to JSON
+	 *
+	 * Used by Relational Queries V2
+	 * @example
+	 * For example, when using bigint we need to cast field to text to preserve data integrity
+	 * ```
+	 * jsonWrap(name: SQL, sql: SQLGenerator, arrayDimensions?: number): SQL {
+	 * 	return sql`${name}::text`
+	 * },
+	 * ```
+	 */
+	jsonWrap?: (name: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/gel-core/columns/custom.ts
+++ b/drizzle-orm/src/gel-core/columns/custom.ts
@@ -240,11 +240,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 *
 	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
@@ -268,11 +268,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 * @example
 	 * For example, when using bigint we need to cast field to text to preserve data integrity
 	 * ```

--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -913,7 +913,7 @@ export class GelDialect {
 
 				case 'GelCustomColumn': {
 					return sql`${
-						(<GelCustomColumn<any>> col).jsonWrapName(name, sql, dimensionCnt > 0 ? dimensionCnt : undefined)
+						(<GelCustomColumn<any>> col).jsonSelectIdentifier(name, sql, dimensionCnt > 0 ? dimensionCnt : undefined)
 					} as ${sql.identifier(key)}`;
 				}
 

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -64,7 +64,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
 	private mapJson?: (value: unknown) => T['data'];
-	private wrapName?: (name: SQL, sql: SQLGenerator) => SQL;
+	private forJsonSelect?: (name: SQL, sql: SQLGenerator) => SQL;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -75,7 +75,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
 		this.mapJson = config.customTypeParams.fromJson;
-		this.wrapName = config.customTypeParams.jsonWrap;
+		this.forJsonSelect = config.customTypeParams.forJsonSelect;
 	}
 
 	getSQLType(): string {
@@ -90,8 +90,8 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		return typeof this.mapJson === 'function' ? this.mapJson(value) : this.mapFromDriverValue(value) as T['data'];
 	}
 
-	jsonWrapName(name: SQL, sql: SQLGenerator): SQL {
-		if (typeof this.wrapName === 'function') return this.wrapName(name, sql);
+	jsonSelectIdentifier(identifier: SQL, sql: SQLGenerator): SQL {
+		if (typeof this.forJsonSelect === 'function') return this.forJsonSelect(identifier, sql);
 
 		const rawType = this.getSQLType().toLowerCase();
 		const parenPos = rawType.indexOf('(');
@@ -105,10 +105,10 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 			case 'decimal':
 			case 'float':
 			case 'bigint': {
-				return sql`cast(${name} as char)`;
+				return sql`cast(${identifier} as char)`;
 			}
 			default: {
-				return name;
+				return identifier;
 			}
 		}
 	}
@@ -129,6 +129,16 @@ export type CustomTypeValues = {
 	 * If you want your column to be `number` type after selecting/or on inserting - use `data: number`. Like `integer`
 	 */
 	data: unknown;
+
+	/**
+	 * Type helper, that represents what type database driver is returning for specific database data type
+	 *
+	 * Needed only in case driver's output and input for type differ
+	 *
+	 * @default
+	 * Defaults to `driverData`
+	 */
+	driverOutput?: unknown;
 
 	/**
 	 * Type helper, that represents what type database driver is accepting for specific database data type
@@ -209,7 +219,7 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	dataType: (config: T['config'] | (Equal<T['configRequired'], true> extends true ? never : undefined)) => string;
 
 	/**
-	 * Optional mapping function, between user input and driver
+	 * Optional mapping function, that is used to transform inputs from desired to be used in code format to one suitable for driver
 	 * @example
 	 * For example, when using jsonb we need to map JS/TS object to string before writing to database
 	 * ```
@@ -221,47 +231,116 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	toDriver?: (value: T['data']) => T['driverData'] | SQL;
 
 	/**
-	 * Optional mapping function, that is responsible for data mapping from database to JS/TS code
+	 * Optional mapping function, that is used for transforming data returned by driver to desired column's output format
 	 * @example
 	 * For example, when using timestamp we need to map string Date representation to JS Date
 	 * ```
 	 * fromDriver(value: string): Date {
 	 * 	return new Date(value);
-	 * },
+	 * }
+	 * ```
+	 *
+	 * It'll cause the returned data to change from:
+	 * ```
+	 * {
+	 * 	customField: "2025-04-07 03:25:16.635";
+	 * }
+	 * ```
+	 * to:
+	 * ```
+	 * {
+	 * 	customField: new Date("2025-04-07 03:25:16.635");
+	 * }
 	 * ```
 	 */
-	fromDriver?: (value: T['driverData']) => T['data'];
+	fromDriver?: (value: 'driverOutput' extends keyof T ? T['driverOutput'] : T['driverData']) => T['data'];
 
 	/**
-	 * Optional mapping function, that is responsible for data mapping from database's JSON format to JS/TS code
+	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by Relational Queries V2
+	 * Used by relational queries
 	 * @example
-	 * For example, when using bigint we need to map it's string representation to JS bigint
+	 * For example, when querying bigint column via RQB or JSON funcitons, the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
 	 * 	return BigInt(value);
 	 * },
 	 * ```
 	 *
+	 * It'll cause the returned data to change from:
+	 * ```
+	 * {
+	 * 	customField: "5044565289845416380";
+	 * }
+	 * ```
+	 * to:
+	 * ```
+	 * {
+	 * 	customField: 5044565289845416380n;
+	 * }
+	 * ```
 	 * @default
-	 * Defaults to `fromDriver` function
+	 * Defaults to {@link fromDriver} function
 	 */
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional name wrapper function, that is responsible for modifying field in selection before it's casted to JSON
+	 * Optional selection modifier function, that is used for modifying selection of column inside JSON functions
 	 *
-	 * Used by Relational Queries V2
+	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
+	 *
+	 * Used by relational queries
 	 * @example
 	 * For example, when using bigint we need to cast field to text to preserve data integrity
 	 * ```
-	 * jsonWrap(name: SQL, sql: SQLGenerator): SQL {
-	 * 	return sql`cast(${name} as char)`
+	 * forJsonSelect(identifier: SQL, sql: SQLGenerator): SQL {
+	 * 	return sql`cast(${identifier} as char)`
 	 * },
 	 * ```
+	 *
+	 * This will change query from:
+	 * ```
+	 * SELECT
+	 * 	json_build_object('bigint', `t`.`bigint`)
+	 * 	FROM
+	 * 	(
+	 * 		SELECT
+	 * 		`table`.`custom_bigint` AS `bigint`
+	 * 		FROM
+	 * 		`table`
+	 * 	) AS `t`
+	 * ```
+	 * to:
+	 * ```
+	 * SELECT
+	 * 	json_build_object('bigint', `t`.`bigint`)
+	 * 	FROM
+	 * 	(
+	 * 		SELECT
+	 * 		cast(`table`.`custom_bigint` as char) AS `bigint`
+	 * 		FROM
+	 * 		`table`
+	 * 	) AS `t`
+	 * ```
+	 *
+	 * Returned by query object will change from:
+	 * ```
+	 * {
+	 * 	bigint: 5044565289845416000; // Partial data loss due to direct conversion to JSON format
+	 * }
+	 * ```
+	 * to:
+	 * ```
+	 * {
+	 * 	bigint: "5044565289845416380"; // Data is preserved due to conversion of field to text before JSON-ification
+	 * }
+	 * ```
+	 *
+	 * @default
+	 * Following types are being casted to text by default: `binary`, `varbinary`, `time`, `datetime`, `decimal`, `float`, 'bigint'
 	 */
-	jsonWrap?: (name: SQL, sql: SQLGenerator) => SQL;
+	forJsonSelect?: (identifier: SQL, sql: SQLGenerator) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { SQL, SQLGenerator } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
@@ -63,6 +63,8 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private mapJson?: (value: unknown) => T['data'];
+	private wrapName?: (name: SQL, sql: SQLGenerator) => SQL;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -72,6 +74,8 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.mapJson = config.customTypeParams.fromJson;
+		this.wrapName = config.customTypeParams.jsonWrap;
 	}
 
 	getSQLType(): string {
@@ -80,6 +84,33 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
 		return typeof this.mapFrom === 'function' ? this.mapFrom(value) : value as T['data'];
+	}
+
+	mapFromJsonValue(value: unknown): T['data'] {
+		return typeof this.mapJson === 'function' ? this.mapJson(value) : this.mapFromDriverValue(value) as T['data'];
+	}
+
+	jsonWrapName(name: SQL, sql: SQLGenerator): SQL {
+		if (typeof this.wrapName === 'function') return this.wrapName(name, sql);
+
+		const rawType = this.getSQLType().toLowerCase();
+		const parenPos = rawType.indexOf('(');
+		const type = (parenPos + 1) ? rawType.slice(0, parenPos) : rawType;
+
+		switch (type) {
+			case 'binary':
+			case 'varbinary':
+			case 'time':
+			case 'datetime':
+			case 'decimal':
+			case 'float':
+			case 'bigint': {
+				return sql`cast(${name} as char)`;
+			}
+			default: {
+				return name;
+			}
+		}
 	}
 
 	override mapToDriverValue(value: T['data']): T['driverParam'] {
@@ -103,6 +134,11 @@ export type CustomTypeValues = {
 	 * Type helper, that represents what type database driver is accepting for specific database data type
 	 */
 	driverData?: unknown;
+
+	/**
+	 * Type helper, that represents what type field returns after being aggregated to JSON
+	 */
+	jsonData?: unknown;
 
 	/**
 	 * What config type should be used for {@link CustomTypeParams} `dataType` generation
@@ -195,6 +231,37 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional mapping function, that is responsible for data mapping from database's JSON format to JS/TS code
+	 *
+	 * Used by Relational Queries V2
+	 * @example
+	 * For example, when using bigint we need to map it's string representation to JS bigint
+	 * ```
+	 * fromJson(value: string): bigint {
+	 * 	return BigInt(value);
+	 * },
+	 * ```
+	 *
+	 * @default
+	 * Defaults to `fromDriver` function
+	 */
+	fromJson?: (value: T['jsonData']) => T['data'];
+
+	/**
+	 * Optional name wrapper function, that is responsible for modifying field in selection before it's casted to JSON
+	 *
+	 * Used by Relational Queries V2
+	 * @example
+	 * For example, when using bigint we need to cast field to text to preserve data integrity
+	 * ```
+	 * jsonWrap(name: SQL, sql: SQLGenerator): SQL {
+	 * 	return sql`cast(${name} as char)`
+	 * },
+	 * ```
+	 */
+	jsonWrap?: (name: SQL, sql: SQLGenerator) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -257,11 +257,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 *
 	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
@@ -285,11 +285,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 *
 	 * Following types are being casted to text by default: `binary`, `varbinary`, `time`, `datetime`, `decimal`, `float`, `bigint`
 	 * @example

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -118,7 +118,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	}
 }
 
-export type CustomTypeValues = {
+export interface CustomTypeValues {
 	/**
 	 * Required type for custom column, that will infer proper type model
 	 *
@@ -135,8 +135,7 @@ export type CustomTypeValues = {
 	 *
 	 * Needed only in case driver's output and input for type differ
 	 *
-	 * @default
-	 * Defaults to `driverData`
+	 * Defaults to {@link driverData}
 	 */
 	driverOutput?: unknown;
 
@@ -184,7 +183,7 @@ export type CustomTypeValues = {
 	 * });
 	 */
 	default?: boolean;
-};
+}
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
@@ -258,9 +257,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 *
+	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying bigint column via RQB or JSON funcitons, the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
@@ -280,17 +281,17 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * 	customField: 5044565289845416380n;
 	 * }
 	 * ```
-	 * @default
-	 * Defaults to {@link fromDriver} function
 	 */
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside JSON functions
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 *
+	 * Following types are being casted to text by default: `binary`, `varbinary`, `time`, `datetime`, `decimal`, `float`, `bigint`
 	 * @example
 	 * For example, when using bigint we need to cast field to text to preserve data integrity
 	 * ```
@@ -336,9 +337,6 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * 	bigint: "5044565289845416380"; // Data is preserved due to conversion of field to text before JSON-ification
 	 * }
 	 * ```
-	 *
-	 * @default
-	 * Following types are being casted to text by default: `binary`, `varbinary`, `time`, `datetime`, `decimal`, `float`, 'bigint'
 	 */
 	forJsonSelect?: (identifier: SQL, sql: SQLGenerator) => SQL;
 }

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -31,6 +31,7 @@ import { Columns, getTableName, getTableUniqueName, Table } from '~/table.ts';
 import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import { MySqlColumn } from './columns/common.ts';
+import type { MySqlCustomColumn } from './columns/custom.ts';
 import type { MySqlDeleteConfig } from './query-builders/delete.ts';
 import type { MySqlInsertConfig } from './query-builders/insert.ts';
 import type {
@@ -1180,6 +1181,10 @@ export class MySqlDialect {
 				case 'MySqlDecimalBigInt':
 				case 'MySqlBigInt64': {
 					return sql`cast(${name} as char) as ${sql.identifier(key)}`;
+				}
+
+				case 'MySqlCustomColumn': {
+					return sql`${(<MySqlCustomColumn<any>> column).jsonWrapName(name, sql)} as ${sql.identifier(key)}`;
 				}
 
 				default: {

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -1184,7 +1184,7 @@ export class MySqlDialect {
 				}
 
 				case 'MySqlCustomColumn': {
-					return sql`${(<MySqlCustomColumn<any>> column).jsonWrapName(name, sql)} as ${sql.identifier(key)}`;
+					return sql`${(<MySqlCustomColumn<any>> column).jsonSelectIdentifier(name, sql)} as ${sql.identifier(key)}`;
 				}
 
 				default: {

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -339,6 +339,20 @@ export class PgArray<
 		return value.map((v) => this.baseColumn.mapFromDriverValue(v));
 	}
 
+	// Needed for arrays of custom types
+	mapFromJsonValue(value: unknown[] | string): T['data'] {
+		if (typeof value === 'string') {
+			// Thank you node-postgres for not parsing enum arrays
+			value = parsePgArray(value);
+		}
+
+		const base = this.baseColumn;
+
+		return 'mapFromJsonValue' in base
+			? value.map((v) => (<(value: unknown) => unknown> base.mapFromJsonValue)(v))
+			: value.map((v) => base.mapFromDriverValue(v));
+	}
+
 	override mapToDriverValue(value: unknown[], isNestedArray = false): unknown[] | string {
 		const a = value.map((v) =>
 			v === null

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -257,11 +257,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 *
 	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
@@ -285,11 +285,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 *
 	 * Following types are being casted to text by default: `bytea`, `geometry`, `timestamp`, `numeric`, `bigint`
 	 * @example

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -64,7 +64,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
 	private mapJson?: (value: unknown) => T['data'];
-	private wrapName?: (name: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
+	private forJsonSelect?: (identifier: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -75,7 +75,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
 		this.mapJson = config.customTypeParams.fromJson;
-		this.wrapName = config.customTypeParams.jsonWrap;
+		this.forJsonSelect = config.customTypeParams.forJsonSelect;
 	}
 
 	getSQLType(): string {
@@ -90,8 +90,8 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		return typeof this.mapJson === 'function' ? this.mapJson(value) : this.mapFromDriverValue(value) as T['data'];
 	}
 
-	jsonWrapName(name: SQL, sql: SQLGenerator, arrayDimensions?: number): SQL {
-		if (typeof this.wrapName === 'function') return this.wrapName(name, sql, arrayDimensions);
+	jsonSelectIdentifier(identifier: SQL, sql: SQLGenerator, arrayDimensions?: number): SQL {
+		if (typeof this.forJsonSelect === 'function') return this.forJsonSelect(identifier, sql, arrayDimensions);
 
 		const rawType = this.getSQLType().toLowerCase();
 		const parenPos = rawType.indexOf('(');
@@ -105,10 +105,10 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 			case 'bigint': {
 				const arrVal = '[]'.repeat(arrayDimensions ?? 0);
 
-				return sql`${name}::text${sql.raw(arrVal).if(arrayDimensions)}`;
+				return sql`${identifier}::text${sql.raw(arrVal).if(arrayDimensions)}`;
 			}
 			default: {
-				return name;
+				return identifier;
 			}
 		}
 	}
@@ -134,6 +134,16 @@ export type CustomTypeValues = {
 	 * Type helper, that represents what type database driver is accepting for specific database data type
 	 */
 	driverData?: unknown;
+
+	/**
+	 * Type helper, that represents what type database driver is returning for specific database data type
+	 *
+	 * Needed only in case driver's output and input for type differ
+	 *
+	 * @default
+	 * Defaults to `driverData`
+	 */
+	driverOutput?: unknown;
 
 	/**
 	 * Type helper, that represents what type field returns after being aggregated to JSON
@@ -209,7 +219,7 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	dataType: (config: T['config'] | (Equal<T['configRequired'], true> extends true ? never : undefined)) => string;
 
 	/**
-	 * Optional mapping function, between user input and driver
+	 * Optional mapping function, that is used to transform inputs from desired to be used in code format to one suitable for driver
 	 * @example
 	 * For example, when using jsonb we need to map JS/TS object to string before writing to database
 	 * ```
@@ -221,47 +231,115 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	toDriver?: (value: T['data']) => T['driverData'] | SQL;
 
 	/**
-	 * Optional mapping function, that is responsible for data mapping from database to JS/TS code
+	 * Optional mapping function, that is used for transforming data returned by driver to desired column's output format
 	 * @example
 	 * For example, when using timestamp we need to map string Date representation to JS Date
 	 * ```
 	 * fromDriver(value: string): Date {
 	 * 	return new Date(value);
-	 * },
+	 * }
+	 * ```
+	 *
+	 * It'll cause the returned data to change from:
+	 * ```
+	 * {
+	 * 	customField: "2025-04-07T03:25:16.635Z";
+	 * }
+	 * ```
+	 * to:
+	 * ```
+	 * {
+	 * 	customField: new Date("2025-04-07T03:25:16.635Z");
+	 * }
 	 * ```
 	 */
-	fromDriver?: (value: T['driverData']) => T['data'];
+	fromDriver?: (value: 'driverOutput' extends keyof T ? T['driverOutput'] : T['driverData']) => T['data'];
 
 	/**
-	 * Optional mapping function, that is responsible for data mapping from database's JSON format to JS/TS code
+	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by Relational Queries V2
+	 * Used by relational queries
 	 * @example
-	 * For example, when using bigint we need to map it's string representation to JS bigint
+	 * For example, when querying bigint column via RQB or JSON funcitons, the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
 	 * 	return BigInt(value);
 	 * },
 	 * ```
 	 *
+	 * It'll cause the returned data to change from:
+	 * ```
+	 * {
+	 * 	customField: "5044565289845416380";
+	 * }
+	 * ```
+	 * to:
+	 * ```
+	 * {
+	 * 	customField: 5044565289845416380n;
+	 * }
+	 * ```
 	 * @default
-	 * Defaults to `fromDriver` function
+	 * Defaults to {@link fromDriver} function
 	 */
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional name wrapper function, that is responsible for modifying field in selection before it's casted to JSON
+	 * Optional selection modifier function, that is used for modifying selection of column inside JSON functions
 	 *
-	 * Used by Relational Queries V2
+	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
+	 *
+	 * Used by relational queries
 	 * @example
 	 * For example, when using bigint we need to cast field to text to preserve data integrity
 	 * ```
-	 * jsonWrap(name: SQL, sql: SQLGenerator, arrayDimensions?: number): SQL {
-	 * 	return sql`${name}::text`
+	 * forJsonSelect(identifier: SQL, sql: SQLGenerator, arrayDimensions?: number): SQL {
+	 * 	return sql`${identifier}::text`
 	 * },
 	 * ```
+	 *
+	 * This will change query from:
+	 * ```
+	 * SELECT
+	 * 	row_to_json("t".*)
+	 * 	FROM
+	 * 	(
+	 * 		SELECT
+	 * 		"table"."custom_bigint" AS "bigint"
+	 * 		FROM
+	 * 		"table"
+	 * 	) AS "t"
+	 * ```
+	 * to:
+	 * ```
+	 * SELECT
+	 * 	row_to_json("t".*)
+	 * 	FROM
+	 * 	(
+	 * 		SELECT
+	 * 		"table"."custom_bigint"::text AS "bigint"
+	 * 		FROM
+	 * 		"table"
+	 * 	) AS "t"
+	 * ```
+	 *
+	 * Returned by query object will change from:
+	 * ```
+	 * {
+	 * 	bigint: 5044565289845416000; // Partial data loss due to direct conversion to JSON format
+	 * }
+	 * ```
+	 * to:
+	 * ```
+	 * {
+	 * 	bigint: "5044565289845416380"; // Data is preserved due to conversion of field to text before JSON-ification
+	 * }
+	 * ```
+	 *
+	 * Following types are being casted to text by default: `bytea`, `geometry`, `timestamp`, `numeric`, `bigint`
 	 */
-	jsonWrap?: (name: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
+	forJsonSelect?: (identifier: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyPgTable } from '~/pg-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { SQL, SQLGenerator } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { PgColumn, PgColumnBuilder } from './common.ts';
 
@@ -63,6 +63,8 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private mapJson?: (value: unknown) => T['data'];
+	private wrapName?: (name: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,6 +74,8 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.mapJson = config.customTypeParams.fromJson;
+		this.wrapName = config.customTypeParams.jsonWrap;
 	}
 
 	getSQLType(): string {
@@ -80,6 +84,33 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
 		return typeof this.mapFrom === 'function' ? this.mapFrom(value) : value as T['data'];
+	}
+
+	mapFromJsonValue(value: unknown): T['data'] {
+		return typeof this.mapJson === 'function' ? this.mapJson(value) : this.mapFromDriverValue(value) as T['data'];
+	}
+
+	jsonWrapName(name: SQL, sql: SQLGenerator, arrayDimensions?: number): SQL {
+		if (typeof this.wrapName === 'function') return this.wrapName(name, sql, arrayDimensions);
+
+		const rawType = this.getSQLType().toLowerCase();
+		const parenPos = rawType.indexOf('(');
+		const type = (parenPos + 1) ? rawType.slice(0, parenPos) : rawType;
+
+		switch (type) {
+			case 'bytea':
+			case 'geometry':
+			case 'timestamp':
+			case 'numeric':
+			case 'bigint': {
+				const arrVal = '[]'.repeat(arrayDimensions ?? 0);
+
+				return sql`${name}::text${sql.raw(arrVal).if(arrayDimensions)}`;
+			}
+			default: {
+				return name;
+			}
+		}
 	}
 
 	override mapToDriverValue(value: T['data']): T['driverParam'] {
@@ -103,6 +134,11 @@ export type CustomTypeValues = {
 	 * Type helper, that represents what type database driver is accepting for specific database data type
 	 */
 	driverData?: unknown;
+
+	/**
+	 * Type helper, that represents what type field returns after being aggregated to JSON
+	 */
+	jsonData?: unknown;
 
 	/**
 	 * What config type should be used for {@link CustomTypeParams} `dataType` generation
@@ -195,6 +231,37 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional mapping function, that is responsible for data mapping from database's JSON format to JS/TS code
+	 *
+	 * Used by Relational Queries V2
+	 * @example
+	 * For example, when using bigint we need to map it's string representation to JS bigint
+	 * ```
+	 * fromJson(value: string): bigint {
+	 * 	return BigInt(value);
+	 * },
+	 * ```
+	 *
+	 * @default
+	 * Defaults to `fromDriver` function
+	 */
+	fromJson?: (value: T['jsonData']) => T['data'];
+
+	/**
+	 * Optional name wrapper function, that is responsible for modifying field in selection before it's casted to JSON
+	 *
+	 * Used by Relational Queries V2
+	 * @example
+	 * For example, when using bigint we need to cast field to text to preserve data integrity
+	 * ```
+	 * jsonWrap(name: SQL, sql: SQLGenerator, arrayDimensions?: number): SQL {
+	 * 	return sql`${name}::text`
+	 * },
+	 * ```
+	 */
+	jsonWrap?: (name: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -118,7 +118,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	}
 }
 
-export type CustomTypeValues = {
+export interface CustomTypeValues {
 	/**
 	 * Required type for custom column, that will infer proper type model
 	 *
@@ -140,8 +140,7 @@ export type CustomTypeValues = {
 	 *
 	 * Needed only in case driver's output and input for type differ
 	 *
-	 * @default
-	 * Defaults to `driverData`
+	 * Defaults to {@link driverData}
 	 */
 	driverOutput?: unknown;
 
@@ -184,7 +183,7 @@ export type CustomTypeValues = {
 	 * });
 	 */
 	default?: boolean;
-};
+}
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
@@ -258,9 +257,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 *
+	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying bigint column via RQB or JSON funcitons, the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
@@ -280,17 +281,17 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * 	customField: 5044565289845416380n;
 	 * }
 	 * ```
-	 * @default
-	 * Defaults to {@link fromDriver} function
 	 */
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside JSON functions
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 *
+	 * Following types are being casted to text by default: `bytea`, `geometry`, `timestamp`, `numeric`, `bigint`
 	 * @example
 	 * For example, when using bigint we need to cast field to text to preserve data integrity
 	 * ```
@@ -336,8 +337,6 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * 	bigint: "5044565289845416380"; // Data is preserved due to conversion of field to text before JSON-ification
 	 * }
 	 * ```
-	 *
-	 * Following types are being casted to text by default: `bytea`, `geometry`, `timestamp`, `numeric`, `bigint`
 	 */
 	forJsonSelect?: (identifier: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
 }

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -935,7 +935,7 @@ export class PgDialect {
 				}
 				case 'PgCustomColumn': {
 					return sql`${
-						(<PgCustomColumn<any>> col).jsonWrapName(name, sql, dimensionCnt > 0 ? dimensionCnt : undefined)
+						(<PgCustomColumn<any>> col).jsonSelectIdentifier(name, sql, dimensionCnt > 0 ? dimensionCnt : undefined)
 					} as ${sql.identifier(key)}`;
 				}
 				default: {

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -792,7 +792,10 @@ export function mapRelationalRow(
 		} else {
 			decoder = field.getSQL().decoder;
 		}
-		row[selectionItem.key] = decoder.mapFromDriverValue(value);
+
+		row[selectionItem.key] = 'mapFromJsonValue' in decoder
+			? (<(value: unknown) => unknown> decoder.mapFromJsonValue)(value)
+			: decoder.mapFromDriverValue(value);
 	}
 
 	return row;

--- a/drizzle-orm/src/singlestore-core/columns/custom.ts
+++ b/drizzle-orm/src/singlestore-core/columns/custom.ts
@@ -260,11 +260,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 *
 	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
@@ -288,11 +288,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 *
 	 * Following types are being casted to text by default: `binary`, `varbinary`, `time`, `datetime`, `decimal`, `float`, `bigint`
 	 * @example

--- a/drizzle-orm/src/singlestore-core/columns/custom.ts
+++ b/drizzle-orm/src/singlestore-core/columns/custom.ts
@@ -121,7 +121,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 	}
 }
 
-export type CustomTypeValues = {
+export interface CustomTypeValues {
 	/**
 	 * Required type for custom column, that will infer proper type model
 	 *
@@ -138,8 +138,7 @@ export type CustomTypeValues = {
 	 *
 	 * Needed only in case driver's output and input for type differ
 	 *
-	 * @default
-	 * Defaults to `driverData`
+	 * Defaults to {@link driverData}
 	 */
 	driverOutput?: unknown;
 
@@ -187,7 +186,7 @@ export type CustomTypeValues = {
 	 * });
 	 */
 	default?: boolean;
-};
+}
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
@@ -261,9 +260,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 *
+	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying bigint column via RQB or JSON funcitons, the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * For example, when querying bigint column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's string representation, as opposed to bigint from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
@@ -283,17 +284,17 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * 	customField: 5044565289845416380n;
 	 * }
 	 * ```
-	 * @default
-	 * Defaults to {@link fromDriver} function
 	 */
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside JSON functions
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 *
+	 * Following types are being casted to text by default: `binary`, `varbinary`, `time`, `datetime`, `decimal`, `float`, `bigint`
 	 * @example
 	 * For example, when using bigint we need to cast field to text to preserve data integrity
 	 * ```
@@ -339,9 +340,6 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * 	bigint: "5044565289845416380"; // Data is preserved due to conversion of field to text before JSON-ification
 	 * }
 	 * ```
-	 *
-	 * @default
-	 * Following types are being casted to text by default: `binary`, `varbinary`, `time`, `datetime`, `decimal`, `float`, 'bigint'
 	 */
 	forJsonSelect?: (identifier: SQL, sql: SQLGenerator) => SQL;
 }

--- a/drizzle-orm/src/singlestore-core/columns/custom.ts
+++ b/drizzle-orm/src/singlestore-core/columns/custom.ts
@@ -67,7 +67,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
 	private mapJson?: (value: unknown) => T['data'];
-	private wrapName?: (name: SQL, sql: SQLGenerator) => SQL;
+	private forJsonSelect?: (name: SQL, sql: SQLGenerator) => SQL;
 
 	constructor(
 		table: AnySingleStoreTable<{ name: T['tableName'] }>,
@@ -78,7 +78,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
 		this.mapJson = config.customTypeParams.fromJson;
-		this.wrapName = config.customTypeParams.jsonWrap;
+		this.forJsonSelect = config.customTypeParams.forJsonSelect;
 	}
 
 	getSQLType(): string {
@@ -93,8 +93,8 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 		return typeof this.mapJson === 'function' ? this.mapJson(value) : this.mapFromDriverValue(value) as T['data'];
 	}
 
-	jsonWrapName(name: SQL, sql: SQLGenerator): SQL {
-		if (typeof this.wrapName === 'function') return this.wrapName(name, sql);
+	jsonSelectIdentifier(identifier: SQL, sql: SQLGenerator): SQL {
+		if (typeof this.forJsonSelect === 'function') return this.forJsonSelect(identifier, sql);
 
 		const rawType = this.getSQLType().toLowerCase();
 		const parenPos = rawType.indexOf('(');
@@ -108,10 +108,10 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 			case 'decimal':
 			case 'float':
 			case 'bigint': {
-				return sql`cast(${name} as char)`;
+				return sql`cast(${identifier} as char)`;
 			}
 			default: {
-				return name;
+				return identifier;
 			}
 		}
 	}
@@ -132,6 +132,16 @@ export type CustomTypeValues = {
 	 * If you want your column to be `number` type after selecting/or on inserting - use `data: number`. Like `integer`
 	 */
 	data: unknown;
+
+	/**
+	 * Type helper, that represents what type database driver is returning for specific database data type
+	 *
+	 * Needed only in case driver's output and input for type differ
+	 *
+	 * @default
+	 * Defaults to `driverData`
+	 */
+	driverOutput?: unknown;
 
 	/**
 	 * Type helper, that represents what type database driver is accepting for specific database data type
@@ -212,7 +222,7 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	dataType: (config: T['config'] | (Equal<T['configRequired'], true> extends true ? never : undefined)) => string;
 
 	/**
-	 * Optional mapping function, between user input and driver
+	 * Optional mapping function, that is used to transform inputs from desired to be used in code format to one suitable for driver
 	 * @example
 	 * For example, when using jsonb we need to map JS/TS object to string before writing to database
 	 * ```
@@ -224,47 +234,116 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	toDriver?: (value: T['data']) => T['driverData'] | SQL;
 
 	/**
-	 * Optional mapping function, that is responsible for data mapping from database to JS/TS code
+	 * Optional mapping function, that is used for transforming data returned by driver to desired column's output format
 	 * @example
 	 * For example, when using timestamp we need to map string Date representation to JS Date
 	 * ```
 	 * fromDriver(value: string): Date {
 	 * 	return new Date(value);
-	 * },
+	 * }
+	 * ```
+	 *
+	 * It'll cause the returned data to change from:
+	 * ```
+	 * {
+	 * 	customField: "2025-04-07 03:25:16.635";
+	 * }
+	 * ```
+	 * to:
+	 * ```
+	 * {
+	 * 	customField: new Date("2025-04-07 03:25:16.635");
+	 * }
 	 * ```
 	 */
-	fromDriver?: (value: T['driverData']) => T['data'];
+	fromDriver?: (value: 'driverOutput' extends keyof T ? T['driverOutput'] : T['driverData']) => T['data'];
 
 	/**
-	 * Optional mapping function, that is responsible for data mapping from database's JSON format to JS/TS code
+	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by Relational Queries V2
+	 * Used by relational queries
 	 * @example
-	 * For example, when using bigint we need to map it's string representation to JS bigint
+	 * For example, when querying bigint column via RQB or JSON funcitons, the result field will be returned as it's string representation, as opposed to bigint from regular query
+	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): bigint {
 	 * 	return BigInt(value);
 	 * },
 	 * ```
 	 *
+	 * It'll cause the returned data to change from:
+	 * ```
+	 * {
+	 * 	customField: "5044565289845416380";
+	 * }
+	 * ```
+	 * to:
+	 * ```
+	 * {
+	 * 	customField: 5044565289845416380n;
+	 * }
+	 * ```
 	 * @default
-	 * Defaults to `fromDriver` function
+	 * Defaults to {@link fromDriver} function
 	 */
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional name wrapper function, that is responsible for modifying field in selection before it's casted to JSON
+	 * Optional selection modifier function, that is used for modifying selection of column inside JSON functions
 	 *
-	 * Used by Relational Queries V2
+	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
+	 *
+	 * Used by relational queries
 	 * @example
 	 * For example, when using bigint we need to cast field to text to preserve data integrity
 	 * ```
-	 * jsonWrap(name: SQL, sql: SQLGenerator): SQL {
-	 * 	return sql`cast(${name} as char)`
+	 * forJsonSelect(identifier: SQL, sql: SQLGenerator): SQL {
+	 * 	return sql`cast(${identifier} as char)`
 	 * },
 	 * ```
+	 *
+	 * This will change query from:
+	 * ```
+	 * SELECT
+	 * 	json_build_object('bigint', `t`.`bigint`)
+	 * 	FROM
+	 * 	(
+	 * 		SELECT
+	 * 		`table`.`custom_bigint` AS `bigint`
+	 * 		FROM
+	 * 		`table`
+	 * 	) AS `t`
+	 * ```
+	 * to:
+	 * ```
+	 * SELECT
+	 * 	json_build_object('bigint', `t`.`bigint`)
+	 * 	FROM
+	 * 	(
+	 * 		SELECT
+	 * 		cast(`table`.`custom_bigint` as char) AS `bigint`
+	 * 		FROM
+	 * 		`table`
+	 * 	) AS `t`
+	 * ```
+	 *
+	 * Returned by query object will change from:
+	 * ```
+	 * {
+	 * 	bigint: 5044565289845416000; // Partial data loss due to direct conversion to JSON format
+	 * }
+	 * ```
+	 * to:
+	 * ```
+	 * {
+	 * 	bigint: "5044565289845416380"; // Data is preserved due to conversion of field to text before JSON-ification
+	 * }
+	 * ```
+	 *
+	 * @default
+	 * Following types are being casted to text by default: `binary`, `varbinary`, `time`, `datetime`, `decimal`, `float`, 'bigint'
 	 */
-	jsonWrap?: (name: SQL, sql: SQLGenerator) => SQL;
+	forJsonSelect?: (identifier: SQL, sql: SQLGenerator) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -461,6 +461,8 @@ export type SQLChunk =
 	| FakePrimitiveParam
 	| Placeholder;
 
+export type SQLGenerator<T = unknown> = typeof sql<T>;
+
 export function sql<T>(strings: TemplateStringsArray, ...params: any[]): SQL<T>;
 /*
 	The type of `params` is specified as `SQLChunk[]`, but that's slightly incorrect -

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -256,11 +256,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 *
 	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying blob column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's hex string representation, as opposed to Buffer from regular query
+	 * For example, when querying blob column via [RQB](https://orm.drizzle.team/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/json-functions), the result field will be returned as it's hex string representation, as opposed to Buffer from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): Buffer {
@@ -284,11 +284,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 * Used by [relational queries](https://orm.drizzle.team/docs/rqb-v2)
 	 *
 	 * Following types are being casted to text by default: `numeric`, `decimal`, `bigint`, `blob` (via `hex()` function)
 	 * @example

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -117,7 +117,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	}
 }
 
-export type CustomTypeValues = {
+export interface CustomTypeValues {
 	/**
 	 * Required type for custom column, that will infer proper type model
 	 *
@@ -139,8 +139,7 @@ export type CustomTypeValues = {
 	 *
 	 * Needed only in case driver's output and input for type differ
 	 *
-	 * @default
-	 * Defaults to `driverData`
+	 * Defaults to {@link driverData}
 	 */
 	driverOutput?: unknown;
 
@@ -183,7 +182,7 @@ export type CustomTypeValues = {
 	 * });
 	 */
 	default?: boolean;
-};
+}
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
@@ -257,9 +256,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	/**
 	 * Optional mapping function, that is used for transforming data returned by transofmed to JSON in database data to desired format
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 *
+	 * Defaults to {@link fromDriver} function
 	 * @example
-	 * For example, when querying blob column via RQB or JSON funcitons, the result field will be returned as it's hex string representation, as opposed to Buffer from regular query
+	 * For example, when querying blob column via [RQB](https://orm.drizzle.team/docs/docs/rqb-v2) or [JSON functions](https://orm.drizzle.team/docs/docs/json-functions), the result field will be returned as it's hex string representation, as opposed to Buffer from regular query
 	 * To handle that, we need a separate function to handle such field's mapping:
 	 * ```
 	 * fromJson(value: string): Buffer {
@@ -279,17 +280,17 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * 	customField: Buffer([...]);
 	 * }
 	 * ```
-	 * @default
-	 * Defaults to {@link fromDriver} function
 	 */
 	fromJson?: (value: T['jsonData']) => T['data'];
 
 	/**
-	 * Optional selection modifier function, that is used for modifying selection of column inside JSON functions
+	 * Optional selection modifier function, that is used for modifying selection of column inside [JSON functions](https://orm.drizzle.team/docs/docs/json-functions)
 	 *
 	 * Additional mapping that could be required for such scenarios can be handled using {@link fromJson} function
 	 *
-	 * Used by relational queries
+	 * Used by [relational queries](https://orm.drizzle.team/docs/docs/rqb-v2)
+	 *
+	 * Following types are being casted to text by default: `numeric`, `decimal`, `bigint`, `blob` (via `hex()` function)
 	 * @example
 	 * For example, when using numeric field for bigint storage we need to cast field to text to preserve data integrity
 	 * ```
@@ -335,9 +336,6 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * 	bigint: "5044565289845416380"; // Data is preserved due to conversion of field to text before JSON-ification
 	 * }
 	 * ```
-	 *
-	 * @default
-	 * Following types are being casted to text by default: `numeric`, `decimal`, `bigint`, `blob` (via `hex()` function)
 	 */
 	forJsonSelect?: (identifier: SQL, sql: SQLGenerator) => SQL;
 }

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -1,7 +1,7 @@
 import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnConfig } from '~/column-builder.ts';
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { SQL, SQLGenerator } from '~/sql/sql.ts';
 import type { AnySQLiteTable } from '~/sqlite-core/table.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { SQLiteColumn, SQLiteColumnBuilder } from './common.ts';
@@ -63,6 +63,8 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private mapJson?: (value: unknown) => T['data'];
+	private wrapName?: (name: SQL, sql: SQLGenerator) => SQL;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -72,6 +74,8 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.mapJson = config.customTypeParams.fromJson;
+		this.wrapName = config.customTypeParams.jsonWrap;
 	}
 
 	getSQLType(): string {
@@ -80,6 +84,32 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
 		return typeof this.mapFrom === 'function' ? this.mapFrom(value) : value as T['data'];
+	}
+
+	mapFromJsonValue(value: unknown): T['data'] {
+		return typeof this.mapJson === 'function' ? this.mapJson(value) : this.mapFromDriverValue(value) as T['data'];
+	}
+
+	jsonWrapName(name: SQL, sql: SQLGenerator): SQL {
+		if (typeof this.wrapName === 'function') return this.wrapName(name, sql);
+
+		const rawType = this.getSQLType().toLowerCase();
+		const parenPos = rawType.indexOf('(');
+		const type = (parenPos + 1) ? rawType.slice(0, parenPos) : rawType;
+
+		switch (type) {
+			case 'numeric':
+			case 'decimal':
+			case 'bigint': {
+				return sql`cast(${name} as text)`;
+			}
+			case 'blob': {
+				return sql`hex(${name})`;
+			}
+			default: {
+				return name;
+			}
+		}
 	}
 
 	override mapToDriverValue(value: T['data']): T['driverParam'] {
@@ -103,6 +133,11 @@ export type CustomTypeValues = {
 	 * Type helper, that represents what type database driver is accepting for specific database data type
 	 */
 	driverData?: unknown;
+
+	/**
+	 * Type helper, that represents what type field returns after being aggregated to JSON
+	 */
+	jsonData?: unknown;
 
 	/**
 	 * What config type should be used for {@link CustomTypeParams} `dataType` generation
@@ -195,6 +230,37 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional mapping function, that is responsible for data mapping from database's JSON format to JS/TS code
+	 *
+	 * Used by Relational Queries V2
+	 * @example
+	 * For example, when using blob we need to map it's hex representation back to Buffer
+	 * ```
+	 * fromJson(value: string): Buffer {
+	 * 	return Buffer.from(value, 'hex');
+	 * },
+	 * ```
+	 *
+	 * @default
+	 * Defaults to `fromDriver` function
+	 */
+	fromJson?: (value: T['jsonData']) => T['data'];
+
+	/**
+	 * Optional name wrapper function, that is responsible for modifying field in selection before it's casted to JSON
+	 *
+	 * Used by Relational Queries V2
+	 * @example
+	 * For example, when using blob we need to cast field to hex to be able to query it in JSON fields
+	 * ```
+	 * jsonWrap(name: SQL, sql: SQLGenerator): SQL {
+	 * 	return sql`hex(${name})`
+	 * },
+	 * ```
+	 */
+	jsonWrap?: (name: SQL, sql: SQLGenerator) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -842,7 +842,7 @@ export abstract class SQLiteDialect {
 				}
 
 				case 'SQLiteCustomColumn': {
-					return sql`${(<SQLiteCustomColumn<any>> column).jsonWrapName(name, sql)} as ${sql.identifier(key)}`;
+					return sql`${(<SQLiteCustomColumn<any>> column).jsonSelectIdentifier(name, sql)} as ${sql.identifier(key)}`;
 				}
 
 				default: {

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -26,7 +26,7 @@ import {
 import type { Name, Placeholder, SQLWrapper, View } from '~/sql/index.ts';
 import { and, eq, isSQLWrapper } from '~/sql/index.ts';
 import { Param, type QueryWithTypings, SQL, sql, type SQLChunk } from '~/sql/sql.ts';
-import { SQLiteColumn } from '~/sqlite-core/columns/index.ts';
+import { SQLiteColumn, type SQLiteCustomColumn } from '~/sqlite-core/columns/index.ts';
 import type {
 	AnySQLiteSelectQueryBuilder,
 	SQLiteDeleteConfig,
@@ -839,6 +839,10 @@ export abstract class SQLiteDialect {
 				case 'SQLiteNumericNumber':
 				case 'SQLiteNumericBigInt': {
 					return sql`cast(${name} as text) as ${sql.identifier(key)}`;
+				}
+
+				case 'SQLiteCustomColumn': {
+					return sql`${(<SQLiteCustomColumn<any>> column).jsonWrapName(name, sql)} as ${sql.identifier(key)}`;
 				}
 
 				default: {

--- a/integration-tests/tests/relational/bettersqlite.test.ts
+++ b/integration-tests/tests/relational/bettersqlite.test.ts
@@ -9,6 +9,7 @@ import {
 	allTypesTable,
 	commentsTable,
 	courseOfferings,
+	customTypesTable,
 	groupsTable,
 	postsTable,
 	studentGrades,
@@ -36,6 +37,7 @@ beforeEach(() => {
 	db.run(sql`drop table if exists \`comments\``);
 	db.run(sql`drop table if exists \`comment_likes\``);
 	db.run(sql`drop table if exists \`all_types\``);
+	db.run(sql`drop table if exists \`custom_types\``);
 	db.run(sql`drop table if exists \`course_offerings\``);
 	db.run(sql`drop table if exists \`student_grades\``);
 	db.run(sql`drop table if exists \`students\``);
@@ -11519,6 +11521,61 @@ test('alltypes', async () => {
 			real: 1.048596,
 			text: 'TEXT STRING',
 			jsonText: { str: 'strvalb', arr: ['strb', 11] },
+		},
+	];
+
+	expect(rawRes).toStrictEqual(expectedRes);
+});
+
+test('custom types', async () => {
+	db.run(sql`
+		CREATE TABLE \`custom_types\` (
+			\`id\` integer,
+			\`big\` blob,
+			\`bytes\` blob,
+			\`time\` integer,
+			\`int\` integer
+		);
+	`);
+
+	db.insert(customTypesTable).values({
+		id: 1,
+		big: 5044565289845416380n,
+		bytes: Buffer.from('BYTES'),
+		time: new Date(1741743161623),
+		int: 250,
+	}).run();
+
+	const rawRes = await db.select().from(customTypesTable);
+	const relationRootRes = await db.query.customTypesTable.findMany();
+	const { self: nestedRelationRes } = (await db.query.customTypesTable.findFirst({
+		with: {
+			self: true,
+		},
+	}))!;
+
+	type ExpectedType = {
+		id: number | null;
+		big: bigint | null;
+		bytes: Buffer | null;
+		time: Date | null;
+		int: number | null;
+	}[];
+
+	expectTypeOf<ExpectedType>().toEqualTypeOf(rawRes);
+	expectTypeOf(relationRootRes).toEqualTypeOf(rawRes);
+	expectTypeOf(nestedRelationRes).toEqualTypeOf(rawRes);
+
+	expect(nestedRelationRes).toStrictEqual(rawRes);
+	expect(relationRootRes).toStrictEqual(rawRes);
+
+	const expectedRes: ExpectedType = [
+		{
+			id: 1,
+			big: 5044565289845416380n,
+			bytes: Buffer.from('BYTES'),
+			time: new Date(1741743161623),
+			int: 250,
 		},
 	];
 

--- a/integration-tests/tests/relational/mysql.relations.ts
+++ b/integration-tests/tests/relational/mysql.relations.ts
@@ -203,4 +203,10 @@ export default defineRelations(schema, (r) => ({
 	courseOfferings: {
 		students: r.many.students(),
 	},
+	customTypesTable: {
+		self: r.many.customTypesTable({
+			from: r.customTypesTable.id,
+			to: r.customTypesTable.id,
+		}),
+	},
 }));

--- a/integration-tests/tests/relational/mysql.schema.ts
+++ b/integration-tests/tests/relational/mysql.schema.ts
@@ -5,6 +5,7 @@ import {
 	binary,
 	boolean,
 	char,
+	customType,
 	date,
 	datetime,
 	decimal,
@@ -314,4 +315,59 @@ export const studentGrades = mysqlTable('student_grades', {
 	courseId: int('course_id').notNull(),
 	semester: varchar({ length: 10 }).notNull(),
 	grade: char({ length: 2 }),
+});
+
+const customBigInt = customType<{
+	data: bigint;
+	driverData: bigint | string;
+	jsonData: string;
+}>({
+	dataType: () => 'bigint',
+	fromDriver: BigInt,
+});
+
+const customBytes = customType<{
+	data: Buffer;
+	driverData: Buffer | Uint8Array;
+	jsonData: string;
+}>({
+	dataType: () => 'blob',
+	fromDriver: (value) => {
+		return Buffer.isBuffer(value) ? value : Buffer.from(value);
+	},
+	fromJson: (value) => {
+		return Buffer.from(value, 'hex');
+	},
+	jsonWrap: (name, sql) => {
+		return sql`hex(${name})`;
+	},
+});
+
+const customTimestamp = customType<{
+	data: Date;
+	driverData: string;
+	jsonData: string;
+}>({
+	dataType: () => 'timestamp',
+	fromDriver: (value: string) => {
+		return new Date(value + '+0000');
+	},
+	toDriver: (value: Date) => {
+		return value.toISOString().slice(0, 19).replace('T', ' ');
+	},
+});
+
+const customInt = customType<{
+	data: number;
+	driverData: number;
+}>({
+	dataType: () => 'int',
+});
+
+export const customTypesTable = mysqlTable('custom_types', {
+	id: int('id'),
+	big: customBigInt(),
+	bytes: customBytes(),
+	time: customTimestamp(),
+	int: customInt(),
 });

--- a/integration-tests/tests/relational/mysql.schema.ts
+++ b/integration-tests/tests/relational/mysql.schema.ts
@@ -319,7 +319,8 @@ export const studentGrades = mysqlTable('student_grades', {
 
 const customBigInt = customType<{
 	data: bigint;
-	driverData: bigint | string;
+	driverData: bigint;
+	driverOutput: string;
 	jsonData: string;
 }>({
 	dataType: () => 'bigint',
@@ -328,7 +329,8 @@ const customBigInt = customType<{
 
 const customBytes = customType<{
 	data: Buffer;
-	driverData: Buffer | Uint8Array;
+	driverData: Buffer;
+	driverOutput: Buffer | Uint8Array;
 	jsonData: string;
 }>({
 	dataType: () => 'blob',
@@ -338,8 +340,8 @@ const customBytes = customType<{
 	fromJson: (value) => {
 		return Buffer.from(value, 'hex');
 	},
-	jsonWrap: (name, sql) => {
-		return sql`hex(${name})`;
+	forJsonSelect: (identifier, sql) => {
+		return sql`hex(${identifier})`;
 	},
 });
 

--- a/integration-tests/tests/relational/pg.relations.ts
+++ b/integration-tests/tests/relational/pg.relations.ts
@@ -203,4 +203,10 @@ export default defineRelations(schema, (r) => ({
 	courseOfferings: {
 		students: r.many.students(),
 	},
+	customTypesTable: {
+		self: r.many.customTypesTable({
+			from: r.customTypesTable.id,
+			to: r.customTypesTable.id,
+		}),
+	},
 }));

--- a/integration-tests/tests/relational/pg.schema.ts
+++ b/integration-tests/tests/relational/pg.schema.ts
@@ -348,7 +348,8 @@ export const studentGrades = pgTable('student_grades', {
 
 const customBigInt = customType<{
 	data: bigint;
-	driverData: string | bigint;
+	driverData: bigint;
+	driverOutput: string;
 	jsonData: string;
 }>({
 	dataType: () => 'bigint',
@@ -365,7 +366,8 @@ const customBytes = customType<{
 	fromJson: (value) => {
 		return Buffer.from(value.slice(2, value.length), 'hex');
 	},
-	jsonWrap: (name, sql, arrayDimensions) => sql`${name}::text${sql.raw('[]'.repeat(arrayDimensions ?? 0))}`,
+	forJsonSelect: (identifier, sql, arrayDimensions) =>
+		sql`${identifier}::text${sql.raw('[]'.repeat(arrayDimensions ?? 0))}`,
 });
 
 const customTimestamp = customType<{

--- a/integration-tests/tests/relational/pg.test.ts
+++ b/integration-tests/tests/relational/pg.test.ts
@@ -12,6 +12,7 @@ import {
 	allTypesTable,
 	commentsTable,
 	courseOfferings,
+	customTypesTable,
 	groupsTable,
 	postsTable,
 	schemaGroups,
@@ -13174,6 +13175,93 @@ test('alltypes', async () => {
 			arrtimestampTzStr: ['2025-03-12 01:32:41.623+00'],
 			arruuid: ['b77c9eef-8e28-4654-88a1-7221b46d2a1c'],
 			arrvarchar: ['C4-'],
+		},
+	];
+
+	expect(rawRes).toStrictEqual(expectedRes);
+});
+
+test('custom types', async () => {
+	await db.execute(sql`
+		CREATE TABLE "custom_types" (
+			"id" serial,
+			"big" bigint,
+			"big_arr" bigint[],
+			"big_mtx" bigint[][],
+			"bytes" bytea,
+			"bytes_arr" bytea[],
+			"bytes_mtx" bytea[][],
+			"time" timestamp(3),
+			"time_arr" timestamp(3)[],
+			"time_mtx" timestamp(3)[][],
+			"int" integer,
+			"int_arr" integer[],
+			"int_mtx" integer[][]
+		);
+	`);
+
+	await db.insert(customTypesTable).values({
+		id: 1,
+		big: 5044565289845416380n,
+		bigArr: [5044565289845416380n],
+		bigMtx: [[5044565289845416380n]],
+		bytes: Buffer.from('BYTES'),
+		bytesArr: [Buffer.from('BYTES')],
+		bytesMtx: [[Buffer.from('BYTES')]],
+		time: new Date(1741743161623),
+		timeArr: [new Date(1741743161623)],
+		timeMtx: [[new Date(1741743161623)]],
+		int: 250,
+		intArr: [250],
+		intMtx: [[250]],
+	});
+
+	const rawRes = await db.select().from(customTypesTable);
+	const relationRootRes = await db.query.customTypesTable.findMany();
+	const { self: nestedRelationRes } = (await db.query.customTypesTable.findFirst({
+		with: {
+			self: true,
+		},
+	}))!;
+
+	type ExpectedType = {
+		id: number;
+		big: bigint | null;
+		bigArr: bigint[] | null;
+		bigMtx: bigint[][] | null;
+		bytes: Buffer | null;
+		bytesArr: Buffer[] | null;
+		bytesMtx: Buffer[][] | null;
+		time: Date | null;
+		timeArr: Date[] | null;
+		timeMtx: Date[][] | null;
+		int: number | null;
+		intArr: number[] | null;
+		intMtx: number[][] | null;
+	}[];
+
+	expectTypeOf<ExpectedType>().toEqualTypeOf(rawRes);
+	expectTypeOf(relationRootRes).toEqualTypeOf(rawRes);
+	expectTypeOf(nestedRelationRes).toEqualTypeOf(rawRes);
+
+	expect(nestedRelationRes).toStrictEqual(rawRes);
+	expect(relationRootRes).toStrictEqual(rawRes);
+
+	const expectedRes: ExpectedType = [
+		{
+			id: 1,
+			big: 5044565289845416380n,
+			bigArr: [5044565289845416380n],
+			bigMtx: [[5044565289845416380n]],
+			bytes: Buffer.from('BYTES'),
+			bytesArr: [Buffer.from('BYTES')],
+			bytesMtx: [[Buffer.from('BYTES')]],
+			time: new Date(1741743161623),
+			timeArr: [new Date(1741743161623)],
+			timeMtx: [[new Date(1741743161623)]],
+			int: 250,
+			intArr: [250],
+			intMtx: [[250]],
 		},
 	];
 

--- a/integration-tests/tests/relational/sqlite.relations.ts
+++ b/integration-tests/tests/relational/sqlite.relations.ts
@@ -154,4 +154,10 @@ export default defineRelations(schema, (r) => ({
 	courseOfferings: {
 		students: r.many.students(),
 	},
+	customTypesTable: {
+		self: r.many.customTypesTable({
+			from: r.customTypesTable.id,
+			to: r.customTypesTable.id,
+		}),
+	},
 }));

--- a/integration-tests/tests/relational/sqlite.schema.ts
+++ b/integration-tests/tests/relational/sqlite.schema.ts
@@ -2,6 +2,7 @@ import {
 	alias,
 	type AnySQLiteColumn,
 	blob,
+	customType,
 	integer,
 	numeric,
 	primaryKey,
@@ -193,4 +194,62 @@ export const studentGrades = sqliteTable('student_grades', {
 	courseId: integer('course_id').notNull(),
 	semester: text().notNull(),
 	grade: text(),
+});
+
+const customBigInt = customType<{
+	data: bigint;
+	driverData: Buffer;
+	jsonData: string;
+}>({
+	dataType: () => 'blob',
+	fromDriver: (value) => {
+		return BigInt(value.toString());
+	},
+	fromJson: (value) => {
+		return BigInt(Buffer.from(value, 'hex').toString());
+	},
+	toDriver: (value) => Buffer.from(value.toString()),
+});
+
+const customBytes = customType<{
+	data: Buffer;
+	driverData: Buffer;
+	jsonData: string;
+}>({
+	dataType: () => 'blob',
+	fromJson: (value) => {
+		return Buffer.from(value, 'hex');
+	},
+	jsonWrap: (name, sql) => {
+		return sql`hex(${name})`;
+	},
+});
+
+const customTimestamp = customType<{
+	data: Date;
+	driverData: number;
+	jsonData: number;
+}>({
+	dataType: () => 'integer',
+	fromDriver: (value: number) => {
+		return new Date(value);
+	},
+	toDriver: (value: Date) => {
+		return value.getTime();
+	},
+});
+
+const customInt = customType<{
+	data: number;
+	driverData: number;
+}>({
+	dataType: () => 'integer',
+});
+
+export const customTypesTable = sqliteTable('custom_types', {
+	id: integer('id'),
+	big: customBigInt(),
+	bytes: customBytes(),
+	time: customTimestamp(),
+	int: customInt(),
 });

--- a/integration-tests/tests/relational/sqlite.schema.ts
+++ b/integration-tests/tests/relational/sqlite.schema.ts
@@ -220,8 +220,8 @@ const customBytes = customType<{
 	fromJson: (value) => {
 		return Buffer.from(value, 'hex');
 	},
-	jsonWrap: (name, sql) => {
-		return sql`hex(${name})`;
+	forJsonSelect: (identifier, sql) => {
+		return sql`hex(${identifier})`;
 	},
 });
 


### PR DESCRIPTION
 - Added mapper from JSON, in-JSON selection name wrapper to custom types
 - Fixed RQBv2 hanging on arrays with over 1 dimension 
 - Enabled array mapping for `gel` columns with custom mappers
 - Related tests
 - Added field for typing driver outputs differing from inputs for custom types
 - Changed types `CustomTypeValues` to interfaces for `JSDoc` link functionality