### PR TITLE
fix: #4494 Postgres join table with more than 100 columns

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -1335,18 +1335,28 @@ export class PgDialect {
 		where = and(joinOn, where);
 
 		if (nestedQueryRelation) {
-			let field = sql`json_build_array(${
-				sql.join(
-					selection.map(({ field, tsKey, isJson }) =>
-						isJson
-							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
-							: is(field, SQL.Aliased)
-							? field.sql
-							: field
-					),
-					sql`, `,
-				)
-			})`;
+			const fieldChunks: SQL[] = [];
+
+			for (let i = 0; i < selection.length; i += 100) {
+				const chunk = selection.slice(i, i + 100);
+				const chunkSql = sql`json_build_array(${
+					sql.join(
+						chunk.map(({ field, tsKey, isJson }) =>
+							isJson
+								? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
+								: is(field, SQL.Aliased)
+								? field.sql
+								: field
+						),
+						sql`, `,
+					)
+				})`;
+				fieldChunks.push(chunkSql);
+			}
+
+			let field = fieldChunks.reduce((acc, chunk, idx) =>
+				idx === 0 ? chunk : sql`${acc}::jsonb || ${chunk}::jsonb`
+			);
 			if (is(nestedQueryRelation, Many)) {
 				field = sql`coalesce(json_agg(${field}${
 					orderBy.length > 0 ? sql` order by ${sql.join(orderBy, sql`, `)}` : undefined


### PR DESCRIPTION
If a relation has more than 100 selected columns, it will split the json_build_array call into chunks of 100, and concatenate them with postgres' json concatenate function `||`
