### PR TITLE
Remove unneeded drizzle-seed warning

### DIFF
--- a/drizzle-seed/src/index.ts
+++ b/drizzle-seed/src/index.ts
@@ -661,11 +661,6 @@ const getPostgresInfo = (
 						&& rel.refTable === relation.refTable
 					)
 				) {
-					console.warn(
-						`You are providing a one-to-many relation between the '${relation.refTable}' and '${relation.table}' tables,\n`
-							+ `while the '${relation.table}' table object already has foreign key constraint in the schema referencing '${relation.refTable}' table.\n`
-							+ `In this case, the foreign key constraint will be used.\n`,
-					);
 					continue;
 				}
 


### PR DESCRIPTION
Issue: https://github.com/drizzle-team/drizzle-orm/issues/4242

It is common and useful to have both relations and foreign keys, so this warning is just noise for most users.