### PR TITLE
Fixing log duplication in expo-sqlite findFirst() method

### DIFF
--- a/drizzle-orm/src/expo-sqlite/session.ts
+++ b/drizzle-orm/src/expo-sqlite/session.ts
@@ -141,10 +141,9 @@ export class ExpoSQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQue
 
 	get(placeholderValues?: Record<string, unknown>): T['get'] {
 		const params = fillPlaceholders(this.query.params, placeholderValues ?? {});
-		this.logger.logQuery(this.query.sql, params);
-
 		const { fields, stmt, joinsNotNullableMap, customResultMapper } = this;
 		if (!fields && !customResultMapper) {
+			this.logger.logQuery(this.query.sql, params);
 			return stmt.executeSync(params as any[]).getFirstSync();
 		}
 


### PR DESCRIPTION
When findFirst() is used with expo-sqlite, it logs the query twice. This happens because the logging is already happening in values() method of ExpoSQLitePreparedQuery. 

findMany() calls ExpoSQLitePreparedQuery::all() 
findFirst() calls ExpoSQLitePreparedQuery::get()

I moved logging in get() to the same place as  in all() method, now logs won't duplicate anymore.