### PR TITLE
[Pg-kit] Ensure consistent ordering in TS from Postgres introspection

### DIFF
--- a/drizzle-kit/src/introspect-gel.ts
+++ b/drizzle-kit/src/introspect-gel.ts
@@ -494,16 +494,16 @@ export const schemaToTypeScript = (schema: GelSchemaInternal, casing: Casing) =>
 	} } from "drizzle-orm/gel-core"
 import { sql } from "drizzle-orm"\n\n`;
 
-	let decalrations = schemaStatements;
-	decalrations += rolesStatements;
-	// decalrations += enumStatements;
-	// decalrations += sequencesStatements;
-	decalrations += '\n';
-	decalrations += tableStatements.join('\n\n');
-	decalrations += '\n';
-	// decalrations += viewsStatements;
+	let declarations = schemaStatements;
+	declarations += rolesStatements;
+	// declarations += enumStatements;
+	// declarations += sequencesStatements;
+	declarations += '\n';
+	declarations += tableStatements.join('\n\n');
+	declarations += '\n';
+	// declarations += viewsStatements;
 
-	const file = importsTs + decalrations;
+	const file = importsTs + declarations;
 
 	// for drizzle studio query runner
 	const schemaEntry = `
@@ -516,7 +516,7 @@ import { sql } from "drizzle-orm"\n\n`;
     }
   `;
 
-	return { file, imports: importsTs, decalrations, schemaEntry };
+	return { file, imports: importsTs, declarations, schemaEntry };
 };
 
 const isCyclic = (fk: ForeignKey) => {

--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -328,12 +328,12 @@ export const schemaToTypeScript = (
 		)
 	} } from "drizzle-orm/mysql-core"\nimport { sql } from "drizzle-orm"\n\n`;
 
-	let decalrations = '';
-	decalrations += tableStatements.join('\n\n');
-	decalrations += '\n';
-	decalrations += viewsStatements.join('\n\n');
+	let declarations = '';
+	declarations += tableStatements.join('\n\n');
+	declarations += '\n';
+	declarations += viewsStatements.join('\n\n');
 
-	const file = importsTs + decalrations;
+	const file = importsTs + declarations;
 
 	const schemaEntry = `
     {
@@ -348,7 +348,7 @@ export const schemaToTypeScript = (
 	return {
 		file, // backward compatible, print to file
 		imports: importsTs,
-		decalrations,
+		declarations,
 		schemaEntry,
 	};
 };

--- a/drizzle-kit/src/introspect-pg.ts
+++ b/drizzle-kit/src/introspect-pg.ts
@@ -610,16 +610,16 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 	} } from "drizzle-orm/pg-core"
 import { sql } from "drizzle-orm"\n\n`;
 
-	let decalrations = schemaStatements;
-	decalrations += rolesStatements;
-	decalrations += enumStatements;
-	decalrations += sequencesStatements;
-	decalrations += '\n';
-	decalrations += tableStatements.join('\n\n');
-	decalrations += '\n';
-	decalrations += viewsStatements;
+	let declarations = schemaStatements;
+	declarations += rolesStatements;
+	declarations += enumStatements;
+	declarations += sequencesStatements;
+	declarations += '\n';
+	declarations += tableStatements.join('\n\n');
+	declarations += '\n';
+	declarations += viewsStatements;
 
-	const file = importsTs + decalrations;
+	const file = importsTs + declarations;
 
 	// for drizzle studio query runner
 	const schemaEntry = `
@@ -632,7 +632,7 @@ import { sql } from "drizzle-orm"\n\n`;
     }
   `;
 
-	return { file, imports: importsTs, decalrations, schemaEntry };
+	return { file, imports: importsTs, declarations, schemaEntry };
 };
 
 const isCyclic = (fk: ForeignKey) => {

--- a/drizzle-kit/src/introspect-singlestore.ts
+++ b/drizzle-kit/src/introspect-singlestore.ts
@@ -313,12 +313,12 @@ export const schemaToTypeScript = (
 		)
 	} } from "drizzle-orm/singlestore-core"\nimport { sql } from "drizzle-orm"\n\n`;
 
-	let decalrations = '';
-	decalrations += tableStatements.join('\n\n');
-	decalrations += '\n';
-	/* decalrations += viewsStatements.join('\n\n'); */
+	let declarations = '';
+	declarations += tableStatements.join('\n\n');
+	declarations += '\n';
+	/* declarations += viewsStatements.join('\n\n'); */
 
-	const file = importsTs + decalrations;
+	const file = importsTs + declarations;
 
 	const schemaEntry = `
     {
@@ -333,7 +333,7 @@ export const schemaToTypeScript = (
 	return {
 		file, // backward compatible, print to file
 		imports: importsTs,
-		decalrations,
+		declarations,
 		schemaEntry,
 	};
 };

--- a/drizzle-kit/src/introspect-sqlite.ts
+++ b/drizzle-kit/src/introspect-sqlite.ts
@@ -225,11 +225,11 @@ export const schemaToTypeScript = (
 	} } from "drizzle-orm/sqlite-core"
   import { sql } from "drizzle-orm"\n\n`;
 
-	let decalrations = tableStatements.join('\n\n');
-	decalrations += '\n\n';
-	decalrations += viewsStatements.join('\n\n');
+	let declarations = tableStatements.join('\n\n');
+	declarations += '\n\n';
+	declarations += viewsStatements.join('\n\n');
 
-	const file = importsTs + decalrations;
+	const file = importsTs + declarations;
 
 	// for drizzle studio query runner
 	const schemaEntry = `
@@ -242,7 +242,7 @@ export const schemaToTypeScript = (
     }
   `;
 
-	return { file, imports: importsTs, decalrations, schemaEntry };
+	return { file, imports: importsTs, declarations, schemaEntry };
 };
 
 const isCyclic = (fk: ForeignKey) => {

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1170,23 +1170,21 @@ WHERE
 		wherePolicies === '' ? '' : ` WHERE ${wherePolicies}`
 	}
 	order by schemaname, tablename, policyname;`);
-
 	for (const dbPolicy of allPolicies) {
 		const { tablename, schemaname, to, withCheck, using, ...rest } = dbPolicy;
-		const tableForPolicy = policiesByTable[`${schemaname}.${tablename}`];
 
 		const parsedTo = typeof to === 'string' ? to.slice(1, -1).split(',') : to;
 
 		const parsedWithCheck = withCheck === null ? undefined : withCheck;
 		const parsedUsing = using === null ? undefined : using;
 
-		if (tableForPolicy) {
-			tableForPolicy[dbPolicy.name] = { ...rest, to: parsedTo } as Policy;
-		} else {
-			policiesByTable[`${schemaname}.${tablename}`] = {
-				[dbPolicy.name]: { ...rest, to: parsedTo, withCheck: parsedWithCheck, using: parsedUsing } as Policy,
-			};
-		}
+		policiesByTable[`${schemaname}.${tablename}`] ??= {};
+		policiesByTable[`${schemaname}.${tablename}`][dbPolicy.name] = {
+			...rest,
+			to: parsedTo,
+			withCheck: parsedWithCheck,
+			using: parsedUsing,
+		} as Policy;
 
 		if (tsSchema?.policies[dbPolicy.name]) {
 			policies[dbPolicy.name] = {

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -9,6 +9,7 @@ import {
 	cidr,
 	date,
 	doublePrecision,
+	foreignKey,
 	index,
 	inet,
 	integer,
@@ -25,6 +26,7 @@ import {
 	pgSchema,
 	pgTable,
 	pgView,
+	primaryKey,
 	real,
 	serial,
 	smallint,
@@ -32,6 +34,7 @@ import {
 	text,
 	time,
 	timestamp,
+	uniqueIndex,
 	uuid,
 	varchar,
 } from 'drizzle-orm/pg-core';
@@ -1103,6 +1106,111 @@ f: integer().notNull(),
 }, (table) => [
 pgPolicy("test_A", { as: "permissive", for: "select", to: ["public"], using: sql\`((6 + 7) = 13)\` }),
 pgPolicy("test_B", { as: "permissive", for: "update", to: ["public"], using: sql\`((1 + 2) = 3)\`, withCheck: sql\`((4 + 5) = 9)\`  }),
+]);`.replace(/ {2}/g, ' ').trim();
+
+	// This is a crude comparison, but it provides all the assertions needed for the test. The tables, columns and policies are alphabetized
+	// and importantly the policies' full `using` and `withCheck` properties are populated. In an attempt to prevent this from failing if there are
+	// whitespace changes in the generator, both strings have all double spaces removed and are trimmed. The generated code has leading whitespace removed.
+	expect(declarations).toEqual(expectedCode);
+});
+
+test('verify that keys are generated in alphabetical order by name but columns are in the order defined by the schema definition', async () => {
+	const client = new PGlite();
+
+	const child = pgTable('child', {
+		key2: integer('key2').notNull(),
+		key1: integer('key1').notNull(),
+		keyA: integer('keyA').notNull(),
+		keyD: uuid('keyD').notNull(),
+		keyC: integer('keyC').notNull(),
+	}, (table) => [
+		foreignKey({
+			columns: [table.key2, table.key1],
+			foreignColumns: [parent1.key4, parent1.key3],
+			name: 'child_parent1_fkey',
+		}),
+		foreignKey({
+			columns: [table.key2, table.key1],
+			foreignColumns: [parent2.key5, parent2.key6],
+			name: 'child_parent2_fkey',
+		}),
+		primaryKey({ columns: [table.key2, table.key1], name: 'child_pkey' }),
+		uniqueIndex('child_keyA_uniq').using(
+			'btree',
+			table.keyA.asc().nullsLast().op('int4_ops'),
+		),
+		index('child_keyC_keyD').using(
+			'btree',
+			table.keyC.asc().nullsLast().op('int4_ops'),
+			table.keyD.asc().nullsLast().op('uuid_ops'),
+		),
+	]);
+
+	const parent1 = pgTable('parent1', {
+		key4: integer('key4').notNull(),
+		key3: integer('key3').notNull(),
+	}, (table) => [
+		primaryKey({ columns: [table.key4, table.key3], name: 'parent1_pkey' }),
+	]);
+	const parent2 = pgTable('parent2', {
+		key5: integer('key5').notNull(),
+		key6: integer('key6').notNull(),
+	}, (table) => [
+		primaryKey({ columns: [table.key5, table.key6], name: 'parent2_pkey' }),
+	]);
+	const schema = { child, parent1, parent2 };
+
+	const { statements, sqlStatements, file } = await introspectPgToFile(
+		client,
+		schema,
+		'alphabetical-key-order-test',
+		['public'],
+		undefined,
+		undefined,
+		true,
+	);
+
+	expect(statements).toStrictEqual([]);
+	expect(sqlStatements.length).toBe(0);
+	if (!file) {
+		throw new Error('File is missing');
+	}
+
+	const declarations = file.declarations.replace(/^[\t ]+/mg, '').replace(/ {2}/g, ' ').trim();
+	const expectedCode = `export const child = pgTable("child", {
+key1: integer().notNull(),
+key2: integer().notNull(),
+keyA: integer().notNull(),
+keyC: integer().notNull(),
+keyD: uuid().notNull(),
+}, (table) => [
+uniqueIndex("child_keyA_uniq").using("btree", table.keyA.asc().nullsLast().op("int4_ops")),
+index("child_keyC_keyD").using("btree", table.keyC.asc().nullsLast().op("int4_ops"), table.keyD.asc().nullsLast().op("uuid_ops")),
+foreignKey({
+columns: [table.key2, table.key1],
+foreignColumns: [parent1.key4, parent1.key3],
+name: "child_parent1_fkey"
+}),
+foreignKey({
+columns: [table.key2, table.key1],
+foreignColumns: [parent2.key5, parent2.key6],
+name: "child_parent2_fkey"
+}),
+primaryKey({ columns: [table.key2, table.key1], name: "child_pkey"}),
+]);
+
+export const parent1 = pgTable("parent1", {
+key3: integer().notNull(),
+key4: integer().notNull(),
+}, (table) => [
+primaryKey({ columns: [table.key4, table.key3], name: "parent1_pkey"}),
+]);
+
+export const parent2 = pgTable("parent2", {
+key5: integer().notNull(),
+key6: integer().notNull(),
+}, (table) => [
+primaryKey({ columns: [table.key5, table.key6], name: "parent2_pkey"}),
 ]);`.replace(/ {2}/g, ' ').trim();
 
 	// This is a crude comparison, but it provides all the assertions needed for the test. The tables, columns and policies are alphabetized

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -942,7 +942,7 @@ test('verify table declarations are in alphabetical order', async () => {
 		a: pgTable('a', { id: integer('id').notNull() }),
 	};
 
-	const { statements, sqlStatements, file } = await introspectPgToFile(
+	const { statements, sqlStatements, schemaTypescriptFile } = await introspectPgToFile(
 		client,
 		schema,
 		'alphabetical-table-order-test',
@@ -954,12 +954,12 @@ test('verify table declarations are in alphabetical order', async () => {
 
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
-	if (!file) {
+	if (!schemaTypescriptFile) {
 		throw new Error('File is missing');
 	}
 
 	// Extract table variable names from the declarations string
-	const declarations = file.declarations;
+	const declarations = schemaTypescriptFile.declarations;
 	const exportPattern = /export const (\w+) = pgTable/g;
 	const tableNames: string[] = [];
 	let match;
@@ -998,7 +998,7 @@ test('verify column declarations are in alphabetical order', async () => {
 		}),
 	};
 
-	const { statements, sqlStatements, file } = await introspectPgToFile(
+	const { statements, sqlStatements, schemaTypescriptFile } = await introspectPgToFile(
 		client,
 		schema,
 		'alphabetical-column-order-test',
@@ -1010,12 +1010,12 @@ test('verify column declarations are in alphabetical order', async () => {
 
 	expect(statements).toStrictEqual([]);
 	expect(sqlStatements.length).toBe(0);
-	if (!file) {
+	if (!schemaTypescriptFile) {
 		throw new Error('File is missing');
 	}
 
 	// Extract column variable names from the declarations string
-	const declarations = file.declarations;
+	const declarations = schemaTypescriptFile.declarations;
 	const exportPattern = /(\w+):\s+integer/g;
 	const columnNames: string[] = [];
 	let match;
@@ -1073,7 +1073,7 @@ test('verify policy declarations are in alphabetical order', async () => {
 		})),
 	};
 
-	const { statements, sqlStatements, file } = await introspectPgToFile(
+	const { statements, sqlStatements, schemaTypescriptFile } = await introspectPgToFile(
 		client,
 		schema,
 		'alphabetical-policy-order-test',
@@ -1085,11 +1085,11 @@ test('verify policy declarations are in alphabetical order', async () => {
 
 	expect(statements).toStrictEqual([]);
 	expect(sqlStatements.length).toBe(0);
-	if (!file) {
+	if (!schemaTypescriptFile) {
 		throw new Error('File is missing');
 	}
 
-	const declarations = file.declarations.replace(/^[\t ]+/mg, '').replace(/ {2}/g, ' ').trim();
+	const declarations = schemaTypescriptFile.declarations.replace(/^[\t ]+/mg, '').replace(/ {2}/g, ' ').trim();
 	const expectedCode = `export const y = pgTable("y", {
 a: integer().notNull(),
 b: integer().notNull(),
@@ -1160,7 +1160,7 @@ test('verify that keys are generated in alphabetical order by name but columns a
 	]);
 	const schema = { child, parent1, parent2 };
 
-	const { statements, sqlStatements, file } = await introspectPgToFile(
+	const { statements, sqlStatements, schemaTypescriptFile, relationsTypescriptFile } = await introspectPgToFile(
 		client,
 		schema,
 		'alphabetical-key-order-test',

--- a/drizzle-kit/tests/rls/pg-policy.test.ts
+++ b/drizzle-kit/tests/rls/pg-policy.test.ts
@@ -14,7 +14,20 @@ test('add policy + enable rls', async (t) => {
 		users: pgTable('users', {
 			id: integer('id').primaryKey(),
 		}, () => ({
-			rls: pgPolicy('test', { as: 'permissive' }),
+			rls: pgPolicy('test_B', {
+				as: 'permissive',
+				for: 'delete',
+				to: 'public',
+				using: sql`1 + 2 = 3`,
+				withCheck: sql`4 + 5 = 9`,
+			}),
+			rls2: pgPolicy('test_A', {
+				as: 'permissive',
+				for: 'select',
+				to: 'public',
+				using: sql`6 + 7 = 13`,
+				withCheck: sql`8 + 9 = 17`,
+			}),
 		})),
 	};
 
@@ -22,7 +35,8 @@ test('add policy + enable rls', async (t) => {
 
 	expect(sqlStatements).toStrictEqual([
 		'ALTER TABLE "users" ENABLE ROW LEVEL SECURITY;',
-		'CREATE POLICY "test" ON "users" AS PERMISSIVE FOR ALL TO public;',
+		'CREATE POLICY "test_B" ON "users" AS PERMISSIVE FOR DELETE TO public USING (1 + 2 = 3) WITH CHECK (4 + 5 = 9);',
+		'CREATE POLICY "test_A" ON "users" AS PERMISSIVE FOR SELECT TO public USING (6 + 7 = 13) WITH CHECK (8 + 9 = 17);',
 	]);
 	expect(statements).toStrictEqual([
 		{
@@ -33,12 +47,30 @@ test('add policy + enable rls', async (t) => {
 		{
 			data: {
 				as: 'PERMISSIVE',
-				for: 'ALL',
-				name: 'test',
-				to: ['public'],
+				for: 'DELETE',
+				name: 'test_B',
 				on: undefined,
-				using: undefined,
-				withCheck: undefined,
+				to: [
+					'public',
+				],
+				using: '1 + 2 = 3',
+				withCheck: '4 + 5 = 9',
+			},
+			schema: '',
+			tableName: 'users',
+			type: 'create_policy',
+		},
+		{
+			data: {
+				as: 'PERMISSIVE',
+				for: 'SELECT',
+				name: 'test_A',
+				on: undefined,
+				to: [
+					'public',
+				],
+				using: '6 + 7 = 13',
+				withCheck: '8 + 9 = 17',
 			},
 			schema: '',
 			tableName: 'users',

--- a/drizzle-kit/tests/schemaDiffer.ts
+++ b/drizzle-kit/tests/schemaDiffer.ts
@@ -2307,6 +2307,7 @@ export const introspectPgToFile = async (
 	schemas: string[] = ['public'],
 	entities?: Entities,
 	casing?: CasingType | undefined,
+	returnFile?: boolean | undefined,
 ) => {
 	// put in db
 	const { sqlStatements } = await applyPgDiffs(initSchema, casing);
@@ -2399,6 +2400,7 @@ export const introspectPgToFile = async (
 	return {
 		sqlStatements: afterFileSqlStatements,
 		statements: afterFileStatements,
+		...(returnFile ? { file } : undefined),
 	};
 };
 


### PR DESCRIPTION
I've added "ORDER BY" statements to all of the SQL that is used to introspect the Postgres database. This helps to make repeated runs of `drizzle-kit introspect` produce the same  `schema.ts`. 

Fixes #2530. Repeats and expands on #3671. 

I've also fixed the spelling of the `declarations` variable so that it's easier to understand what it's used for. 

In the course of my testing I also discovered that policies weren't being fully generated, so I've hopefully fixed that too. 
Fixes #4407