### PR TITLE
add banned_until to supabase rls.ts

### DIFF
--- a/drizzle-orm/src/supabase/rls.ts
+++ b/drizzle-orm/src/supabase/rls.ts
@@ -19,6 +19,7 @@ export const authUsers = auth.table('users', {
 	phoneConfirmedAt: timestamp('phone_confirmed_at', { withTimezone: true }),
 	lastSignInAt: timestamp('last_sign_in_at', { withTimezone: true }),
 	createdAt: timestamp('created_at', { withTimezone: true }),
+	bannedUntil: timestamp('banned_until', { withTimezone: true }),
 	updatedAt: timestamp('updated_at', { withTimezone: true }),
 });
 


### PR DESCRIPTION
Adds banned_until column from the Supabase auth table.
I manually updated the drizzle-orm/supabase/* files to try it out and it does work if we add the column.
![image](https://github.com/user-attachments/assets/b4a0f812-6156-4882-a9c7-46667a49a025)
