### PR TITLE
[SQLite-kit]: Fix SQLite partial index `where` inspection

### DIFF
--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -768,10 +768,12 @@ export const fromDatabase = async (
 		indexName: string;
 		columnName: string;
 		isUnique: number;
+		isPartial: number;
 		seq: string;
 	}>(`SELECT 
     	  m.tbl_name as tableName,
     	  il.name as indexName,
+				il.partial as isPartial,
     	  ii.name as columnName,
     	  il.[unique] as isUnique,
     	  il.seq as seq
@@ -789,6 +791,7 @@ export const fromDatabase = async (
 		const constraintName = idxRow.indexName;
 		const columnName: string = idxRow.columnName;
 		const isUnique = idxRow.isUnique === 1;
+		const isPartial = idxRow.isPartial === 1;
 
 		const tableInResult = result[tableName];
 		if (typeof tableInResult === 'undefined') continue;
@@ -797,6 +800,13 @@ export const fromDatabase = async (
 		if (progressCallback) {
 			progressCallback('indexes', indexesCount, 'fetching');
 		}
+
+		let where: string | undefined = undefined;
+		if (isPartial) 
+			where = (await db.query<{sql:string}>(`
+					SELECT sql FROM sqlite_master
+					WHERE type = 'index' AND name = '${escapeSingleQuotes(constraintName)}'
+					`))[0].sql.match(/WHERE\s+(.+?)(?=\s*(?:;|$))/i)?.[1];
 
 		if (
 			typeof tableInResult.indexes[constraintName] !== 'undefined'
@@ -808,6 +818,7 @@ export const fromDatabase = async (
 				name: constraintName,
 				columns: columnName ? [columnName] : [],
 				isUnique: isUnique,
+				where: where,
 			};
 		}
 		// if (isUnique) {

--- a/drizzle-kit/tests/push/sqlite.test.ts
+++ b/drizzle-kit/tests/push/sqlite.test.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import chalk from 'chalk';
-import { sql } from 'drizzle-orm';
+import { sql, isNotNull } from 'drizzle-orm';
 import {
 	blob,
 	check,
@@ -59,7 +59,13 @@ test('nothing changed in schema', async (t) => {
 			id: integer('id').primaryKey(),
 			content: text('content'),
 			authorId: integer('author_id'),
-		}),
+			},
+			(table) => [
+				uniqueIndex('content_unique_author_nonnull_idx')
+					.on(table.content)
+					.where(isNotNull(table.authorId)),
+			],
+		),
 	};
 
 	const {


### PR DESCRIPTION
Fix Drizzle Kit failing to detect SQLite partial index 'WHERE' clauses during remote introspection phase, which caused infinite drop/recreate cycles.

Changed:
- drizzle-kit/src/serializer/sqliteSerializer.ts: add way to recognize if an index is a partial index, and if so then introspect its "where" part
- Added partial index test to sqlite "nothing changed in schema" part

Fixes #4688 