### PR TITLE
fix(bun-sqlite): add lastInsertRowid support to match Bun SQLite API

### DIFF
--- a/drizzle-orm/src/bun-sqlite/driver.ts
+++ b/drizzle-orm/src/bun-sqlite/driver.ts
@@ -12,11 +12,11 @@ import {
 import { BaseSQLiteDatabase } from '~/sqlite-core/db.ts';
 import { SQLiteSyncDialect } from '~/sqlite-core/dialect.ts';
 import { type DrizzleConfig, isConfig } from '~/utils.ts';
-import { SQLiteBunSession } from './session.ts';
+import { type BunSQLiteRunResult, SQLiteBunSession } from './session.ts';
 
 export class BunSQLiteDatabase<
 	TSchema extends Record<string, unknown> = Record<string, never>,
-> extends BaseSQLiteDatabase<'sync', void, TSchema> {
+> extends BaseSQLiteDatabase<'sync', BunSQLiteRunResult, TSchema> {
 	static override readonly [entityKind]: string = 'BunSQLiteDatabase';
 }
 

--- a/drizzle-orm/src/bun-sqlite/session.ts
+++ b/drizzle-orm/src/bun-sqlite/session.ts
@@ -1,6 +1,8 @@
 /// <reference types="bun-types" />
 
 import type { Database, Statement as BunStatement } from 'bun:sqlite';
+
+export type BunSQLiteRunResult = ReturnType<BunStatement<any>['run']>;
 import { entityKind } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { NoopLogger } from '~/logger.ts';
@@ -27,7 +29,7 @@ type Statement = BunStatement<any>;
 export class SQLiteBunSession<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteSession<'sync', void, TFullSchema, TSchema> {
+> extends SQLiteSession<'sync', BunSQLiteRunResult, TFullSchema, TSchema> {
 	static override readonly [entityKind]: string = 'SQLiteBunSession';
 
 	private logger: Logger;
@@ -82,7 +84,7 @@ export class SQLiteBunSession<
 export class SQLiteBunTransaction<
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'sync', void, TFullSchema, TSchema> {
+> extends SQLiteTransaction<'sync', BunSQLiteRunResult, TFullSchema, TSchema> {
 	static override readonly [entityKind]: string = 'SQLiteBunTransaction';
 
 	override transaction<T>(transaction: (tx: SQLiteBunTransaction<TFullSchema, TSchema>) => T): T {
@@ -101,7 +103,7 @@ export class SQLiteBunTransaction<
 }
 
 export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends PreparedQueryBase<
-	{ type: 'sync'; run: void; all: T['all']; get: T['get']; values: T['values']; execute: T['execute'] }
+	{ type: 'sync'; run: BunSQLiteRunResult; all: T['all']; get: T['get']; values: T['values']; execute: T['execute'] }
 > {
 	static override readonly [entityKind]: string = 'SQLiteBunPreparedQuery';
 
@@ -117,7 +119,7 @@ export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> 
 		super('sync', executeMethod, query);
 	}
 
-	run(placeholderValues?: Record<string, unknown>) {
+	run(placeholderValues?: Record<string, unknown>): BunSQLiteRunResult {
 		const params = fillPlaceholders(this.query.params, placeholderValues ?? {});
 		this.logger.logQuery(this.query.sql, params);
 		return this.stmt.run(...params);

--- a/integration-tests/tests/bun/sqlite.test.ts
+++ b/integration-tests/tests/bun/sqlite.test.ts
@@ -70,6 +70,14 @@ test('select bigint', () => {
 	expect(result).toEqual({ bigInt: BigInt(100) });
 });
 
+test('lastInsertRowid access', () => {
+	const insertResult = db.insert(usersTable).values({ name: 'Alice' }).run();
+	
+	expect(insertResult.lastInsertRowid).toBeDefined();
+	expect(typeof insertResult.lastInsertRowid).toBe('number');
+	expect(insertResult.changes).toBe(1);
+});
+
 // test.serial('select partial', (t) => {
 // 	const { db } = t.context;
 


### PR DESCRIPTION
I migrated from LibSQL to Bun SQLite and was worried that my lastInsertId is missing, but it was just wrongly typed. `console.log` shows the last insert id