### PR TITLE
Fix: Tag Invalidation in non auto invalidated case

### DIFF
--- a/drizzle-orm/src/cache/upstash/cache.ts
+++ b/drizzle-orm/src/cache/upstash/cache.ts
@@ -130,13 +130,14 @@ export class UpstashCache extends Cache {
 		isTag: boolean = false,
 		isAutoInvalidate?: boolean,
 	): Promise<any[] | undefined> {
-		if (!isAutoInvalidate) {
-			const result = await this.redis.hget(UpstashCache.nonAutoInvalidateTablePrefix, key);
-			return result === null ? undefined : result as any[];
-		}
 
 		if (isTag) {
 			const result = await this.luaScripts.getByTagScript.exec([UpstashCache.tagsMapKey], [key]);
+			return result === null ? undefined : result as any[];
+		}
+
+		if (!isAutoInvalidate) {
+			const result = await this.redis.hget(UpstashCache.nonAutoInvalidateTablePrefix, key);
 			return result === null ? undefined : result as any[];
 		}
 
@@ -160,6 +161,11 @@ export class UpstashCache extends Cache {
 		const hexOptions = config && config.hexOptions ? config.hexOptions : this.internalConfig?.hexOptions;
 
 		if (!isAutoInvalidate) {
+			if (isTag) {
+				pipeline.hset(UpstashCache.tagsMapKey, { [key]: UpstashCache.nonAutoInvalidateTablePrefix });
+				pipeline.hset(UpstashCache.nonAutoInvalidateTablePrefix, { [key]: response });
+			}
+
 			pipeline.hset(UpstashCache.nonAutoInvalidateTablePrefix, { [key]: response });
 			pipeline.hexpire(UpstashCache.nonAutoInvalidateTablePrefix, key, ttlSeconds, hexOptions);
 			await pipeline.exec();


### PR DESCRIPTION
When you tried to invalidate a tag (which was saved when auto invalidation was disabled) by name, it didn't work.

This is because in invalidation, we try to find the tag in tagsMap. But when auto invalidation was off, we didn't save the tag there. So the SDK didn't know where the tag was.

Now,
- in `put`, we also save the whereabouts of the tag to the tags map.
- in `get`, works the same way as before
- `onMutate` works the same way as before.