### PR TITLE
v0.44.5

### DIFF
--- a/changelogs/drizzle-orm/0.44.5.md
+++ b/changelogs/drizzle-orm/0.44.5.md
@@ -1,1 +1,4 @@
 - Fixed invalid usage of `.one()` in `durable-sqlite` session
+- Fixed spread operator related crash in sqlite `blob` columns
+- Better browser support for sqlite `blob` columns 
+- Improved sqlite `blob` mapping

--- a/changelogs/drizzle-orm/0.44.5.md
+++ b/changelogs/drizzle-orm/0.44.5.md
@@ -1,0 +1,1 @@
+- Fixed invalid usage of `.one()` in `durable-sqlite` session

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drizzle-orm",
-	"version": "0.44.4",
+	"version": "0.44.5",
 	"description": "Drizzle ORM package for SQL databases",
 	"type": "module",
 	"scripts": {

--- a/drizzle-orm/src/durable-sqlite/session.ts
+++ b/drizzle-orm/src/durable-sqlite/session.ts
@@ -146,7 +146,7 @@ export class SQLiteDOPreparedQuery<T extends PreparedQueryConfig = PreparedQuery
 
 		const { fields, client, joinsNotNullableMap, customResultMapper, query } = this;
 		if (!fields && !customResultMapper) {
-			return params.length > 0 ? client.sql.exec(query.sql, ...params).one() : client.sql.exec(query.sql).one();
+			return (params.length > 0 ? client.sql.exec(query.sql, ...params) : client.sql.exec(query.sql)).next().value;
 		}
 
 		const rows = this.values(placeholderValues) as unknown[][];

--- a/drizzle-orm/src/sqlite-core/columns/blob.ts
+++ b/drizzle-orm/src/sqlite-core/columns/blob.ts
@@ -47,7 +47,9 @@ export class SQLiteBigInt<T extends ColumnBaseConfig<'bigint', 'SQLiteBigInt'>> 
 				// eslint-disable-next-line no-instanceof/no-instanceof
 				: value instanceof ArrayBuffer
 				? Buffer.from(value)
-				: Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+				: value.buffer
+				? Buffer.from(value.buffer, value.byteOffset, value.byteLength)
+				: Buffer.from(value);
 			return BigInt(buf.toString('utf8'));
 		}
 
@@ -102,7 +104,9 @@ export class SQLiteBlobJson<T extends ColumnBaseConfig<'json', 'SQLiteBlobJson'>
 				// eslint-disable-next-line no-instanceof/no-instanceof
 				: value instanceof ArrayBuffer
 				? Buffer.from(value)
-				: Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+				: value.buffer
+				? Buffer.from(value.buffer, value.byteOffset, value.byteLength)
+				: Buffer.from(value);
 			return JSON.parse(buf.toString('utf8'));
 		}
 

--- a/drizzle-orm/src/sqlite-core/columns/blob.ts
+++ b/drizzle-orm/src/sqlite-core/columns/blob.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnySQLiteTable } from '~/sqlite-core/table.ts';
-import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
+import { type Equal, getColumnNameAndConfig, textDecoder } from '~/utils.ts';
 import { SQLiteColumn, SQLiteColumnBuilder } from './common.ts';
 
 type BlobMode = 'buffer' | 'json' | 'bigint';
@@ -41,18 +41,17 @@ export class SQLiteBigInt<T extends ColumnBaseConfig<'bigint', 'SQLiteBigInt'>> 
 	}
 
 	override mapFromDriverValue(value: Buffer | Uint8Array | ArrayBuffer): bigint {
-		if (Buffer.isBuffer(value)) {
-			return BigInt(value.toString());
+		if (typeof Buffer !== 'undefined' && Buffer.from) {
+			const buf = Buffer.isBuffer(value)
+				? value
+				// eslint-disable-next-line no-instanceof/no-instanceof
+				: value instanceof ArrayBuffer
+				? Buffer.from(value)
+				: Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+			return BigInt(buf.toString('utf8'));
 		}
 
-		// for sqlite durable objects
-		// eslint-disable-next-line no-instanceof/no-instanceof
-		if (value instanceof ArrayBuffer) {
-			const decoder = new TextDecoder();
-			return BigInt(decoder.decode(value));
-		}
-
-		return BigInt(String.fromCodePoint(...value));
+		return BigInt(textDecoder!.decode(value));
 	}
 
 	override mapToDriverValue(value: bigint): Buffer {
@@ -97,18 +96,17 @@ export class SQLiteBlobJson<T extends ColumnBaseConfig<'json', 'SQLiteBlobJson'>
 	}
 
 	override mapFromDriverValue(value: Buffer | Uint8Array | ArrayBuffer): T['data'] {
-		if (Buffer.isBuffer(value)) {
-			return JSON.parse(value.toString());
+		if (typeof Buffer !== 'undefined' && Buffer.from) {
+			const buf = Buffer.isBuffer(value)
+				? value
+				// eslint-disable-next-line no-instanceof/no-instanceof
+				: value instanceof ArrayBuffer
+				? Buffer.from(value)
+				: Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+			return JSON.parse(buf.toString('utf8'));
 		}
 
-		// for sqlite durable objects
-		// eslint-disable-next-line no-instanceof/no-instanceof
-		if (value instanceof ArrayBuffer) {
-			const decoder = new TextDecoder();
-			return JSON.parse(decoder.decode(value));
-		}
-
-		return JSON.parse(String.fromCodePoint(...value));
+		return JSON.parse(textDecoder!.decode(value));
 	}
 
 	override mapToDriverValue(value: T['data']): Buffer {

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -321,3 +321,5 @@ export function isConfig(data: any): boolean {
 }
 
 export type NeonAuthToken = string | (() => string | Promise<string>);
+
+export const textDecoder = typeof TextDecoder === 'undefined' ? null : new TextDecoder('utf8');

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -322,4 +322,4 @@ export function isConfig(data: any): boolean {
 
 export type NeonAuthToken = string | (() => string | Promise<string>);
 
-export const textDecoder = typeof TextDecoder === 'undefined' ? null : new TextDecoder('utf8');
+export const textDecoder = typeof TextDecoder === 'undefined' ? null : new TextDecoder();

--- a/integration-tests/tests/pg/node-postgres.test.ts
+++ b/integration-tests/tests/pg/node-postgres.test.ts
@@ -384,7 +384,7 @@ test('test mode string for timestamp with timezone in different timezone', async
 	const timezone = await db.execute<{ TimeZone: string }>(sql`show timezone`);
 
 	// set timezone to HST (UTC - 10)
-	await db.execute(sql`set time zone 'HST'`);
+	await db.execute(sql`set time zone '-10'`);
 
 	const table = pgTable('all_columns', {
 		id: serial('id').primaryKey(),

--- a/integration-tests/tests/pg/pg-proxy.test.ts
+++ b/integration-tests/tests/pg/pg-proxy.test.ts
@@ -398,7 +398,7 @@ test('test mode string for timestamp with timezone in different timezone', async
 	const timezone = await db.execute<{ TimeZone: string }>(sql`show timezone`);
 
 	// set timezone to HST (UTC - 10)
-	await db.execute(sql`set time zone 'HST'`);
+	await db.execute(sql`set time zone '-10'`);
 
 	const table = pgTable('all_columns', {
 		id: serial('id').primaryKey(),

--- a/integration-tests/tests/pg/postgres-js.test.ts
+++ b/integration-tests/tests/pg/postgres-js.test.ts
@@ -390,7 +390,7 @@ test('test mode string for timestamp with timezone in different timezone', async
 	const [timezone] = await db.execute<{ TimeZone: string }>(sql`show timezone`);
 
 	// set timezone to HST (UTC - 10)
-	await db.execute(sql`set time zone 'HST'`);
+	await db.execute(sql`set time zone '-10'`);
 
 	const table = pgTable('all_columns', {
 		id: serial('id').primaryKey(),


### PR DESCRIPTION
- Fixed invalid usage of `.one()` in `durable-sqlite` session
- Fixed spread operator related crash in sqlite `blob` columns
- Better browser support for sqlite `blob` columns 
- Improved sqlite `blob` mapping