### PR TITLE
fix(drizzle-seed): change uuid generator

### DIFF
--- a/drizzle-seed/src/services/Generators.ts
+++ b/drizzle-seed/src/services/Generators.ts
@@ -1537,7 +1537,7 @@ export class GenerateUUID extends AbstractGenerator<{
 		const strLength = 36;
 
 		// uuid v4
-		const uuidTemplate = '########-####-4###-####-############';
+		const uuidTemplate = '########-####-4###-N###-############';
 		currStr = '';
 		for (let i = 0; i < strLength; i++) {
 			[idx, this.state.rng] = prand.uniformIntDistribution(
@@ -1548,6 +1548,10 @@ export class GenerateUUID extends AbstractGenerator<{
 
 			if (uuidTemplate[i] === '#') {
 				currStr += stringChars[idx];
+				continue;
+			}
+			if (uuidTemplate[i] === 'N') {
+				currStr += '89ab'[idx % 4];
 				continue;
 			}
 			currStr += uuidTemplate[i];


### PR DESCRIPTION
Add a restriction to the [uuid-v4 format](https://www.rfc-editor.org/rfc/rfc9562.html#uuidv4) to make it adhere to  RFC9562: the [variant field](https://www.rfc-editor.org/rfc/rfc9562.html#variant_field) should be in the `8..b` range.

This RFC spec is used by npm's `uuid` package.

While this change would likely alter UUIDs generated by previous `drizzle-seed` versions, the current implementation would cause issues in applications where the UUID value is validated. 

For example, Payload CMS is validating the id when querying for a document by a UUID key using `findById`, and I ran into an issue when invalid UUIDs were generated by `drizzle-seed`. This also broke the Payload CMS admin panel, as select queries failed to fetch data.
