### PR TITLE
[SQL]: Make `not()` accept undefined and return undefined

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -176,8 +176,8 @@ export function or(
  */
 
 export function not(condition?: SQLWrapper): SQL | undefined {
-  if (!condition) return undefined;
-  return sql`not ${condition}`;
+	if (!condition) return undefined;
+	return sql`not ${condition}`;
 }
 
 /**

--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -174,8 +174,14 @@ export function or(
  *   .where(not(inArray(cars.make, ['GM', 'Ford'])))
  * ```
  */
-export function not(condition: SQLWrapper): SQL {
-	return sql`not ${condition}`;
+//	Previous code 
+// export function not(condition: SQLWrapper): SQL {
+// 	return sql`not ${condition}`;
+// }
+
+export function not(condition?: SQLWrapper): SQL | undefined {
+  if (condition === undefined) return undefined;
+  return sql`not ${condition}`;
 }
 
 /**

--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -174,13 +174,9 @@ export function or(
  *   .where(not(inArray(cars.make, ['GM', 'Ford'])))
  * ```
  */
-//	Previous code 
-// export function not(condition: SQLWrapper): SQL {
-// 	return sql`not ${condition}`;
-// }
 
 export function not(condition?: SQLWrapper): SQL | undefined {
-  if (condition === undefined) return undefined;
+  if (!condition) return undefined;
   return sql`not ${condition}`;
 }
 


### PR DESCRIPTION
## ✅ PR Title

```
fix(sql): make `not()` accept `undefined` for optional SQL conditions
```

---

## 📝 PR Description

### What

This PR updates the `not()` SQL helper to **safely accept `undefined`** as an input. If `undefined` is passed, it returns `undefined`—similar to how `and()` or `or()` handle optional expressions.

---

### Why

Fixes [[#1818](https://github.com/drizzle-team/drizzle-orm/issues/1818)](https://github.com/drizzle-team/drizzle-orm/issues/1818)

Currently, `not()` throws or generates invalid SQL when passed `undefined`, which breaks dynamic SQL composition and requires unnecessary conditional checks in userland code.

---

### Example

Before:

```ts
//  Throws or generates broken SQL
db.query.users.findFirst({
  where: not(and(undefined, ilike(users.name, '%ronak%')))
});
```

After:

```ts
// Working Solution 
db.query.users.findFirst({
  where: not(and(undefined, ilike(users.name, '%ronak%')))
});
```

---

### ✅ Changes Made

File: `drizzle-orm/src/sql/expressions/conditions.ts`

```ts
// Before:
// export function not(condition: SQLWrapper): SQL {
//   return sql`not ${condition}`;
// }

export function not(condition?: SQLWrapper): SQL | undefined {
  if (condition === undefined) return undefined;
  return sql`not ${condition}`;
}
```

---

### Impact

* ✅ Backward compatible
* ✅ Matches behavior of `and()` and `or()`
* ✅ Enables safer and more flexible dynamic query building

---

### Related

Closes [[#1818](https://github.com/drizzle-team/drizzle-orm/issues/1818)](https://github.com/drizzle-team/drizzle-orm/issues/1818)

