### PR TITLE
feat: add `$replicas` reference

### DIFF
--- a/changelogs/drizzle-orm/0.44.6.md
+++ b/changelogs/drizzle-orm/0.44.6.md
@@ -1,0 +1,1 @@
+- feat: add $replicas reference #4874

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drizzle-orm",
-	"version": "0.44.5",
+	"version": "0.44.6",
 	"description": "Drizzle ORM package for SQL databases",
 	"type": "module",
 	"scripts": {

--- a/drizzle-orm/src/gel-core/db.ts
+++ b/drizzle-orm/src/gel-core/db.ts
@@ -622,7 +622,7 @@ export class GelDatabase<
 	}
 }
 
-export type GelWithReplicas<Q> = Q & { $primary: Q };
+export type GelWithReplicas<Q> = Q & { $primary: Q, $replicas: Q[] };
 
 export const withReplicas = <
 	HKT extends GelQueryResultHKT,
@@ -661,6 +661,7 @@ export const withReplicas = <
 		transaction,
 		// refreshMaterializedView,
 		$primary: primary,
+		$replicas: replicas,
 		select,
 		selectDistinct,
 		selectDistinctOn,

--- a/drizzle-orm/src/mysql-core/db.ts
+++ b/drizzle-orm/src/mysql-core/db.ts
@@ -488,7 +488,7 @@ export class MySqlDatabase<
 	}
 }
 
-export type MySQLWithReplicas<Q> = Q & { $primary: Q };
+export type MySQLWithReplicas<Q> = Q & { $primary: Q, $replicas: Q[] };
 
 export const withReplicas = <
 	HKT extends MySqlQueryResultHKT,
@@ -525,6 +525,7 @@ export const withReplicas = <
 		execute,
 		transaction,
 		$primary: primary,
+		$replicas: replicas,
 		select,
 		selectDistinct,
 		$count,

--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -641,7 +641,7 @@ export class PgDatabase<
 	}
 }
 
-export type PgWithReplicas<Q> = Q & { $primary: Q };
+export type PgWithReplicas<Q> = Q & { $primary: Q, $replicas: Q[] };
 
 export const withReplicas = <
 	HKT extends PgQueryResultHKT,
@@ -681,6 +681,7 @@ export const withReplicas = <
 		transaction,
 		refreshMaterializedView,
 		$primary: primary,
+		$replicas: replicas,
 		select,
 		selectDistinct,
 		selectDistinctOn,

--- a/drizzle-orm/src/singlestore-core/db.ts
+++ b/drizzle-orm/src/singlestore-core/db.ts
@@ -490,7 +490,7 @@ export class SingleStoreDatabase<
 	}
 }
 
-export type SingleStoreWithReplicas<Q> = Q & { $primary: Q };
+export type SingleStoreWithReplicas<Q> = Q & { $primary: Q, $replicas: Q[] };
 
 export const withReplicas = <
 	Q extends SingleStoreDriverDatabase,
@@ -518,6 +518,7 @@ export const withReplicas = <
 		execute,
 		transaction,
 		$primary: primary,
+		$replicas: replicas,
 		select,
 		selectDistinct,
 		$count,

--- a/drizzle-orm/src/sqlite-core/db.ts
+++ b/drizzle-orm/src/sqlite-core/db.ts
@@ -594,7 +594,7 @@ export class BaseSQLiteDatabase<
 	}
 }
 
-export type SQLiteWithReplicas<Q> = Q & { $primary: Q };
+export type SQLiteWithReplicas<Q> = Q & { $primary: Q, $replicas: Q[] };
 
 export const withReplicas = <
 	TResultKind extends 'sync' | 'async',
@@ -637,6 +637,7 @@ export const withReplicas = <
 		values,
 		transaction,
 		$primary: primary,
+		$replicas: replicas,
 		select,
 		selectDistinct,
 		$count,


### PR DESCRIPTION
This PR adds a new `$replicas` property, which allows us to reference read replicas.

Close https://github.com/drizzle-team/drizzle-orm/issues/4873