### PR TITLE
docs: update Node compat instructions for CloudFlare

### DIFF
--- a/examples/cloudflare-d1/README.md
+++ b/examples/cloudflare-d1/README.md
@@ -10,8 +10,8 @@ To setup project for your Cloudflare D1 - please refer to [official docs](https:
 
 name = "YOUR PROJECT NAME"
 main = "src/index.ts"
-compatibility_date = "2022-11-07"
-node_compat = true
+compatibility_date = "2024-09-23"
+compatibility_flags = [ "nodejs_compat" ]
 
 [[ d1_databases ]]
 binding = "DB"

--- a/examples/neon-cloudflare/readme.md
+++ b/examples/neon-cloudflare/readme.md
@@ -10,9 +10,9 @@ First let's setup your Cloudflare Worker project based on [official docs](https:
 
 name = "neon-cf-demo"
 main = "src/index.ts"
-compatibility_date = "2022-12-09"
+compatibility_date = "2024-09-23"
 usage_model = "unbound"
-node_compat = true
+compatibility_flags = [ "nodejs_compat" ]
 ```
 
 Setup Neon Serverless database - [official docs](https://neon.tech/docs/get-started-with-neon/signing-up), grab database url with project tag, put them in `.dev.vars`. You will need project name for `postgres.js` driver to run migrations - [read here](https://neon.tech/docs/guides/node)

--- a/examples/neon-cloudflare/wrangler.toml
+++ b/examples/neon-cloudflare/wrangler.toml
@@ -1,5 +1,5 @@
 name = "neon-cf-demo"
 main = "src/index.ts"
-compatibility_date = "2022-12-09"
+compatibility_date = "2024-09-23"
 usage_model = "unbound"
-node_compat = true
+compatibility_flags = [ "nodejs_compat" ]


### PR DESCRIPTION
This PR updates the instructions for CloudFlare integrations so that it's no longer using a deprecated API