### PR TITLE
fix: use toISOString when mapping an inline Date param

### DIFF
--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -299,6 +299,9 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 			return escapeString(chunk);
 		}
 		if (typeof chunk === 'object') {
+			if (chunk instanceof Date) {
+				return escapeString(chunk.toISOString());
+			}
 			const mappedValueAsString = chunk.toString();
 			if (mappedValueAsString === '[object Object]') {
 				return escapeString(JSON.stringify(chunk));


### PR DESCRIPTION
When using `SQL#inlineParams`, we should use toISOString on any Date params. As you can see below, the `toString` value is much longer and potentially less likely to be supported by the target database.

```
> d = new Date()
2025-07-24T23:50:17.041Z
> d.toISOString()
'2025-07-24T23:50:17.041Z'
> d.toString()
'Thu Jul 24 2025 19:50:17 GMT-0400 (Eastern Daylight Time)'
```
