### PR TITLE
Make custom error throwable in Rollback

### DIFF
--- a/drizzle-orm/src/gel-core/session.ts
+++ b/drizzle-orm/src/gel-core/session.ts
@@ -227,7 +227,10 @@ export abstract class GelTransaction<
 		super(dialect, session, schema);
 	}
 
-	rollback(): never {
+	rollback(error?: Error): never {
+		if (error) {
+			throw error;
+		}
 		throw new TransactionRollbackError();
 	}
 

--- a/drizzle-orm/src/mysql-core/session.ts
+++ b/drizzle-orm/src/mysql-core/session.ts
@@ -255,7 +255,10 @@ export abstract class MySqlTransaction<
 		super(dialect, session, schema, mode);
 	}
 
-	rollback(): never {
+	rollback(error?: Error): never {
+		if (error) {
+			throw error;
+		}
 		throw new TransactionRollbackError();
 	}
 

--- a/drizzle-orm/src/pg-core/session.ts
+++ b/drizzle-orm/src/pg-core/session.ts
@@ -253,7 +253,10 @@ export abstract class PgTransaction<
 		super(dialect, session, schema);
 	}
 
-	rollback(): never {
+	rollback(error?: Error): never {
+		if (error) {
+			throw error;
+		}
 		throw new TransactionRollbackError();
 	}
 

--- a/drizzle-orm/src/singlestore-core/session.ts
+++ b/drizzle-orm/src/singlestore-core/session.ts
@@ -255,7 +255,10 @@ export abstract class SingleStoreTransaction<
 		super(dialect, session, schema);
 	}
 
-	rollback(): never {
+	rollback(error?: Error): never {
+		if (error) {
+			throw error;
+		}
 		throw new TransactionRollbackError();
 	}
 

--- a/drizzle-orm/src/sqlite-core/session.ts
+++ b/drizzle-orm/src/sqlite-core/session.ts
@@ -348,7 +348,10 @@ export abstract class SQLiteTransaction<
 		super(resultType, dialect, session, schema);
 	}
 
-	rollback(): never {
+	rollback(error?: Error): never {
+		if (error) {
+			throw error;
+		}
 		throw new TransactionRollbackError();
 	}
 }

--- a/integration-tests/tests/bun/bun-sql.test.ts
+++ b/integration-tests/tests/bun/bun-sql.test.ts
@@ -2586,6 +2586,13 @@ test('transaction rollback', async () => {
 		});
 	})()).rejects.toThrowError(TransactionRollbackError);
 
+	await expect((async () => {
+		await db.transaction(async (tx) => {
+			await tx.insert(users).values({ balance: 100 });
+			tx.rollback(new Error("my custom error"));
+		});
+	})()).rejects.toThrowError(new Error("my custom error"));
+
 	const result = await db.select().from(users);
 
 	expect(result).toEqual([]);
@@ -2641,6 +2648,13 @@ test('nested transaction rollback', async () => {
 				tx.rollback();
 			});
 		})()).rejects.toThrowError(TransactionRollbackError);
+
+		await expect((async () => {
+			await db.transaction(async (tx) => {
+				await tx.insert(users).values({ balance: 100 });
+				tx.rollback(new Error("my custom error message"));
+			});
+		})()).rejects.toThrowError("my custom error message");
 	});
 
 	const result = await db.select().from(users);

--- a/integration-tests/tests/mysql/mysql-common.ts
+++ b/integration-tests/tests/mysql/mysql-common.ts
@@ -2316,6 +2316,13 @@ export function tests(driver?: string) {
 				});
 			})()).rejects.toThrowError(TransactionRollbackError);
 
+			await expect((async () => {
+				await db.transaction(async (tx) => {
+					await tx.insert(users).values({ balance: 100 });
+					tx.rollback(new Error("my custom error message"));
+				});
+			})()).rejects.toThrowError("my custom error message");
+
 			const result = await db.select().from(users);
 
 			expect(result).toEqual([]);
@@ -2375,6 +2382,13 @@ export function tests(driver?: string) {
 						tx.rollback();
 					});
 				})()).rejects.toThrowError(TransactionRollbackError);
+
+				await expect((async () => {
+					await tx.transaction(async (tx) => {
+						await tx.update(users).set({ balance: 200 });
+						tx.rollback(new Error("my custom error"));
+					});
+				})()).rejects.toThrowError(new Error("my custom error"));
 			});
 
 			const result = await db.select().from(users);

--- a/integration-tests/tests/mysql/mysql-prefixed.test.ts
+++ b/integration-tests/tests/mysql/mysql-prefixed.test.ts
@@ -1313,6 +1313,13 @@ test('transaction rollback', async () => {
 		});
 	})()).rejects.toThrowError(TransactionRollbackError);
 
+	await expect((async () => {
+		await db.transaction(async (tx) => {
+			await tx.insert(users).values({ balance: 100 });
+			tx.rollback(new Error("my custom error"));
+		});
+	})()).rejects.toThrowError(new Error("my custom error"));
+
 	const result = await db.select().from(users);
 
 	await db.execute(sql`drop table ${users}`);
@@ -1368,6 +1375,13 @@ test('nested transaction rollback', async () => {
 				tx.rollback();
 			});
 		})()).rejects.toThrowError(TransactionRollbackError);
+
+		await expect((async () => {
+				await db.transaction(async (tx) => {
+					await tx.update(users).set({ balance: 200 });
+					tx.rollback(new Error("my custom error"));
+				});
+			})()).rejects.toThrowError(new Error("my custom error"));
 	});
 
 	const result = await db.select().from(users);

--- a/integration-tests/tests/pg/awsdatapi.test.ts
+++ b/integration-tests/tests/pg/awsdatapi.test.ts
@@ -1112,6 +1112,13 @@ test('transaction rollback', async () => {
 		}),
 	).rejects.toThrowError(TransactionRollbackError);
 
+	await expect(
+		db.transaction(async (tx) => {
+			await tx.insert(users).values({ balance: 100 });
+			tx.rollback(new Error("my custom error"));
+		}),
+	).rejects.toThrowError(new Error("my custom error"));
+
 	const result = await db.select().from(users);
 
 	expect(result).toEqual([]);
@@ -1167,6 +1174,13 @@ test('nested transaction rollback', async () => {
 				tx2.rollback();
 			}),
 		).rejects.toThrowError(TransactionRollbackError);
+
+		await expect(
+			tx.transaction(async (tx2) => {
+				await tx2.update(users).set({ balance: 200 });
+				tx2.rollback(new Error("my custom error"));
+			}),
+		).rejects.toThrowError(new Error("my custom error"));
 	});
 
 	const result = await db.select().from(users);

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -3199,6 +3199,17 @@ export function tests() {
 				})()).rejects.toThrowError(TransactionRollbackError);
 			});
 
+			await db.transaction(async (tx) => {
+				await tx.insert(users).values({ balance: 100 });
+
+				await expect((async () => {
+					await tx.transaction(async (tx) => {
+						await tx.update(users).set({ balance: 200 });
+						tx.rollback(new Error("my custom error"));
+					});
+				})()).rejects.toThrowError(new Error("my custom error"));
+			});
+
 			const result = await db.select().from(users);
 
 			expect(result).toEqual([{ id: 1, balance: 100 }]);

--- a/integration-tests/tests/relational/bettersqlite.test.ts
+++ b/integration-tests/tests/relational/bettersqlite.test.ts
@@ -869,6 +869,34 @@ test('[Find Many] Get users with posts in rollbacked transaction', () => {
 		})
 	).toThrow(TransactionRollbackError);
 
+	expect(() =>
+		db.transaction((tx) => {
+			tx.insert(usersTable).values([
+				{ id: 1, name: 'Dan' },
+				{ id: 2, name: 'Andrew' },
+				{ id: 3, name: 'Alex' },
+			]).run();
+
+			tx.insert(postsTable).values([
+				{ ownerId: 1, content: 'Post1' },
+				{ ownerId: 1, content: 'Post1.1' },
+				{ ownerId: 2, content: 'Post2' },
+				{ ownerId: 3, content: 'Post3' },
+			]).run();
+
+			tx.rollback(new Error("my custom error"));
+
+			usersWithPosts = tx.query.usersTable.findMany({
+				where: (({ id }, { eq }) => eq(id, 1)),
+				with: {
+					posts: {
+						where: (({ id }, { eq }) => eq(id, 1)),
+					},
+				},
+			}).sync();
+		})
+	).toThrow(new Error("my custom error"));
+
 	expectTypeOf(usersWithPosts).toEqualTypeOf<{
 		id: number;
 		name: string;

--- a/integration-tests/tests/relational/mysql.planetscale.test.ts
+++ b/integration-tests/tests/relational/mysql.planetscale.test.ts
@@ -910,6 +910,32 @@ test('[Find Many] Get users with posts in rollbacked transaction', async () => {
 		});
 	})).rejects.toThrowError(new TransactionRollbackError());
 
+	await expect(db.transaction(async (tx) => {
+		await tx.insert(usersTable).values([
+			{ id: 1, name: 'Dan' },
+			{ id: 2, name: 'Andrew' },
+			{ id: 3, name: 'Alex' },
+		]);
+
+		await tx.insert(postsTable).values([
+			{ ownerId: 1, content: 'Post1' },
+			{ ownerId: 1, content: 'Post1.1' },
+			{ ownerId: 2, content: 'Post2' },
+			{ ownerId: 3, content: 'Post3' },
+		]);
+
+		tx.rollback(new Error("my custom error"));
+
+		usersWithPosts = await tx.query.usersTable.findMany({
+			where: (({ id }, { eq }) => eq(id, 1)),
+			with: {
+				posts: {
+					where: (({ id }, { eq }) => eq(id, 1)),
+				},
+			},
+		});
+	})).rejects.toThrowError(new Error("my custom error"));
+
 	expectTypeOf(usersWithPosts).toEqualTypeOf<{
 		id: number;
 		name: string;

--- a/integration-tests/tests/relational/mysql.test.ts
+++ b/integration-tests/tests/relational/mysql.test.ts
@@ -993,6 +993,32 @@ test('[Find Many] Get users with posts in rollbacked transaction', async (t) => 
 		});
 	})).rejects.toThrowError(new TransactionRollbackError());
 
+	await expect(db.transaction(async (tx) => {
+		await tx.insert(usersTable).values([
+			{ id: 1, name: 'Dan' },
+			{ id: 2, name: 'Andrew' },
+			{ id: 3, name: 'Alex' },
+		]);
+
+		await tx.insert(postsTable).values([
+			{ ownerId: 1, content: 'Post1' },
+			{ ownerId: 1, content: 'Post1.1' },
+			{ ownerId: 2, content: 'Post2' },
+			{ ownerId: 3, content: 'Post3' },
+		]);
+
+		tx.rollback(new Error("my custom error"));
+
+		usersWithPosts = await tx.query.usersTable.findMany({
+			where: (({ id }, { eq }) => eq(id, 1)),
+			with: {
+				posts: {
+					where: (({ id }, { eq }) => eq(id, 1)),
+				},
+			},
+		});
+	})).rejects.toThrowError(new Error("my custom error"));
+
 	expectTypeOf(usersWithPosts).toEqualTypeOf<{
 		id: number;
 		name: string;

--- a/integration-tests/tests/relational/pg.postgresjs.test.ts
+++ b/integration-tests/tests/relational/pg.postgresjs.test.ts
@@ -995,6 +995,32 @@ test('[Find Many] Get users with posts in rollbacked transaction', async (t) => 
 		});
 	})).rejects.toThrowError(new TransactionRollbackError());
 
+	await expect(db.transaction(async (tx) => {
+		await tx.insert(usersTable).values([
+			{ id: 1, name: 'Dan' },
+			{ id: 2, name: 'Andrew' },
+			{ id: 3, name: 'Alex' },
+		]);
+
+		await tx.insert(postsTable).values([
+			{ ownerId: 1, content: 'Post1' },
+			{ ownerId: 1, content: 'Post1.1' },
+			{ ownerId: 2, content: 'Post2' },
+			{ ownerId: 3, content: 'Post3' },
+		]);
+
+		tx.rollback(new Error("my custom error"));
+
+		usersWithPosts = await tx.query.usersTable.findMany({
+			where: (({ id }, { eq }) => eq(id, 1)),
+			with: {
+				posts: {
+					where: (({ id }, { eq }) => eq(id, 1)),
+				},
+			},
+		});
+	})).rejects.toThrowError(new Error("my custom error"));
+
 	expectTypeOf(usersWithPosts).toEqualTypeOf<{
 		id: number;
 		name: string;

--- a/integration-tests/tests/relational/pg.test.ts
+++ b/integration-tests/tests/relational/pg.test.ts
@@ -992,6 +992,32 @@ test('[Find Many] Get users with posts in rollbacked transaction', async (t) => 
 		});
 	})).rejects.toThrowError(new TransactionRollbackError());
 
+	await expect(db.transaction(async (tx) => {
+		await tx.insert(usersTable).values([
+			{ id: 1, name: 'Dan' },
+			{ id: 2, name: 'Andrew' },
+			{ id: 3, name: 'Alex' },
+		]);
+
+		await tx.insert(postsTable).values([
+			{ ownerId: 1, content: 'Post1' },
+			{ ownerId: 1, content: 'Post1.1' },
+			{ ownerId: 2, content: 'Post2' },
+			{ ownerId: 3, content: 'Post3' },
+		]);
+
+		tx.rollback(new Error("my custom error"));
+
+		usersWithPosts = await tx.query.usersTable.findMany({
+			where: (({ id }, { eq }) => eq(id, 1)),
+			with: {
+				posts: {
+					where: (({ id }, { eq }) => eq(id, 1)),
+				},
+			},
+		});
+	})).rejects.toThrowError(new Error("my custom error"));
+
 	expectTypeOf(usersWithPosts).toEqualTypeOf<{
 		id: number;
 		name: string;

--- a/integration-tests/tests/relational/turso.test.ts
+++ b/integration-tests/tests/relational/turso.test.ts
@@ -893,6 +893,32 @@ test('[Find Many] Get users with posts in rollbacked transaction', async () => {
 		});
 	})).rejects.toThrowError(new TransactionRollbackError());
 
+	expect(db.transaction(async (tx) => {
+		await tx.insert(usersTable).values([
+			{ id: 1, name: 'Dan' },
+			{ id: 2, name: 'Andrew' },
+			{ id: 3, name: 'Alex' },
+		]).run();
+
+		await tx.insert(postsTable).values([
+			{ ownerId: 1, content: 'Post1' },
+			{ ownerId: 1, content: 'Post1.1' },
+			{ ownerId: 2, content: 'Post2' },
+			{ ownerId: 3, content: 'Post3' },
+		]).run();
+
+		await tx.rollback(new Error("my custom error"));
+
+		usersWithPosts = await tx.query.usersTable.findMany({
+			where: (({ id }, { eq }) => eq(id, 1)),
+			with: {
+				posts: {
+					where: (({ id }, { eq }) => eq(id, 1)),
+				},
+			},
+		});
+	})).rejects.toThrowError(new Error("my custom error"));
+
 	expectTypeOf(usersWithPosts).toEqualTypeOf<{
 		id: number;
 		name: string;

--- a/integration-tests/tests/singlestore/singlestore-common.ts
+++ b/integration-tests/tests/singlestore/singlestore-common.ts
@@ -2204,6 +2204,13 @@ export function tests(driver?: string) {
 				});
 			})()).rejects.toThrowError(TransactionRollbackError);
 
+			await expect((async () => {
+				await db.transaction(async (tx) => {
+					await tx.insert(users).values({ balance: 100 });
+					tx.rollback(new Error("my custom error"));
+				});
+			})()).rejects.toThrowError(new Error("my custom error"));
+
 			const result = await db.select().from(users);
 
 			expect(result).toEqual([]);

--- a/integration-tests/tests/singlestore/singlestore-prefixed.test.ts
+++ b/integration-tests/tests/singlestore/singlestore-prefixed.test.ts
@@ -1340,6 +1340,13 @@ test('transaction rollback', async () => {
 		});
 	})()).rejects.toThrowError(TransactionRollbackError);
 
+	await expect((async () => {
+		await db.transaction(async (tx) => {
+			await tx.insert(users).values({ balance: 100 });
+			tx.rollback(new Error("my custom error"));
+		});
+	})()).rejects.toThrowError(new Error("my custom error"));
+
 	const result = await db.select().from(users);
 
 	await db.execute(sql`drop table ${users}`);

--- a/integration-tests/tests/sqlite/sqlite-common.ts
+++ b/integration-tests/tests/sqlite/sqlite-common.ts
@@ -1768,6 +1768,13 @@ export function tests() {
 				});
 			}).rejects.toThrowError(TransactionRollbackError);
 
+			await expect((async () => {
+				await db.transaction(async (tx) => {
+					await tx.insert(users).values({ balance: 100 }).run();
+					tx.rollback(new Error("my custom error message"));
+				});
+			})()).rejects.toThrowError("my custom error message");
+
 			const result = await db.select().from(users).all();
 
 			expect(result).toEqual([]);
@@ -1827,6 +1834,13 @@ export function tests() {
 						tx.rollback();
 					});
 				}).rejects.toThrowError(TransactionRollbackError);
+
+				await expect((async () => {
+					await db.transaction(async (tx) => {
+						await tx.update(users).set({ balance: 200 }).run();
+						tx.rollback(new Error("my custom error"));
+					});
+				})()).rejects.toThrowError("my custom error");
 			});
 
 			const result = await db.select().from(users).all();


### PR DESCRIPTION
Currently, `tx.rollback()` throws a `TransactionRollbackError`. When implementing complex business logic in a transaction, it is desirable to throw better errors.