### PR TITLE
[Pg,Gel,MySql,SQLite,SingleStore] feat: a config to prevent any update without a where clause

### DIFF
--- a/drizzle-orm/src/aws-data-api/pg/driver.ts
+++ b/drizzle-orm/src/aws-data-api/pg/driver.ts
@@ -98,7 +98,7 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 ): AwsDataApiPgDatabase<TSchema> & {
 	$client: AwsDataApiClient;
 } {
-	const dialect = new AwsPgDialect({ casing: config.casing });
+	const dialect = new AwsPgDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/better-sqlite3/driver.ts
+++ b/drizzle-orm/src/better-sqlite3/driver.ts
@@ -33,7 +33,7 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 ): BetterSQLite3Database<TSchema> & {
 	$client: Database;
 } {
-	const dialect = new SQLiteSyncDialect({ casing: config.casing });
+	const dialect = new SQLiteSyncDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/bun-sql/driver.ts
+++ b/drizzle-orm/src/bun-sql/driver.ts
@@ -28,7 +28,7 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 ): BunSQLDatabase<TSchema> & {
 	$client: SQL;
 } {
-	const dialect = new PgDialect({ casing: config.casing });
+	const dialect = new PgDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/bun-sqlite/driver.ts
+++ b/drizzle-orm/src/bun-sqlite/driver.ts
@@ -54,7 +54,7 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 ): BunSQLiteDatabase<TSchema> & {
 	$client: Database;
 } {
-	const dialect = new SQLiteSyncDialect({ casing: config.casing });
+	const dialect = new SQLiteSyncDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/d1/driver.ts
+++ b/drizzle-orm/src/d1/driver.ts
@@ -45,7 +45,7 @@ export function drizzle<
 ): DrizzleD1Database<TSchema> & {
 	$client: TClient;
 } {
-	const dialect = new SQLiteAsyncDialect({ casing: config.casing });
+	const dialect = new SQLiteAsyncDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/durable-sqlite/driver.ts
+++ b/drizzle-orm/src/durable-sqlite/driver.ts
@@ -31,7 +31,7 @@ export function drizzle<
 ): DrizzleSqliteDODatabase<TSchema> & {
 	$client: TClient;
 } {
-	const dialect = new SQLiteSyncDialect({ casing: config.casing });
+	const dialect = new SQLiteSyncDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/expo-sqlite/driver.ts
+++ b/drizzle-orm/src/expo-sqlite/driver.ts
@@ -24,7 +24,7 @@ export function drizzle<TSchema extends Record<string, unknown> = Record<string,
 ): ExpoSQLiteDatabase<TSchema> & {
 	$client: SQLiteDatabase;
 } {
-	const dialect = new SQLiteSyncDialect({ casing: config.casing });
+	const dialect = new SQLiteSyncDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/gel/driver.ts
+++ b/drizzle-orm/src/gel/driver.ts
@@ -55,7 +55,7 @@ function construct<
 ): GelJsDatabase<TSchema> & {
 	$client: GelClient extends TClient ? Client : TClient;
 } {
-	const dialect = new GelDialect({ casing: config.casing });
+	const dialect = new GelDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/libsql/driver-core.ts
+++ b/drizzle-orm/src/libsql/driver-core.ts
@@ -35,7 +35,7 @@ export function construct<
 >(client: Client, config: DrizzleConfig<TSchema> = {}): LibSQLDatabase<TSchema> & {
 	$client: Client;
 } {
-	const dialect = new SQLiteAsyncDialect({ casing: config.casing });
+	const dialect = new SQLiteAsyncDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/mysql-proxy/driver.ts
+++ b/drizzle-orm/src/mysql-proxy/driver.ts
@@ -27,7 +27,7 @@ export function drizzle<TSchema extends Record<string, unknown> = Record<string,
 	callback: RemoteCallback,
 	config: DrizzleConfig<TSchema> = {},
 ): MySqlRemoteDatabase<TSchema> {
-	const dialect = new MySqlDialect({ casing: config.casing });
+	const dialect = new MySqlDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/mysql2/driver.ts
+++ b/drizzle-orm/src/mysql2/driver.ts
@@ -66,7 +66,7 @@ function construct<
 ): MySql2Database<TSchema> & {
 	$client: AnyMySql2Connection extends TClient ? CallbackPool : TClient;
 } {
-	const dialect = new MySqlDialect({ casing: config.casing });
+	const dialect = new MySqlDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/neon-http/driver.ts
+++ b/drizzle-orm/src/neon-http/driver.ts
@@ -130,7 +130,7 @@ function construct<
 ): NeonHttpDatabase<TSchema> & {
 	$client: TClient;
 } {
-	const dialect = new PgDialect({ casing: config.casing });
+	const dialect = new PgDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/neon-serverless/driver.ts
+++ b/drizzle-orm/src/neon-serverless/driver.ts
@@ -55,7 +55,7 @@ function construct<
 ): NeonDatabase<TSchema> & {
 	$client: NeonClient extends TClient ? Pool : TClient;
 } {
-	const dialect = new PgDialect({ casing: config.casing });
+	const dialect = new PgDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/node-postgres/driver.ts
+++ b/drizzle-orm/src/node-postgres/driver.ts
@@ -55,7 +55,7 @@ function construct<
 ): NodePgDatabase<TSchema> & {
 	$client: NodePgClient extends TClient ? Pool : TClient;
 } {
-	const dialect = new PgDialect({ casing: config.casing });
+	const dialect = new PgDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/op-sqlite/driver.ts
+++ b/drizzle-orm/src/op-sqlite/driver.ts
@@ -24,7 +24,7 @@ export function drizzle<TSchema extends Record<string, unknown> = Record<string,
 ): OPSQLiteDatabase<TSchema> & {
 	$client: OPSQLiteConnection;
 } {
-	const dialect = new SQLiteAsyncDialect({ casing: config.casing });
+	const dialect = new SQLiteAsyncDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -58,6 +58,7 @@ import type { PgMaterializedView } from './view.ts';
 
 export interface PgDialectConfig {
 	casing?: Casing;
+	safeMutations?: boolean;
 }
 
 export class PgDialect {
@@ -66,8 +67,11 @@ export class PgDialect {
 	/** @internal */
 	readonly casing: CasingCache;
 
+	safeMutations: boolean;
+
 	constructor(config?: PgDialectConfig) {
 		this.casing = new CasingCache(config?.casing);
+		this.safeMutations = config?.safeMutations ?? false;
 	}
 
 	async migrate(migrations: MigrationMeta[], session: PgSession, config: string | MigrationConfig): Promise<void> {
@@ -138,6 +142,10 @@ export class PgDialect {
 	}
 
 	buildDeleteQuery({ table, where, returning, withList }: PgDeleteConfig): SQL {
+		if (this.safeMutations && !where) {
+			throw new Error('Delete query must have a "where" clause');
+		}
+
 		const withSql = this.buildWithCTE(withList);
 
 		const returningSql = returning
@@ -171,6 +179,10 @@ export class PgDialect {
 	}
 
 	buildUpdateQuery({ table, set, where, returning, withList, from, joins }: PgUpdateConfig): SQL {
+		if (this.safeMutations && !where) {
+			throw new Error('Update query must have a "where" clause');
+		}
+		
 		const withSql = this.buildWithCTE(withList);
 
 		const tableName = table[PgTable.Symbol.Name];

--- a/drizzle-orm/src/pg-proxy/driver.ts
+++ b/drizzle-orm/src/pg-proxy/driver.ts
@@ -27,7 +27,7 @@ export type RemoteCallback = (
 export function drizzle<TSchema extends Record<string, unknown> = Record<string, never>>(
 	callback: RemoteCallback,
 	config: DrizzleConfig<TSchema> = {},
-	_dialect: () => PgDialect = () => new PgDialect({ casing: config.casing }),
+	_dialect: () => PgDialect = () => new PgDialect({ casing: config.casing, safeMutations: config.safeMutations }),
 ): PgRemoteDatabase<TSchema> {
 	const dialect = _dialect();
 	let logger;

--- a/drizzle-orm/src/pglite/driver.ts
+++ b/drizzle-orm/src/pglite/driver.ts
@@ -52,7 +52,7 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 ): PgliteDatabase<TSchema> & {
 	$client: PgliteClient;
 } {
-	const dialect = new PgDialect({ casing: config.casing });
+	const dialect = new PgDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/planetscale-serverless/driver.ts
+++ b/drizzle-orm/src/planetscale-serverless/driver.ts
@@ -52,7 +52,7 @@ const db = drizzle(client);
 		`);
 	}
 
-	const dialect = new MySqlDialect({ casing: config.casing });
+	const dialect = new MySqlDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/postgres-js/driver.ts
+++ b/drizzle-orm/src/postgres-js/driver.ts
@@ -35,7 +35,7 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 	client.options.serializers['114'] = transparentParser;
 	client.options.serializers['3802'] = transparentParser;
 
-	const dialect = new PgDialect({ casing: config.casing });
+	const dialect = new PgDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/prisma/mysql/driver.ts
+++ b/drizzle-orm/src/prisma/mysql/driver.ts
@@ -15,8 +15,8 @@ export class PrismaMySqlDatabase
 {
 	static override readonly [entityKind]: string = 'PrismaMySqlDatabase';
 
-	constructor(client: PrismaClient, logger: Logger | undefined) {
-		const dialect = new MySqlDialect();
+	constructor(client: PrismaClient, logger: Logger | undefined, safeMutations: boolean = false) {
+		const dialect = new MySqlDialect({ safeMutations });
 		super(dialect, new PrismaMySqlSession(dialect, client, { logger }), undefined, 'default');
 	}
 }
@@ -35,7 +35,7 @@ export function drizzle(config: PrismaMySqlConfig = {}) {
 		return client.$extends({
 			name: 'drizzle',
 			client: {
-				$drizzle: new PrismaMySqlDatabase(client, logger),
+				$drizzle: new PrismaMySqlDatabase(client, logger, config.safeMutations),
 			},
 		});
 	});

--- a/drizzle-orm/src/prisma/pg/driver.ts
+++ b/drizzle-orm/src/prisma/pg/driver.ts
@@ -13,8 +13,8 @@ import { PrismaPgSession } from './session.ts';
 export class PrismaPgDatabase extends PgDatabase<PrismaPgQueryResultHKT, Record<string, never>> {
 	static override readonly [entityKind]: string = 'PrismaPgDatabase';
 
-	constructor(client: PrismaClient, logger: Logger | undefined) {
-		const dialect = new PgDialect();
+	constructor(client: PrismaClient, logger: Logger | undefined, safeMutations: boolean = false) {
+		const dialect = new PgDialect({ safeMutations });
 		super(dialect, new PrismaPgSession(dialect, client, { logger }), undefined);
 	}
 }
@@ -33,7 +33,7 @@ export function drizzle(config: PrismaPgConfig = {}) {
 		return client.$extends({
 			name: 'drizzle',
 			client: {
-				$drizzle: new PrismaPgDatabase(client, logger),
+				$drizzle: new PrismaPgDatabase(client, logger, config.safeMutations),
 			},
 		});
 	});

--- a/drizzle-orm/src/prisma/sqlite/driver.ts
+++ b/drizzle-orm/src/prisma/sqlite/driver.ts
@@ -11,7 +11,7 @@ export type PrismaSQLiteDatabase = BaseSQLiteDatabase<'async', []>;
 export type PrismaSQLiteConfig = Omit<DrizzleConfig, 'schema'>;
 
 export function drizzle(config: PrismaSQLiteConfig = {}) {
-	const dialect = new SQLiteAsyncDialect();
+	const dialect = new SQLiteAsyncDialect({ safeMutations: config.safeMutations });
 	let logger: Logger | undefined;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/singlestore-proxy/driver.ts
+++ b/drizzle-orm/src/singlestore-proxy/driver.ts
@@ -31,7 +31,7 @@ export function drizzle<TSchema extends Record<string, unknown> = Record<string,
 	callback: RemoteCallback,
 	config: DrizzleConfig<TSchema> = {},
 ): SingleStoreRemoteDatabase<TSchema> {
-	const dialect = new SingleStoreDialect({ casing: config.casing });
+	const dialect = new SingleStoreDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/singlestore/driver.ts
+++ b/drizzle-orm/src/singlestore/driver.ts
@@ -67,7 +67,7 @@ function construct<
 ): SingleStoreDriverDatabase<TSchema> & {
 	$client: AnySingleStoreDriverConnection extends TClient ? CallbackPool : TClient;
 } {
-	const dialect = new SingleStoreDialect({ casing: config.casing });
+	const dialect = new SingleStoreDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/sqlite-proxy/driver.ts
+++ b/drizzle-orm/src/sqlite-proxy/driver.ts
@@ -55,7 +55,7 @@ export function drizzle<TSchema extends Record<string, unknown> = Record<string,
 	batchCallback?: AsyncBatchRemoteCallback | DrizzleConfig<TSchema>,
 	config?: DrizzleConfig<TSchema>,
 ): SqliteRemoteDatabase<TSchema> {
-	const dialect = new SQLiteAsyncDialect({ casing: config?.casing });
+	const dialect = new SQLiteAsyncDialect({ casing: config?.casing, safeMutations: config?.safeMutations });
 	let logger;
 	let cache;
 	let _batchCallback: AsyncBatchRemoteCallback | undefined;

--- a/drizzle-orm/src/tidb-serverless/driver.ts
+++ b/drizzle-orm/src/tidb-serverless/driver.ts
@@ -31,7 +31,7 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 ): TiDBServerlessDatabase<TSchema> & {
 	$client: Connection;
 } {
-	const dialect = new MySqlDialect({ casing: config.casing });
+	const dialect = new MySqlDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -221,6 +221,7 @@ export interface DrizzleConfig<TSchema extends Record<string, unknown> = Record<
 	schema?: TSchema;
 	casing?: Casing;
 	cache?: Cache;
+	safeMutations?: boolean;
 }
 export type ValidateShape<T, ValidShape, TResult = T> = T extends ValidShape
 	? Exclude<keyof T, keyof ValidShape> extends never ? TResult

--- a/drizzle-orm/src/vercel-postgres/driver.ts
+++ b/drizzle-orm/src/vercel-postgres/driver.ts
@@ -51,7 +51,7 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 ): VercelPgDatabase<TSchema> & {
 	$client: VercelPgClient;
 } {
-	const dialect = new PgDialect({ casing: config.casing });
+	const dialect = new PgDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/drizzle-orm/src/xata-http/driver.ts
+++ b/drizzle-orm/src/xata-http/driver.ts
@@ -55,7 +55,7 @@ export function drizzle<TSchema extends Record<string, unknown> = Record<string,
 ): XataHttpDatabase<TSchema> & {
 	$client: XataHttpClient;
 } {
-	const dialect = new PgDialect({ casing: config.casing });
+	const dialect = new PgDialect({ casing: config.casing, safeMutations: config.safeMutations });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();

--- a/integration-tests/tests/gel/gel.test.ts
+++ b/integration-tests/tests/gel/gel.test.ts
@@ -5251,4 +5251,33 @@ describe('some', async () => {
 		// @ts-expect-error
 		expect(db.select().from(sq).getUsedTables()).toStrictEqual(['users']);
 	});
+	test('safeMutations: update without where clause', async (ctx) => {
+		const { db } = ctx.gel;
+
+		// @ts-expect-error Modify safeMutations to prevent updates without where clause
+		db.dialect.safeMutations = true;
+
+		await db.insert(usersTable).values({ id1: 1, name: 'John' });
+		await expect(async () => await db.update(usersTable).set({ name: 'Maria' })).rejects.toThrowError();
+		await expect(db.update(usersTable).set({ name: 'Maria' }).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+		// @ts-expect-error Modify safeMutations back to default
+		db.dialect.safeMutations = false;
+		await expect(db.update(usersTable).set({ name: 'John' })).resolves.not.toThrow();
+	});
+
+	test('safeMutations: delete without where clause', async (ctx) => {
+		const { db } = ctx.gel;
+
+		// @ts-expect-error Modify safeMutations to prevent deletes without where clause
+		db.dialect.safeMutations = true;
+
+		await db.insert(usersTable).values({ id1: 1, name: 'John' });
+		await expect(async () => await db.delete(usersTable)).rejects.toThrowError();
+		await expect(db.delete(usersTable).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+		// @ts-expect-error Modify safeMutations back to default
+		db.dialect.safeMutations = false;
+		await expect(db.delete(usersTable)).resolves.not.toThrow();
+	});
 });

--- a/integration-tests/tests/mysql/mysql-common.ts
+++ b/integration-tests/tests/mysql/mysql-common.ts
@@ -5360,4 +5360,34 @@ export function tests(driver?: string) {
 		expect(result1).toEqual([{ userId: 1, data: { name: 'John' } }]);
 		expect(result2).toEqual([{ userId: 2, data: { name: 'Jane' } }]);
 	});
+
+	test('safeMutations: update without where clause', async (ctx) => {
+		const { db } = ctx.mysql;
+
+		// @ts-expect-error Modify safeMutations to prevent updates without where clause
+		db.dialect.safeMutations = true;
+
+		await db.insert(usersTable).values({ name: 'John' });
+		await expect(async () => await db.update(usersTable).set({ name: 'Maria' })).rejects.toThrowError();
+		await expect(db.update(usersTable).set({ name: 'Maria' }).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+		// @ts-expect-error Modify safeMutations back to default
+		db.dialect.safeMutations = false;
+		await expect(db.update(usersTable).set({ name: 'John' })).resolves.not.toThrow();
+	});
+
+	test('safeMutations: delete without where clause', async (ctx) => {
+		const { db } = ctx.mysql;
+
+		// @ts-expect-error Modify safeMutations to prevent deletes without where clause
+		db.dialect.safeMutations = true;
+
+		await db.insert(usersTable).values({ name: 'John' });
+		await expect(async () => await db.delete(usersTable)).rejects.toThrowError();
+		await expect(db.delete(usersTable).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+		// @ts-expect-error Modify safeMutations back to default
+		db.dialect.safeMutations = false;
+		await expect(db.delete(usersTable)).resolves.not.toThrow();
+	});
 }

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -6404,5 +6404,35 @@ export function tests() {
 			expectTypeOf(rawRes).toEqualTypeOf<ExpectedType>();
 			expect(rawRes).toStrictEqual(expectedRes);
 		});
+
+		test('safeMutations: update without where clause', async (ctx) => {
+			const { db } = ctx.pg;
+
+			// @ts-expect-error Modify safeMutations to prevent updates without where clause
+			db.dialect.safeMutations = true;
+
+			await db.insert(usersTable).values({ name: 'John' });
+			await expect(async () => await db.update(usersTable).set({ name: 'Maria' })).rejects.toThrowError();
+			await expect(db.update(usersTable).set({ name: 'Maria' }).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+			// @ts-expect-error Modify safeMutations back to default
+			db.dialect.safeMutations = false;
+			await expect(db.update(usersTable).set({ name: 'John' })).resolves.not.toThrow();
+		});
+
+		test('safeMutations: delete without where clause', async (ctx) => {
+			const { db } = ctx.pg;
+
+			// @ts-expect-error Modify safeMutations to prevent deletes without where clause
+			db.dialect.safeMutations = true;
+
+			await db.insert(usersTable).values({ name: 'John' });
+			await expect(async () => await db.delete(usersTable)).rejects.toThrowError();
+			await expect(db.delete(usersTable).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+			// @ts-expect-error Modify safeMutations back to default
+			db.dialect.safeMutations = false;
+			await expect(db.delete(usersTable)).resolves.not.toThrow();
+		});
 	});
 }

--- a/integration-tests/tests/singlestore/singlestore-common.ts
+++ b/integration-tests/tests/singlestore/singlestore-common.ts
@@ -3923,4 +3923,34 @@ export function tests(driver?: string) {
 			expect(rawRes).toStrictEqual(expectedRes);
 		});
 	});
+
+	test('safeMutations: update without where clause', async (ctx) => {
+		const { db } = ctx.singlestore;
+
+		// @ts-expect-error Modify safeMutations to prevent updates without where clause
+		db.dialect.safeMutations = true;
+
+		await db.insert(usersTable).values({ name: 'John' });
+		await expect(async () => await db.update(usersTable).set({ name: 'Maria' })).rejects.toThrowError();
+		await expect(db.update(usersTable).set({ name: 'Maria' }).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+		// @ts-expect-error Modify safeMutations back to default
+		db.dialect.safeMutations = false;
+		await expect(db.update(usersTable).set({ name: 'John' })).resolves.not.toThrow();
+	});
+
+	test('safeMutations: delete without where clause', async (ctx) => {
+		const { db } = ctx.singlestore;
+
+		// @ts-expect-error Modify safeMutations to prevent deletes without where clause
+		db.dialect.safeMutations = true;
+
+		await db.insert(usersTable).values({ name: 'John' });
+		await expect(async () => await db.delete(usersTable)).rejects.toThrowError();
+		await expect(db.delete(usersTable).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+		// @ts-expect-error Modify safeMutations back to default
+		db.dialect.safeMutations = false;
+		await expect(db.delete(usersTable)).resolves.not.toThrow();
+	});
 }

--- a/integration-tests/tests/sqlite/sqlite-common.ts
+++ b/integration-tests/tests/sqlite/sqlite-common.ts
@@ -3845,4 +3845,34 @@ export function tests() {
 		expect(result1).toEqual([{ userId: 1, data: { name: 'John' } }]);
 		expect(result2).toEqual([{ userId: 2, data: { name: 'Jane' } }]);
 	});
+
+	test('safeMutations: update without where clause', async (ctx) => {
+		const { db } = ctx.sqlite;
+
+		// @ts-expect-error Modify safeMutations to prevent updates without where clause
+		db.dialect.safeMutations = true;
+
+		await db.insert(usersTable).values({ name: 'John' });
+		await expect(async () => await db.update(usersTable).set({ name: 'Maria' })).rejects.toThrowError();
+		await expect(db.update(usersTable).set({ name: 'Maria' }).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+		// @ts-expect-error Modify safeMutations back to default
+		db.dialect.safeMutations = false;
+		await expect(db.update(usersTable).set({ name: 'John' })).resolves.not.toThrow();
+	});
+
+	test('safeMutations: delete without where clause', async (ctx) => {
+		const { db } = ctx.sqlite;
+
+		// @ts-expect-error Modify safeMutations to prevent deletes without where clause
+		db.dialect.safeMutations = true;
+
+		await db.insert(usersTable).values({ name: 'John' });
+		await expect(async () => await db.delete(usersTable)).rejects.toThrowError();
+		await expect(db.delete(usersTable).where(eq(usersTable.name, 'John'))).resolves.not.toThrow();
+
+		// @ts-expect-error Modify safeMutations back to default
+		db.dialect.safeMutations = false;
+		await expect(db.delete(usersTable)).resolves.not.toThrow();
+	});
 }


### PR DESCRIPTION
This PR implements the necessary changes and tests to prevent any `update` or `delete` query without a where clause from running. #4324

This is implemented as an opt-IN feature in the drizzle config (for backwards compatibility), but I can see a case for a breaking change that turns this opt-out:

```ts
const db = drizzle({ 
  connection: {
    connectionString: '...',
  },
  safeMutations: true, // update/delete now require a where clause (defaults to false, i.e. no clause needed)
});
```

With these changes, running an `update` or `delete` query without a where clause will result in either

```ts
throw new Error('Update query must have a "where" clause');
throw new Error('Delete query must have a "where" clause');
```

This does not affect the type information, this is strictly a runtime check that will throw on a bad query