### PR TITLE
fix(drizzle-kit): omit schema prefix if schema is undefined for `SET DATA TYPE` statement

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -1909,7 +1909,9 @@ class PgAlterTableAlterColumnSetTypeConvertor extends Convertor {
 
 		const statements: string[] = [];
 
-		const type = parseType(`"${typeSchema}".`, newDataType.name);
+		const schemaPrefix = typeSchema ? `"${typeSchema}".` : '';
+
+		const type = parseType(schemaPrefix, newDataType.name);
 
 		if (!oldDataType.isEnum && !newDataType.isEnum) {
 			statements.push(


### PR DESCRIPTION
Example error that is prevented by this PR:
```
ALTER TABLE "inquiry" ALTER COLUMN "mode" SET DATA TYPE "undefined"."inquiry_mode";
error: schema "undefined" does not exist
```