### PR TITLE
[Pg-kit] Fix invalid javascript syntax for default() values in generated schema.

### DIFF
--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -366,6 +366,7 @@ export function escapeSingleQuotes(str: string) {
 }
 
 export function unescapeSingleQuotes(str: string, ignoreFirstAndLastChar: boolean) {
+	if (str === "''") return str;
 	const regex = ignoreFirstAndLastChar ? /(?<!^)'(?!$)/g : /'/g;
 	return str.replace(/''/g, "'").replace(regex, "\\'");
 }

--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -1,4 +1,3 @@
-import type { RunResult } from 'better-sqlite3';
 import chalk from 'chalk';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
@@ -366,7 +365,77 @@ export function escapeSingleQuotes(str: string) {
 }
 
 export function unescapeSingleQuotes(str: string, ignoreFirstAndLastChar: boolean) {
-	if (str === "''") return str;
-	const regex = ignoreFirstAndLastChar ? /(?<!^)'(?!$)/g : /'/g;
-	return str.replace(/''/g, "'").replace(regex, "\\'");
+	const regex = ignoreFirstAndLastChar ? /(?<!^)''(?!$)/g : /''/g;
+	const unescaped = str.replace(regex, "'");
+	return formatForSingleQuotedString(unescaped, ignoreFirstAndLastChar);
+}
+
+/**
+ * Formats a string for use in a JS single-quoted string literal.
+ *
+ * This function handles proper escaping of special characters:
+ * - Single quotes are escaped as \'
+ * - Double quotes are left as-is
+ * - Backslashes are escaped as \\
+ * - Common control characters (\b, \f, \n, etc.) are properly escaped
+ * - Null characters (\0) followed by a digit are escaped as \x00
+ * - Other control characters (ASCII < 32) are escaped as \xHH hex representation
+ *
+ * @param value The string to format
+ * @param ignoreFirstAndLastChar If true, the first and last characters of the input string are ignored
+ * @returns A properly formatted JS string literal with single quotes
+ */
+export function formatForSingleQuotedString(value: string, ignoreFirstAndLastChar: boolean): string {
+	const replacements: { [key: string]: string } = {
+		'\\': '\\\\',
+		'\b': '\\b',
+		'\f': '\\f',
+		'\n': '\\n',
+		'\r': '\\r',
+		'\t': '\\t',
+		'\v': '\\v',
+		'\0': '\\0',
+		'\u2028': '\\u2028',
+		'\u2029': '\\u2029',
+	};
+
+	let product = '';
+	const maxIndex = value.length - 1;
+	for (let i = 0; i <= maxIndex; i++) {
+		const c: string = value[i];
+
+		if (ignoreFirstAndLastChar && (i === 0 || i === maxIndex)) {
+			product += c;
+			continue;
+		}
+
+		if (c === "'") {
+			product += "\\'";
+			continue;
+		}
+
+		if (c === '"') {
+			product += '"';
+			continue;
+		}
+
+		if (c === '\0' && i + 1 <= maxIndex && /[0-9]/.test(value[i + 1])) {
+			product += '\\x00';
+			continue;
+		}
+
+		if (replacements[c]) {
+			product += replacements[c];
+			continue;
+		}
+
+		if (c < ' ') {
+			const hexString = c.charCodeAt(0).toString(16);
+			product += '\\x' + ('00' + hexString).substring(hexString.length);
+			continue;
+		}
+
+		product += c;
+	}
+	return product;
 }

--- a/drizzle-kit/tests/introspect/mysql.test.ts
+++ b/drizzle-kit/tests/introspect/mysql.test.ts
@@ -317,3 +317,22 @@ test('instrospect strings with single quotes', async () => {
 
 	await client.query(`drop table columns;`);
 });
+
+test('introspect strings with empty string as default', async () => {
+	const schema = {
+		columns: mysqlTable('columns', {
+			text: text('text').default(''),
+			varchar: varchar('varchar').default(''),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectMySQLToFile(
+		client,
+		schema,
+		'introspect-strings-with-empty-string-as-default',
+		'drizzle',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -315,7 +315,7 @@ test('instrospect all column types', async () => {
 	expect(sqlStatements.length).toBe(0);
 });
 
-test('instrospect all column array types', async () => {
+test('introspect all column array types', async () => {
 	const client = new PGlite();
 
 	const myEnum = pgEnum('my_enum', ['a', 'b', 'c']);
@@ -358,7 +358,6 @@ test('instrospect all column array types', async () => {
 		schema,
 		'introspect-all-columns-array-types',
 	);
-
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
 });
@@ -466,6 +465,99 @@ test('introspect strings with single quotes', async () => {
 			enum: myEnum('my_enum').default('escape\'s quotes " '),
 			text: text('text').default('escape\'s quotes " '),
 			varchar: varchar('varchar').default('escape\'s quotes " '),
+			// A single regular character
+			text_single_char: text('text_single_char').default('a'),
+			varchar_single_char: varchar('varchar_single_char', { length: 255 }).default('a'),
+
+			// A single quote character
+			text_single_quote: text('text_single_quote').default("'"),
+			varchar_single_quote: varchar('varchar_single_quote', { length: 255 }).default("'"),
+
+			// Two adjacent single quotes
+			text_two_quotes: text('text_two_quotes').default("''"),
+			varchar_two_quotes: varchar('varchar_two_quotes', { length: 255 }).default("''"),
+
+			// Three adjacent single quotes
+			text_three_quotes: text('text_three_quotes').default("'''"),
+			varchar_three_quotes: varchar('varchar_three_quotes', { length: 255 }).default("'''"),
+
+			// Four adjacent single quotes
+			text_four_quotes: text('text_four_quotes').default("''''"),
+			varchar_four_quotes: varchar('varchar_four_quotes', { length: 255 }).default("''''"),
+
+			// Starts with two single quotes
+			text_starts_with_quotes: text('text_starts_with_quotes').default("''a"),
+			varchar_starts_with_quotes: varchar('varchar_starts_with_quotes', { length: 255 }).default("''a"),
+
+			// Ends with two single quotes
+			text_ends_with_quotes: text('text_ends_with_quotes').default("a''"),
+			varchar_ends_with_quotes: varchar('varchar_ends_with_quotes', { length: 255 }).default("a''"),
+
+			// Starts and ends with single quotes
+			text_wrapped_in_single: text('text_wrapped_in_single').default("'a'"),
+			varchar_wrapped_in_single: varchar('varchar_wrapped_in_single', { length: 255 }).default("'a'"),
+
+			// Starts and ends with two single quotes
+			text_wrapped_in_double: text('text_wrapped_in_double').default("''a''"),
+			varchar_wrapped_in_double: varchar('varchar_wrapped_in_double', { length: 255 }).default("''a''"),
+
+			// Single quote surrounded by spaces
+			text_space_quote_space: text('text_space_quote_space').default(" ' "),
+			varchar_space_quote_space: varchar('varchar_space_quote_space', { length: 255 }).default(" ' "),
+
+			// Two single quotes surrounded by spaces
+			text_space_quotes_space: text('text_space_quotes_space').default(" '' "),
+			varchar_space_quotes_space: varchar('varchar_space_quotes_space', { length: 255 }).default(" '' "),
+
+			// A backslash followed by a single quote
+			text_backslash_quote: text('text_backslash_quote').default("\\'"),
+			varchar_backslash_quote: varchar('varchar_backslash_quote', { length: 255 }).default("\\'"),
+
+			// Two backslashes followed by a single quote
+			text_two_backslash_quote: text('text_two_backslash_quote').default("\\\\'"),
+			varchar_two_backslash_quote: varchar('varchar_two_backslash_quote', { length: 255 }).default("\\\\'"),
+
+			// A single quote followed by a backslash
+			text_quote_backslash: text('text_quote_backslash').default("'\\"),
+			varchar_quote_backslash: varchar('varchar_quote_backslash', { length: 255 }).default("'\\"),
+
+			// Multiple groups of adjacent single quotes
+			text_multiple_quote_groups: text('text_multiple_quote_groups').default("a''b'''c"),
+			varchar_multiple_quote_groups: varchar('varchar_multiple_quote_groups', { length: 255 }).default("a''b'''c"),
+
+			// A single double-quote character
+			text_double_quote: text('text_double_quote').default('"'),
+			varchar_double_quote: varchar('varchar_double_quote', { length: 255 }).default('"'),
+
+			// Mixed single and double quotes
+			text_mixed_quotes: text('text_mixed_quotes').default('it\'s a "test"'),
+			varchar_mixed_quotes: varchar('varchar_mixed_quotes', { length: 255 }).default('it\'s a "test"'),
+
+			// String containing characters that might be in a regex
+			text_regex_like: text('text_regex_like').default('^(?!$)[a-z]+.*$'),
+			varchar_regex_like: varchar('varchar_regex_like', { length: 255 }).default('^(?!$)[a-z]+.*$'),
+
+			// Newline characters mixed with quotes
+			text_newline_quotes: text('text_newline_quotes').default("start\\n''\\nmiddle\\'\\nend"),
+			varchar_newline_quotes: varchar('varchar_newline_quotes', { length: 255 }).default(
+				"start\\n''\\nmiddle\\'\\nend",
+			),
+
+			// Special characters
+			text_special_chars: text('text_special_chars').default('\\b\\f\\n\\r\\t\\v\\0'),
+			varchar_special_chars: varchar({ length: 50 }).default('\\b\\f\\n\\r\\t\\v\\0'),
+
+			// Control characters
+			text_control_chars: text('text_control_chars').default('\u0001\u0002\u0003'),
+			varchar_control_chars: varchar({ length: 50 }).default('\u0001\u0002\u0003'),
+
+			// Unicode and emoji
+			text_unicode: text('text_unicode').default('你好世界🌍'),
+			varchar_unicode: varchar({ length: 50 }).default('你好世界🌍'),
+
+			// Complex mix
+			text_complex: text('text_complex').default("a''b\\n'c\\t\"de"),
+			varchar_complex: varchar({ length: 50 }).default("a''b\\n'c\\t\"de"),
 		}),
 	};
 
@@ -484,8 +576,9 @@ test('introspect strings with empty string as default', async () => {
 
 	const schema = {
 		columns: pgTable('columns', {
-			text: text('text').default(''),
-			varchar: varchar('varchar').default(''),
+			// Empty string
+			text_empty: text('text_empty').default(''),
+			varchar_empty: varchar('varchar_empty', { length: 255 }).default(''),
 		}),
 	};
 
@@ -494,7 +587,6 @@ test('introspect strings with empty string as default', async () => {
 		schema,
 		'introspect-strings-with-empty-string-as-default',
 	);
-
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
 });

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -456,7 +456,7 @@ test('introspect enum with similar name to native type', async () => {
 	expect(sqlStatements.length).toBe(0);
 });
 
-test('instrospect strings with single quotes', async () => {
+test('introspect strings with single quotes', async () => {
 	const client = new PGlite();
 
 	const myEnum = pgEnum('my_enum', ['escape\'s quotes " ']);
@@ -473,6 +473,26 @@ test('instrospect strings with single quotes', async () => {
 		client,
 		schema,
 		'introspect-strings-with-single-quotes',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
+test('introspect strings with empty string as default', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		columns: pgTable('columns', {
+			text: text('text').default(''),
+			varchar: varchar('varchar').default(''),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'introspect-strings-with-empty-string-as-default',
 	);
 
 	expect(statements.length).toBe(0);

--- a/drizzle-kit/tests/introspect/singlestore.test.ts
+++ b/drizzle-kit/tests/introspect/singlestore.test.ts
@@ -273,3 +273,22 @@ test('handle unsigned numerical types', async () => {
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
 });
+
+test('introspect strings with empty string as default', async () => {
+	const schema = {
+		columns: singlestoreTable('columns', {
+			text: text('text').default(''),
+			varchar: varchar('varchar').default(''),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectSingleStoreToFile(
+		client,
+		schema,
+		'introspect-strings-with-empty-string-as-default',
+		'drizzle',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});

--- a/drizzle-kit/tests/introspect/sqlite.test.ts
+++ b/drizzle-kit/tests/introspect/sqlite.test.ts
@@ -75,6 +75,25 @@ test('instrospect strings with single quotes', async () => {
 	expect(sqlStatements.length).toBe(0);
 });
 
+test('introspect strings with empty string as default', async () => {
+	const sqlite = new Database(':memory:');
+
+	const schema = {
+		columns: sqliteTable('columns', {
+			text: text('text').default(''),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectSQLiteToFile(
+		sqlite,
+		schema,
+		'introspect-strings-with-empty-string-as-default',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
 test('introspect checks', async () => {
 	const sqlite = new Database(':memory:');
 

--- a/drizzle-kit/tests/utils.test.ts
+++ b/drizzle-kit/tests/utils.test.ts
@@ -1,0 +1,205 @@
+import { expect, test } from 'vitest';
+import { formatForSingleQuotedString, unescapeSingleQuotes } from '../src/utils';
+
+test('formatForSingleQuotedString basic functionality, ignoreFirstAndLastChar: false', () => {
+	// Simple strings
+	expect(formatForSingleQuotedString('abc', false)).toBe('abc');
+	expect(formatForSingleQuotedString('', false)).toBe('');
+
+	// Ignoring first and last character
+	expect(formatForSingleQuotedString('abc', true)).toBe('abc');
+	expect(formatForSingleQuotedString('a', true)).toBe('a');
+
+	// Special characters
+	expect(formatForSingleQuotedString("'", false)).toBe("\\'"); // Single quote
+	expect(formatForSingleQuotedString('"', false)).toBe('"'); // Double quote
+	expect(formatForSingleQuotedString('\\', false)).toBe('\\\\'); // Backslash
+
+	// Control characters
+	expect(formatForSingleQuotedString('\n', false)).toBe('\\n');
+	expect(formatForSingleQuotedString('\r', false)).toBe('\\r');
+	expect(formatForSingleQuotedString('\t', false)).toBe('\\t');
+	expect(formatForSingleQuotedString('\0', false)).toBe('\\0');
+
+	// Control characters below ASCII 32 (not in the replacements map)
+	expect(formatForSingleQuotedString('\u0001', false)).toBe('\\x01');
+	expect(formatForSingleQuotedString('\u0002', false)).toBe('\\x02');
+
+	// Null character followed by a digit special case where a null character (`\0`) is followed by a digit, which should be escaped as `\x00` rather than `\0`.
+	expect(formatForSingleQuotedString('\u00001', false)).toBe('\\x001');
+
+	// Mixed special characters
+	expect(formatForSingleQuotedString("a'b\\c\nd", false)).toBe("a\\'b\\\\c\\nd");
+
+	// Unicode characters
+	expect(formatForSingleQuotedString('你好', false)).toBe('你好');
+	expect(formatForSingleQuotedString('🌍', false)).toBe('🌍');
+
+	// Line terminators
+	expect(formatForSingleQuotedString('\u2028', false)).toBe('\\u2028');
+	expect(formatForSingleQuotedString('\u2029', false)).toBe('\\u2029');
+
+	// Complex mix of characters
+	const complexString = "a'\nb\tc\rd\0e\u0001f\\g\u2028h";
+	expect(formatForSingleQuotedString(complexString, false))
+		.toBe("a\\'\\nb\\tc\\rd\\0e\\x01f\\\\g\\u2028h");
+});
+
+test('formatForSingleQuotedString basic functionality, ignoreFirstAndLastChar: true', () => {
+	// Simple strings
+	expect(formatForSingleQuotedString('abc', true)).toBe('abc');
+	expect(formatForSingleQuotedString('', true)).toBe('');
+
+	// Ignoring first and last character
+	expect(formatForSingleQuotedString('abc', true)).toBe('abc');
+	expect(formatForSingleQuotedString('a', true)).toBe('a');
+
+	// Special characters
+	expect(formatForSingleQuotedString("'", true)).toBe("'"); // Single quote
+	expect(formatForSingleQuotedString('"', true)).toBe('"'); // Double quote
+	expect(formatForSingleQuotedString('\\', true)).toBe('\\'); // Backslash
+
+	// Control characters
+	expect(formatForSingleQuotedString('\n', true)).toBe('\n');
+	expect(formatForSingleQuotedString('\r', true)).toBe('\r');
+	expect(formatForSingleQuotedString('\t', true)).toBe('\t');
+	expect(formatForSingleQuotedString('\0', true)).toBe('\0');
+
+	// Control characters below ASCII 32 (not in the replacements map)
+	expect(formatForSingleQuotedString('\u0001', true)).toBe('\x01');
+	expect(formatForSingleQuotedString('\u0002', true)).toBe('\x02');
+
+	// Null character followed by a digit (special case)
+	expect(formatForSingleQuotedString('\u00001', true)).toBe('\u00001');
+
+	// Mixed special characters
+	expect(formatForSingleQuotedString("a'b\\c\nd", true)).toBe("a\\'b\\\\c\\nd");
+
+	// Unicode characters
+	expect(formatForSingleQuotedString('你好', true)).toBe('你好');
+	expect(formatForSingleQuotedString('🌍', true)).toBe('🌍');
+
+	// Line terminators
+	expect(formatForSingleQuotedString('\u2028', true)).toBe('\u2028');
+	expect(formatForSingleQuotedString('\u2029', true)).toBe('\u2029');
+
+	// Complex mix of characters
+	const complexString = "a'\nb\tc\rd\0e\u0001f\\g\u2028h";
+	expect(formatForSingleQuotedString(complexString, true))
+		.toBe("a\\'\\nb\\tc\\rd\\0e\\x01f\\\\g\\u2028h");
+});
+
+test('unescapeSingleQuotes functionality, ignoreFirstAndLastChar: false', () => {
+	// Basic unescaping
+	expect(unescapeSingleQuotes("a''b", false)).toBe("a\\'b");
+	expect(unescapeSingleQuotes("''", false)).toBe("\\'");
+
+	// Only interior quotes should be unescaped
+	expect(unescapeSingleQuotes("''a''b''", false)).toBe("\\'a\\'b\\'");
+
+	// With ignoreFirstAndLastChar
+	expect(unescapeSingleQuotes("'a''b'", false)).toBe("\\'a\\'b\\'");
+	expect(unescapeSingleQuotes("''a''b''", false)).toBe("\\'a\\'b\\'");
+
+	// Complex case
+	expect(unescapeSingleQuotes("'a''b''c\nd'", false)).toBe("\\'a\\'b\\'c\\nd\\'");
+
+	// Simple strings
+	expect(unescapeSingleQuotes('abc', false)).toBe('abc');
+	expect(unescapeSingleQuotes('', false)).toBe('');
+
+	// Ignoring first and last character
+	expect(unescapeSingleQuotes('abc', true)).toBe('abc');
+	expect(unescapeSingleQuotes('a', true)).toBe('a');
+
+	// Special characters
+	expect(unescapeSingleQuotes("'", false)).toBe("\\'"); // Single quote
+	expect(unescapeSingleQuotes('"', false)).toBe('"'); // Double quote
+	expect(unescapeSingleQuotes('\\', false)).toBe('\\\\'); // Backslash
+
+	// Control characters
+	expect(unescapeSingleQuotes('\n', false)).toBe('\\n');
+	expect(unescapeSingleQuotes('\r', false)).toBe('\\r');
+	expect(unescapeSingleQuotes('\t', false)).toBe('\\t');
+	expect(unescapeSingleQuotes('\0', false)).toBe('\\0');
+
+	// Control characters below ASCII 32 (not in the replacements map)
+	expect(unescapeSingleQuotes('\u0001', false)).toBe('\\x01');
+	expect(unescapeSingleQuotes('\u0002', false)).toBe('\\x02');
+
+	// Null character followed by a digit special case where a null character (`\0`) is followed by a digit, which should be escaped as `\x00` rather than `\0`.
+	expect(unescapeSingleQuotes('\u00001', false)).toBe('\\x001');
+
+	// Mixed special characters
+	expect(unescapeSingleQuotes("a'b\\c\nd", false)).toBe("a\\'b\\\\c\\nd");
+
+	// Unicode characters
+	expect(unescapeSingleQuotes('你好', false)).toBe('你好');
+	expect(unescapeSingleQuotes('🌍', false)).toBe('🌍');
+
+	// Line terminators
+	expect(unescapeSingleQuotes('\u2028', false)).toBe('\\u2028');
+	expect(unescapeSingleQuotes('\u2029', false)).toBe('\\u2029');
+
+	// Complex mix of characters
+	const complexString = "a'\nb\tc\rd\0e\u0001f\\g\u2028h";
+	expect(unescapeSingleQuotes(complexString, false))
+		.toBe("a\\'\\nb\\tc\\rd\\0e\\x01f\\\\g\\u2028h");
+});
+test('unescapeSingleQuotes functionality, ignoreFirstAndLastChar: true', () => {
+	// Basic unescaping
+	expect(unescapeSingleQuotes("a''b", true)).toBe("a\\'b");
+	expect(unescapeSingleQuotes("''", true)).toBe("''");
+
+	// Only interior quotes should be unescaped
+	expect(unescapeSingleQuotes("''a''b''", true)).toBe("'\\'a\\'b\\''");
+
+	// With ignoreFirstAndLastChar
+	expect(unescapeSingleQuotes("'a''b'", true)).toBe("'a\\'b'");
+	expect(unescapeSingleQuotes("''a''b''", true)).toBe("'\\'a\\'b\\''");
+
+	// Complex case
+	expect(unescapeSingleQuotes("'a''b''c\nd'", true)).toBe("'a\\'b\\'c\\nd'");
+
+	// Simple strings
+	expect(unescapeSingleQuotes('abc', true)).toBe('abc');
+	expect(unescapeSingleQuotes('', true)).toBe('');
+
+	// Ignoring first and last character
+	expect(unescapeSingleQuotes('abc', true)).toBe('abc');
+	expect(unescapeSingleQuotes('a', true)).toBe('a');
+
+	// Special characters
+	expect(unescapeSingleQuotes("'", true)).toBe("'"); // Single quote
+	expect(unescapeSingleQuotes('"', true)).toBe('"'); // Double quote
+	expect(unescapeSingleQuotes('\\', true)).toBe('\\'); // Backslash
+
+	// Control characters
+	expect(unescapeSingleQuotes('\n', true)).toBe('\n');
+	expect(unescapeSingleQuotes('\r', true)).toBe('\r');
+	expect(unescapeSingleQuotes('\t', true)).toBe('\t');
+	expect(unescapeSingleQuotes('\0', true)).toBe('\0');
+
+	// Control characters below ASCII 32 (not in the replacements map)
+	expect(unescapeSingleQuotes('\u0001', true)).toBe('\x01');
+	expect(unescapeSingleQuotes('\u0002', true)).toBe('\x02');
+
+	// Null character followed by a digit special case where a null character (`\0`) is followed by a digit, which should be escaped as `\x00` rather than `\0`.
+	expect(unescapeSingleQuotes('\u00001', true)).toBe('\u00001');
+
+	// Mixed special characters
+	expect(unescapeSingleQuotes("a'b\\c\nd", true)).toBe("a\\'b\\\\c\\nd");
+
+	// Unicode characters
+	expect(unescapeSingleQuotes('你好', true)).toBe('你好');
+	expect(unescapeSingleQuotes('🌍', true)).toBe('🌍');
+
+	// Line terminators
+	expect(unescapeSingleQuotes('\u2028', true)).toBe('\u2028');
+	expect(unescapeSingleQuotes('\u2029', true)).toBe('\u2029');
+
+	// Complex mix of characters
+	const complexString = "a'\nb\tc\rd\0e\u0001f\\g\u2028h";
+	expect(unescapeSingleQuotes(complexString, true))
+		.toBe("a\\'\\nb\\tc\\rd\\0e\\x01f\\\\g\\u2028h");
+});


### PR DESCRIPTION
[Pg] Correctly escape default value string with special characters in them for writing to the TS schema files after introspection. 

Fixes #4121 #3559 #4085 #3549

Duplicates some of the work in #4043, but that doesn't seem to be moving forward at the moment, so hopefully this simpler PR can be merged instead. 

