### PR TITLE
feat: allow passing a number/boolean/null to `sql.raw`

### DIFF
--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -508,11 +508,11 @@ export namespace sql {
 	}
 
 	/**
-	 * Convenience function to create an SQL query from a raw string.
-	 * @param str The raw SQL query string.
+	 * Convenience function to create an SQL query from a raw string or a primitive value.
+	 * @param input The raw SQL query string or a primitive value.
 	 */
-	export function raw(str: string): SQL {
-		return new SQL([new StringChunk(str)]);
+	export function raw<T extends string | number | boolean | null>(input: T): SQL<T extends string ? unknown : T> {
+		return new SQL([new StringChunk(String(input))]);
 	}
 
 	/**


### PR DESCRIPTION
Improve the ergonomics of `sql.raw` by allowing primitives that are safe to stringify without escaping.