### PR TITLE
feat(drizzle-kit): add --omitSuffixForSchema to control schema suffix in introspected outputs

### DIFF
--- a/drizzle-kit/src/cli/commands/introspect.ts
+++ b/drizzle-kit/src/cli/commands/introspect.ts
@@ -61,6 +61,7 @@ export const introspectPostgres = async (
 	schemasFilter: string[],
 	prefix: Prefix,
 	entities: Entities,
+	omitSuffixForSchema: string,
 ) => {
 	const { preparePostgresDB } = await import('../connections');
 	const db = await preparePostgresDB(credentials);
@@ -108,7 +109,7 @@ export const introspectPostgres = async (
 	);
 
 	const schema = { id: originUUID, prevId: '', ...res } as PgSchema;
-	const ts = postgresSchemaToTypeScript(schema, casing);
+	const ts = postgresSchemaToTypeScript(schema, casing, omitSuffixForSchema);
 	const relationsTs = relationsToTypeScript(schema, casing);
 	const { internal, ...schemaWithoutInternals } = schema;
 
@@ -187,6 +188,7 @@ export const introspectGel = async (
 	schemasFilter: string[],
 	prefix: Prefix,
 	entities: Entities,
+	omitSuffixForSchema: string,
 ) => {
 	const { prepareGelDB } = await import('../connections');
 	const db = await prepareGelDB(credentials);
@@ -234,7 +236,7 @@ export const introspectGel = async (
 	);
 
 	const schema = { id: originUUID, prevId: '', ...res } as GelSchema;
-	const ts = gelSchemaToTypeScript(schema, casing);
+	const ts = gelSchemaToTypeScript(schema, casing, omitSuffixForSchema);
 	const relationsTs = relationsToTypeScript(schema, casing);
 	const { internal, ...schemaWithoutInternals } = schema;
 

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -461,6 +461,7 @@ export const preparePullConfig = async (
 		| {
 			dialect: 'postgresql';
 			credentials: PostgresCredentials;
+			omitSuffixForSchema: string;
 		}
 		| {
 			dialect: 'sqlite';
@@ -477,6 +478,7 @@ export const preparePullConfig = async (
 		| {
 			dialect: 'gel';
 			credentials?: GelCredentials;
+			omitSuffixForSchema: string;
 		}
 	) & {
 		out: string;

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -47,6 +47,10 @@ const optionDriver = string()
 
 const optionCasing = string().enum('camelCase', 'snake_case').desc('Casing for serialization');
 
+const optionOmitSuffixForSchema = string().desc(
+	`Schema name to treat as suffixless; when schema equals this value, the In<Schema> suffix is not appended. Defaults to 'public'.`
+);
+
 export const generate = command({
 	name: 'generate',
 	options: {
@@ -476,6 +480,7 @@ export const pull = command({
 		out: optionOut,
 		breakpoints: optionBreakpoints,
 		casing: string('introspect-casing').enum('camel', 'preserve'),
+		omitSuffixForSchema: optionOmitSuffixForSchema,
 		...optionsFilters,
 		...optionsDatabaseCredentials,
 	},
@@ -502,6 +507,7 @@ export const pull = command({
 				'schemaFilters',
 				'extensionsFilters',
 				'tlsSecurity',
+				'omitSuffixForSchema',
 			],
 		);
 		return preparePullConfig(opts, from);
@@ -567,6 +573,7 @@ export const pull = command({
 					schemasFilter,
 					prefix,
 					entities,
+					config.omitSuffixForSchema
 				);
 			} else if (dialect === 'mysql') {
 				const { introspectMysql } = await import('./commands/introspect');
@@ -619,6 +626,7 @@ export const pull = command({
 					schemasFilter,
 					prefix,
 					entities,
+					config.omitSuffixForSchema
 				);
 			} else {
 				assertUnreachable(dialect);

--- a/drizzle-kit/src/cli/validations/common.ts
+++ b/drizzle-kit/src/cli/validations/common.ts
@@ -128,6 +128,7 @@ export const introspectParams = object({
 	introspect: object({
 		casing,
 	}).default({ casing: 'camel' }),
+	omitSuffixForSchema: string().optional().default('public'),
 });
 
 export type IntrospectParams = TypeOf<typeof introspectParams>;
@@ -142,6 +143,7 @@ export const configIntrospectCliSchema = object({
 	introspectCasing: union([literal('camel'), literal('preserve')]).default(
 		'camel',
 	),
+	omitSuffixForSchema: string().optional().default('public')
 });
 
 export const configGenerateSchema = object({

--- a/drizzle-kit/tests/schemaDiffer.ts
+++ b/drizzle-kit/tests/schemaDiffer.ts
@@ -2307,6 +2307,7 @@ export const introspectPgToFile = async (
 	schemas: string[] = ['public'],
 	entities?: Entities,
 	casing?: CasingType | undefined,
+	omitSuffixForSchema?: string,
 ) => {
 	// put in db
 	const { sqlStatements } = await applyPgDiffs(initSchema, casing);
@@ -2341,7 +2342,7 @@ export const introspectPgToFile = async (
 	const validatedCur = pgSchema.parse(initSch);
 
 	// write to ts file
-	const file = schemaToTypeScript(introspectedSchema, 'camel');
+	const file = schemaToTypeScript(introspectedSchema, 'camel', omitSuffixForSchema);
 
 	fs.writeFileSync(`tests/introspect/postgres/${testName}.ts`, file.file);
 
@@ -2408,6 +2409,7 @@ export const introspectGelToFile = async (
 	schemas: string[] = ['public'],
 	entities?: Entities,
 	casing?: CasingType | undefined,
+	omitSuffixForSchema?: string
 ) => {
 	// introspect to schema
 	const introspectedSchema = await fromGelDatabase(
@@ -2423,7 +2425,7 @@ export const introspectGelToFile = async (
 	);
 
 	// write to ts file
-	const file = schemaToTypeScriptGel(introspectedSchema, 'camel');
+	const file = schemaToTypeScriptGel(introspectedSchema, 'camel', omitSuffixForSchema);
 
 	const path = `tests/introspect/gel/${testName}.ts`;
 	fs.writeFileSync(path, file.file);


### PR DESCRIPTION
Add --omitSuffixForSchema to control schema suffix in introspected outputs

* add CLI option --omitSuffixForSchema (defaults to 'public')
* plumb config through validations and utils
* apply to introspection generators:
  * update paramNameFor() to accept omitSuffixForSchema
  * update schemaToTypeScript() to accept and pass omitSuffixForSchema *propagate to FK/column helpers for PG and Gel
* wire option into introspect for Postgres and Gel flows
* default behavior remains unchanged for schema 'public'