### PR TITLE
docs(turso): fix field name typo

### DIFF
--- a/examples/libsql/src/schema.ts
+++ b/examples/libsql/src/schema.ts
@@ -17,7 +17,7 @@ export const posts = sqliteTable('posts', {
 	body: text('body').notNull(),
 	authorId: integer('author_id').notNull().references(() => users.id),
 	createdAt: integer('created_at', { mode: 'timestamp' }).default(sql`(strftime('%s', 'now'))`),
-	updateAt: integer('updated_at', { mode: 'timestamp' }).default(sql`(strftime('%s', 'now'))`),
+	updatedAt: integer('updated_at', { mode: 'timestamp' }).default(sql`(strftime('%s', 'now'))`),
 });
 export const insertPostSchema = createInsertSchema(posts);
 export const selectPostSchema = createSelectSchema(posts);


### PR DESCRIPTION
Reading through docs and encountered a minor typo on the field name.
> https://orm.drizzle.team/docs/tutorials/drizzle-with-turso#create-tables

```ts
createdAt: integer('created_at', { mode: 'timestamp' }).default(sql`(strftime('%s', 'now'))`),
updateAt: integer('updated_at', { mode: 'timestamp' }).default(sql`(strftime('%s', 'now'))`),
```


Changes:
```diff
- updateAt: [...]
+ updatedAt: [...]
```