### PR TITLE
Fix one-to-one relation for MySQL versions which do not support LIMIT parameter

### DIFF
--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -37,6 +37,8 @@ import type { MySqlSession } from './session.ts';
 import { MySqlTable } from './table.ts';
 import { MySqlViewBase } from './view-base.ts';
 
+const LIMIT_ONE = sql.raw('1') as unknown as Placeholder;
+
 export interface MySqlDialectConfig {
 	casing?: Casing;
 }
@@ -1022,8 +1024,8 @@ export class MySqlDialect {
 					tableConfig: schema[relationTableTsName]!,
 					queryConfig: is(relation, One)
 						? (selectedRelationConfigValue === true
-							? { limit: 1 }
-							: { ...selectedRelationConfigValue, limit: 1 })
+							? { limit: LIMIT_ONE }
+							: { ...selectedRelationConfigValue, limit: LIMIT_ONE })
 						: selectedRelationConfigValue,
 					tableAlias: relationTableAlias,
 					joinOn,


### PR DESCRIPTION
Hello Drizzle team,

This might look like a strange fix to you, so I'm open for a discussion.

We are using Drizzle ORM for Atlassian Forge SQL (https://developer.atlassian.com/platform/forge/storage-reference/sql/) which is based on [TiDB](https://docs.pingcap.com/tidb/stable/) database.

With help of [forge-sql-orm](https://github.com/vzakharchenko/forge-sql-orm) project we managed to make the Drizzle ORM work in our case, though we had to hack and change `mode` of query builders from `default` to `planetscale`.

Now we faced an issue with relations. The thing is that TiDB doesn't support `LIMIT` parameters/substitutions. So basically `LIMIT ?` throws a parse error. Therefore we have to wrap numbers into `sql.raw` when we call `limit/offset` methods in `select` or pass `limit/offset` to query builders.

The issue is that the query builder has `1` hardcoded and we can't modify it from our code.

This fix works for our case, though it's not at all elegant. Maybe a different `mode` will be needed to support Forge SQL.