### PR TITLE
[Pg,Gel,MySql] Add "isUnique" type

### DIFF
--- a/drizzle-orm/src/column-builder.ts
+++ b/drizzle-orm/src/column-builder.ts
@@ -170,10 +170,20 @@ export type IsIdentity<
 > = T & {
 	_: {
 		notNull: true;
+		isUnique: true;
 		hasDefault: true;
 		identity: TType;
 	};
 };
+
+export type IsUnique<
+	T extends ColumnBuilderBase,
+> = T & {
+	_: {
+		isUnique: true;
+	};
+};
+
 export interface ColumnBuilderBase<
 	T extends ColumnBuilderBaseConfig<ColumnDataType, string> = ColumnBuilderBaseConfig<ColumnDataType, string>,
 	TTypeConfig extends object = object,

--- a/drizzle-orm/src/gel-core/columns/common.ts
+++ b/drizzle-orm/src/gel-core/columns/common.ts
@@ -5,6 +5,7 @@ import type {
 	ColumnBuilderRuntimeConfig,
 	ColumnDataType,
 	HasGenerated,
+	IsUnique,
 	MakeColumnConfig,
 } from '~/column-builder.ts';
 import { ColumnBuilder } from '~/column-builder.ts';
@@ -75,11 +76,11 @@ export abstract class GelColumnBuilder<
 	unique(
 		name?: string,
 		config?: { nulls: 'distinct' | 'not distinct' },
-	): this {
+	): IsUnique<this> {
 		this.config.isUnique = true;
 		this.config.uniqueName = name;
 		this.config.uniqueType = config?.nulls;
-		return this;
+		return this as IsUnique<this>;
 	}
 
 	generatedAlwaysAs(as: SQL | T['data'] | (() => SQL)): HasGenerated<this, {

--- a/drizzle-orm/src/mysql-core/columns/common.ts
+++ b/drizzle-orm/src/mysql-core/columns/common.ts
@@ -8,6 +8,7 @@ import type {
 	HasDefault,
 	HasGenerated,
 	IsAutoincrement,
+	IsUnique,
 	MakeColumnConfig,
 } from '~/column-builder.ts';
 import type { ColumnBaseConfig } from '~/column.ts';
@@ -56,10 +57,10 @@ export abstract class MySqlColumnBuilder<
 		return this;
 	}
 
-	unique(name?: string): this {
+	unique(name?: string): IsUnique<this> {
 		this.config.isUnique = true;
 		this.config.uniqueName = name;
-		return this;
+		return this as IsUnique<this>;
 	}
 
 	generatedAlwaysAs(as: SQL | T['data'] | (() => SQL), config?: MySqlGeneratedColumnConfig): HasGenerated<this, {

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -5,6 +5,7 @@ import type {
 	ColumnBuilderRuntimeConfig,
 	ColumnDataType,
 	HasGenerated,
+	IsUnique,
 	MakeColumnConfig,
 } from '~/column-builder.ts';
 import { ColumnBuilder } from '~/column-builder.ts';
@@ -76,11 +77,11 @@ export abstract class PgColumnBuilder<
 	unique(
 		name?: string,
 		config?: { nulls: 'distinct' | 'not distinct' },
-	): this {
+	): IsUnique<this> {
 		this.config.isUnique = true;
 		this.config.uniqueName = name;
 		this.config.uniqueType = config?.nulls;
-		return this;
+		return this as IsUnique<this>;
 	}
 
 	generatedAlwaysAs(as: SQL | T['data'] | (() => SQL)): HasGenerated<this, {

--- a/drizzle-orm/src/sqlite-core/columns/common.ts
+++ b/drizzle-orm/src/sqlite-core/columns/common.ts
@@ -5,6 +5,7 @@ import type {
 	ColumnBuilderRuntimeConfig,
 	ColumnDataType,
 	HasGenerated,
+	IsUnique,
 	MakeColumnConfig,
 } from '~/column-builder.ts';
 import { ColumnBuilder } from '~/column-builder.ts';
@@ -57,10 +58,10 @@ export abstract class SQLiteColumnBuilder<
 
 	unique(
 		name?: string,
-	): this {
+	): IsUnique<this> {
 		this.config.isUnique = true;
 		this.config.uniqueName = name;
-		return this;
+		return this as IsUnique<this>;
 	}
 
 	generatedAlwaysAs(as: SQL | T['data'] | (() => SQL), config?: SQLiteGeneratedColumnConfig): HasGenerated<this, {

--- a/drizzle-orm/type-tests/geldb/tables.ts
+++ b/drizzle-orm/type-tests/geldb/tables.ts
@@ -670,12 +670,14 @@ export const citiesCustom = customSchema.table('cities_table', {
 	const cities1 = gelTable('cities_table', {
 		id: integer('id').primaryKey(),
 		name: text('name').notNull().primaryKey(),
+		postalCode: text('postal_code').notNull().unique(),
 		role: text('role').$type<'admin' | 'user'>().default('user').notNull(),
 		population: integer('population').default(0),
 	});
 	const cities2 = gelTable('cities_table', ({ text, integer }) => ({
 		id: integer('id').primaryKey(),
 		name: text('name').notNull().primaryKey(),
+		postalCode: text('postal_code').notNull().unique(),
 		role: text('role').$type<'admin' | 'user'>().default('user').notNull(),
 		population: integer('population').default(0),
 	}));
@@ -719,6 +721,27 @@ export const citiesCustom = customSchema.table('cities_table', {
 				isAutoincrement: false;
 				hasRuntimeDefault: false;
 			}>;
+			postalCode: GelColumn<
+				{
+					tableName: 'cities_table';
+					name: 'postal_code';
+					dataType: 'string';
+					columnType: 'GelText';
+					data: string;
+					driverParam: string;
+					notNull: true;
+					hasDefault: false;
+					isPrimaryKey: false;
+					isAutoincrement: false;
+					hasRuntimeDefault: false;
+					enumValues: undefined;
+					baseColumn: never;
+					identity: undefined;
+					generated: undefined;
+				},
+				{},
+				{ isUnique: true }
+			>;
 			role: GelColumn<
 				{
 					tableName: 'cities_table';

--- a/drizzle-orm/type-tests/mysql/tables.ts
+++ b/drizzle-orm/type-tests/mysql/tables.ts
@@ -84,6 +84,7 @@ export const users = mysqlTable(
 export const cities = mysqlTable('cities_table', {
 	id: serial('id').primaryKey(),
 	name: text('name_db').notNull(),
+	postalCode: text('postal_code').notNull().unique(),
 	population: int('population').default(0),
 }, (cities) => ({
 	citiesNameIdx: index('citiesNameIdx').on(cities.id),
@@ -134,6 +135,29 @@ Expect<
 				{},
 				{}
 			>;
+			postalCode: MySqlColumn<
+				{
+					name: 'postal_code';
+					tableName: 'cities_table';
+					dataType: 'string';
+					columnType: 'MySqlText';
+					data: string;
+					driverParam: string;
+					notNull: true;
+					hasDefault: false;
+					isPrimaryKey: false;
+					isAutoincrement: false;
+					hasRuntimeDefault: false;
+					enumValues: [string, ...string[]];
+					baseColumn: never;
+					identity: undefined;
+					generated: undefined;
+				},
+				{},
+				{
+					isUnique: true;
+				}
+			>;
 			population: MySqlColumn<
 				{
 					name: 'population';
@@ -164,6 +188,7 @@ Expect<
 	Equal<{
 		id: number;
 		name_db: string;
+		postal_code: string;
 		population: number | null;
 	}, InferSelectModel<typeof cities, { dbColumnNames: true }>>
 >;
@@ -172,6 +197,7 @@ Expect<
 	Equal<{
 		id?: number;
 		name: string;
+		postalCode: string;
 		population?: number | null;
 	}, typeof cities.$inferInsert>
 >;
@@ -181,6 +207,7 @@ export const customSchema = mysqlSchema('custom_schema');
 export const citiesCustom = customSchema.table('cities_table', {
 	id: serial('id').primaryKey(),
 	name: text('name_db').notNull(),
+	postalCode: text('postal_code').notNull().unique(),
 	population: int('population').default(0),
 }, (cities) => ({
 	citiesNameIdx: index('citiesNameIdx').on(cities.id),

--- a/drizzle-orm/type-tests/pg/tables.ts
+++ b/drizzle-orm/type-tests/pg/tables.ts
@@ -130,10 +130,123 @@ Expect<Equal<InferInsertModel<typeof users>, typeof users['_']['inferInsert']>>;
 export const cities = pgTable('cities_table', {
 	id: serial('id').primaryKey(),
 	name: text('name').notNull(),
+	postalCode: text('postal_code').notNull().unique(),
 	population: integer('population').default(0),
 }, (cities) => ({
 	citiesNameIdx: index().on(cities.id),
 }));
+
+Expect<
+	Equal<
+		{
+			id: PgColumn<
+				{
+					name: 'id';
+					tableName: 'cities_table';
+					dataType: 'number';
+					columnType: 'PgSerial';
+					data: number;
+					driverParam: number;
+					notNull: true;
+					hasDefault: true;
+					isPrimaryKey: true;
+					isAutoincrement: false;
+					hasRuntimeDefault: false;
+					enumValues: undefined;
+					baseColumn: never;
+					identity: undefined;
+					generated: undefined;
+				},
+				{},
+				{}
+			>;
+			name: PgColumn<
+				{
+					name: 'name';
+					tableName: 'cities_table';
+					dataType: 'string';
+					columnType: 'PgText';
+					data: string;
+					driverParam: string;
+					notNull: true;
+					hasDefault: false;
+					isPrimaryKey: false;
+					isAutoincrement: false;
+					hasRuntimeDefault: false;
+					enumValues: [string, ...string[]];
+					baseColumn: never;
+					identity: undefined;
+					generated: undefined;
+				},
+				{},
+				{}
+			>;
+			postalCode: PgColumn<
+				{
+					name: 'postal_code';
+					tableName: 'cities_table';
+					dataType: 'string';
+					columnType: 'PgText';
+					data: string;
+					driverParam: string;
+					notNull: true;
+					hasDefault: false;
+					isPrimaryKey: false;
+					isAutoincrement: false;
+					hasRuntimeDefault: false;
+					enumValues: [string, ...string[]];
+					baseColumn: never;
+					identity: undefined;
+					generated: undefined;
+				},
+				{},
+				{
+					isUnique: true;
+				}
+			>;
+			population: PgColumn<
+				{
+					name: 'population';
+					tableName: 'cities_table';
+					dataType: 'number';
+					columnType: 'PgInteger';
+					data: number;
+					driverParam: string | number;
+					notNull: false;
+					hasDefault: true;
+					isPrimaryKey: false;
+					isAutoincrement: false;
+					hasRuntimeDefault: false;
+					enumValues: undefined;
+					baseColumn: never;
+					identity: undefined;
+					generated: undefined;
+				},
+				{},
+				{}
+			>;
+		},
+		typeof cities._.columns
+	>
+>;
+
+Expect<
+	Equal<{
+		id: number;
+		name: string;
+		postal_code: string;
+		population: number | null;
+	}, InferSelectModel<typeof cities, { dbColumnNames: true }>>
+>;
+
+Expect<
+	Equal<{
+		id?: number;
+		name: string;
+		postalCode: string;
+		population?: number | null;
+	}, typeof cities.$inferInsert>
+>;
 
 export const smallSerialTest = pgTable('cities_table', {
 	id: smallserial('id').primaryKey(),


### PR DESCRIPTION
# Why I Opened This Pull Request

I'm currently working on a type-safe library that relies on drizzle-orm. As part of this, I wanted to create a type that picks all keys from tables that are both NOT NULL and UNIQUE. However, the current ColumnBuilder does not expose an isUnique type, which makes this difficult.

# What I Did
- [x] Introduced an `isUnique` type and added it to the `unique()` method of `PgColumnBuilder`, `MySqlColumnBuilder`, and `SQLiteColumnBuilder`
- [x] Updated the `primaryKey()` method to be compatible with the new `isUnique` type
- [x] Added additional tests to verify the typing behavior of `unique()`

# Checklist
- [x] Followed [CONTRIBUTING.md](https://github.com/drizzle-team/drizzle-orm/blob/main/CONTRIBUTING.md#contribution-guidelines)

# Notes
I'm not sure which code formatter the project uses—feel free to reformat this PR as needed.