### PR TITLE
Fix check constraint with operators

### DIFF
--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -120,7 +120,7 @@ export const generateMySqlSnapshot = (
 								chalk.underline.blue(
 									tableName,
 								)
-							} table. 
+							} table.
           The unique constraint ${
 								chalk.underline.blue(
 									column.uniqueName,
@@ -399,7 +399,7 @@ export const generateMySqlSnapshot = (
 
 			checkConstraintObject[checkName] = {
 				name: checkName,
-				value: dialect.sqlToQuery(check.value).sql,
+				value: dialect.sqlToQuery(check.value.inlineParams()).sql,
 			};
 		});
 
@@ -787,7 +787,7 @@ export const fromDatabase = async (
 	}
 	try {
 		const fks = await db.query(
-			`SELECT 
+			`SELECT
       kcu.TABLE_SCHEMA,
       kcu.TABLE_NAME,
       kcu.CONSTRAINT_NAME,
@@ -797,12 +797,12 @@ export const fromDatabase = async (
       kcu.REFERENCED_COLUMN_NAME,
       rc.UPDATE_RULE,
       rc.DELETE_RULE
-  FROM 
+  FROM
       INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-  LEFT JOIN 
-      information_schema.referential_constraints rc 
+  LEFT JOIN
+      information_schema.referential_constraints rc
       ON kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
-  WHERE kcu.TABLE_SCHEMA = '${inputSchema}' AND kcu.CONSTRAINT_NAME != 'PRIMARY' 
+  WHERE kcu.TABLE_SCHEMA = '${inputSchema}' AND kcu.CONSTRAINT_NAME != 'PRIMARY'
       AND kcu.REFERENCED_TABLE_NAME IS NOT NULL;`,
 		);
 
@@ -948,18 +948,18 @@ export const fromDatabase = async (
 	}
 
 	const checkConstraints = await db.query(
-		`SELECT 
-    tc.table_name, 
-    tc.constraint_name, 
+		`SELECT
+    tc.table_name,
+    tc.constraint_name,
     cc.check_clause
-FROM 
+FROM
     information_schema.table_constraints tc
-JOIN 
-    information_schema.check_constraints cc 
+JOIN
+    information_schema.check_constraints cc
     ON tc.constraint_name = cc.constraint_name
-WHERE 
+WHERE
     tc.constraint_schema = '${inputSchema}'
-AND 
+AND
     tc.constraint_type = 'CHECK';`,
 	);
 

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -219,7 +219,7 @@ export const generatePgSnapshot = (
 								chalk.underline.blue(
 									tableName,
 								)
-							} table. 
+							} table.
           The unique constraint ${
 								chalk.underline.blue(
 									column.uniqueName,
@@ -301,7 +301,7 @@ export const generatePgSnapshot = (
 				console.log(
 					`\n${
 						withStyle.errorWarning(
-							`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(tableName)} table. 
+							`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(tableName)} table.
         The unique constraint ${chalk.underline.blue(name)} on the ${
 								chalk.underline.blue(
 									columnNames.join(','),
@@ -567,7 +567,7 @@ export const generatePgSnapshot = (
 
 			checksObject[checkName] = {
 				name: checkName,
-				value: dialect.sqlToQuery(check.value).sql,
+				value: dialect.sqlToQuery(check.value.inlineParams()).sql,
 			};
 		});
 
@@ -804,7 +804,7 @@ export const generatePgSnapshot = (
 						console.log(
 							`\n${
 								withStyle.errorWarning(
-									`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(viewName)} table. 
+									`We\'ve found duplicated unique constraint names in ${chalk.underline.blue(viewName)} table.
           The unique constraint ${chalk.underline.blue(column.uniqueName)} on the ${
 										chalk.underline.blue(
 											column.name,
@@ -991,21 +991,21 @@ export const fromDatabase = async (
 	const where = schemaFilters.map((t) => `n.nspname = '${t}'`).join(' or ');
 
 	const allTables = await db.query<{ table_schema: string; table_name: string; type: string; rls_enabled: boolean }>(
-		`SELECT 
-    n.nspname AS table_schema, 
-    c.relname AS table_name, 
-    CASE 
+		`SELECT
+    n.nspname AS table_schema,
+    c.relname AS table_name,
+    CASE
         WHEN c.relkind = 'r' THEN 'table'
         WHEN c.relkind = 'v' THEN 'view'
         WHEN c.relkind = 'm' THEN 'materialized_view'
     END AS type,
 	c.relrowsecurity AS rls_enabled
-FROM 
+FROM
     pg_catalog.pg_class c
-JOIN 
+JOIN
     pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-WHERE 
-	c.relkind IN ('r', 'v', 'm') 
+WHERE
+	c.relkind IN ('r', 'v', 'm')
     ${where === '' ? '' : ` AND ${where}`};`,
 	);
 
@@ -1236,25 +1236,25 @@ WHERE
       WHERE tc.table_name = '${tableName}' and constraint_schema = '${tableSchema}';`,
 					);
 
-					const tableChecks = await db.query(`SELECT 
+					const tableChecks = await db.query(`SELECT
 						tc.constraint_name,
 						tc.constraint_type,
 						pg_get_constraintdef(con.oid) AS constraint_definition
-					FROM 
+					FROM
 						information_schema.table_constraints AS tc
-						JOIN pg_constraint AS con 
+						JOIN pg_constraint AS con
 							ON tc.constraint_name = con.conname
 							AND con.conrelid = (
-								SELECT oid 
-								FROM pg_class 
-								WHERE relname = tc.table_name 
+								SELECT oid
+								FROM pg_class
+								WHERE relname = tc.table_name
 								AND relnamespace = (
-									SELECT oid 
-									FROM pg_namespace 
+									SELECT oid
+									FROM pg_namespace
 									WHERE nspname = tc.constraint_schema
 								)
 							)
-					WHERE 
+					WHERE
 						tc.table_name = '${tableName}'
 						AND tc.constraint_schema = '${tableSchema}'
 						AND tc.constraint_type = 'CHECK';`);
@@ -1407,8 +1407,8 @@ WHERE
 							const tableCompositePkName = await db.query(
 								`SELECT conname AS primary_key
             FROM   pg_constraint join pg_class on (pg_class.oid = conrelid)
-            WHERE  contype = 'p' 
-            AND    connamespace = $1::regnamespace  
+            WHERE  contype = 'p'
+            AND    connamespace = $1::regnamespace
             AND    pg_class.relname = $2;`,
 								[tableSchema, tableName],
 							);
@@ -1850,7 +1850,7 @@ FROM
 JOIN
     pg_namespace n ON c.relnamespace = n.oid
 LEFT JOIN
-    pg_tablespace ts ON c.reltablespace = ts.oid 
+    pg_tablespace ts ON c.reltablespace = ts.oid
 WHERE
     (c.relkind = 'm' OR c.relkind = 'v')
     AND n.nspname = '${viewSchema}'
@@ -2027,25 +2027,25 @@ const defaultForColumn = (column: any, internals: PgKitInternals, tableName: str
 
 const getColumnsInfoQuery = ({ schema, table, db }: { schema: string; table: string; db: DB }) => {
 	return db.query(
-		`SELECT 
+		`SELECT
     a.attrelid::regclass::text AS table_name,  -- Table, view, or materialized view name
     a.attname AS column_name,   -- Column name
-    CASE 
-        WHEN NOT a.attisdropped THEN 
-            CASE 
+    CASE
+        WHEN NOT a.attisdropped THEN
+            CASE
                 WHEN a.attnotnull THEN 'NO'
                 ELSE 'YES'
-            END 
-        ELSE NULL 
+            END
+        ELSE NULL
     END AS is_nullable,  -- NULL or NOT NULL constraint
     a.attndims AS array_dimensions,  -- Array dimensions
-    CASE 
-        WHEN a.atttypid = ANY ('{int,int8,int2}'::regtype[]) 
+    CASE
+        WHEN a.atttypid = ANY ('{int,int8,int2}'::regtype[])
         AND EXISTS (
             SELECT FROM pg_attrdef ad
-            WHERE ad.adrelid = a.attrelid 
-            AND ad.adnum = a.attnum 
-            AND pg_get_expr(ad.adbin, ad.adrelid) = 'nextval(''' 
+            WHERE ad.adrelid = a.attrelid
+            AND ad.adnum = a.attnum
+            AND pg_get_expr(ad.adbin, ad.adrelid) = 'nextval('''
                 || pg_get_serial_sequence(a.attrelid::regclass::text, a.attname)::regclass || '''::regclass)'
         )
         THEN CASE a.atttypid
@@ -2070,27 +2070,27 @@ const getColumnsInfoQuery = ({ schema, table, db }: { schema: string; table: str
     c.identity_minimum,  -- Minimum value for identity column
     c.identity_cycle,  -- Does the identity column cycle?
     enum_ns.nspname AS type_schema  -- Schema of the enum type
-FROM 
+FROM
     pg_attribute a
-JOIN 
+JOIN
     pg_class cls ON cls.oid = a.attrelid  -- Join pg_class to get table/view/materialized view info
-JOIN 
+JOIN
     pg_namespace ns ON ns.oid = cls.relnamespace  -- Join namespace to get schema info
-LEFT JOIN 
-    information_schema.columns c ON c.column_name = a.attname 
-        AND c.table_schema = ns.nspname 
+LEFT JOIN
+    information_schema.columns c ON c.column_name = a.attname
+        AND c.table_schema = ns.nspname
         AND c.table_name = cls.relname  -- Match schema and table/view name
-LEFT JOIN 
+LEFT JOIN
     pg_type enum_t ON enum_t.oid = a.atttypid  -- Join to get the type info
-LEFT JOIN 
+LEFT JOIN
     pg_namespace enum_ns ON enum_ns.oid = enum_t.typnamespace  -- Join to get the enum schema
-WHERE 
+WHERE
     a.attnum > 0  -- Valid column numbers only
     AND NOT a.attisdropped  -- Skip dropped columns
     AND cls.relkind IN ('r', 'v', 'm')  -- Include regular tables ('r'), views ('v'), and materialized views ('m')
     AND ns.nspname = '${schema}'  -- Filter by schema
     AND cls.relname = '${table}'  -- Filter by table name
-ORDER BY 
+ORDER BY
     a.attnum;  -- Order by column number`,
 	);
 };

--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -108,7 +108,7 @@ export const generateSqliteSnapshot = (
 								chalk.underline.blue(
 									tableName,
 								)
-							} table. 
+							} table.
           The unique constraint ${
 								chalk.underline.blue(
 									column.uniqueName,
@@ -309,7 +309,7 @@ export const generateSqliteSnapshot = (
 
 			checkConstraintObject[checkName] = {
 				name: checkName,
-				value: dialect.sqlToQuery(check.value).sql,
+				value: dialect.sqlToQuery(check.value.inlineParams()).sql,
 			};
 		});
 
@@ -530,7 +530,7 @@ export const fromDatabase = async (
 		hidden: number;
 		sql: string;
 		type: 'view' | 'table';
-	}>(`SELECT 
+	}>(`SELECT
 		  m.name as "tableName",
 		  p.name as "columnName",
 		  p.type as "columnType",
@@ -542,7 +542,7 @@ export const fromDatabase = async (
 		  m.type as type
 		FROM sqlite_master AS m
 		JOIN pragma_table_xinfo(m.name) AS p
-		WHERE (m.type = 'table' OR m.type = 'view') 
+		WHERE (m.type = 'table' OR m.type = 'view')
 		  AND ${filterIgnoredTablesByField('m.tbl_name')};`);
 
 	const tablesWithSeq: string[] = [];
@@ -769,18 +769,18 @@ export const fromDatabase = async (
 		columnName: string;
 		isUnique: number;
 		seq: string;
-	}>(`SELECT 
+	}>(`SELECT
     	  m.tbl_name as tableName,
     	  il.name as indexName,
     	  ii.name as columnName,
     	  il.[unique] as isUnique,
     	  il.seq as seq
-		FROM 
+		FROM
 		  sqlite_master AS m,
     	  pragma_index_list(m.name) AS il,
     	  pragma_index_info(il.name) AS ii
-		WHERE 
-		  m.type = 'table' 
+		WHERE
+		  m.type = 'table'
     	  AND il.name NOT LIKE 'sqlite\\_autoindex\\_%' ESCAPE '\\'
     	  AND ${filterIgnoredTablesByField('m.tbl_name')};`);
 
@@ -884,7 +884,7 @@ export const fromDatabase = async (
 	}>(`SELECT
 		  name as "tableName",
 		  sql as "sql"
-		FROM sqlite_master 
+		FROM sqlite_master
 		WHERE type = 'table'
 		  AND ${filterIgnoredTablesByField('tbl_name')};`);
 	for (const check of checks) {

--- a/drizzle-kit/tests/mysql-checks.test.ts
+++ b/drizzle-kit/tests/mysql-checks.test.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { eq, gt, gte, lt, lte, ne, sql } from 'drizzle-orm';
 import { check, int, mysqlTable, serial, varchar } from 'drizzle-orm/mysql-core';
 import { expect, test } from 'vitest';
 import { diffTestSchemasMysql } from './schemaDiffer';
@@ -288,4 +288,93 @@ test('create checks with same names', async (t) => {
 	};
 
 	await expect(diffTestSchemasMysql({}, to, [])).rejects.toThrowError();
+});
+
+test('create table with check constraint using operator functions', async (t) => {
+  const to = {
+    users: mysqlTable('users', {
+      id: serial('id').primaryKey(),
+      age: int('age'),
+      score: int('score'),
+      balance: int('balance'),
+    }, (table) => [
+      // Test all comparison operators
+      check('age_gt_18', gt(table.age, 18)),
+      check('age_gte_18', gte(table.age, 18)),
+      check('age_lt_100', lt(table.age, 100)),
+      check('age_lte_99', lte(table.age, 99)),
+      check('score_eq_100', eq(table.score, 100)),
+      check('balance_ne_0', ne(table.balance, 0)),
+      // For comparison with sql literal (should work the same)
+      check('age_sql_gt_18', sql`${table.age} > 18`),
+    ]),
+  };
+
+  const { sqlStatements, statements } = await diffTestSchemasMysql({}, to, []);
+
+  expect(statements.length).toBe(1);
+  expect(statements[0]).toStrictEqual({
+    type: 'create_table',
+    tableName: 'users',
+    columns: [
+      {
+        name: 'id',
+        type: 'serial',
+        notNull: true,
+        primaryKey: false,
+        autoincrement: true,
+      },
+      {
+        name: 'age',
+        type: 'int',
+        notNull: false,
+        primaryKey: false,
+        autoincrement: false,
+      },
+      {
+        name: 'score',
+        type: 'int',
+        notNull: false,
+        primaryKey: false,
+        autoincrement: false,
+      },
+      {
+        name: 'balance',
+        type: 'int',
+        notNull: false,
+        primaryKey: false,
+        autoincrement: false,
+      },
+    ],
+    compositePKs: [
+      'users_id;id',
+    ],
+    checkConstraints: [
+      'age_gt_18;`users`.`age` > 18',
+      'age_gte_18;`users`.`age` >= 18',
+      'age_lt_100;`users`.`age` < 100',
+      'age_lte_99;`users`.`age` <= 99',
+      'score_eq_100;`users`.`score` = 100',
+      'balance_ne_0;`users`.`balance` <> 0',
+      'age_sql_gt_18;`users`.`age` > 18',
+    ],
+    compositePkName: 'users_id',
+    internals: {
+      tables: {},
+      indexes: {},
+    },
+    schema: undefined,
+    uniqueConstraints: [],
+  });
+
+  expect(sqlStatements.length).toBe(1);
+
+  // The key test: all check constraints should contain literal values, not parameters
+  const expectedSql = 'CREATE TABLE `users` (\n\t`id` serial AUTO_INCREMENT NOT NULL,\n\t`age` int,\n\t`score` int,\n\t`balance` int,\n\tCONSTRAINT `users_id` PRIMARY KEY(`id`),\n\tCONSTRAINT `age_gt_18` CHECK(`users`.`age` > 18),\n\tCONSTRAINT `age_gte_18` CHECK(`users`.`age` >= 18),\n\tCONSTRAINT `age_lt_100` CHECK(`users`.`age` < 100),\n\tCONSTRAINT `age_lte_99` CHECK(`users`.`age` <= 99),\n\tCONSTRAINT `score_eq_100` CHECK(`users`.`score` = 100),\n\tCONSTRAINT `balance_ne_0` CHECK(`users`.`balance` <> 0),\n\tCONSTRAINT `age_sql_gt_18` CHECK(`users`.`age` > 18)\n);\n';
+
+  expect(sqlStatements[0]).toBe(expectedSql);
+
+  // Verify that no parameterized placeholders (?, $1, etc.) are in the output
+  expect(sqlStatements[0]).not.toMatch(/\?/);
+  expect(sqlStatements[0]).not.toMatch(/\\$\\d+/);
 });

--- a/drizzle-kit/tests/pg-checks.test.ts
+++ b/drizzle-kit/tests/pg-checks.test.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { eq, gt, gte, lt, lte, ne, sql } from 'drizzle-orm';
 import { check, integer, pgTable, serial, varchar } from 'drizzle-orm/pg-core';
 import { JsonCreateTableStatement } from 'src/jsonStatements';
 import { expect, test } from 'vitest';
@@ -279,4 +279,97 @@ test('create checks with same names', async (t) => {
 	};
 
 	await expect(diffTestSchemas({}, to, [])).rejects.toThrowError();
+});
+
+test('create table with check constraint using operator functions', async (t) => {
+  const to = {
+    users: pgTable('users', {
+      id: integer('id').primaryKey(),
+      age: integer('age'),
+      score: integer('score'),
+      balance: integer('balance'),
+    }, (table) => [
+      // Test all comparison operators
+      check('age_gt_18', gt(table.age, 18)),
+      check('age_gte_18', gte(table.age, 18)),
+      check('age_lt_100', lt(table.age, 100)),
+      check('age_lte_99', lte(table.age, 99)),
+      check('score_eq_100', eq(table.score, 100)),
+      check('balance_ne_0', ne(table.balance, 0)),
+      // For comparison with sql literal (should work the same)
+      check('age_sql_gt_18', sql`${table.age} > 18`),
+	]),
+  };
+
+  const { sqlStatements, statements } = await diffTestSchemas({}, to, []);
+
+  expect(statements.length).toBe(1);
+  expect(statements[0]).toStrictEqual({
+    type: 'create_table',
+    tableName: 'users',
+    schema: '',
+    columns: [
+      {
+        name: 'id',
+        type: 'integer',
+        notNull: true,
+        primaryKey: true,
+      },
+      {
+        name: 'age',
+        type: 'integer',
+        notNull: false,
+        primaryKey: false,
+      },
+      {
+        name: 'score',
+        type: 'integer',
+        notNull: false,
+        primaryKey: false,
+      },
+      {
+        name: 'balance',
+        type: 'integer',
+        notNull: false,
+        primaryKey: false,
+      },
+    ],
+    compositePKs: [],
+    checkConstraints: [
+      'age_gt_18;"users"."age" > 18',
+      'age_gte_18;"users"."age" >= 18',
+      'age_lt_100;"users"."age" < 100',
+      'age_lte_99;"users"."age" <= 99',
+      'score_eq_100;"users"."score" = 100',
+      'balance_ne_0;"users"."balance" <> 0',
+      'age_sql_gt_18;"users"."age" > 18',
+    ],
+    compositePkName: '',
+    uniqueConstraints: [],
+    isRLSEnabled: false,
+    policies: [],
+  });
+
+  expect(sqlStatements.length).toBe(1);
+
+  // The key test: all check constraints should contain literal values, not parameters
+  const expectedSql = `CREATE TABLE "users" (
+\t"id" integer PRIMARY KEY NOT NULL,
+\t"age" integer,
+\t"score" integer,
+\t"balance" integer,
+\tCONSTRAINT "age_gt_18" CHECK ("users"."age" > 18),
+\tCONSTRAINT "age_gte_18" CHECK ("users"."age" >= 18),
+\tCONSTRAINT "age_lt_100" CHECK ("users"."age" < 100),
+\tCONSTRAINT "age_lte_99" CHECK ("users"."age" <= 99),
+\tCONSTRAINT "score_eq_100" CHECK ("users"."score" = 100),
+\tCONSTRAINT "balance_ne_0" CHECK ("users"."balance" <> 0),
+\tCONSTRAINT "age_sql_gt_18" CHECK ("users"."age" > 18)
+);
+`;
+
+  expect(sqlStatements[0]).toBe(expectedSql);
+
+  // Verify that no parameterized placeholders ($1, $2, etc.) are in the output
+  expect(sqlStatements[0]).not.toMatch(/\$\d+/);
 });

--- a/drizzle-kit/tests/sqlite-checks.test.ts
+++ b/drizzle-kit/tests/sqlite-checks.test.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { eq, gt, gte, lt, lte, ne, sql } from 'drizzle-orm';
 import { check, int, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { expect, test } from 'vitest';
 import { diffTestSchemasSqlite } from './schemaDiffer';
@@ -305,4 +305,98 @@ test('create checks with same names', async (t) => {
 	};
 
 	await expect(diffTestSchemasSqlite({}, to, [])).rejects.toThrowError();
+});
+
+test('create table with check constraint using operator functions', async (t) => {
+  const to = {
+    users: sqliteTable('users', {
+      id: int('id').primaryKey(),
+      age: int('age'),
+      score: int('score'),
+      balance: int('balance'),
+    }, (table) => [
+      // Test all comparison operators
+      check('age_gt_18', gt(table.age, 18)),
+      check('age_gte_18', gte(table.age, 18)),
+      check('age_lt_100', lt(table.age, 100)),
+      check('age_lte_99', lte(table.age, 99)),
+      check('score_eq_100', eq(table.score, 100)),
+      check('balance_ne_0', ne(table.balance, 0)),
+      // For comparison with sql literal (should work the same)
+      check('age_sql_gt_18', sql`${table.age} > 18`),
+    ]),
+  };
+
+  const { sqlStatements, statements } = await diffTestSchemasSqlite({}, to, []);
+
+  expect(statements.length).toBe(1);
+  expect(statements[0]).toStrictEqual({
+    type: 'sqlite_create_table',
+    tableName: 'users',
+    columns: [
+      {
+        name: 'id',
+        type: 'integer',
+        notNull: true,
+        primaryKey: true,
+        autoincrement: false,
+      },
+      {
+        name: 'age',
+        type: 'integer',
+        notNull: false,
+        primaryKey: false,
+        autoincrement: false,
+      },
+      {
+        name: 'score',
+        type: 'integer',
+        notNull: false,
+        primaryKey: false,
+        autoincrement: false,
+      },
+      {
+        name: 'balance',
+        type: 'integer',
+        notNull: false,
+        primaryKey: false,
+        autoincrement: false,
+      },
+    ],
+    compositePKs: [],
+    checkConstraints: [
+      'age_gt_18;"users"."age" > 18',
+      'age_gte_18;"users"."age" >= 18',
+      'age_lt_100;"users"."age" < 100',
+      'age_lte_99;"users"."age" <= 99',
+      'score_eq_100;"users"."score" = 100',
+      'balance_ne_0;"users"."balance" <> 0',
+      'age_sql_gt_18;"users"."age" > 18',
+    ],
+    referenceData: [],
+    uniqueConstraints: [],
+  });
+
+  expect(sqlStatements.length).toBe(1);
+
+  // The key test: all check constraints should contain literal values, not parameters
+  const expectedSql = `CREATE TABLE \`users\` (
+\t\`id\` integer PRIMARY KEY NOT NULL,
+\t\`age\` integer,
+\t\`score\` integer,
+\t\`balance\` integer,
+\tCONSTRAINT "age_gt_18" CHECK("users"."age" > 18),
+\tCONSTRAINT "age_gte_18" CHECK("users"."age" >= 18),
+\tCONSTRAINT "age_lt_100" CHECK("users"."age" < 100),
+\tCONSTRAINT "age_lte_99" CHECK("users"."age" <= 99),
+\tCONSTRAINT "score_eq_100" CHECK("users"."score" = 100),
+\tCONSTRAINT "balance_ne_0" CHECK("users"."balance" <> 0),
+\tCONSTRAINT "age_sql_gt_18" CHECK("users"."age" > 18)
+);
+`;
+
+  expect(sqlStatements[0]).toBe(expectedSql);
+
+  // Verify that no parameterized placeholders ($1, $2, etc.) are in the output
+  expect(sqlStatements[0]).not.toMatch(/\$\d+/);
 });


### PR DESCRIPTION
This PR attempts to fix https://github.com/drizzle-team/drizzle-orm/issues/4661 to allow the usage of filter and conditional operators like eq, ne, gt, gte in check constraint.

```ts
export const users = pgTable(
  "users",
  {
    id: uuid().defaultRandom().primaryKey(),
    username: text().notNull(),
    age: integer(),
  },
  (table) => [
    check("age_check1", gt(table.age, 21)), // instead of check("age_check1", sql`${table.age} > 21`),
  ]
);
```