### PR TITLE
[drizzle-kit]: Fix push deleting then re-adding unchanged unique constraints

### DIFF
--- a/drizzle-kit/src/serializer/gelSchema.ts
+++ b/drizzle-kit/src/serializer/gelSchema.ts
@@ -419,7 +419,7 @@ export const GelSquasher = {
 		return { name: splitted[1], columns: splitted[0].split(',') };
 	},
 	squashUnique: (unq: UniqueConstraint) => {
-		return `${unq.name};${unq.columns.join(',')};${unq.nullsNotDistinct}`;
+		return `${unq.name};${unq.columns.sort().join(',')};${unq.nullsNotDistinct}`;
 	},
 	unsquashUnique: (unq: string): UniqueConstraint => {
 		const [name, columns, nullsNotDistinct] = unq.split(';');

--- a/drizzle-kit/src/serializer/mysqlSchema.ts
+++ b/drizzle-kit/src/serializer/mysqlSchema.ts
@@ -246,7 +246,7 @@ export const MySqlSquasher = {
 		return { name: splitted[0], columns: splitted[1].split(',') };
 	},
 	squashUnique: (unq: UniqueConstraint) => {
-		return `${unq.name};${unq.columns.join(',')}`;
+		return `${unq.name};${unq.columns.sort().join(',')}`;
 	},
 	unsquashUnique: (unq: string): UniqueConstraint => {
 		const [name, columns] = unq.split(';');

--- a/drizzle-kit/src/serializer/pgSchema.ts
+++ b/drizzle-kit/src/serializer/pgSchema.ts
@@ -672,7 +672,7 @@ export const PgSquasher = {
 		return { name: splitted[1], columns: splitted[0].split(',') };
 	},
 	squashUnique: (unq: UniqueConstraint) => {
-		return `${unq.name};${unq.columns.join(',')};${unq.nullsNotDistinct}`;
+		return `${unq.name};${unq.columns.sort().join(',')};${unq.nullsNotDistinct}`;
 	},
 	unsquashUnique: (unq: string): UniqueConstraint => {
 		const [name, columns, nullsNotDistinct] = unq.split(';');

--- a/drizzle-kit/src/serializer/singlestoreSchema.ts
+++ b/drizzle-kit/src/serializer/singlestoreSchema.ts
@@ -161,7 +161,7 @@ export const SingleStoreSquasher = {
 		return { name: splitted[0], columns: splitted[1].split(',') };
 	},
 	squashUnique: (unq: UniqueConstraint) => {
-		return `${unq.name};${unq.columns.join(',')}`;
+		return `${unq.name};${unq.columns.sort().join(',')}`;
 	},
 	unsquashUnique: (unq: string): UniqueConstraint => {
 		const [name, columns] = unq.split(';');

--- a/drizzle-kit/src/serializer/sqliteSchema.ts
+++ b/drizzle-kit/src/serializer/sqliteSchema.ts
@@ -187,7 +187,7 @@ export const SQLiteSquasher = {
 		return result;
 	},
 	squashUnique: (unq: UniqueConstraint) => {
-		return `${unq.name};${unq.columns.join(',')}`;
+		return `${unq.name};${unq.columns.sort().join(',')}`;
 	},
 	unsquashUnique: (unq: string): UniqueConstraint => {
 		const [name, columns] = unq.split(';');


### PR DESCRIPTION
Fix drizzle-kit push deleting then re-adding unchanged unique constraints.

During push, the TS schema and database might have different column orders in unique keys, resulting in `drizzle-kit push` deleting then readding the same unique constraint (and generating a warning that needs to be manually responded to too). This PR adds `sort()` to all `squashUnique()` methods.

This fixes #2888. I know there are a couple of other fixes out there (as part of #3999 and part of #4043), but I believe this to be a much more concise solution.

See my original discussion for a deep-dive of why this is happening https://github.com/drizzle-team/drizzle-orm/issues/2888#issuecomment-2910717759