### PR TITLE
feat(drizzle-zod): add a zod .meta to pgTable fields to add OpenAPI descriptions

### DIFF
--- a/drizzle-orm/src/column-builder.ts
+++ b/drizzle-orm/src/column-builder.ts
@@ -115,6 +115,7 @@ export type ColumnBuilderRuntimeConfig<TData, TRuntimeConfig extends object = ob
 	columnType: string;
 	generated: GeneratedColumnConfig<TData> | undefined;
 	generatedIdentity: GeneratedIdentityConfig | undefined;
+	meta: Record<string, unknown> | undefined;
 } & TRuntimeConfig;
 
 export interface ColumnBuilderExtraConfig {
@@ -208,6 +209,7 @@ export abstract class ColumnBuilder<
 			dataType,
 			columnType,
 			generated: undefined,
+			meta: undefined,
 		} as ColumnBuilderRuntimeConfig<T['data'], TRuntimeConfig>;
 	}
 
@@ -287,6 +289,22 @@ export abstract class ColumnBuilder<
 	 * Alias for {@link $onUpdateFn}.
 	 */
 	$onUpdate = this.$onUpdateFn;
+
+	/**
+	 * Adds metadata to the column definition. This can be used by external tools like drizzle-zod
+	 * to add additional information to generated schemas.
+	 *
+	 * @example
+	 * ```ts
+	 * const users = pgTable('users', {
+	 *   age: integer('age').meta({ description: 'User age in years' }),
+	 * });
+	 * ```
+	 */
+	meta(meta: Record<string, unknown>): this {
+		this.config.meta = { ...this.config.meta, ...meta };
+		return this;
+	}
 
 	/**
 	 * Adds a `primary key` clause to the column definition. This implicitly makes the column `not null`.

--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -85,6 +85,7 @@ export abstract class Column<
 	readonly enumValues: T['enumValues'] = undefined;
 	readonly generated: GeneratedColumnConfig<T['data']> | undefined = undefined;
 	readonly generatedIdentity: GeneratedIdentityConfig | undefined = undefined;
+	readonly meta: Record<string, unknown> | undefined;
 
 	protected config: ColumnRuntimeConfig<T['data'], TRuntimeConfig>;
 
@@ -108,6 +109,7 @@ export abstract class Column<
 		this.columnType = config.columnType;
 		this.generated = config.generated;
 		this.generatedIdentity = config.generatedIdentity;
+		this.meta = config.meta;
 	}
 
 	abstract getSQLType(): string;

--- a/drizzle-zod/src/column.ts
+++ b/drizzle-zod/src/column.ts
@@ -131,6 +131,11 @@ export function columnToSchema(
 		schema = z.any();
 	}
 
+	// Apply metadata if available
+	if (column.meta && typeof column.meta === 'object') {
+		schema = schema.meta(column.meta);
+	}
+
 	return schema;
 }
 


### PR DESCRIPTION
It's nicer to be able to add a zod `schema.meta({ description: "This is my OpenAPI description"})` directly on the pgTable (or any table) fields, so this allows `createSelectSchema`, `createInsertSchema` and `createUpdateSchema` to get the description for their schema

Then when using zod-openapi, we get a nice description of the API, directly from the table description!