### PR TITLE
Update MySQL password validation to allow empty strings

### DIFF
--- a/drizzle-kit/src/cli/validations/mysql.ts
+++ b/drizzle-kit/src/cli/validations/mysql.ts
@@ -8,7 +8,7 @@ export const mysqlCredentials = union([
 		host: string().min(1),
 		port: coerce.number().min(1).optional(),
 		user: string().min(1).optional(),
-		password: string().min(1).optional(),
+		password: string().optional(),
 		database: string().min(1),
 		ssl: union([
 			string(),


### PR DESCRIPTION
Closes https://github.com/drizzle-team/drizzle-orm/issues/4772
