### PR TITLE
sqlite: Fix duplicate index statements in upgrade

### DIFF
--- a/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
+++ b/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
@@ -304,9 +304,12 @@ export const logSuggestionsAndReturn = async (
 			}
 		} else {
 			const fromJsonStatement = fromJson([statement], 'sqlite', 'push');
-			statementsToExecute.push(
-				...(Array.isArray(fromJsonStatement) ? fromJsonStatement : [fromJsonStatement]),
-			);
+			const pending = Array.isArray(fromJsonStatement) ? fromJsonStatement : [fromJsonStatement];
+			pending.forEach(i => {
+				if (statementsToExecute.indexOf(i) == -1) {
+					statementsToExecute.push(i)
+				}
+			})
 		}
 	}
 


### PR DESCRIPTION
The fall through case in logSuggestionsAndReturn simply appended whatever was received to the existing list. This in turn lead to duplicate index creation steps as seen in issue #3574.  

In the upgrade scenario, the call to _moveDataStatements would create the statements to create the indexes on the new table. Then the foreach would turn right around and add more create index statements.  This is resulted in broken upgrade experience b/c upgrade would attempt to create 2x indexes as needed.

The fix verifies a statement does not already exist before appending to the statement list. 
