### PR TITLE
[neon-http|pg-core]: Don't Try To Manipulate the `public` Schema

### DIFF
--- a/drizzle-orm/src/neon-http/migrator.ts
+++ b/drizzle-orm/src/neon-http/migrator.ts
@@ -25,7 +25,9 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 			created_at bigint
 		)
 	`;
-	await db.session.execute(sql`CREATE SCHEMA IF NOT EXISTS ${sql.identifier(migrationsSchema)}`);
+	if (migrationsSchema !== 'public') {
+		await db.session.execute(sql`CREATE SCHEMA IF NOT EXISTS ${sql.identifier(migrationsSchema)}`);
+	}
 	await db.session.execute(migrationTableCreate);
 
 	const dbMigrations = await db.session.all<{ id: number; hash: string; created_at: string }>(

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -82,7 +82,9 @@ export class PgDialect {
 				created_at bigint
 			)
 		`;
-		await session.execute(sql`CREATE SCHEMA IF NOT EXISTS ${sql.identifier(migrationsSchema)}`);
+		if (migrationsSchema !== 'public') {
+			await session.execute(sql`CREATE SCHEMA IF NOT EXISTS ${sql.identifier(migrationsSchema)}`);
+		}
 		await session.execute(migrationTableCreate);
 
 		const dbMigrations = await session.all<{ id: number; hash: string; created_at: string }>(


### PR DESCRIPTION
This pull request introduces a small but important improvement to the migration logic in both the Neon HTTP migrator and the PostgreSQL dialect. The change ensures that the schema for migrations is created only if it is not the default `public` schema, helping to prevent unnecessary operations and potential errors when using custom schemas.

Migration logic improvement:

* Added a conditional check to create the schema only when `migrationsSchema` is not `'public'` in both `migrate` function (`drizzle-orm/src/neon-http/migrator.ts`) and `PgDialect` class (`drizzle-orm/src/pg-core/dialect.ts`). 

Fixes: https://github.com/drizzle-team/drizzle-orm/issues/3584