### PR TITLE
Allow iterables to be used in insert statements

### DIFF
--- a/drizzle-orm/src/gel-core/query-builders/insert.ts
+++ b/drizzle-orm/src/gel-core/query-builders/insert.ts
@@ -19,7 +19,7 @@ import type { Subquery } from '~/subquery.ts';
 import type { InferInsertModel } from '~/table.ts';
 import { Columns, Table } from '~/table.ts';
 import { tracer } from '~/tracing.ts';
-import { haveSameKeys, type NeonAuthToken, orderSelectedFields } from '~/utils.ts';
+import { haveSameKeys, isIterable, type NeonAuthToken, orderSelectedFields } from '~/utils.ts';
 import type { AnyGelColumn, GelColumn } from '../columns/common.ts';
 import { QueryBuilder } from './query-builder.ts';
 import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
@@ -78,9 +78,9 @@ export class GelInsertBuilder<
 	values(value: GelInsertValue<TTable, OverrideT>): GelInsertBase<TTable, TQueryResult>;
 	values(values: GelInsertValue<TTable, OverrideT>[]): GelInsertBase<TTable, TQueryResult>;
 	values(
-		values: GelInsertValue<TTable, OverrideT> | GelInsertValue<TTable, OverrideT>[],
+		rawValues: GelInsertValue<TTable, OverrideT> | GelInsertValue<TTable, OverrideT>[],
 	): GelInsertBase<TTable, TQueryResult> {
-		values = Array.isArray(values) ? values : [values];
+		const values = isIterable(rawValues) ? [...rawValues] : [rawValues];
 		if (values.length === 0) {
 			throw new Error('values() must be called with at least one value');
 		}

--- a/drizzle-orm/src/mysql-core/query-builders/insert.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/insert.ts
@@ -17,7 +17,7 @@ import type { Placeholder, Query, SQLWrapper } from '~/sql/sql.ts';
 import { Param, SQL, sql } from '~/sql/sql.ts';
 import type { InferModelFromColumns } from '~/table.ts';
 import { Columns, Table } from '~/table.ts';
-import { haveSameKeys, mapUpdateSet } from '~/utils.ts';
+import { haveSameKeys, isIterable, mapUpdateSet } from '~/utils.ts';
 import type { AnyMySqlColumn } from '../columns/common.ts';
 import { QueryBuilder } from './query-builder.ts';
 import type { SelectedFieldsOrdered } from './select.types.ts';
@@ -67,9 +67,9 @@ export class MySqlInsertBuilder<
 	values(value: MySqlInsertValue<TTable>): MySqlInsertBase<TTable, TQueryResult, TPreparedQueryHKT>;
 	values(values: MySqlInsertValue<TTable>[]): MySqlInsertBase<TTable, TQueryResult, TPreparedQueryHKT>;
 	values(
-		values: MySqlInsertValue<TTable> | MySqlInsertValue<TTable>[],
+		rawValues: MySqlInsertValue<TTable> | MySqlInsertValue<TTable>[],
 	): MySqlInsertBase<TTable, TQueryResult, TPreparedQueryHKT> {
-		values = Array.isArray(values) ? values : [values];
+		const values = isIterable(rawValues) ? [...rawValues] : [rawValues];
 		if (values.length === 0) {
 			throw new Error('values() must be called with at least one value');
 		}

--- a/drizzle-orm/src/pg-core/query-builders/insert.ts
+++ b/drizzle-orm/src/pg-core/query-builders/insert.ts
@@ -20,7 +20,7 @@ import type { Subquery } from '~/subquery.ts';
 import type { InferInsertModel } from '~/table.ts';
 import { Columns, getTableName, Table } from '~/table.ts';
 import { tracer } from '~/tracing.ts';
-import { haveSameKeys, mapUpdateSet, type NeonAuthToken, orderSelectedFields } from '~/utils.ts';
+import { haveSameKeys, isIterable, mapUpdateSet, type NeonAuthToken, orderSelectedFields } from '~/utils.ts';
 import type { AnyPgColumn, PgColumn } from '../columns/common.ts';
 import { QueryBuilder } from './query-builder.ts';
 import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
@@ -80,9 +80,9 @@ export class PgInsertBuilder<
 	values(value: PgInsertValue<TTable, OverrideT>): PgInsertBase<TTable, TQueryResult>;
 	values(values: PgInsertValue<TTable, OverrideT>[]): PgInsertBase<TTable, TQueryResult>;
 	values(
-		values: PgInsertValue<TTable, OverrideT> | PgInsertValue<TTable, OverrideT>[],
+		rawValues: PgInsertValue<TTable, OverrideT> | PgInsertValue<TTable, OverrideT>[],
 	): PgInsertBase<TTable, TQueryResult> {
-		values = Array.isArray(values) ? values : [values];
+		const values = isIterable(rawValues) ? [...rawValues] : [rawValues];
 		if (values.length === 0) {
 			throw new Error('values() must be called with at least one value');
 		}

--- a/drizzle-orm/src/singlestore-core/query-builders/insert.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/insert.ts
@@ -16,7 +16,7 @@ import type { Placeholder, Query, SQLWrapper } from '~/sql/sql.ts';
 import { Param, SQL, sql } from '~/sql/sql.ts';
 import type { InferModelFromColumns } from '~/table.ts';
 import { Table } from '~/table.ts';
-import { mapUpdateSet, orderSelectedFields } from '~/utils.ts';
+import { isIterable, mapUpdateSet, orderSelectedFields } from '~/utils.ts';
 import type { AnySingleStoreColumn, SingleStoreColumn } from '../columns/common.ts';
 import type { SelectedFieldsOrdered } from './select.types.ts';
 import type { SingleStoreUpdateSetSource } from './update.ts';
@@ -60,9 +60,9 @@ export class SingleStoreInsertBuilder<
 	values(value: SingleStoreInsertValue<TTable>): SingleStoreInsertBase<TTable, TQueryResult, TPreparedQueryHKT>;
 	values(values: SingleStoreInsertValue<TTable>[]): SingleStoreInsertBase<TTable, TQueryResult, TPreparedQueryHKT>;
 	values(
-		values: SingleStoreInsertValue<TTable> | SingleStoreInsertValue<TTable>[],
+		rawValues: SingleStoreInsertValue<TTable> | Iterable<SingleStoreInsertValue<TTable>>,
 	): SingleStoreInsertBase<TTable, TQueryResult, TPreparedQueryHKT> {
-		values = Array.isArray(values) ? values : [values];
+		const values = isIterable(rawValues) ? [...rawValues] : [rawValues];
 		if (values.length === 0) {
 			throw new Error('values() must be called with at least one value');
 		}

--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -11,7 +11,14 @@ import type { SQLitePreparedQuery, SQLiteSession } from '~/sqlite-core/session.t
 import { SQLiteTable } from '~/sqlite-core/table.ts';
 import type { Subquery } from '~/subquery.ts';
 import { Columns, Table } from '~/table.ts';
-import { type DrizzleTypeError, haveSameKeys, mapUpdateSet, orderSelectedFields, type Simplify } from '~/utils.ts';
+import {
+	type DrizzleTypeError,
+	haveSameKeys,
+	isIterable,
+	mapUpdateSet,
+	orderSelectedFields,
+	type Simplify,
+} from '~/utils.ts';
 import type { AnySQLiteColumn, SQLiteColumn } from '../columns/common.ts';
 import { QueryBuilder } from './query-builder.ts';
 import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
@@ -51,11 +58,11 @@ export class SQLiteInsertBuilder<
 	) {}
 
 	values(value: SQLiteInsertValue<TTable>): SQLiteInsertBase<TTable, TResultType, TRunResult>;
-	values(values: SQLiteInsertValue<TTable>[]): SQLiteInsertBase<TTable, TResultType, TRunResult>;
+	values(values: Iterable<SQLiteInsertValue<TTable>>): SQLiteInsertBase<TTable, TResultType, TRunResult>;
 	values(
-		values: SQLiteInsertValue<TTable> | SQLiteInsertValue<TTable>[],
+		rawValues: SQLiteInsertValue<TTable> | Iterable<SQLiteInsertValue<TTable>>,
 	): SQLiteInsertBase<TTable, TResultType, TRunResult> {
-		values = Array.isArray(values) ? values : [values];
+		const values = isIterable(rawValues) ? [...rawValues] : [rawValues];
 		if (values.length === 0) {
 			throw new Error('values() must be called with at least one value');
 		}

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -4,8 +4,8 @@ import { is } from './entity.ts';
 import type { Logger } from './logger.ts';
 import type { SelectedFieldsOrdered } from './operations.ts';
 import type { TableLike } from './query-builders/select.types.ts';
-import { Param, SQL, View } from './sql/sql.ts';
 import type { DriverValueDecoder } from './sql/sql.ts';
+import { Param, SQL, View } from './sql/sql.ts';
 import { Subquery } from './subquery.ts';
 import { getTableName, Table } from './table.ts';
 import { ViewBaseConfig } from './view-common.ts';
@@ -317,3 +317,7 @@ export function isConfig(data: any): boolean {
 }
 
 export type NeonAuthToken = string | (() => string | Promise<string>);
+
+export function isIterable<T>(data: unknown): data is Iterable<T> {
+	return typeof data === 'object' && data !== null && Symbol.iterator in data;
+}


### PR DESCRIPTION
With the advent of iterator helpers landing this avoids having to wrap iterators in `Array.from` everywhere when using iterables