### PR TITLE
fix(drizzle-zod): correct mapping of number type when coercing

### DIFF
--- a/drizzle-zod/src/column.ts
+++ b/drizzle-zod/src/column.ts
@@ -241,10 +241,11 @@ function numberColumnToSchema(
 	}
 
 	let schema = coerce === true || coerce?.number
-		? integer ? z.coerce.number() : z.coerce.number().int()
+		? integer ? z.coerce.number().int() : z.coerce.number()
 		: integer
 		? z.int()
 		: z.number();
+
 	schema = schema.gte(min).lte(max);
 	return schema;
 }


### PR DESCRIPTION
Closes #4572 