### PR TITLE
Add "pg_stat_statements" to list of postgres extensionsFilters

### DIFF
--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -517,7 +517,16 @@ export const preparePullConfig = async (
 			&& dialect === 'postgresql'
 		) {
 			tablesFilter.push(
-				...['!geography_columns', '!geometry_columns', '!spatial_ref_sys'],
+				'!geography_columns', '!geometry_columns', '!spatial_ref_sys',
+			);
+		}
+
+		if (
+			config.extensionsFilters.includes('pg_stat_statements')
+			&& dialect === 'postgresql'
+		) {
+			tablesFilter.push(
+				'!pg_stat_statements', '!pg_stat_statements_info',
 			);
 		}
 	}

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -517,7 +517,9 @@ export const preparePullConfig = async (
 			&& dialect === 'postgresql'
 		) {
 			tablesFilter.push(
-				'!geography_columns', '!geometry_columns', '!spatial_ref_sys',
+				'!geography_columns',
+				'!geometry_columns',
+				'!spatial_ref_sys',
 			);
 		}
 
@@ -526,7 +528,8 @@ export const preparePullConfig = async (
 			&& dialect === 'postgresql'
 		) {
 			tablesFilter.push(
-				'!pg_stat_statements', '!pg_stat_statements_info',
+				'!pg_stat_statements',
+				'!pg_stat_statements_info',
 			);
 		}
 	}

--- a/drizzle-kit/src/cli/validations/cli.ts
+++ b/drizzle-kit/src/cli/validations/cli.ts
@@ -1,4 +1,4 @@
-import { enum as zEnum, boolean, intersection, object, string, TypeOf, union } from 'zod';
+import { boolean, enum as zEnum, intersection, object, string, TypeOf, union } from 'zod';
 import { dialect } from '../../schemaValidator';
 import { casing, casingType, prefix } from './common';
 

--- a/drizzle-kit/src/cli/validations/cli.ts
+++ b/drizzle-kit/src/cli/validations/cli.ts
@@ -1,4 +1,4 @@
-import { array, boolean, intersection, literal, object, string, TypeOf, union } from 'zod';
+import { enum as zEnum, boolean, intersection, object, string, TypeOf, union } from 'zod';
 import { dialect } from '../../schemaValidator';
 import { casing, casingType, prefix } from './common';
 
@@ -23,7 +23,7 @@ export const pushParams = object({
 	schemaFilter: union([string(), string().array()])
 		.optional()
 		.default(['public']),
-	extensionsFilters: literal('postgis').array().optional(),
+	extensionsFilters: zEnum(['postgis', 'pg_stat_statements']).array().optional(),
 	verbose: boolean().optional(),
 	strict: boolean().optional(),
 	entities: object({
@@ -45,7 +45,7 @@ export const pullParams = object({
 	schemaFilter: union([string(), string().array()])
 		.optional()
 		.default(['public']),
-	extensionsFilters: literal('postgis').array().optional(),
+	extensionsFilters: zEnum(['postgis', 'pg_stat_statements']).array().optional(),
 	casing,
 	breakpoints: boolean().optional().default(true),
 	migrations: object({

--- a/drizzle-kit/src/extensions/getTablesFilterByExtensions.ts
+++ b/drizzle-kit/src/extensions/getTablesFilterByExtensions.ts
@@ -4,13 +4,21 @@ export const getTablesFilterByExtensions = ({
 	extensionsFilters,
 	dialect,
 }: Pick<Config, 'extensionsFilters' | 'dialect'>): string[] => {
+	const tableFilters: string[] = [];
 	if (extensionsFilters) {
 		if (
 			extensionsFilters.includes('postgis')
 			&& dialect === 'postgresql'
 		) {
-			return ['!geography_columns', '!geometry_columns', '!spatial_ref_sys'];
+			tableFilters.push('!geography_columns', '!geometry_columns', '!spatial_ref_sys');
+		}
+
+		if (
+			extensionsFilters.includes('pg_stat_statements')
+			&& dialect === 'postgresql'
+		) {
+			tableFilters.push('!pg_stat_statements', '!pg_stat_statements_info');
 		}
 	}
-	return [];
+	return tableFilters;
 };

--- a/drizzle-kit/src/index.ts
+++ b/drizzle-kit/src/index.ts
@@ -112,7 +112,7 @@ export type Config =
 		out?: string;
 		breakpoints?: boolean;
 		tablesFilter?: string | string[];
-		extensionsFilters?: 'postgis'[];
+		extensionsFilters?: ('postgis' | 'pg_stat_statements')[];
 		schemaFilter?: string | string[];
 		schema?: string | string[];
 		verbose?: boolean;


### PR DESCRIPTION
Simply put, this PR adds the "pg_stat_statements" extension to the list of possible values for "extensionsFilters" when using "postgresql" as the dialect.

The extension is known to add two views to the `public` schema: `pg_stat_statements, pg_stat_statements_info`. So it appends these two tables to `tablesFilter` (with the preceding "!" to exclude them) when this extension is enabled.

```
tablesFilter: ["!pg_stat_statements", "!pg_stat_statements_info"],
```