### PR TITLE
Fix `handleColumns` usage of `factory.zodInstance`

### DIFF
--- a/drizzle-zod/src/column.ts
+++ b/drizzle-zod/src/column.ts
@@ -119,11 +119,11 @@ export function columnToSchema(
 		} else if (column.dataType === 'string') {
 			schema = stringColumnToSchema(column, z, coerce);
 		} else if (column.dataType === 'json') {
-			schema = jsonSchema;
+			schema = z.union([z.union([z.string(), z.number(), z.boolean(), z.null()]), z.record(z.string(), z.any()), z.array(z.any())]);
 		} else if (column.dataType === 'custom') {
 			schema = z.any();
 		} else if (column.dataType === 'buffer') {
-			schema = bufferSchema;
+			schema = z.custom<Buffer>((v) => v instanceof Buffer);
 		}
 	}
 

--- a/drizzle-zod/src/schema.ts
+++ b/drizzle-zod/src/schema.ts
@@ -59,8 +59,8 @@ function handleColumns(
 			}
 		}
 	}
-
-	return z.object(columnSchemas) as any;
+	const zod: typeof z = factory?.zodInstance ?? z;
+	return zod.object(columnSchemas) as any;
 }
 
 function handleEnum(

--- a/drizzle-zod/src/schema.ts
+++ b/drizzle-zod/src/schema.ts
@@ -21,10 +21,11 @@ function handleColumns(
 	refinements: Record<string, any>,
 	conditions: Conditions,
 	factory?: CreateSchemaFactoryOptions<
-		Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined
+	Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined
 	>,
 ): z.ZodType {
 	const columnSchemas: Record<string, z.ZodType> = {};
+	const zod: typeof z = factory?.zodInstance ?? z;
 
 	for (const [key, selected] of Object.entries(columns)) {
 		if (!is(selected, Column) && !is(selected, SQL) && !is(selected, SQL.Aliased) && typeof selected === 'object') {
@@ -40,7 +41,7 @@ function handleColumns(
 		}
 
 		const column = is(selected, Column) ? selected : undefined;
-		const schema = column ? columnToSchema(column, factory) : z.any();
+		const schema = column ? columnToSchema(column, factory) : zod.any();
 		const refined = typeof refinement === 'function' ? refinement(schema) : schema;
 
 		if (conditions.never(column)) {
@@ -59,7 +60,6 @@ function handleColumns(
 			}
 		}
 	}
-	const zod: typeof z = factory?.zodInstance ?? z;
 	return zod.object(columnSchemas) as any;
 }
 


### PR DESCRIPTION
The `handleColumns` used in `drizzle-zod` now uses the `zodInstance` passed in to the `factory` options.

The previous implementation caused `createSchemaFactory` to return its methods using `z.object(columnSchemas)` ignoring the custom zod instance passed to the `CreateSchemaFactoryOptions`.

Btw, love the work!