### PR TITLE
fix(drizzle-kit): pulling a mysql db should only keep requested views

### DIFF
--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -917,6 +917,9 @@ export const fromDatabase = async (
 	}
 	for await (const view of views) {
 		const viewName = view['TABLE_NAME'];
+		if (!result[viewName]) {
+			continue;
+		}
 		const definition = view['VIEW_DEFINITION'];
 
 		const withCheckOption = view['CHECK_OPTION'] === 'NONE' ? undefined : view['CHECK_OPTION'].toLowerCase();


### PR DESCRIPTION
closes #4170 

without this fix i'm unable to use drizzle-kit.

i recommend banning unchecked index access in drizzle-kits tsconfig. after enabling it on a local branch i saw 600+ tsc errors.