### PR TITLE
test(select): add suite to cover .single() behavior

### DIFF
--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -757,7 +757,7 @@ export function tests() {
 				.single(); 
 		
 			expect(user).toEqual({
-				name: 'JOHN',
+				name: 'John',
 			});
 		});
 

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -747,6 +747,20 @@ export function tests() {
 			expect(result).toEqual([{ name: 'JOHN' }, { name: 'JANE' }, { name: 'JANE' }]);
 		});
 
+		test('select with .single() returns one row', async (ctx) => {
+			const { db } = ctx.pg;
+			await db.insert(usersTable).values({ name: 'John' });
+			const user = await db
+				.select()
+				.from(usersTable)
+				.where(eq(usersTable.name, 'John'))
+				.single(); 
+		
+			expect(user).toEqual({
+				name: 'JOHN',
+			});
+		});
+
 		test('$default function', async (ctx) => {
 			const { db } = ctx.pg;
 


### PR DESCRIPTION
Add test suite for .single(). Just adds a test covering the expected behavior:

the idea:

- should return the row if exactly one is returned
- should throw if zero results
- should throw if more than one result

didn't implement the method itself, just the test, so maintainers can decide how/if they want to include it

Referencing: 
- [#4363](https://github.com/drizzle-team/drizzle-orm/issues/4363)
- [#1499](https://github.com/drizzle-team/drizzle-orm/discussions/1499)