### PR TITLE
[Pg-core]: add typed references to PostgreSQL columns

### DIFF
--- a/drizzle-orm/type-tests/pg/references.ts
+++ b/drizzle-orm/type-tests/pg/references.ts
@@ -1,0 +1,31 @@
+import { type Equal, Expect } from "type-tests/utils";
+import { pgTable, uuid, varchar } from "~/pg-core";
+
+const users = pgTable("users", {
+  id: uuid("id").primaryKey(),
+  name: varchar("name", { length: 255 }).notNull(),
+});
+
+const posts = pgTable("posts", {
+  id: uuid("id").primaryKey(),
+  title: varchar("title", { length: 255 }).notNull(),
+  userId: uuid("user_id").references(() => users.id),
+});
+
+const nonNullPosts = pgTable("non_null_posts", {
+  id: uuid("id").primaryKey(),
+  title: varchar("title", { length: 255 }).notNull(),
+  userId: uuid("user_id").references(() => users.id).notNull(),
+});
+
+{
+  type PostReference = typeof posts.userId.references;
+
+  Expect<Equal<PostReference, typeof users.id | undefined>>();
+}
+
+{
+  type NonNullPostReference = typeof nonNullPosts.userId.references;
+
+  Expect<Equal<NonNullPostReference, typeof users.id>>();
+}


### PR DESCRIPTION
### TLDR
Add proper type tracking for PostgreSQL column references with optional/required distinction.

## Change Summary

#### Added Features:
1. **Typed References in PostgreSQL**:
   - Added proper type information to references between columns
   - Implemented typed `references` property on columns to track reference relationship
   - Distinction between optional and required references based on `notNull` status

#### Code Changes:
1. **In `column-builder.ts`**:
   - Refactored `BuildColumn` type with conditional types to track reference relationships
   - Added reference type parameter to `PgColumn` generic interface
   - Added differentiation between optional and required references

2. **In `pg-core/columns/common.ts`**:
   - Made `ReferenceConfig` generic to preserve type of referenced column
   - Updated `references()` method to return enhanced type with reference information
   - Added `references` property to `PgColumn` class to store reference target
   - Set reference during foreign key setup in column creation

#### Tests:
1. **In `type-tests/pg/references.ts`**:
   - Added type tests to validate optional and required reference behavior
   - Verified correct type inference for both reference scenarios

### Context
- This change improves the type safety of column references in PostgreSQL, allowing TypeScript to track the relationship between columns and providing better autocomplete and type checking for referenced columns (#4387)