### PR TITLE
feat: add drizzle-kit init command

### DIFF
--- a/drizzle-kit/src/cli/commands/init.ts
+++ b/drizzle-kit/src/cli/commands/init.ts
@@ -1,0 +1,184 @@
+import chalk from 'chalk';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { renderWithTask } from 'hanji';
+import { createInterface } from 'readline';
+import { dialects } from 'src/schemaValidator';
+import { Select } from '../selector-ui';
+
+interface InitConfig {
+	dialect: string;
+	out: string;
+	schema: string;
+	useDotenv: boolean;
+}
+
+class SimpleInput {
+	constructor(private defaultValue: string = '') {}
+	
+	async prompt(question: string): Promise<string> {
+		const rl = createInterface({
+			input: process.stdin,
+			output: process.stdout
+		});
+		
+		return new Promise((resolve) => {
+			rl.question(question, (answer) => {
+				rl.close();
+				resolve(answer.trim() || this.defaultValue);
+			});
+		});
+	}
+}
+
+export async function initHandler(): Promise<void> {
+	console.log(chalk.green('🚀 Welcome to Drizzle Kit!'));
+	console.log(chalk.gray('Let\'s set up your project with Drizzle ORM.\n'));
+
+	// Ask for dialect
+	const dialectPrompt = new Select([
+		'postgresql',
+		'mysql', 
+		'sqlite',
+		'turso',
+		'singlestore'
+	]);
+	
+	console.log(chalk.bold('Which database dialect are you using?'));
+	const { index: dialectIndex } = await renderWithTask(dialectPrompt);
+	const dialect = ['postgresql', 'mysql', 'sqlite', 'turso', 'singlestore'][dialectIndex]!;
+
+	// Ask for migrations folder
+	const migrationsInput = new SimpleInput('drizzle');
+	console.log(chalk.bold('\nWhere would you like to store your migrations?'));
+	console.log(chalk.gray('(default: drizzle)'));
+	const out = await migrationsInput.prompt('> ');
+
+	// Ask for schema location
+	const schemaInput = new SimpleInput('./src/db/schema.ts');
+	console.log(chalk.bold('\nWhere is your schema file located?'));
+	console.log(chalk.gray('(default: ./src/db/schema.ts)'));
+	const schema = await schemaInput.prompt('> ');
+
+	// Ask about dotenv
+	const dotenvPrompt = new Select(['Yes', 'No']);
+	console.log(chalk.bold('\nDo you want to use environment variables (.env)?'));
+	const { index: dotenvIndex } = await renderWithTask(dotenvPrompt);
+	const useDotenv = dotenvIndex === 0;
+
+	const config: InitConfig = {
+		dialect,
+		out,
+		schema,
+		useDotenv
+	};
+
+	// Generate config file
+	await generateConfigFile(config);
+	
+	// Update package.json
+	await updatePackageJson();
+
+	console.log('\n' + chalk.green('✅ Drizzle configuration created successfully!'));
+	console.log(chalk.gray('You can now run:'));
+	console.log(chalk.cyan('  drizzle-kit generate'));
+	console.log(chalk.cyan('  drizzle-kit migrate'));
+	console.log(chalk.cyan('  drizzle-kit studio'));
+}
+
+async function generateConfigFile(config: InitConfig): Promise<void> {
+	const configContent = generateConfigContent(config);
+	const configPath = 'drizzle.config.ts';
+	
+	writeFileSync(configPath, configContent);
+	console.log(chalk.green(`\n📝 Created ${configPath}`));
+}
+
+function generateConfigContent(config: InitConfig): string {
+	const { dialect, out, schema, useDotenv } = config;
+	
+	let imports = `import { defineConfig } from 'drizzle-kit';\n`;
+	if (useDotenv) {
+		imports += `import 'dotenv/config';\n`;
+	}
+
+	let connectionConfig = '';
+	
+	if (dialect === 'postgresql') {
+		connectionConfig = useDotenv 
+			? `  url: process.env.DATABASE_URL!,`
+			: `  url: 'postgresql://username:password@localhost:5432/dbname',`;
+	} else if (dialect === 'mysql') {
+		connectionConfig = useDotenv
+			? `  url: process.env.DATABASE_URL!,`
+			: `  url: 'mysql://username:password@localhost:3306/dbname',`;
+	} else if (dialect === 'sqlite') {
+		connectionConfig = `  url: './sqlite.db',`;
+	} else if (dialect === 'turso') {
+		connectionConfig = useDotenv
+			? `  url: process.env.TURSO_DATABASE_URL!,\n  authToken: process.env.TURSO_AUTH_TOKEN!,`
+			: `  url: 'libsql://your-database-url.turso.io',\n  authToken: 'your-auth-token',`;
+	} else if (dialect === 'singlestore') {
+		connectionConfig = useDotenv
+			? `  url: process.env.DATABASE_URL!,`
+			: `  url: 'mysql://username:password@localhost:3306/dbname',`;
+	}
+
+	return `${imports}
+export default defineConfig({
+  dialect: '${dialect}',
+  schema: '${schema}',
+  out: '${out}',
+  dbCredentials: {
+${connectionConfig}
+  },
+});
+`;
+}
+
+async function updatePackageJson(): Promise<void> {
+	const packageJsonPath = 'package.json';
+	
+	if (!existsSync(packageJsonPath)) {
+		console.log(chalk.yellow('⚠️  No package.json found. You may need to run npm init first.'));
+		return;
+	}
+
+	try {
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+		
+		// Check if dependencies exist
+		const dependencies = packageJson.dependencies || {};
+		const devDependencies = packageJson.devDependencies || {};
+		
+		let needsUpdate = false;
+		const toAdd: { [key: string]: string } = {};
+		
+		// Check for drizzle-orm
+		if (!dependencies['drizzle-orm'] && !devDependencies['drizzle-orm']) {
+			toAdd['drizzle-orm'] = '^0.44.0';
+			needsUpdate = true;
+		}
+		
+		// Check for drizzle-kit  
+		if (!dependencies['drizzle-kit'] && !devDependencies['drizzle-kit']) {
+			toAdd['drizzle-kit'] = '^0.31.0';
+			needsUpdate = true;
+		}
+		
+		if (needsUpdate) {
+			if (!packageJson.devDependencies) {
+				packageJson.devDependencies = {};
+			}
+			
+			Object.assign(packageJson.devDependencies, toAdd);
+			
+			writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+			console.log(chalk.green('📦 Updated package.json with Drizzle dependencies'));
+			console.log(chalk.gray('Run npm install to install the new dependencies'));
+		} else {
+			console.log(chalk.green('📦 Drizzle dependencies already present in package.json'));
+		}
+	} catch (error) {
+		console.log(chalk.yellow('⚠️  Could not update package.json automatically'));
+	}
+}

--- a/drizzle-kit/src/cli/index.ts
+++ b/drizzle-kit/src/cli/index.ts
@@ -1,6 +1,6 @@
 import { command, run } from '@drizzle-team/brocli';
 import chalk from 'chalk';
-import { check, drop, exportRaw, generate, migrate, pull, push, studio, up } from './schema';
+import { check, drop, exportRaw, generate, init, migrate, pull, push, studio, up } from './schema';
 import { ormCoreVersions } from './utils';
 
 const version = async () => {
@@ -42,7 +42,7 @@ const legacy = [
 	legacyCommand('check:sqlite', 'check'),
 ];
 
-run([generate, migrate, pull, push, studio, up, check, drop, exportRaw, ...legacy], {
+run([init, generate, migrate, pull, push, studio, up, check, drop, exportRaw, ...legacy], {
 	name: 'drizzle-kit',
 	version: version,
 });

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -11,6 +11,7 @@ import { assertV1OutFolder } from '../utils';
 import { certs } from '../utils/certs';
 import { checkHandler } from './commands/check';
 import { dropMigration } from './commands/drop';
+import { initHandler } from './commands/init';
 import { upMysqlHandler } from './commands/mysqlUp';
 import { upPgHandler } from './commands/pgUp';
 import { upSinglestoreHandler } from './commands/singlestoreUp';
@@ -850,5 +851,13 @@ export const exportRaw = command({
 		} else {
 			assertUnreachable(dialect);
 		}
+	},
+});
+
+export const init = command({
+	name: 'init',
+	desc: 'Initialize a new Drizzle project with interactive setup',
+	handler: async () => {
+		await initHandler();
 	},
 });

--- a/drizzle-kit/tests/init.test.ts
+++ b/drizzle-kit/tests/init.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { initHandler } from '../src/cli/commands/init';
+
+describe('drizzle-kit init command', () => {
+	it('should exist and be callable', () => {
+		expect(typeof initHandler).toBe('function');
+	});
+});


### PR DESCRIPTION
## Summary

Implements an interactive `drizzle-kit init` command that helps users set up new Drizzle projects quickly and easily.

### Features Added

- **Interactive CLI prompts** for project configuration
- **Database dialect selection** (postgresql, mysql, sqlite, turso, singlestore)
- **Configurable migrations folder** location (default: drizzle)
- **Schema file path** configuration (default: ./src/db/schema.ts)
- **Environment variables support** option (.env)
- **Automatic config generation** - creates `drizzle.config.ts` with appropriate settings
- **Package.json management** - adds drizzle-orm and drizzle-kit dependencies if missing

### Usage

```bash
drizzle-kit init
```

The command will guide users through:
1. Database dialect selection
2. Migrations folder location
3. Schema file location  
4. Environment variable usage preference
5. Automatic config file generation
6. Dependency management

### Implementation Details

- Uses existing `Select` UI component for dialect selection
- Custom `SimpleInput` class for text input with defaults
- Generates appropriate config based on dialect and preferences
- Safely updates package.json without overwriting existing dependencies

### Files Modified

- `drizzle-kit/src/cli/commands/init.ts` - Main implementation
- `drizzle-kit/src/cli/schema.ts` - Command definition  
- `drizzle-kit/src/cli/index.ts` - CLI registration
- `drizzle-kit/tests/init.test.ts` - Basic test

Resolves #389