### PR TITLE
Fix zod/v4 uuid compatibility

### DIFF
--- a/drizzle-seed/src/services/Generators.ts
+++ b/drizzle-seed/src/services/Generators.ts
@@ -1537,7 +1537,7 @@ export class GenerateUUID extends AbstractGenerator<{
 		const strLength = 36;
 
 		// uuid v4
-		const uuidTemplate = '########-####-4###-####-############';
+		const uuidTemplate = '########-####-4###-9###-############';
 		currStr = '';
 		for (let i = 0; i < strLength; i++) {
 			[idx, this.state.rng] = prand.uniformIntDistribution(


### PR DESCRIPTION
This is a simpler fix than described in [the UUID discussion](https://github.com/drizzle-team/drizzle-orm/issues/3690#issuecomment-2900157551) and implemented in #4503 serving to hopefully be an easier thing to merge. This works by changing the 4th group to start with a valid number.

This change has the same issue as #4503 in that it leads to changed UUIDs given an existing seed, but the alternative here would be to add a flag to the `seed` options and that seems overly cumbersome.

Resolves #4551