### PR TITLE
feat: add `columnList` to Subquery class

### DIFF
--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -266,11 +266,15 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 				if (chunk._.isWith) {
 					return { sql: escapeName(chunk._.alias), params: [] };
 				}
+				const columnList = chunk._.columnList
+					? sql` (${sql.join(chunk._.columnList.map(sql.identifier), new StringChunk(','))})`
+					: undefined;
 				return this.buildQueryFromSourceParams([
 					new StringChunk('('),
 					chunk._.sql,
 					new StringChunk(') '),
 					new Name(chunk._.alias),
+					columnList,
 				], config);
 			}
 

--- a/drizzle-orm/src/subquery.ts
+++ b/drizzle-orm/src/subquery.ts
@@ -22,9 +22,10 @@ export class Subquery<
 		alias: TAlias;
 		isWith: boolean;
 		usedTables?: string[];
+		columnList: string[] | undefined;
 	};
 
-	constructor(sql: SQL, fields: TSelectedFields, alias: string, isWith = false, usedTables: string[] = []) {
+	constructor(sql: SQL, fields: TSelectedFields, alias: string, isWith = false, usedTables: string[] = [], columnList?: string[]) {
 		this._ = {
 			brand: 'Subquery',
 			sql,
@@ -32,6 +33,7 @@ export class Subquery<
 			alias: alias as TAlias,
 			isWith,
 			usedTables,
+			columnList,
 		};
 	}
 


### PR DESCRIPTION
This adds an extra property to Subquery that allows defining a column list to be added after the subquery's alias. This is particularly useful for implementing the `(VALUES (…)) AS foo (…)` syntax.
