### PR TITLE
[SQLite-kit] Add missing comma

### DIFF
--- a/drizzle-kit/src/introspect-sqlite.ts
+++ b/drizzle-kit/src/introspect-sqlite.ts
@@ -491,7 +491,7 @@ const createTablePKs = (pks: PrimaryKey[], casing: Casing): string => {
 				})
 				.join(', ')
 		}]${it.name ? `, name: "${it.name}"` : ''}}`;
-		statement += ')';
+		statement += '),';
 	});
 
 	return statement;


### PR DESCRIPTION
Adds a missing comma after the generation of primaryKey during sqlite introspection. Without it, databases that contain checks for example will result in schemas with syntax errors with the error being a missing comma.
Closes #4582 




This is also my first PR and I had issues with building the project, majority of them being typescript issues, I followed the contributing instructions `pnpm install && pnpm build` steps, however it still didn't work, would appreciate a lot some input on what am I missing, thanks!