### PR TITLE
Add error names to DrizzleQueryError and TransactionRollbackError

### DIFF
--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -17,6 +17,7 @@ export class DrizzleQueryError extends Error {
 		public override cause?: Error,
 	) {
 		super(`Failed query: ${query}\nparams: ${params}`);
+		this.name = "DrizzleQueryError";
 		Error.captureStackTrace(this, DrizzleQueryError);
 
 		// ES2022+: preserves original error on `.cause`
@@ -29,5 +30,6 @@ export class TransactionRollbackError extends DrizzleError {
 
 	constructor() {
 		super({ message: 'Rollback' });
+		this.name = "TransactionRollbackError";
 	}
 }


### PR DESCRIPTION
Error names were missing in DrizzleQueryError and TransactionRollbackError