### PR TITLE
[SQLite] Add support for transaction behavior in LibSQL

### DIFF
--- a/drizzle-orm/src/better-sqlite3/session.ts
+++ b/drizzle-orm/src/better-sqlite3/session.ts
@@ -28,7 +28,7 @@ type PreparedQueryConfig = Omit<PreparedQueryConfigBase, 'statement' | 'run'>;
 export class BetterSQLiteSession<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteSession<'sync', RunResult, TFullSchema, TSchema> {
+> extends SQLiteSession<'sync', RunResult, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'BetterSQLiteSession';
 
 	private logger: Logger;
@@ -85,7 +85,7 @@ export class BetterSQLiteSession<
 export class BetterSQLiteTransaction<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'sync', RunResult, TFullSchema, TSchema> {
+> extends SQLiteTransaction<'sync', RunResult, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'BetterSQLiteTransaction';
 
 	override transaction<T>(transaction: (tx: BetterSQLiteTransaction<TFullSchema, TSchema>) => T): T {

--- a/drizzle-orm/src/bun-sqlite/session.ts
+++ b/drizzle-orm/src/bun-sqlite/session.ts
@@ -27,7 +27,7 @@ type Statement = BunStatement<any>;
 export class SQLiteBunSession<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteSession<'sync', void, TFullSchema, TSchema> {
+> extends SQLiteSession<'sync', void, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'SQLiteBunSession';
 
 	private logger: Logger;
@@ -82,7 +82,7 @@ export class SQLiteBunSession<
 export class SQLiteBunTransaction<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'sync', void, TFullSchema, TSchema> {
+> extends SQLiteTransaction<'sync', void, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'SQLiteBunTransaction';
 
 	override transaction<T>(transaction: (tx: SQLiteBunTransaction<TFullSchema, TSchema>) => T): T {

--- a/drizzle-orm/src/d1/session.ts
+++ b/drizzle-orm/src/d1/session.ts
@@ -30,7 +30,7 @@ type PreparedQueryConfig = Omit<PreparedQueryConfigBase, 'statement' | 'run'>;
 export class SQLiteD1Session<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteSession<'async', D1Result, TFullSchema, TSchema> {
+> extends SQLiteSession<'async', D1Result, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'SQLiteD1Session';
 
 	private logger: Logger;
@@ -128,7 +128,7 @@ export class SQLiteD1Session<
 export class D1Transaction<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'async', D1Result, TFullSchema, TSchema> {
+> extends SQLiteTransaction<'async', D1Result, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'D1Transaction';
 
 	override async transaction<T>(transaction: (tx: D1Transaction<TFullSchema, TSchema>) => Promise<T>): Promise<T> {

--- a/drizzle-orm/src/durable-sqlite/session.ts
+++ b/drizzle-orm/src/durable-sqlite/session.ts
@@ -25,7 +25,8 @@ export class SQLiteDOSession<TFullSchema extends Record<string, unknown>, TSchem
 		'sync',
 		SqlStorageCursor<Record<string, SqlStorageValue>>,
 		TFullSchema,
-		TSchema
+		TSchema,
+		SQLiteTransactionConfig
 	>
 {
 	static override readonly [entityKind]: string = 'SQLiteDOSession';
@@ -62,7 +63,7 @@ export class SQLiteDOSession<TFullSchema extends Record<string, unknown>, TSchem
 
 	override transaction<T>(
 		transaction: (
-			tx: SQLiteTransaction<'sync', SqlStorageCursor<Record<string, SqlStorageValue>>, TFullSchema, TSchema>,
+			tx: SQLiteTransaction<'sync', SqlStorageCursor<Record<string, SqlStorageValue>>, TFullSchema, TSchema, SQLiteTransactionConfig>,
 		) => T,
 		_config?: SQLiteTransactionConfig,
 	): T {
@@ -79,7 +80,8 @@ export class SQLiteDOTransaction<TFullSchema extends Record<string, unknown>, TS
 		'sync',
 		SqlStorageCursor<Record<string, SqlStorageValue>>,
 		TFullSchema,
-		TSchema
+		TSchema,
+		SQLiteTransactionConfig
 	>
 {
 	static override readonly [entityKind]: string = 'SQLiteDOTransaction';

--- a/drizzle-orm/src/expo-sqlite/session.ts
+++ b/drizzle-orm/src/expo-sqlite/session.ts
@@ -25,7 +25,7 @@ type PreparedQueryConfig = Omit<PreparedQueryConfigBase, 'statement' | 'run'>;
 export class ExpoSQLiteSession<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteSession<'sync', SQLiteRunResult, TFullSchema, TSchema> {
+> extends SQLiteSession<'sync', SQLiteRunResult, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'ExpoSQLiteSession';
 
 	private logger: Logger;
@@ -79,7 +79,7 @@ export class ExpoSQLiteSession<
 export class ExpoSQLiteTransaction<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'sync', SQLiteRunResult, TFullSchema, TSchema> {
+> extends SQLiteTransaction<'sync', SQLiteRunResult, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'ExpoSQLiteTransaction';
 
 	override transaction<T>(transaction: (tx: ExpoSQLiteTransaction<TFullSchema, TSchema>) => T): T {

--- a/drizzle-orm/src/libsql/driver-core.ts
+++ b/drizzle-orm/src/libsql/driver-core.ts
@@ -12,11 +12,17 @@ import {
 import { BaseSQLiteDatabase } from '~/sqlite-core/db.ts';
 import { SQLiteAsyncDialect } from '~/sqlite-core/dialect.ts';
 import type { DrizzleConfig } from '~/utils.ts';
-import { LibSQLSession } from './session.ts';
+import { LibSQLSession, LibSQLTransactionConfig } from './session.ts';
 
 export class LibSQLDatabase<
 	TSchema extends Record<string, unknown> = Record<string, never>,
-> extends BaseSQLiteDatabase<'async', ResultSet, TSchema> {
+> extends BaseSQLiteDatabase<
+	'async',
+	ResultSet,
+	TSchema,
+	ExtractTablesWithRelations<TSchema>,
+	LibSQLTransactionConfig
+> {
 	static override readonly [entityKind]: string = 'LibSQLDatabase';
 
 	/** @internal */

--- a/drizzle-orm/src/op-sqlite/session.ts
+++ b/drizzle-orm/src/op-sqlite/session.ts
@@ -28,7 +28,7 @@ type PreparedQueryConfig = Omit<PreparedQueryConfigBase, 'statement' | 'run'>;
 export class OPSQLiteSession<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteSession<'async', QueryResult, TFullSchema, TSchema> {
+> extends SQLiteSession<'async', QueryResult, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'OPSQLiteSession';
 
 	private logger: Logger;
@@ -91,7 +91,7 @@ export class OPSQLiteSession<
 export class OPSQLiteTransaction<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'async', QueryResult, TFullSchema, TSchema> {
+> extends SQLiteTransaction<'async', QueryResult, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'OPSQLiteTransaction';
 
 	override transaction<T>(transaction: (tx: OPSQLiteTransaction<TFullSchema, TSchema>) => T): T {

--- a/drizzle-orm/src/prisma/sqlite/session.ts
+++ b/drizzle-orm/src/prisma/sqlite/session.ts
@@ -59,7 +59,7 @@ export interface PrismaSQLiteSessionOptions {
 	logger?: Logger;
 }
 
-export class PrismaSQLiteSession extends SQLiteSession<'async', unknown, Record<string, never>, Record<string, never>> {
+export class PrismaSQLiteSession extends SQLiteSession<'async', unknown, Record<string, never>, Record<string, never>, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'PrismaSQLiteSession';
 
 	private readonly logger: Logger;
@@ -82,7 +82,7 @@ export class PrismaSQLiteSession extends SQLiteSession<'async', unknown, Record<
 	}
 
 	override transaction<T>(
-		_transaction: (tx: SQLiteTransaction<'async', unknown, Record<string, never>, Record<string, never>>) => Promise<T>,
+		_transaction: (tx: SQLiteTransaction<'async', unknown, Record<string, never>, Record<string, never>, SQLiteTransactionConfig>) => Promise<T>,
 		_config?: SQLiteTransactionConfig,
 	): Promise<T> {
 		throw new Error('Method not implemented.');

--- a/drizzle-orm/src/sql-js/session.ts
+++ b/drizzle-orm/src/sql-js/session.ts
@@ -24,7 +24,7 @@ type PreparedQueryConfig = Omit<PreparedQueryConfigBase, 'statement' | 'run'>;
 export class SQLJsSession<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteSession<'sync', void, TFullSchema, TSchema> {
+> extends SQLiteSession<'sync', void, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'SQLJsSession';
 
 	private logger: Logger;
@@ -68,7 +68,7 @@ export class SQLJsSession<
 export class SQLJsTransaction<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'sync', void, TFullSchema, TSchema> {
+> extends SQLiteTransaction<'sync', void, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'SQLJsTransaction';
 
 	override transaction<T>(transaction: (tx: SQLJsTransaction<TFullSchema, TSchema>) => T): T {

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -817,7 +817,7 @@ export class SQLiteSyncDialect extends SQLiteDialect {
 
 	migrate(
 		migrations: MigrationMeta[],
-		session: SQLiteSession<'sync', unknown, Record<string, unknown>, TablesRelationalConfig>,
+		session: SQLiteSession<'sync', unknown, Record<string, unknown>, TablesRelationalConfig, any>,
 		config?: string | MigrationConfig,
 	): void {
 		const migrationsTable = config === undefined
@@ -869,7 +869,7 @@ export class SQLiteAsyncDialect extends SQLiteDialect {
 
 	async migrate(
 		migrations: MigrationMeta[],
-		session: SQLiteSession<'async', any, any, any>,
+		session: SQLiteSession<'async', any, any, any, any>,
 		config?: string | MigrationConfig,
 	): Promise<void> {
 		const migrationsTable = config === undefined

--- a/drizzle-orm/src/sqlite-core/query-builders/count.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/count.ts
@@ -5,7 +5,7 @@ import type { SQLiteTable } from '../table.ts';
 import type { SQLiteView } from '../view.ts';
 
 export class SQLiteCountBuilder<
-	TSession extends SQLiteSession<any, any, any, any>,
+	TSession extends SQLiteSession<any, any, any, any, any>,
 > extends SQL<number> implements Promise<number>, SQLWrapper {
 	private sql: SQL<number>;
 

--- a/drizzle-orm/src/sqlite-core/query-builders/delete.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/delete.ts
@@ -148,7 +148,7 @@ export class SQLiteDeleteBase<
 
 	constructor(
 		private table: TTable,
-		private session: SQLiteSession<any, any, any, any>,
+		private session: SQLiteSession<any, any, any, any, any>,
 		private dialect: SQLiteDialect,
 		withList?: Subquery[],
 	) {

--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -46,7 +46,7 @@ export class SQLiteInsertBuilder<
 
 	constructor(
 		protected table: TTable,
-		protected session: SQLiteSession<any, any, any, any>,
+		protected session: SQLiteSession<any, any, any, any, any>,
 		protected dialect: SQLiteDialect,
 		private withList?: Subquery[],
 	) {}
@@ -241,7 +241,7 @@ export class SQLiteInsertBase<
 	constructor(
 		table: TTable,
 		values: SQLiteInsertConfig['values'],
-		private session: SQLiteSession<any, any, any, any>,
+		private session: SQLiteSession<any, any, any, any, any>,
 		private dialect: SQLiteDialect,
 		withList?: Subquery[],
 		select?: boolean,

--- a/drizzle-orm/src/sqlite-core/query-builders/query.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/query.ts
@@ -12,7 +12,7 @@ import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, QueryWithTypings, SQL, SQLWrapper } from '~/sql/sql.ts';
 import type { KnownKeysOnly } from '~/utils.ts';
 import type { SQLiteDialect } from '../dialect.ts';
-import type { PreparedQueryConfig, SQLitePreparedQuery, SQLiteSession } from '../session.ts';
+import type { AbstractSQLiteTransactionConfig, PreparedQueryConfig, SQLitePreparedQuery, SQLiteSession } from '../session.ts';
 import type { SQLiteTable } from '../table.ts';
 
 export type SQLiteRelationalQueryKind<TMode extends 'sync' | 'async', TResult> = TMode extends 'async'
@@ -24,6 +24,7 @@ export class RelationalQueryBuilder<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
 	TFields extends TableRelationalConfig,
+	TTransactionConfig extends AbstractSQLiteTransactionConfig<string>,
 > {
 	static readonly [entityKind]: string = 'SQLiteAsyncRelationalQueryBuilder';
 
@@ -35,7 +36,7 @@ export class RelationalQueryBuilder<
 		protected table: SQLiteTable,
 		protected tableConfig: TableRelationalConfig,
 		protected dialect: SQLiteDialect,
-		protected session: SQLiteSession<'async', unknown, TFullSchema, TSchema>,
+		protected session: SQLiteSession<'async', unknown, TFullSchema, TSchema, TTransactionConfig>,
 	) {}
 
 	findMany<TConfig extends DBQueryConfig<'many', true, TSchema, TFields>>(
@@ -117,7 +118,7 @@ export class SQLiteRelationalQuery<TType extends 'sync' | 'async', TResult> exte
 		public table: SQLiteTable,
 		private tableConfig: TableRelationalConfig,
 		private dialect: SQLiteDialect,
-		private session: SQLiteSession<'sync' | 'async', unknown, Record<string, unknown>, TablesRelationalConfig>,
+		private session: SQLiteSession<'sync' | 'async', unknown, Record<string, unknown>, TablesRelationalConfig, any>,
 		private config: DBQueryConfig<'many', true> | true,
 		mode: 'many' | 'first',
 	) {

--- a/drizzle-orm/src/sqlite-core/query-builders/select.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/select.ts
@@ -62,7 +62,7 @@ export class SQLiteSelectBuilder<
 	static readonly [entityKind]: string = 'SQLiteSelectBuilder';
 
 	private fields: TSelection;
-	private session: SQLiteSession<any, any, any, any> | undefined;
+	private session: SQLiteSession<any, any, any, any, any> | undefined;
 	private dialect: SQLiteDialect;
 	private withList: Subquery[] | undefined;
 	private distinct: boolean | undefined;
@@ -70,7 +70,7 @@ export class SQLiteSelectBuilder<
 	constructor(
 		config: {
 			fields: TSelection;
-			session: SQLiteSession<any, any, any, any> | undefined;
+			session: SQLiteSession<any, any, any, any, any> | undefined;
 			dialect: SQLiteDialect;
 			withList?: Subquery[];
 			distinct?: boolean;
@@ -162,7 +162,7 @@ export abstract class SQLiteSelectQueryBuilderBase<
 	protected joinsNotNullableMap: Record<string, boolean>;
 	private tableName: string | undefined;
 	private isPartialSelect: boolean;
-	protected session: SQLiteSession<any, any, any, any> | undefined;
+	protected session: SQLiteSession<any, any, any, any, any> | undefined;
 	protected dialect: SQLiteDialect;
 	protected cacheConfig?: WithCacheConfig = undefined;
 	protected usedTables: Set<string> = new Set();
@@ -172,7 +172,7 @@ export abstract class SQLiteSelectQueryBuilderBase<
 			table: SQLiteSelectConfig['table'];
 			fields: SQLiteSelectConfig['fields'];
 			isPartialSelect: boolean;
-			session: SQLiteSession<any, any, any, any> | undefined;
+			session: SQLiteSession<any, any, any, any, any> | undefined;
 			dialect: SQLiteDialect;
 			withList: Subquery[] | undefined;
 			distinct: boolean | undefined;

--- a/drizzle-orm/src/sqlite-core/query-builders/update.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/update.ts
@@ -59,7 +59,7 @@ export class SQLiteUpdateBuilder<
 
 	constructor(
 		protected table: TTable,
-		protected session: SQLiteSession<any, any, any, any>,
+		protected session: SQLiteSession<any, any, any, any, any>,
 		protected dialect: SQLiteDialect,
 		private withList?: Subquery[],
 	) {}
@@ -244,7 +244,7 @@ export class SQLiteUpdateBase<
 	constructor(
 		table: TTable,
 		set: UpdateSet,
-		private session: SQLiteSession<any, any, any, any>,
+		private session: SQLiteSession<any, any, any, any, any>,
 		private dialect: SQLiteDialect,
 		withList?: Subquery[],
 	) {

--- a/drizzle-orm/src/sqlite-proxy/session.ts
+++ b/drizzle-orm/src/sqlite-proxy/session.ts
@@ -29,7 +29,7 @@ export type PreparedQueryConfig = Omit<PreparedQueryConfigBase, 'statement' | 'r
 export class SQLiteRemoteSession<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteSession<'async', SqliteRemoteResult, TFullSchema, TSchema> {
+> extends SQLiteSession<'async', SqliteRemoteResult, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'SQLiteRemoteSession';
 
 	private logger: Logger;
@@ -120,7 +120,7 @@ export class SQLiteRemoteSession<
 export class SQLiteProxyTransaction<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'async', SqliteRemoteResult, TFullSchema, TSchema> {
+> extends SQLiteTransaction<'async', SqliteRemoteResult, TFullSchema, TSchema, SQLiteTransactionConfig> {
 	static override readonly [entityKind]: string = 'SQLiteProxyTransaction';
 
 	override async transaction<T>(


### PR DESCRIPTION
This PR adds support for handling specified transaction behavior in the LibSQL database Session. As the [documentation of transaction mode in LibSQL](https://tursodatabase.github.io/libsql-client-ts/types/TransactionMode.html) states, it is not compatible with any other implementation of SQLite, namely:
- "immediate" mode is named as "write",
- "exclusive" mode is not supported,
- "read" mode is introduced, which is a LibSQL extension.

To achieve full type-safety of the `config` parameter passed to `transaction` function, this parameter must be typed in generic way. For that purpose, additional types were introduced and existing modified:
- `AbstractSQLiteTransactionConfig<T>` (sqlite-core), which provides base type for `config` parameter, that has `behavior` field typed as `T`,
- `SQLiteTransactionConfig` now implements interface `AbstractSQLiteTransactionConfig`, typed as `T = 'deferred' | 'immediate' | 'exclusive'`,
- `LibSQLTransactionConfig` provides typings for LibSQL-specific transaction modes.

Types related to Transactions, Session and Database were also modified, as I couldn't find a way to provide a default type for the introduced parameter `TTransactionConfig`, without making the type-checker angry. It is important to note, that outside of `"drizzle-orm/src/libsql/session.ts"` which is only file that contains runtime changes, all changes in other files are made to satisfy new type constraints.

Additionally, the `batch` function now also supports an optional transaction config, to align functionality with the LibSQL client.

This PR relates to feature request - it closes #1331.