### PR TITLE
[Pg] Support for timescaledb continuous aggregates

### DIFF
--- a/drizzle-kit/src/serializer/gelSchema.ts
+++ b/drizzle-kit/src/serializer/gelSchema.ts
@@ -161,6 +161,8 @@ const matViewWithOption = object({
 	autovacuumMultixactFreezeTableAge: number().optional(),
 	logAutovacuumMinDuration: number().optional(),
 	userCatalogTable: boolean().optional(),
+	"timescaledb.continuous": boolean().optional(),
+	"timescaledb.materializedOnly": boolean().optional(),
 }).strict();
 
 export const mergedViewWithOption = viewWithOption.merge(matViewWithOption).strict();

--- a/drizzle-kit/src/serializer/pgSchema.ts
+++ b/drizzle-kit/src/serializer/pgSchema.ts
@@ -272,6 +272,8 @@ const matViewWithOption = object({
 	autovacuumMultixactFreezeTableAge: number().optional(),
 	logAutovacuumMinDuration: number().optional(),
 	userCatalogTable: boolean().optional(),
+	"timescaledb.continuous": boolean().optional(),
+	"timescaledb.materializedOnly": boolean().optional(),
 }).strict();
 
 export const mergedViewWithOption = viewWithOption.merge(matViewWithOption).strict();

--- a/drizzle-kit/tests/pg-views.test.ts
+++ b/drizzle-kit/tests/pg-views.test.ts
@@ -476,6 +476,8 @@ test('create table and materialized view #3', async () => {
 			parallelWorkers: 1,
 			toastTupleTarget: 1,
 			userCatalogTable: true,
+			'timescaledb.continuous': true,
+	    'timescaledb.materializedOnly': false,
 			vacuumIndexCleanup: 'off',
 			vacuumTruncate: false,
 		}).as((qb) => qb.select().from(users)),
@@ -534,6 +536,8 @@ test('create table and materialized view #3', async () => {
 			parallelWorkers: 1,
 			toastTupleTarget: 1,
 			userCatalogTable: true,
+			"timescaledb.continuous": true,
+	    "timescaledb.materializedOnly": false,
 			vacuumIndexCleanup: 'off',
 			vacuumTruncate: false,
 		},
@@ -551,7 +555,7 @@ test('create table and materialized view #3', async () => {
 		`CREATE MATERIALIZED VIEW "public"."some_view1" AS (SELECT * FROM "users");`,
 	);
 	expect(sqlStatements[2]).toBe(
-		`CREATE MATERIALIZED VIEW "public"."some_view2" USING "heap" WITH (autovacuum_enabled = true, autovacuum_freeze_max_age = 1, autovacuum_freeze_min_age = 1, autovacuum_freeze_table_age = 1, autovacuum_multixact_freeze_max_age = 1, autovacuum_multixact_freeze_min_age = 1, autovacuum_multixact_freeze_table_age = 1, autovacuum_vacuum_cost_delay = 1, autovacuum_vacuum_cost_limit = 1, autovacuum_vacuum_scale_factor = 1, autovacuum_vacuum_threshold = 1, fillfactor = 1, log_autovacuum_min_duration = 1, parallel_workers = 1, toast_tuple_target = 1, user_catalog_table = true, vacuum_index_cleanup = off, vacuum_truncate = false) TABLESPACE some_tablespace AS (select "id" from "users") WITH NO DATA;`,
+		`CREATE MATERIALIZED VIEW "public"."some_view2" USING "heap" WITH (autovacuum_enabled = true, autovacuum_freeze_max_age = 1, autovacuum_freeze_min_age = 1, autovacuum_freeze_table_age = 1, autovacuum_multixact_freeze_max_age = 1, autovacuum_multixact_freeze_min_age = 1, autovacuum_multixact_freeze_table_age = 1, autovacuum_vacuum_cost_delay = 1, autovacuum_vacuum_cost_limit = 1, autovacuum_vacuum_scale_factor = 1, autovacuum_vacuum_threshold = 1, fillfactor = 1, log_autovacuum_min_duration = 1, parallel_workers = 1, toast_tuple_target = 1, user_catalog_table = true, timescaledb.continuous = true, timescaledb.materialized_only = false, vacuum_index_cleanup = off, vacuum_truncate = false) TABLESPACE some_tablespace AS (select "id" from "users") WITH NO DATA;`,
 	);
 });
 

--- a/drizzle-orm/src/gel-core/view.ts
+++ b/drizzle-orm/src/gel-core/view.ts
@@ -149,6 +149,8 @@ export type GelMaterializedViewWithConfig = RequireAtLeastOne<{
 	autovacuumMultixactFreezeTableAge: number;
 	logAutovacuumMinDuration: number;
 	userCatalogTable: boolean;
+	"timescaledb.continuous": boolean;
+	"timescaledb.materializedOnly": boolean;
 }>;
 
 export class MaterializedViewBuilderCore<TConfig extends { name: string; columns?: unknown }> {

--- a/drizzle-orm/src/pg-core/view.ts
+++ b/drizzle-orm/src/pg-core/view.ts
@@ -149,6 +149,8 @@ export type PgMaterializedViewWithConfig = RequireAtLeastOne<{
 	autovacuumMultixactFreezeTableAge: number;
 	logAutovacuumMinDuration: number;
 	userCatalogTable: boolean;
+	"timescaledb.continuous": boolean;
+	"timescaledb.materializedOnly": boolean;
 }>;
 
 export class MaterializedViewBuilderCore<TConfig extends { name: string; columns?: unknown }> {


### PR DESCRIPTION
This PR adds 2 options for the MaterializedViewWithConfig that can to be passed to create a continuous aggregate.

Example:
```ts
export const yourView = pgMaterializedView("your_view")
  .with({
    "timescaledb.continuous": true,
    "timescaledb.materializedOnly": false,
  })
  .as((qb) => /*...*/)
```

You can then use `drizzle-kit generate` to generate the migration.

You should probably add a refresh policy to your continuous aggregate. The refresh policy is not generated automatically, but you can easily add it to the end of your migration, or with a new custom migration.

```sql
CREATE MATERIALIZED VIEW "your_view"
WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS /* Generated query... */;
--> statement-breakpoint
-- Add your policy down here
SELECT add_continuous_aggregate_policy('your_view',
  start_offset => INTERVAL '1 month',
  end_offset => INTERVAL '1 hour',
  schedule_interval => INTERVAL '1 hour');
  ```
  
  <hr>

An open feature request for general timescaledb support can be found here: https://github.com/drizzle-team/drizzle-orm/issues/2962
This PR adds only partial support.

If you want to use continuous aggregates without waiting for this PR to be approved and merged, you can use the patch files I left in this comment: https://github.com/drizzle-team/drizzle-orm/issues/2962#issuecomment-2951185541