### PR TITLE
[Pg-kit] Fix Aurora DSQL primary key index detection to prevent unnecessary DROP INDEX

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1572,16 +1572,22 @@ WHERE
 
 					const dbIndexFromConstraint = await db.query(
 						`SELECT
-          idx.indexrelname AS index_name,
-          idx.relname AS table_name,
-          schemaname,
-          CASE WHEN con.conname IS NOT NULL THEN 1 ELSE 0 END AS generated_by_constraint
+          i.relname AS index_name,
+          t.relname AS table_name,
+          ns.nspname AS schemaname,
+          CASE WHEN con.oid IS NOT NULL THEN 1 ELSE 0 END AS generated_by_constraint
         FROM
-          pg_stat_user_indexes idx
+          pg_class t
         LEFT JOIN
-          pg_constraint con ON con.conindid = idx.indexrelid
-        WHERE idx.relname = '${tableName}' and schemaname = '${tableSchema}'
-        group by index_name, table_name,schemaname, generated_by_constraint;`,
+          pg_namespace ns ON ns.oid = t.relnamespace
+        LEFT JOIN
+          pg_index x ON x.indrelid  = t.oid
+        LEFT JOIN
+          pg_class i ON i.oid = x.indexrelid
+        LEFT JOIN
+          pg_constraint con ON con.conindid = i.oid
+        WHERE t.relname = '${tableName}' AND ns.nspname = '${tableSchema}'
+        GROUP BY i.relname, t.relname, ns.nspname, generated_by_constraint;`,
 					);
 
 					const idxsInConsteraint = dbIndexFromConstraint.filter((it) => it.generated_by_constraint === 1).map((it) =>


### PR DESCRIPTION
## Summary

Fixes an issue where `drizzle-kit push` would generate unnecessary `DROP INDEX` statements for primary key indexes when working with Amazon Aurora DSQL, causing failures with the error "cannot drop index because constraint requires it".

Fixes: #4779

## Problem

Aurora DSQL's `pg_stat_user_indexes` view does not correctly identify primary key indexes as constraint-generated. This causes the schema introspection logic in drizzle-kit to incorrectly classify primary key indexes as regular indexes that should be dropped during schema synchronization.

When running `drizzle-kit push` on a subsequent run, it would attempt to drop primary key indexes.

## Solution

Replaced the `pg_stat_user_indexes` query with direct system catalog queries using: pg_class, pg_namespace and pg_index.

This approach correctly identifies constraint-generated indexes in both Aurora DSQL and standard PostgreSQL environments.

