### PR TITLE
[MySQL] Add name parameter to MySqlColumnBuilder references

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/common.ts
+++ b/drizzle-orm/src/mysql-core/columns/common.ts
@@ -26,6 +26,7 @@ export interface ReferenceConfig {
 		onUpdate?: UpdateDeleteAction;
 		onDelete?: UpdateDeleteAction;
 	};
+	name?: string;
 }
 
 export interface MySqlColumnBuilderBase<
@@ -51,8 +52,8 @@ export abstract class MySqlColumnBuilder<
 
 	private foreignKeyConfigs: ReferenceConfig[] = [];
 
-	references(ref: ReferenceConfig['ref'], actions: ReferenceConfig['actions'] = {}): this {
-		this.foreignKeyConfigs.push({ ref, actions });
+	references(ref: ReferenceConfig['ref'], actions: ReferenceConfig['actions'] = {}, name: ReferenceConfig['name'] = undefined): this {
+		this.foreignKeyConfigs.push({ ref, actions, name });
 		return this;
 	}
 
@@ -75,11 +76,11 @@ export abstract class MySqlColumnBuilder<
 
 	/** @internal */
 	buildForeignKeys(column: MySqlColumn, table: MySqlTable): ForeignKey[] {
-		return this.foreignKeyConfigs.map(({ ref, actions }) => {
-			return ((ref, actions) => {
+		return this.foreignKeyConfigs.map(({ ref, actions, name }) => {
+			return ((ref, actions, name) => {
 				const builder = new ForeignKeyBuilder(() => {
 					const foreignColumn = ref();
-					return { columns: [column], foreignColumns: [foreignColumn] };
+					return { columns: [column], foreignColumns: [foreignColumn], name };
 				});
 				if (actions.onUpdate) {
 					builder.onUpdate(actions.onUpdate);
@@ -88,7 +89,7 @@ export abstract class MySqlColumnBuilder<
 					builder.onDelete(actions.onDelete);
 				}
 				return builder.build(table);
-			})(ref, actions);
+			})(ref, actions, name);
 		});
 	}
 

--- a/integration-tests/tests/mysql/mysql-common.ts
+++ b/integration-tests/tests/mysql/mysql-common.ts
@@ -166,6 +166,12 @@ const users2Table = mysqlTable('users2', {
 	cityId: int('city_id').references(() => citiesTable.id),
 });
 
+const users3Table = mysqlTable('users3', {
+	id: serial('id').primaryKey(),
+	name: text('name').notNull(),
+	cityId: int('city_id').references(() => citiesTable.id, {}, "users3_city_id_fk"),
+});
+
 const citiesTable = mysqlTable('cities', {
 	id: serial('id').primaryKey(),
 	name: text('name').notNull(),
@@ -4439,6 +4445,20 @@ export function tests(driver?: string) {
 
 			expectTypeOf(rawRes).toEqualTypeOf<ExpectedType>();
 			expect(rawRes).toStrictEqual(expectedRes);
+		});
+
+		test('column builder: generated foreign key', (ctx) => {
+			const tableConfig = getTableConfig(users2Table);
+
+			expect(tableConfig.foreignKeys).toHaveLength(1);
+			expect(tableConfig.foreignKeys[0]!.getName()).toBe('users2_city_id_cities_id_fk');
+		});
+
+		test('column builder: provided foreign key', (ctx) => {
+			const tableConfig = getTableConfig(users3Table);
+
+			expect(tableConfig.foreignKeys).toHaveLength(1);
+			expect(tableConfig.foreignKeys[0]!.getName()).toBe('users3_city_id_fk');
 		});
 	});
 


### PR DESCRIPTION
Allows to specify a name for a foreign key configuration by expanding the references method in MySqlColumnBuilder.

Closes #3244 