### PR TITLE
fix: fix single quote unescape when the string is only quotes

### DIFF
--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -368,6 +368,7 @@ export function escapeSingleQuotes(str: string) {
 }
 
 export function unescapeSingleQuotes(str: string, ignoreFirstAndLastChar: boolean) {
+	if (str === "''") return "''";
 	const regex = ignoreFirstAndLastChar ? /(?<!^)'(?!$)/g : /'/g;
 	return str.replace(/''/g, "'").replace(regex, "\\'");
 }


### PR DESCRIPTION
This fixes #4349, where a column in the database has an empty value as the default.


Tested on MySQL

Not sure what tests to add for this though.

Table:

```
CREATE TABLE `countries` (
  `id` int NOT NULL AUTO_INCREMENT,
  `name` varchar(255) NOT NULL DEFAULT '',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=68 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
```

Result before:

```
name: varchar({ length: 255 }).default(').notNull(),
```

Result after:

```
name: varchar({ length: 255 }).default('').notNull(),
```