### PR TITLE
add note on negative innerProduct, link to example

### DIFF
--- a/drizzle-orm/src/sql/functions/vector.ts
+++ b/drizzle-orm/src/sql/functions/vector.ts
@@ -69,7 +69,9 @@ export function l1Distance(
 }
 
 /**
- * Used in sorting and in querying, if used in sorting,
+ * Returns the negative inner product since Postgres only supports ASC order
+ * index scans on operators. See: https://neon.tech/docs/extensions/pgvector
+ * Used in sorting and in querying. If used in sorting,
  * this specifies that the given column or expression should be sorted in an order
  * that minimizes the inner product distance to the given value.
  * If used in querying, this specifies that it should return the inner product distance


### PR DESCRIPTION
Couldn't find mention of this in the Drizzle docs for Inner Product (read this: https://orm.drizzle.team/docs/latest-releases/drizzle-orm-v0310#l2-distance-inner-product-and-cosine-distance).

Updated the docstring so info's avail easily. Added a link to another example too

Wasn't sure where to update the docs for Drizzle's site, sorry about that