### PR TITLE
fix: allow prototype access through SelectionProxyHandler

### DIFF
--- a/drizzle-orm/src/selection-proxy.ts
+++ b/drizzle-orm/src/selection-proxy.ts
@@ -74,6 +74,11 @@ export class SelectionProxyHandler<T extends Subquery | Record<string, unknown> 
 			: is(subquery, View)
 			? subquery[ViewBaseConfig].selectedFields
 			: subquery;
+
+		if (!columns.hasOwnProperty(prop)) {
+			return subquery[prop as keyof typeof subquery];
+		}
+
 		const value: unknown = columns[prop as keyof typeof columns];
 
 		if (is(value, SQL.Aliased)) {


### PR DESCRIPTION
This allows calling `subquery.getSQL()` even when the subquery is wrapped with `SelectionProxyHandler` (e.g. the subquery was wrapped with `db.$with`).