### PR TITLE
fix(drizzle-valibot): add generated column type to be included in select schema

### DIFF
--- a/drizzle-valibot/src/schema.types.internal.ts
+++ b/drizzle-valibot/src/schema.types.internal.ts
@@ -14,37 +14,37 @@ type BuildRefineField<T> = T extends v.GenericSchema ? ((schema: T) => v.Generic
 export type BuildRefine<
 	TColumns extends Record<string, any>,
 > = {
-	[K in keyof TColumns as TColumns[K] extends Column | SelectedFieldsFlat<Column> | Table | View ? K : never]?:
+		[K in keyof TColumns as TColumns[K] extends Column | SelectedFieldsFlat<Column> | Table | View ? K : never]?:
 		TColumns[K] extends Column ? BuildRefineField<
-				GetValibotType<
-					TColumns[K]['_']['data'],
-					TColumns[K]['_']['dataType'],
-					TColumns[K]['_']['columnType'],
-					TColumns[K]['_']['enumValues'],
-					HasBaseColumn<TColumns[K]> extends true ? Assume<TColumns[K]['_']['baseColumn'], Column> : undefined,
-					ExtractAdditionalProperties<TColumns[K]>
-				>
+			GetValibotType<
+				TColumns[K]['_']['data'],
+				TColumns[K]['_']['dataType'],
+				TColumns[K]['_']['columnType'],
+				TColumns[K]['_']['enumValues'],
+				HasBaseColumn<TColumns[K]> extends true ? Assume<TColumns[K]['_']['baseColumn'], Column> : undefined,
+				ExtractAdditionalProperties<TColumns[K]>
 			>
-			: BuildRefine<GetSelection<TColumns[K]>>;
-};
+		>
+		: BuildRefine<GetSelection<TColumns[K]>>;
+	};
 
 type HandleRefinement<
 	TType extends 'select' | 'insert' | 'update',
 	TRefinement,
 	TColumn extends Column,
 > = TRefinement extends (schema: any) => v.GenericSchema ? (
-		TColumn['_']['notNull'] extends true ? ReturnType<TRefinement>
-			: v.NullableSchema<ReturnType<TRefinement>, undefined>
-	) extends infer TSchema ? TType extends 'update' ? v.OptionalSchema<Assume<TSchema, v.GenericSchema>, undefined>
-		: TSchema
-	: v.AnySchema
+	TColumn['_']['notNull'] extends true ? ReturnType<TRefinement>
+	: v.NullableSchema<ReturnType<TRefinement>, undefined>
+) extends infer TSchema ? TType extends 'update' ? v.OptionalSchema<Assume<TSchema, v.GenericSchema>, undefined>
+: TSchema
+: v.AnySchema
 	: TRefinement;
 
 type IsRefinementDefined<
 	TRefinements extends Record<string | symbol | number, any> | undefined,
 	TKey extends string | symbol | number,
 > = TRefinements extends object ? TRefinements[TKey] extends v.GenericSchema | ((schema: any) => any) ? true
-	: false
+: false
 	: false;
 
 export type BuildSchema<
@@ -54,17 +54,20 @@ export type BuildSchema<
 > = v.ObjectSchema<
 	Simplify<
 		{
-			readonly [K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? never : K]:
-				TColumns[K] extends infer TColumn extends Column
-					? IsRefinementDefined<TRefinements, Assume<K, string>> extends true
-						? Assume<HandleRefinement<TType, TRefinements[K & keyof TRefinements], TColumn>, v.GenericSchema>
-					: HandleColumn<TType, TColumn>
-					: TColumns[K] extends infer TObject extends SelectedFieldsFlat<Column> | Table | View ? BuildSchema<
-							TType,
-							GetSelection<TObject>,
-							TRefinements extends object ? TRefinements[K & keyof TRefinements] : undefined
-						>
-					: v.AnySchema;
+			readonly [K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true
+			? TType extends 'select' ? K : never
+			: K]
+			:
+			TColumns[K] extends infer TColumn extends Column
+			? IsRefinementDefined<TRefinements, Assume<K, string>> extends true
+			? Assume<HandleRefinement<TType, TRefinements[K & keyof TRefinements], TColumn>, v.GenericSchema>
+			: HandleColumn<TType, TColumn>
+			: TColumns[K] extends infer TObject extends SelectedFieldsFlat<Column> | Table | View ? BuildSchema<
+				TType,
+				GetSelection<TObject>,
+				TRefinements extends object ? TRefinements[K & keyof TRefinements] : undefined
+			>
+			: v.AnySchema;
 		}
 	>,
 	undefined
@@ -74,8 +77,8 @@ export type NoUnknownKeys<
 	TRefinement extends Record<string, any>,
 	TCompare extends Record<string, any>,
 > = {
-	[K in keyof TRefinement]: K extends keyof TCompare
+		[K in keyof TRefinement]: K extends keyof TCompare
 		? TRefinement[K] extends Record<string, v.GenericSchema> ? NoUnknownKeys<TRefinement[K], TCompare[K]>
 		: TRefinement[K]
 		: DrizzleTypeError<`Found unknown key in refinement: "${K & string}"`>;
-};
+	};

--- a/drizzle-valibot/tests/mysql.test.ts
+++ b/drizzle-valibot/tests/mysql.test.ts
@@ -25,11 +25,12 @@ const textSchema = v.pipe(v.string(), v.maxLength(CONSTANTS.INT16_UNSIGNED_MAX a
 test('table - select', (t) => {
 	const table = mysqlTable('test', {
 		id: serial().primaryKey(),
+		generated: int().generatedAlwaysAs(1).notNull(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = v.object({ id: serialNumberModeSchema, name: textSchema });
+	const expected = v.object({ id: serialNumberModeSchema, generated: intSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });

--- a/drizzle-valibot/tests/pg.test.ts
+++ b/drizzle-valibot/tests/pg.test.ts
@@ -26,11 +26,12 @@ const textSchema = v.string();
 test('table - select', (t) => {
 	const table = pgTable('test', {
 		id: serial().primaryKey(),
+		generated: integer().generatedAlwaysAsIdentity(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = v.object({ id: integerSchema, name: textSchema });
+	const expected = v.object({ id: integerSchema, generated: integerSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });

--- a/drizzle-valibot/tests/singlestore.test.ts
+++ b/drizzle-valibot/tests/singlestore.test.ts
@@ -25,11 +25,12 @@ const textSchema = v.pipe(v.string(), v.maxLength(CONSTANTS.INT16_UNSIGNED_MAX a
 test('table - select', (t) => {
 	const table = singlestoreTable('test', {
 		id: serial().primaryKey(),
+		generated: int().generatedAlwaysAs(1).notNull(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = v.object({ id: serialNumberModeSchema, name: textSchema });
+	const expected = v.object({ id: serialNumberModeSchema, generated: intSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });

--- a/drizzle-valibot/tests/sqlite.test.ts
+++ b/drizzle-valibot/tests/sqlite.test.ts
@@ -19,11 +19,12 @@ const textSchema = v.string();
 test('table - select', (t) => {
 	const table = sqliteTable('test', {
 		id: int().primaryKey({ autoIncrement: true }),
+		generated: int().generatedAlwaysAs(1).notNull(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = v.object({ id: intSchema, name: textSchema });
+	const expected = v.object({ id: intSchema, generated: intSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });


### PR DESCRIPTION
fixes #4556 