### PR TITLE
fix(types): infer table selection from SQL instance if possible

### DIFF
--- a/drizzle-orm/src/query-builders/select.types.ts
+++ b/drizzle-orm/src/query-builders/select.types.ts
@@ -155,7 +155,8 @@ export type GetSelectTableName<TTable extends TableLike> = TTable extends Table 
 
 export type GetSelectTableSelection<TTable extends TableLike> = TTable extends Table ? TTable['_']['columns']
 	: TTable extends Subquery | View ? Assume<TTable['_']['selectedFields'], ColumnsSelection>
-	: TTable extends SQL ? {}
+	: TTable extends SQL<infer T> ? T extends ColumnsSelection ? T
+		: {}
 	: never;
 
 export type SelectResultField<T, TDeep extends boolean = true> = T extends DrizzleTypeError<any> ? T


### PR DESCRIPTION
If a typed `SQL` instance is used in a place where a table is expected, I think it's safe to assume its type represents the table selection. This will be particularly useful for my `(VALUES (...values)) AS alias (...columns)` implementation.
