### PR TITLE
[SingleStore]: Add temporary table support

### DIFF
--- a/drizzle-orm/src/singlestore-core/db.ts
+++ b/drizzle-orm/src/singlestore-core/db.ts
@@ -27,6 +27,7 @@ import type {
 } from './session.ts';
 import type { WithBuilder } from './subquery.ts';
 import type { SingleStoreTable } from './table.ts';
+import { SingleStoreTempTableBuilder } from './temp-table.ts';
 
 export class SingleStoreDatabase<
 	TQueryResult extends SingleStoreQueryResultHKT,
@@ -487,6 +488,26 @@ export class SingleStoreDatabase<
 		config?: SingleStoreTransactionConfig,
 	): Promise<T> {
 		return this.session.transaction(transaction, config);
+	}
+
+	/**
+	 * Creates a temporary table builder.
+	 *
+	 * @param name The name for the temporary table
+	 *
+	 * @example
+	 * ```ts
+	 * const myTemporaryTable = await db
+	 *   .temp('my_temporary_table')
+	 *   .as(db.select().from(users));
+	 *
+	 * const rows = await db.select().from(myTemporaryTable);
+	 *
+	 * await myTemporaryTable.drop();
+	 * ```
+	 */
+	temp(name: string): SingleStoreTempTableBuilder {
+		return new SingleStoreTempTableBuilder(name, (sql: SQL) => this.execute(sql), this.dialect);
 	}
 }
 

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -34,6 +34,7 @@ import type {
 import type { SingleStoreUpdateConfig } from './query-builders/update.ts';
 import type { SingleStoreSession } from './session.ts';
 import { SingleStoreTable } from './table.ts';
+import { SingleStoreTempTable } from './temp-table.ts';
 /* import { SingleStoreViewBase } from './view-base.ts'; */
 
 export interface SingleStoreDialectConfig {
@@ -300,6 +301,10 @@ export class SingleStoreDialect {
 				return sql`${sql`${sql.identifier(table[Table.Symbol.Schema] ?? '')}.`.if(table[Table.Symbol.Schema])}${
 					sql.identifier(table[Table.Symbol.OriginalName])
 				} ${sql.identifier(table[Table.Symbol.Name])}`;
+			}
+
+			if (is(table, SingleStoreTempTable)) {
+				return sql`${sql.identifier(table.tableName)}`;
 			}
 
 			return table;

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -341,6 +341,15 @@ export class SingleStoreDialect {
 							viewSchema ? sql`${sql.identifier(viewSchema)}.` : undefined
 						}${sql.identifier(origViewName)}${alias && sql` ${sql.identifier(alias)}`}${onSql}`,
 					);
+				} else if (is(table, SingleStoreTempTable)) {
+					// Handle temp tables - they should not be wrapped in parentheses
+					// Only add alias if it's different from the table name
+					const alias = joinMeta.alias !== table.tableName ? joinMeta.alias : undefined;
+					joinsArray.push(
+						sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${sql.identifier(table.tableName)}${
+							alias && sql` ${sql.identifier(alias)}`
+						}${onSql}`,
+					);
 				} else {
 					joinsArray.push(
 						sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${table}${onSql}`,

--- a/drizzle-orm/src/singlestore-core/index.ts
+++ b/drizzle-orm/src/singlestore-core/index.ts
@@ -9,6 +9,7 @@ export * from './schema.ts';
 export * from './session.ts';
 export * from './subquery.ts';
 export * from './table.ts';
+export * from './temp-table.ts';
 export * from './unique-constraint.ts';
 export * from './utils.ts';
 /* export * from './view-common.ts';

--- a/drizzle-orm/src/singlestore-core/temp-table.ts
+++ b/drizzle-orm/src/singlestore-core/temp-table.ts
@@ -1,0 +1,164 @@
+import { entityKind } from '~/entity.ts';
+import type { TypedQueryBuilder } from '~/query-builders/query-builder.ts';
+import { SQL, sql } from '~/sql/sql.ts';
+import { Subquery } from '~/subquery.ts';
+import { Table } from '~/table.ts';
+import type { SingleStoreDialect } from './dialect.ts';
+
+/**
+ * Temporary table builder for creating temporary tables from queries.
+ */
+export class SingleStoreTempTableBuilder {
+	static readonly [entityKind]: string = 'SingleStoreTempTableBuilder';
+
+	constructor(
+		public readonly name: string,
+		private readonly executeQuery: (sql: SQL) => Promise<any>,
+		private readonly dialect: SingleStoreDialect,
+	) {}
+
+	/**
+	 * Creates a temporary table from a SELECT query.
+	 */
+	async as<TSelectedFields extends Record<string, unknown>>(
+		query: TypedQueryBuilder<TSelectedFields> | SQL,
+	): Promise<SingleStoreTempTable<TSelectedFields> & TSelectedFields> {
+		let querySQL: SQL;
+		if ('getSQL' in query) {
+			querySQL = query.getSQL();
+		} else {
+			querySQL = query;
+		}
+
+		const builtQuery = this.dialect.sqlToQuery(querySQL);
+
+		// Remove parentheses from the beginning and end if they exist
+		let cleanSQL = builtQuery.sql.trim();
+		if (cleanSQL.startsWith('(') && cleanSQL.endsWith(')')) {
+			cleanSQL = cleanSQL.slice(1, -1);
+		}
+
+		const finalSQL = `CREATE TEMPORARY TABLE \`${this.name}\` AS ${cleanSQL}`;
+		const createSQL = sql.raw(finalSQL);
+
+		if (builtQuery.params && builtQuery.params.length > 0) {
+			let paramIndex = 0;
+			const parameterizedSQL = finalSQL.replace(/\?/g, () => {
+				const param = builtQuery.params[paramIndex++];
+				return typeof param === 'string' ? `'${param.replace(/'/g, "''")}'` : String(param);
+			});
+			await this.executeQuery(sql.raw(parameterizedSQL));
+		} else {
+			await this.executeQuery(createSQL);
+		}
+
+		const selectedFields = 'getSelectedFields' in query
+			? query.getSelectedFields()
+			: ({} as TSelectedFields);
+
+		const tempTable = new SingleStoreTempTable(this.name, selectedFields, this.executeQuery);
+
+		return tempTable as SingleStoreTempTable<TSelectedFields> & TSelectedFields;
+	}
+}
+
+/**
+ * Helper type to infer select model from selected fields
+ */
+export type InferTempTableSelectModel<T extends SingleStoreTempTable<any>> = T extends
+	SingleStoreTempTable<infer TSelectedFields> ? TSelectedFields
+	: never;
+
+/**
+ * Helper type to infer insert model from selected fields (same as select for temp tables)
+ */
+export type InferTempTableInsertModel<T extends SingleStoreTempTable<any>> = InferTempTableSelectModel<T>;
+
+/**
+ * A temporary table that extends Subquery to be compatible with .from() clauses.
+ */
+export class SingleStoreTempTable<TSelectedFields extends Record<string, unknown> = Record<string, unknown>>
+	extends Subquery<string, TSelectedFields>
+{
+	static override readonly [entityKind]: string = 'SingleStoreTempTable';
+
+	declare readonly $inferSelect: TSelectedFields;
+	declare readonly $inferInsert: TSelectedFields;
+
+	constructor(
+		public readonly tableName: string,
+		public readonly selectedFields: TSelectedFields,
+		private readonly executeQuery: (sql: SQL) => Promise<any>,
+	) {
+		super(
+			sql`${sql.identifier(tableName)}`,
+			selectedFields,
+			tableName,
+			false,
+			[],
+		);
+
+		// Set up the table symbols like a real table to make temp table work properly
+		(this as any)[Table.Symbol.Name] = tableName;
+		(this as any)[Table.Symbol.OriginalName] = tableName;
+		(this as any)[Table.Symbol.BaseName] = tableName;
+		(this as any)[Table.Symbol.Schema] = undefined;
+		(this as any)[Table.Symbol.IsAlias] = false;
+
+		// Create column proxies that reference THIS temp table instead of the original table
+		const builtColumns: Record<string, any> = {};
+
+		for (const [key, column] of Object.entries(selectedFields)) {
+			// If this is a column object, create a proxy that references this temp table
+			if (column && typeof column === 'object' && 'table' in column) {
+				// Create a new column object that points to our temp table
+				const tempColumnProxy = Object.create(Object.getPrototypeOf(column));
+				// Copy all properties from the original column
+				Object.assign(tempColumnProxy, column);
+				// But change the table reference to point to this temp table
+				Object.defineProperty(tempColumnProxy, 'table', {
+					value: this,
+					writable: false,
+					enumerable: true,
+					configurable: false,
+				});
+				builtColumns[key] = tempColumnProxy;
+			} else {
+				// Not a column, keep as is
+				builtColumns[key] = column;
+			}
+		}
+
+		// Set up the column symbols
+		(this as any)[Table.Symbol.Columns] = builtColumns;
+		(this as any)[Table.Symbol.ExtraConfigColumns] = builtColumns;
+
+		// Add columns as properties, avoiding conflicts with existing methods
+		const safeSelectedFields = Object.fromEntries(
+			Object.entries(builtColumns).filter(([key]) => !(key in this)),
+		);
+		Object.assign(this, safeSelectedFields);
+	}
+
+	/**
+	 * Override getSQL to return just the table identifier without parentheses.
+	 */
+	override getSQL(): SQL {
+		return sql`${sql.identifier(this.tableName)}`;
+	}
+
+	/**
+	 * Prevents the temp table from being wrapped in parentheses in SQL generation.
+	 */
+	override shouldOmitSQLParens(): boolean {
+		return true;
+	}
+
+	/**
+	 * Drop the temporary table.
+	 */
+	async drop(): Promise<void> {
+		const dropSQL = sql`DROP TEMPORARY TABLE ${sql.identifier(this.tableName)}`;
+		await this.executeQuery(dropSQL);
+	}
+}

--- a/drizzle-orm/src/singlestore/index.ts
+++ b/drizzle-orm/src/singlestore/index.ts
@@ -1,2 +1,3 @@
+export * from '../singlestore-core/index.ts';
 export * from './driver.ts';
 export * from './session.ts';

--- a/integration-tests/tests/singlestore/singlestore-common.ts
+++ b/integration-tests/tests/singlestore/singlestore-common.ts
@@ -4022,7 +4022,7 @@ export function tests(driver?: string) {
 
 			// Test with SQL injection attempt in parameter
 			const maliciousDomains = ["safe.com'; DROP TABLE test_companies_injection; --", 'test.com'];
-			
+
 			// This should safely create temp table with parameterized query
 			const tempTable = await db
 				.temp('safe_temp_table')
@@ -4030,7 +4030,7 @@ export function tests(driver?: string) {
 					db
 						.select({ companyId: companiesTable.companyId })
 						.from(companiesTable)
-						.where(inArray(companiesTable.domain, maliciousDomains))
+						.where(inArray(companiesTable.domain, maliciousDomains)),
 				);
 
 			// Verify the table still exists and injection was prevented

--- a/integration-tests/tests/singlestore/singlestore-common.ts
+++ b/integration-tests/tests/singlestore/singlestore-common.ts
@@ -3923,4 +3923,163 @@ export function tests(driver?: string) {
 			expect(rawRes).toStrictEqual(expectedRes);
 		});
 	});
+
+	describe('Temporary Tables', () => {
+		test('db.temp().as() API - create temporary table from query', async (ctx) => {
+			const { db } = ctx.singlestore;
+
+			const usersTable = singlestoreTable('test_users_for_temp', {
+				id: int().primaryKey(),
+				name: varchar({ length: 255 }).notNull(),
+				email: varchar({ length: 255 }),
+				active: boolean().default(true),
+			});
+
+			await db.execute(sql`
+				CREATE TABLE IF NOT EXISTS test_users_for_temp (
+								id INT PRIMARY KEY,
+								name VARCHAR(255) NOT NULL,
+								email VARCHAR(255),
+								active BOOLEAN DEFAULT TRUE
+							)
+			`);
+
+			await db.execute(sql`
+				INSERT INTO test_users_for_temp VALUES 
+								(1, 'John Doe', 'john@example.com', TRUE),
+								(2, 'Jane Smith', 'jane@example.com', TRUE),
+								(3, 'Bob Johnson', 'bob@example.com', FALSE)
+			`);
+
+			const myTemporaryTable = await db
+				.temp('my_temporary_table')
+				.as(
+					db
+						.select()
+						.from(usersTable)
+						.where(eq(usersTable.active, true)),
+				);
+
+			expectTypeOf(myTemporaryTable).toHaveProperty('id');
+			expectTypeOf(myTemporaryTable).toHaveProperty('name');
+			expectTypeOf(myTemporaryTable).toHaveProperty('email');
+			expectTypeOf(myTemporaryTable).toHaveProperty('active');
+			expectTypeOf(myTemporaryTable).toHaveProperty('drop');
+			expectTypeOf(myTemporaryTable.drop).toEqualTypeOf<() => Promise<void>>();
+
+			const rows = await db.select().from(myTemporaryTable);
+
+			expectTypeOf(rows).toEqualTypeOf<
+				Array<{
+					id: number;
+					name: string;
+					email: string | null;
+					active: boolean | null;
+				}>
+			>();
+
+			expect(rows).toHaveLength(2);
+
+			if (rows.length > 0) {
+				const firstRow = rows[0]!;
+				expectTypeOf(firstRow.id).toEqualTypeOf<number>();
+				expectTypeOf(firstRow.name).toEqualTypeOf<string>();
+				expectTypeOf(firstRow.email).toEqualTypeOf<string | null>();
+				expectTypeOf(firstRow.active).toEqualTypeOf<boolean | null>();
+			}
+
+			await myTemporaryTable.drop();
+			await db.execute(sql`DROP TABLE test_users_for_temp`);
+		});
+
+		test('Complex query with joins and aggregations', async (ctx) => {
+			const { db } = ctx.singlestore;
+
+			const ordersTable = singlestoreTable('temp_orders', {
+				id: int().primaryKey(),
+				userId: int().notNull(),
+				amount: decimal({ precision: 10, scale: 2 }).notNull(),
+				status: varchar({ length: 50 }).notNull(),
+			});
+
+			const customersTable = singlestoreTable('temp_customers', {
+				id: int().primaryKey(),
+				name: varchar({ length: 255 }).notNull(),
+			});
+
+			await db.execute(sql`
+				CREATE TABLE IF NOT EXISTS temp_orders (
+							id INT PRIMARY KEY,
+							userId INT NOT NULL,
+							amount DECIMAL(10,2) NOT NULL,
+							status VARCHAR(50) NOT NULL
+						)
+			`);
+
+			await db.execute(sql`
+				CREATE TABLE IF NOT EXISTS temp_customers (
+							id INT PRIMARY KEY,
+							name VARCHAR(255) NOT NULL
+						)
+			`);
+
+			await db.execute(sql`
+				INSERT INTO temp_customers VALUES 
+							(1, 'Alice Johnson'),
+							(2, 'Bob Smith')
+			`);
+
+			await db.execute(sql`
+				INSERT INTO temp_orders VALUES 
+							(1, 1, 100.50, 'completed'),
+							(2, 1, 75.25, 'completed'),
+							(3, 2, 200.00, 'pending'),
+							(4, 2, 150.75, 'completed')
+			`);
+
+			const customerSummary = await db
+				.temp('customer_order_summary')
+				.as(
+					db
+						.select({
+							customerId: customersTable.id,
+							customerName: customersTable.name,
+							totalAmount: sum(ordersTable.amount).as('totalAmount'),
+							orderCount: count(ordersTable.id).as('orderCount'),
+						})
+						.from(customersTable)
+						.innerJoin(ordersTable, eq(customersTable.id, ordersTable.userId))
+						.where(eq(ordersTable.status, 'completed'))
+						.groupBy(customersTable.id, customersTable.name),
+				);
+
+			expectTypeOf(customerSummary).toHaveProperty('customerId');
+			expectTypeOf(customerSummary).toHaveProperty('customerName');
+			expectTypeOf(customerSummary).toHaveProperty('totalAmount');
+			expectTypeOf(customerSummary).toHaveProperty('orderCount');
+			expectTypeOf(customerSummary).toHaveProperty('drop');
+			expectTypeOf(customerSummary.drop).toEqualTypeOf<() => Promise<void>>();
+
+			const summary = await db.select({
+				id: customerSummary.customerId,
+			}).from(customerSummary).where(eq(customerSummary.customerId, 1));
+
+			expectTypeOf(summary).toEqualTypeOf<Array<{ id: number }>>();
+			expect(summary).toHaveLength(1);
+
+			const fullSummary = await db.select().from(customerSummary);
+			expectTypeOf(fullSummary).toEqualTypeOf<
+				Array<{
+					customerId: number;
+					customerName: string;
+					totalAmount: string | null;
+					orderCount: number;
+				}>
+			>();
+
+			await customerSummary.drop();
+			await db.execute(sql`DROP TABLE temp_orders`);
+			await db.execute(sql`DROP TABLE temp_customers`);
+		});
+	});
 }


### PR DESCRIPTION
This PR implements temporary table functionality for SingleStore, including:

- New `temp-table.ts` module in `singlestore-core` with table creation utilities
- Updated database interface to support temporary table operations  
- Integration tests for temporary table functionality
- Proper type definitions and core functionality

The implementation follows existing patterns in other dialects and maintains consistency with the Drizzle ORM architecture.

The design for this was inspired by this issue for postgres temporary tables #3104 