### PR TITLE
feat: Initial Supabase Functions/Triggers implementation

### DIFF
--- a/drizzle-orm/src/supabase/functions.ts
+++ b/drizzle-orm/src/supabase/functions.ts
@@ -1,0 +1,70 @@
+import type { SQL } from '~/sql/sql.ts';
+import { entityKind } from '~/entity.ts';
+
+export type FunctionReturns =
+  | 'void'
+  | 'record'
+  | 'trigger'
+  | 'integer'
+  | 'bool'
+  | 'bytea'
+  | 'date'
+  | 'double precision'
+  | 'float4'
+  | 'float8'
+  | 'int2'
+  | 'int4'
+  | 'int8'
+  | 'json'
+  | 'jsonb'
+  | 'numeric'
+  | 'text'
+  | 'time'
+  | 'timestamp'
+  | 'timestamptz'
+  | 'timetz'
+  | 'uuid'
+  | 'varchar'
+  | 'vector';
+
+export type FunctionLanguage = 'plpgsql' | 'sql';
+export type FunctionBehavior = 'immutable' | 'stable' | 'volatile';
+export type FunctionSecurity = 'definer' | 'invoker';
+
+export interface PgFunctionConfig {
+  returns?: FunctionReturns;
+  language?: FunctionLanguage;
+  behavior?: FunctionBehavior;
+  security?: FunctionSecurity;
+  searchPath?: string;
+  body?: SQL;
+}
+
+export class PgFunction implements PgFunctionConfig {
+  static readonly [entityKind]: string = 'PgFunction';
+
+  readonly returns: PgFunctionConfig['returns'];
+  readonly language: PgFunctionConfig['language'];
+  readonly behavior: PgFunctionConfig['behavior'];
+  readonly security: PgFunctionConfig['security'];
+  readonly searchPath: PgFunctionConfig['searchPath'];
+  readonly body: PgFunctionConfig['body'];
+
+  constructor(
+    readonly name: string,
+    config?: PgFunctionConfig
+  ) {
+    if (config) {
+      this.returns = config.returns;
+      this.language = config.language;
+      this.behavior = config.behavior;
+      this.security = config.security;
+      this.searchPath = config.searchPath;
+      this.body = config.body;
+    }
+  }
+}
+
+export function pgFunction(name: string, config?: PgFunctionConfig) {
+  return new PgFunction(name, config);
+}

--- a/drizzle-orm/src/supabase/index.ts
+++ b/drizzle-orm/src/supabase/index.ts
@@ -1,1 +1,3 @@
 export * from './rls.ts';
+export * from './functions.ts';
+export * from './triggers.ts';

--- a/drizzle-orm/src/supabase/triggers.ts
+++ b/drizzle-orm/src/supabase/triggers.ts
@@ -1,0 +1,42 @@
+import type { PgTable } from '~/pg-core/table.ts';
+import type { PgFunction } from './functions.ts';
+import { entityKind } from '~/entity.ts';
+
+export type TriggerEvent = 'insert' | 'update' | 'delete';
+export type TriggerType = 'before' | 'after';
+export type TriggerOrientation = 'row' | 'statement';
+
+export interface PgTriggerConfig {
+  table?: PgTable;
+  events?: TriggerEvent[];
+  triggerType?: TriggerType;
+  orientation?: TriggerOrientation;
+  function?: PgFunction;
+}
+
+export class PgTrigger implements PgTriggerConfig {
+  static readonly [entityKind]: string = 'PgTrigger';
+
+  readonly table: PgTriggerConfig['table'];
+  readonly events: PgTriggerConfig['events'];
+  readonly triggerType: PgTriggerConfig['triggerType'];
+  readonly orientation: PgTriggerConfig['orientation'];
+  readonly function: PgTriggerConfig['function'];
+
+  constructor(
+    readonly name: string,
+    config?: PgTriggerConfig
+  ) {
+    if (config) {
+      this.table = config.table;
+      this.events = config.events;
+      this.triggerType = config.triggerType;
+      this.orientation = config.orientation;
+      this.function = config.function;
+    }
+  }
+}
+
+export function pgTrigger(name: string, config?: PgTriggerConfig) {
+  return new PgTrigger(name, config);
+}


### PR DESCRIPTION
This PR introduces a foundational implementation for managing PostgreSQL functions and triggers using Drizzle ORM in a Supabase environment. It provides a type-safe, declarative API to define database functions and their associated triggers.

Details:

1. Added `PgFunction` class and factory with support for:
PostgreSQL function properties such as return type, language, behavior, security, search path, and SQL body.

2. Added `PgTrigger` class and factory supporting:
Trigger configuration on tables, including multiple events, trigger type, orientation (row/statement), and linked function execution.

Example:
```ts
import { sql } from "drizzle-orm/sql";
import { authUsers, pgFunction, pgTrigger } from "drizzle-orm/supabase";

export const handleNewUser = pgFunction("handle_new_user", {
  returns: "trigger",
  language: "plpgsql",
  security: "definer",
  behavior: "volatile",
  searchPath: "",
  body: sql`$$
    begin
      insert into public.users (id, email)
      values (new.id, new.email);
      return new;
    end;
    $$`,
});

export const onAuthUserCreated = pgTrigger("on_auth_user_created", {
  table: authUsers,
  events: ["insert"],
  triggerType: "after",
  orientation: "row",
  function: handleNewUser,
});

```