### PR TITLE
feat(sql): add `as` method to SQL.Aliased

### DIFF
--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -588,6 +588,10 @@ export namespace SQL {
 			return this.sql as SQL<T>;
 		}
 
+		as(alias: string): SQL.Aliased<T> {
+			return new SQL.Aliased(new SQL([this]), alias);
+		}
+
 		/** @internal */
 		clone() {
 			return new Aliased<T>(this.sql, this.fieldAlias);


### PR DESCRIPTION
Add `SQL.Aliased#as(alias)` method, allowing you to alias a subquery column.

When using `db.$with().as()`, a subquery is returned, whose columns may be a `SQL.Aliased` instance. If you want to reference a subquery's column in another subquery, but use a different column name, this PR will make it easier to do that.

#### Current workaround

The drawback of this workaround is it doesn't automatically inherit the type from the referenced column, so you have to manually specify it, which is fragile.

```ts
sql<string>`${subquery.foo}`.as('alias')
```