### PR TITLE
feat: InferPgEnum utility type

### DIFF
--- a/drizzle-orm/src/pg-core/columns/enum.ts
+++ b/drizzle-orm/src/pg-core/columns/enum.ts
@@ -28,6 +28,8 @@ export interface PgEnum<TValues extends [string, ...string[]]> {
 	[isPgEnumSym]: true;
 }
 
+export type InferPgEnum<T extends PgEnum<any>> = T['enumValues'][number];
+
 export function isPgEnum(obj: unknown): obj is PgEnum<[string, ...string[]]> {
 	return !!obj && typeof obj === 'function' && isPgEnumSym in obj && obj[isPgEnumSym] === true;
 }


### PR DESCRIPTION
A utility type to infer a union type from a pgEnum.

e.g.

```
const rolesEnum = pgEnum("roles", ["guest", "user", "admin"]);
type Role = InferPgEnum<typeof rolesEnum>
```

_____


We can also use `infer` if preferred but I think this initial contribution is cleanest and most performant

```
type InferPgEnum<T extends PgEnum<any>> = T extends PgEnum<infer Values> ? Values[number] : never;
```