### PR TITLE
fix:Handle semicolons in check constraint unsquash by splitting only on the first

### DIFF
--- a/drizzle-kit/src/serializer/gelSchema.ts
+++ b/drizzle-kit/src/serializer/gelSchema.ts
@@ -493,10 +493,9 @@ export const GelSquasher = {
 		return `${check.name};${check.value}`;
 	},
 	unsquashCheck: (input: string): CheckConstraint => {
-		const [
-			name,
-			value,
-		] = input.split(';');
+		const i = input.indexOf(";");
+		const name = input.substring(0, i);
+		const value = input.substring(i + 1);
 
 		return { name, value };
 	},

--- a/drizzle-kit/src/serializer/mysqlSchema.ts
+++ b/drizzle-kit/src/serializer/mysqlSchema.ts
@@ -283,7 +283,9 @@ export const MySqlSquasher = {
 		return `${input.name};${input.value}`;
 	},
 	unsquashCheck: (input: string): CheckConstraint => {
-		const [name, value] = input.split(';');
+		const i = input.indexOf(";");
+		const name = input.substring(0, i);
+		const value = input.substring(i + 1);
 
 		return { name, value };
 	},

--- a/drizzle-kit/src/serializer/pgSchema.ts
+++ b/drizzle-kit/src/serializer/pgSchema.ts
@@ -746,10 +746,9 @@ export const PgSquasher = {
 		return `${check.name};${check.value}`;
 	},
 	unsquashCheck: (input: string): CheckConstraint => {
-		const [
-			name,
-			value,
-		] = input.split(';');
+		const i = input.indexOf(";");
+		const name = input.substring(0, i);
+		const value = input.substring(i + 1);
 
 		return { name, value };
 	},

--- a/drizzle-kit/src/serializer/sqliteSchema.ts
+++ b/drizzle-kit/src/serializer/sqliteSchema.ts
@@ -256,10 +256,9 @@ export const SQLiteSquasher = {
 		return `${check.name};${check.value}`;
 	},
 	unsquashCheck: (input: string): CheckConstraint => {
-		const [
-			name,
-			value,
-		] = input.split(';');
+		const i = input.indexOf(";");
+		const name = input.substring(0, i);
+		const value = input.substring(i + 1);
 
 		return { name, value };
 	},


### PR DESCRIPTION
Check constraints can contain semicolons (;) within their expressions.

Previously, we split the string on all semicolons, which could break valid constraint definitions.

This change updates the logic to split only on the first semicolon, preserving the rest of the expression intact.