### PR TITLE
[drizzle-kit]: Fix SQL syntax error in unique index breakpoint generation

### DIFF
--- a/drizzle-kit/src/cli/commands/migrate.ts
+++ b/drizzle-kit/src/cli/commands/migrate.ts
@@ -1413,7 +1413,7 @@ export const writeResult = ({
 		JSON.stringify(toSave, null, 2),
 	);
 
-	const sqlDelimiter = breakpoints ? BREAKPOINT : '\n';
+	const sqlDelimiter = breakpoints ? `\n${BREAKPOINT}` : '\n';
 	let sql = sqlStatements.join(sqlDelimiter);
 
 	if (type === 'introspect') {

--- a/drizzle-kit/tests/sqlite-unique-breakpoint.test.ts
+++ b/drizzle-kit/tests/sqlite-unique-breakpoint.test.ts
@@ -1,0 +1,83 @@
+import { int, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+import { expect, test } from 'vitest';
+import { BREAKPOINT } from '../src/cli/commands/migrate';
+import { diffTestSchemasSqlite } from './schemaDiffer';
+
+test('unique constraint with breakpoints', async () => {
+	const from = {};
+	const to = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey(),
+			email: text('email').notNull(),
+			name: text('name'),
+		}, (t) => ({
+			emailUnique: unique('email_unique').on(t.email),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite(from, to, []);
+
+	expect(sqlStatements.length).toBe(2);
+	expect(sqlStatements).toStrictEqual([
+		'CREATE TABLE `users` (\n\t`id` integer PRIMARY KEY NOT NULL,\n\t`email` text NOT NULL,\n\t`name` text\n);\n',
+		'CREATE UNIQUE INDEX `email_unique` ON `users` (`email`);',
+	]);
+});
+
+test('multiple unique constraints with breakpoints', async () => {
+	const from = {};
+	const to = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey(),
+			email: text('email').notNull(),
+			username: text('username').notNull(),
+			name: text('name'),
+		}, (t) => ({
+			emailUnique: unique('email_unique').on(t.email),
+			usernameUnique: unique('username_unique').on(t.username),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite(from, to, []);
+
+	expect(sqlStatements.length).toBe(3);
+	expect(sqlStatements).toStrictEqual([
+		'CREATE TABLE `users` (\n\t`id` integer PRIMARY KEY NOT NULL,\n\t`email` text NOT NULL,\n\t`username` text NOT NULL,\n\t`name` text\n);\n',
+		'CREATE UNIQUE INDEX `email_unique` ON `users` (`email`);',
+		'CREATE UNIQUE INDEX `username_unique` ON `users` (`username`);',
+	]);
+});
+
+test('unique constraints in migration scenario', async () => {
+	const from = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey(),
+			email: text('email').notNull(),
+		}),
+	};
+
+	const to = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey(),
+			email: text('email').notNull(),
+			username: text('username').notNull(),
+		}, (t) => ({
+			emailUnique: unique('email_unique').on(t.email),
+			usernameUnique: unique('username_unique').on(t.username),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite(from, to, []);
+
+	expect(sqlStatements.length).toBeGreaterThan(0);
+
+	const sqlWithBreakpoints = sqlStatements.join(`\n${BREAKPOINT}`);
+
+	const breakpointCount = (sqlWithBreakpoints.match(/--> statement-breakpoint/g) || []).length;
+	expect(breakpointCount).toBe(Math.max(0, sqlStatements.length - 1));
+
+	sqlStatements.forEach((statement) => {
+		expect(statement).not.toMatch(/^--> statement-breakpoint/);
+		expect(statement).not.toMatch(/--> statement-breakpoint$/);
+	});
+});


### PR DESCRIPTION
**Summary**
This PR fixes a SQL syntax error that occurred when generating SQLite migrations with statement breakpoints enabled and unique constraints present.

Closes #4814 

**Problem**
When using `.unique()` constraints in SQLite schemas with breakpoints enabled, the generated migration SQL had syntax errors due to missing newlines before statement-breakpoint comments. This caused the SQL to be malformed:
```sql
CREATE UNIQUE INDEX `email_unique` ON `users` (`email`);--> statement-breakpoint
```
instead of the correct format
```sql
CREATE UNIQUE INDEX `email_unique` ON `users` (`email`);
--> statement-breakpoint
```

**Solution**
Updated the `sqlDelimiter` logic in the `writeResult` function in `migrate.ts` to ensure proper newline formatting when breakpoints are enabled:

The BREAKPOINT constant already includes the trailing newline ('--> statement-breakpoint\n'), so this ensures proper separation between SQL statements and breakpoint comments.

**Changes Made**
Fixed: Updated sqlDelimiter construction in writeResult function to include proper newline before BREAKPOINT
Added: Test suite covering unique constraint scenarios with breakpoints

**Tests Added**
- Unique constraint SQL generation validation
- Multiple unique constraints with breakpoints
- Real-world migration scenario simulation