### PR TITLE
[neon-http] fix: use correct method for querying rqb v2

### DIFF
--- a/drizzle-orm/src/neon-http/session.ts
+++ b/drizzle-orm/src/neon-http/session.ts
@@ -101,9 +101,9 @@ export class NeonHttpPreparedQuery<
 
 		this.logger.logQuery(this.query.sql, params);
 
-		const { client, query, customResultMapper } = this;
+		const { clientQuery, query, customResultMapper } = this;
 
-		const result = await client(
+		const result = await clientQuery(
 			query.sql,
 			params,
 			token === undefined


### PR DESCRIPTION
Fixes this error when querying a Neon DB through RQB V2 with the  neon-http driver:

```
Error: This function can now be called only as a tagged-template function: sql`SELECT ${value}`, not sql("SELECT $1", [value], options). For a conventional function call with value placeholders ($1, $2, etc.), use sql.query("SELECT $1", [value], options).
```

It works on the main branch because they it still uses the V1 relations that query with `queryClient()`, but for some reason in V2 we query with `client()` instead. Patching this fixes the issue in my project.