### PR TITLE
[Pg-kit]: Fix enum migration when dropping values used as defaults

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -1475,6 +1475,10 @@ class AlterTypeDropValueConvertor extends Convertor {
 				: `"${withEnum.table}"`;
 
 			statements.push(
+				`ALTER TABLE ${tableNameWithSchema} ALTER COLUMN "${withEnum.column}" DROP DEFAULT;`,
+			);
+
+			statements.push(
 				`ALTER TABLE ${tableNameWithSchema} ALTER COLUMN "${withEnum.column}" SET DATA TYPE text;`,
 			);
 			if (withEnum.default) {

--- a/drizzle-kit/tests/pg-enums.test.ts
+++ b/drizzle-kit/tests/pg-enums.test.ts
@@ -640,16 +640,17 @@ test('drop enum value. enum is columns data type', async () => {
 	};
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
-
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements.length).toBe(8);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[3]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[4]).toBe(`DROP TYPE "public"."enum";`);
+	expect(sqlStatements[5]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3');`);
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum" USING "column"::"public"."enum";`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[7]).toBe(
 		`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE "public"."enum" USING "column"::"public"."enum";`,
 	);
 
@@ -714,15 +715,17 @@ test('shuffle enum values', async () => {
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements.length).toBe(8);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[3]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[4]).toBe(`DROP TYPE "public"."enum";`);
+	expect(sqlStatements[5]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum" USING "column"::"public"."enum";`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[7]).toBe(
 		`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE "public"."enum" USING "column"::"public"."enum";`,
 	);
 
@@ -801,15 +804,16 @@ test('column is enum type with default value. shuffle enum', async () => {
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::text;`);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::text;`);
+	expect(sqlStatements[3]).toBe(`DROP TYPE "public"."enum";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[5]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::"public"."enum";`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum" USING "column"::"public"."enum";`,
 	);
 
@@ -859,15 +863,16 @@ test('column is array enum type with default value. shuffle enum', async () => {
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT '{"value3"}'::text;`);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);		
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT '{"value3"}'::text;`);
+	expect(sqlStatements[3]).toBe(`DROP TYPE "public"."enum";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[5]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT '{"value3"}'::"public"."enum"[];`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum"[] USING "column"::"public"."enum"[];`,
 	);
 
@@ -917,15 +922,16 @@ test('column is array enum with custom size type with default value. shuffle enu
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT '{"value2"}'::text;`);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT '{"value2"}'::text;`);
+	expect(sqlStatements[3]).toBe(`DROP TYPE "public"."enum";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[5]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT '{"value2"}'::"public"."enum"[3];`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum"[3] USING "column"::"public"."enum"[3];`,
 	);
 
@@ -975,11 +981,12 @@ test('column is array enum with custom size type. shuffle enum', async () => {
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(4);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`DROP TYPE "public"."enum";`);
-	expect(sqlStatements[2]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[3]).toBe(
+	expect(sqlStatements.length).toBe(5);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum";`);
+	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[4]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum"[3] USING "column"::"public"."enum"[3];`,
 	);
 
@@ -1029,11 +1036,12 @@ test('column is array of enum with multiple dimenions with custom sizes type. sh
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(4);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`DROP TYPE "public"."enum";`);
-	expect(sqlStatements[2]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[3]).toBe(
+	expect(sqlStatements.length).toBe(5);	
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum";`);
+	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[4]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum"[3][2] USING "column"::"public"."enum"[3][2];`,
 	);
 
@@ -1083,15 +1091,16 @@ test('column is array of enum with multiple dimenions type with custom size with
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT '{{"value2"}}'::text;`);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT '{{"value2"}}'::text;`);
+	expect(sqlStatements[3]).toBe(`DROP TYPE "public"."enum";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[5]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT '{{"value2"}}'::"public"."enum"[3][2];`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum"[3][2] USING "column"::"public"."enum"[3][2];`,
 	);
 
@@ -1144,15 +1153,16 @@ test('column is enum type with default value. custom schema. shuffle enum', asyn
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::text;`);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "new_schema"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "new_schema"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::text;`);
+	expect(sqlStatements[3]).toBe(`DROP TYPE "new_schema"."enum";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "new_schema"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[5]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::"new_schema"."enum";`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "new_schema"."enum" USING "column"::"new_schema"."enum";`,
 	);
 
@@ -1204,17 +1214,18 @@ test('column is array enum type with default value. custom schema. shuffle enum'
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(
 		`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DEFAULT '{"value2"}'::text;`,
 	);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "new_schema"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "new_schema"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements[3]).toBe(`DROP TYPE "new_schema"."enum";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "new_schema"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[5]).toBe(
 		`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DEFAULT '{"value2"}'::"new_schema"."enum"[];`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE "new_schema"."enum"[] USING "column"::"new_schema"."enum"[];`,
 	);
 
@@ -1266,17 +1277,18 @@ test('column is array enum type with custom size with default value. custom sche
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(
 		`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DEFAULT '{"value2"}'::text;`,
 	);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "new_schema"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "new_schema"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements[3]).toBe(`DROP TYPE "new_schema"."enum";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "new_schema"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[5]).toBe(
 		`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DEFAULT '{"value2"}'::"new_schema"."enum"[3];`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE "new_schema"."enum"[3] USING "column"::"new_schema"."enum"[3];`,
 	);
 
@@ -1328,11 +1340,12 @@ test('column is array enum type with custom size. custom schema. shuffle enum', 
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(4);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`DROP TYPE "new_schema"."enum";`);
-	expect(sqlStatements[2]).toBe(`CREATE TYPE "new_schema"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[3]).toBe(
+	expect(sqlStatements.length).toBe(5);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`DROP TYPE "new_schema"."enum";`);
+	expect(sqlStatements[3]).toBe(`CREATE TYPE "new_schema"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[4]).toBe(
 		`ALTER TABLE "new_schema"."table" ALTER COLUMN "column" SET DATA TYPE "new_schema"."enum"[3] USING "column"::"new_schema"."enum"[3];`,
 	);
 
@@ -2447,15 +2460,16 @@ test('check filtering json statements. here we have recreate enum + set new type
 
 	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::text;`);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum1";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum1" AS ENUM('value3', 'value1', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::text;`);
+	expect(sqlStatements[3]).toBe(`DROP TYPE "public"."enum1";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "public"."enum1" AS ENUM('value3', 'value1', 'value2');`);
+	expect(sqlStatements[5]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::"public"."enum1";`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum1" USING "column"::"public"."enum1";`,
 	);
 
@@ -2501,5 +2515,56 @@ test('check filtering json statements. here we have recreate enum + set new type
 		tableName: 'table',
 		type: 'pg_alter_table_alter_column_set_type',
 		typeSchema: 'public',
+	});
+});
+
+test('drop enum value that is used as default - should handle gracefully', async () => {
+	const enum1 = pgEnum('status', ['active', 'pending', 'inactive']);
+
+	const from = {
+		enum1,
+		table: pgTable('users', {
+			status: enum1('status').default('pending'),
+		}),
+	};
+
+	const enum2 = pgEnum('status', ['active', 'inactive']);
+	const to = {
+		enum2,
+		table: pgTable('users', {
+			status: enum2('status').default('active'),
+		}),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "users" ALTER COLUMN "status" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "users" ALTER COLUMN "status" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "users" ALTER COLUMN "status" SET DEFAULT 'active'::text;`);
+	expect(sqlStatements[3]).toBe(`DROP TYPE "public"."status";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "public"."status" AS ENUM('active', 'inactive');`);
+	expect(sqlStatements[5]).toBe(
+		`ALTER TABLE "users" ALTER COLUMN "status" SET DEFAULT 'active'::"public"."status";`,
+	);
+	expect(sqlStatements[6]).toBe(
+		`ALTER TABLE "users" ALTER COLUMN "status" SET DATA TYPE "public"."status" USING "status"::"public"."status";`,
+	);
+
+	expect(statements.length).toBe(1);
+	expect(statements[0]).toStrictEqual({
+		type: 'alter_type_drop_value',
+		name: 'status',
+		deletedValues: ['pending'],
+		newValues: ['active', 'inactive'],
+		columnsWithEnum: [{
+			schema: '',
+			table: 'users',
+			column: 'status',
+			typeSchema: 'public',
+			isArray: false,
+			dimensions: 0,
+			rawDimensions: 0,
+		}],
 	});
 });

--- a/drizzle-kit/tests/push/pg.test.ts
+++ b/drizzle-kit/tests/push/pg.test.ts
@@ -2824,23 +2824,29 @@ test('drop enum values', async () => {
 		}],
 	});
 
-	expect(sqlStatements.length).toBe(6);
+	expect(sqlStatements.length).toBe(8);
 	expect(sqlStatements[0]).toBe(
-		`ALTER TABLE "enum_table" ALTER COLUMN "id" SET DATA TYPE text;`,
+		`ALTER TABLE "enum_table" ALTER COLUMN "id" DROP DEFAULT;`,
 	);
 	expect(sqlStatements[1]).toBe(
-		`ALTER TABLE "mySchema"."enum_table" ALTER COLUMN "id" SET DATA TYPE text;`,
+		`ALTER TABLE "enum_table" ALTER COLUMN "id" SET DATA TYPE text;`,
 	);
 	expect(sqlStatements[2]).toBe(
-		`DROP TYPE "public"."enum_users_customer_and_ship_to_settings_roles";`,
+		`ALTER TABLE "mySchema"."enum_table" ALTER COLUMN "id" DROP DEFAULT;`,
 	);
 	expect(sqlStatements[3]).toBe(
-		`CREATE TYPE "public"."enum_users_customer_and_ship_to_settings_roles" AS ENUM('addedToTop', 'custAll', 'custAdmin', 'custClerk', 'custInvoiceManager', 'custApprover', 'custOrderWriter', 'custBuyer');`,
+		`ALTER TABLE "mySchema"."enum_table" ALTER COLUMN "id" SET DATA TYPE text;`,
 	);
 	expect(sqlStatements[4]).toBe(
-		`ALTER TABLE "enum_table" ALTER COLUMN "id" SET DATA TYPE "public"."enum_users_customer_and_ship_to_settings_roles" USING "id"::"public"."enum_users_customer_and_ship_to_settings_roles";`,
+		`DROP TYPE "public"."enum_users_customer_and_ship_to_settings_roles";`,
 	);
 	expect(sqlStatements[5]).toBe(
+		`CREATE TYPE "public"."enum_users_customer_and_ship_to_settings_roles" AS ENUM('addedToTop', 'custAll', 'custAdmin', 'custClerk', 'custInvoiceManager', 'custApprover', 'custOrderWriter', 'custBuyer');`,
+	);
+	expect(sqlStatements[6]).toBe(
+		`ALTER TABLE "enum_table" ALTER COLUMN "id" SET DATA TYPE "public"."enum_users_customer_and_ship_to_settings_roles" USING "id"::"public"."enum_users_customer_and_ship_to_settings_roles";`,
+	);
+	expect(sqlStatements[7]).toBe(
 		`ALTER TABLE "mySchema"."enum_table" ALTER COLUMN "id" SET DATA TYPE "public"."enum_users_customer_and_ship_to_settings_roles" USING "id"::"public"."enum_users_customer_and_ship_to_settings_roles";`,
 	);
 });
@@ -2875,15 +2881,16 @@ test('column is enum type with default value. shuffle enum', async () => {
 		undefined,
 	);
 
-	expect(sqlStatements.length).toBe(6);
-	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
-	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::text;`);
-	expect(sqlStatements[2]).toBe(`DROP TYPE "public"."enum";`);
-	expect(sqlStatements[3]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
-	expect(sqlStatements[4]).toBe(
+	expect(sqlStatements.length).toBe(7);
+	expect(sqlStatements[0]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" DROP DEFAULT;`);
+	expect(sqlStatements[1]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE text;`);
+	expect(sqlStatements[2]).toBe(`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::text;`);
+	expect(sqlStatements[3]).toBe(`DROP TYPE "public"."enum";`);
+	expect(sqlStatements[4]).toBe(`CREATE TYPE "public"."enum" AS ENUM('value1', 'value3', 'value2');`);
+	expect(sqlStatements[5]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DEFAULT 'value2'::"public"."enum";`,
 	);
-	expect(sqlStatements[5]).toBe(
+	expect(sqlStatements[6]).toBe(
 		`ALTER TABLE "table" ALTER COLUMN "column" SET DATA TYPE "public"."enum" USING "column"::"public"."enum";`,
 	);
 


### PR DESCRIPTION
## Summary
Fixes PostgreSQL enum migration errors when dropping enum values that are used as column defaults.

## Problem
When attempting to drop an enum value that is currently used as a default value for a column, PostgreSQL throws an error:
```
cannot drop type "enum_name" because other objects depend on it
```

This occurs because PostgreSQL cannot drop or modify an enum type while it's still referenced by a default constraint.

## Solution
Added logic to drop default constraints before converting columns to text type during enum modifications. This ensures proper handling of dependencies when enum values are dropped.

## Changes
- Modified `AlterTypeDropValueConvertor` in `sqlgenerator.ts` to add `DROP DEFAULT` statements
- Updated all affected tests to expect the new DROP DEFAULT statements
- Added specific test case for the reported issue

## Test plan
- [x] All existing enum tests pass with updated expectations
- [x] New test case specifically validates the fix for dropping enum values used as defaults
- [x] Migration generation correctly handles enum modifications with default values

Fixes #4295

🤖 Generated with [Claude Code](https://claude.ai/code)