### PR TITLE
Add option to set headers when using Turso/libSQL

### DIFF
--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -56,6 +56,7 @@
 		"@hono/node-server": "^1.9.0",
 		"@hono/zod-validator": "^0.2.1",
 		"@libsql/client": "^0.10.0",
+		"@libsql/isomorphic-fetch": "^0.3.1",
 		"@neondatabase/serverless": "^0.9.1",
 		"@originjs/vite-plugin-commonjs": "^1.0.3",
 		"@planetscale/database": "^1.16.0",

--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -7,7 +7,7 @@ import { assertUnreachable } from '../global';
 import type { ProxyParams } from '../serializer/studio';
 import {
 	type DB,
-	LibSQLDB,
+	type LibSQLDB,
 	normalisePGliteUrl,
 	normaliseSQLiteUrl,
 	type Proxy,
@@ -16,7 +16,7 @@ import {
 } from '../utils';
 import { assertPackages, checkPackage } from './utils';
 import { GelCredentials } from './validations/gel';
-import { LibSQLCredentials } from './validations/libsql';
+import type { LibSQLCredentials } from './validations/libsql';
 import type { MysqlCredentials } from './validations/mysql';
 import { withStyle } from './validations/outputs';
 import type { PostgresCredentials } from './validations/postgres';
@@ -1209,12 +1209,21 @@ export const connectToLibSQL = async (credentials: LibSQLCredentials): Promise<
 > => {
 	if (await checkPackage('@libsql/client')) {
 		const { createClient } = await import('@libsql/client');
+		const { fetch: libsqlFetch } = await import('@libsql/isomorphic-fetch');
 		const { drizzle } = await import('drizzle-orm/libsql');
 		const { migrate } = await import('drizzle-orm/libsql/migrator');
 
 		const client = createClient({
 			url: normaliseSQLiteUrl(credentials.url, 'libsql'),
 			authToken: credentials.authToken,
+			...(credentials.headers && {
+				fetch: async (request: Request) => {
+					for (const [key, value] of Object.entries(credentials.headers!)) {
+						request.headers.set(key, value);
+					}
+					return libsqlFetch(request);
+				},
+			}),
 		});
 		const drzl = drizzle(client);
 		const migrateFn = async (config: MigrationConfig) => {

--- a/drizzle-kit/src/cli/validations/libsql.ts
+++ b/drizzle-kit/src/cli/validations/libsql.ts
@@ -1,16 +1,18 @@
 import { softAssertUnreachable } from 'src/global';
-import { object, string, TypeOf } from 'zod';
+import { object, record, string, TypeOf } from 'zod';
 import { error } from '../views';
 import { wrapParam } from './common';
 
 export const libSQLCredentials = object({
 	url: string().min(1),
 	authToken: string().min(1).optional(),
+	headers: record(string().min(1)).optional(),
 });
 
 export type LibSQLCredentials = {
 	url: string;
 	authToken?: string;
+	headers?: Record<string, string>;
 };
 
 const _: LibSQLCredentials = {} as TypeOf<typeof libSQLCredentials>;
@@ -23,5 +25,6 @@ export const printConfigConnectionIssues = (
 	console.log(error(text));
 	console.log(wrapParam('url', options.url));
 	console.log(wrapParam('authToken', options.authToken, true, 'secret'));
+	console.log(wrapParam('headers', options.headers, true));
 	process.exit(1);
 };

--- a/drizzle-kit/src/cli/validations/sqlite.ts
+++ b/drizzle-kit/src/cli/validations/sqlite.ts
@@ -1,5 +1,5 @@
 import { softAssertUnreachable } from 'src/global';
-import { literal, object, string, TypeOf, undefined, union } from 'zod';
+import { literal, object, record, string, type TypeOf, undefined, union } from 'zod';
 import { error } from '../views';
 import { sqliteDriver, wrapParam } from './common';
 
@@ -8,6 +8,7 @@ export const sqliteCredentials = union([
 		driver: literal('turso'),
 		url: string().min(1),
 		authToken: string().min(1).optional(),
+		headers: record(string()).optional(),
 	}),
 	object({
 		driver: literal('d1-http'),

--- a/drizzle-kit/src/index.ts
+++ b/drizzle-kit/src/index.ts
@@ -136,6 +136,7 @@ export type Config =
 			dbCredentials: {
 				url: string;
 				authToken?: string;
+				headers?: Record<string, string>;
 			};
 		}
 		| {

--- a/drizzle-kit/tests/validations.test.ts
+++ b/drizzle-kit/tests/validations.test.ts
@@ -22,6 +22,18 @@ test('turso #2', () => {
 });
 
 test('turso #3', () => {
+	sqliteCredentials.parse({
+		dialect: 'sqlite',
+		driver: 'turso',
+		url: 'https://turso.tech',
+		authToken: 'token',
+		headers: {
+			'x-namespace': 'prod',
+		},
+	});
+});
+
+test('turso #4', () => {
 	expect(() =>
 		sqliteCredentials.parse({
 			dialect: 'sqlite',
@@ -32,7 +44,7 @@ test('turso #3', () => {
 	).toThrowError();
 });
 
-test('turso #4', () => {
+test('turso #5', () => {
 	expect(() => {
 		sqliteCredentials.parse({
 			dialect: 'sqlite',
@@ -43,13 +55,25 @@ test('turso #4', () => {
 	}).toThrowError();
 });
 
-test('turso #5', () => {
+test('turso #6', () => {
 	expect(() => {
 		sqliteCredentials.parse({
 			dialect: 'sqlite',
 			driver: 'turso',
 			url: '',
 			authToken: '',
+		});
+	}).toThrowError();
+});
+
+test('turso #7', () => {
+	expect(() => {
+		sqliteCredentials.parse({
+			dialect: 'sqlite',
+			driver: 'turso',
+			url: '',
+			authToken: '',
+			headers: {},
 		});
 	}).toThrowError();
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 5.2.2(prettier@3.5.3)
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.7.3
-        version: 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.6.3)
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/experimental-utils':
         specifier: ^5.62.0
         version: 5.62.0(eslint@8.57.1)(typescript@5.6.3)
@@ -40,7 +40,7 @@ importers:
         version: link:drizzle-orm/dist
       drizzle-orm-old:
         specifier: npm:drizzle-orm@^0.27.2
-        version: drizzle-orm@0.27.2(bun-types@1.2.15)
+        version: drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.10.0)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7)
       eslint:
         specifier: ^8.50.0
         version: 8.57.1
@@ -49,7 +49,7 @@ importers:
         version: link:eslint/eslint-plugin-drizzle-internal
       eslint-plugin-import:
         specifier: ^2.28.1
-        version: 2.31.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)
+        version: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
       eslint-plugin-no-instanceof:
         specifier: ^1.0.1
         version: 1.0.1
@@ -58,7 +58,7 @@ importers:
         version: 48.0.1(eslint@8.57.1)
       eslint-plugin-unused-imports:
         specifier: ^3.0.0
-        version: 3.2.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.57.1)
+        version: 3.2.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
       glob:
         specifier: ^10.3.10
         version: 10.4.5
@@ -73,7 +73,7 @@ importers:
         version: 0.8.23(typescript@5.6.3)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(tsx@4.19.4)(typescript@5.6.3)
+        version: 8.5.0(postcss@8.5.4)(tsx@4.19.4)(typescript@5.6.3)(yaml@2.8.0)
       tsx:
         specifier: ^4.10.5
         version: 4.19.4
@@ -118,10 +118,10 @@ importers:
         version: 4.19.4
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.6.3)
+        version: 4.3.2(typescript@5.6.3)(vite@5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0))
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@18.19.108)
+        version: 3.1.4(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
       zx:
         specifier: ^7.2.2
         version: 7.2.3
@@ -161,7 +161,10 @@ importers:
         version: 0.2.2(hono@4.7.10)(zod@3.25.42)
       '@libsql/client':
         specifier: ^0.10.0
-        version: 0.10.0
+        version: 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@libsql/isomorphic-fetch':
+        specifier: ^0.3.1
+        version: 0.3.1
       '@neondatabase/serverless':
         specifier: ^0.9.1
         version: 0.9.5
@@ -209,7 +212,7 @@ importers:
         version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.2.0
-        version: 7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.6.3)
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/parser':
         specifier: ^7.2.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.6.3)
@@ -260,7 +263,7 @@ importers:
         version: 9.1.0(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: ^5.1.3
-        version: 5.4.1(eslint-config-prettier@9.1.0)(eslint@8.57.1)(prettier@3.5.3)
+        version: 5.4.1(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3)
       gel:
         specifier: ^2.0.0
         version: 2.1.0
@@ -314,7 +317,7 @@ importers:
         version: 2.2.2
       tsup:
         specifier: ^8.3.5
-        version: 8.5.0(tsx@3.14.0)(typescript@5.6.3)
+        version: 8.5.0(postcss@8.5.4)(tsx@3.14.0)(typescript@5.6.3)(yaml@2.8.0)
       tsx:
         specifier: ^3.12.1
         version: 3.14.0
@@ -326,13 +329,13 @@ importers:
         version: 9.0.1
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.6.3)
+        version: 4.3.2(typescript@5.6.3)(vite@5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0))
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@18.19.108)
+        version: 3.1.4(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
       ws:
         specifier: ^8.18.2
-        version: 8.18.2
+        version: 8.18.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       zod:
         specifier: ^3.20.2
         version: 3.25.42
@@ -353,7 +356,7 @@ importers:
         version: 0.2.12
       '@libsql/client':
         specifier: ^0.10.0
-        version: 0.10.0
+        version: 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@libsql/client-wasm':
         specifier: ^0.10.0
         version: 0.10.0
@@ -365,7 +368,7 @@ importers:
         version: 0.10.0
       '@op-engineering/op-sqlite':
         specifier: ^2.0.16
-        version: 2.0.22(react-native@0.79.2)(react@18.3.1)
+        version: 2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
       '@opentelemetry/api':
         specifier: ^1.4.1
         version: 1.9.0
@@ -416,7 +419,7 @@ importers:
         version: 10.1.0
       expo-sqlite:
         specifier: ^14.0.0
-        version: 14.0.6(expo@53.0.9)
+        version: 14.0.6(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))
       gel:
         specifier: ^2.0.0
         version: 2.1.0
@@ -461,10 +464,10 @@ importers:
         version: 3.14.0
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.6.3)
+        version: 4.3.2(typescript@5.6.3)(vite@5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0))
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1)
+        version: 3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1)(lightningcss@1.27.0)(terser@5.40.0)
       zod:
         specifier: ^3.20.2
         version: 3.25.42
@@ -549,7 +552,7 @@ importers:
         version: 10.0.0
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@22.15.27)
+        version: 3.1.4(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0)
       zx:
         specifier: ^8.1.5
         version: 8.5.4
@@ -582,10 +585,10 @@ importers:
         version: 3.29.5
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.6.3)
+        version: 4.3.2(typescript@5.6.3)(vite@5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0))
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@18.19.108)
+        version: 3.1.4(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
       zx:
         specifier: ^7.2.2
         version: 7.2.3
@@ -618,10 +621,10 @@ importers:
         version: 1.0.0-beta.7(typescript@5.6.3)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.6.3)
+        version: 4.3.2(typescript@5.6.3)(vite@5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0))
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@18.19.108)
+        version: 3.1.4(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
       zx:
         specifier: ^7.2.2
         version: 7.2.3
@@ -651,10 +654,10 @@ importers:
         version: 3.29.5
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.6.3)
+        version: 4.3.2(typescript@5.6.3)(vite@5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0))
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@18.19.108)
+        version: 3.1.4(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
       zod:
         specifier: 3.25.1
         version: 3.25.1
@@ -687,7 +690,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1)
+        version: 3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1)(lightningcss@1.27.0)(terser@5.40.0)
 
   integration-tests:
     dependencies:
@@ -702,7 +705,7 @@ importers:
         version: 0.2.12
       '@libsql/client':
         specifier: ^0.10.0
-        version: 0.10.0
+        version: 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@miniflare/d1':
         specifier: ^2.14.4
         version: 2.14.4
@@ -792,10 +795,10 @@ importers:
         version: 0.5.6
       vitest:
         specifier: ^3.1.3
-        version: 3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1)
+        version: 3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1)(lightningcss@1.27.0)(terser@5.40.0)
       ws:
         specifier: ^8.18.2
-        version: 8.18.2
+        version: 8.18.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       zod:
         specifier: ^3.20.2
         version: 3.25.42
@@ -862,7 +865,7 @@ importers:
         version: 4.19.4
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.6.3)
+        version: 4.3.2(typescript@5.6.3)(vite@5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0))
       zx:
         specifier: ^8.3.2
         version: 8.5.4
@@ -2416,6 +2419,10 @@ packages:
 
   '@libsql/isomorphic-fetch@0.2.5':
     resolution: {integrity: sha512-8s/B2TClEHms2yb+JGpsVRTPBfy1ih/Pq6h6gvyaNcYnMVJvgQRY7wAa8U2nD0dppbCuDU5evTNMEhrQ17ZKKg==}
+    engines: {node: '>=18.0.0'}
+
+  '@libsql/isomorphic-fetch@0.3.1':
+    resolution: {integrity: sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==}
     engines: {node: '>=18.0.0'}
 
   '@libsql/isomorphic-ws@0.1.5':
@@ -5888,7 +5895,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
@@ -7459,9 +7465,6 @@ packages:
 
   sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
 
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
@@ -9898,7 +9901,7 @@ snapshots:
     dependencies:
       heap: 0.2.7
 
-  '@expo/cli@0.24.13':
+  '@expo/cli@0.24.13(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
       '@0no-co/graphql.web': 1.1.2
       '@babel/runtime': 7.27.3
@@ -9917,7 +9920,7 @@ snapshots:
       '@expo/spawn-async': 1.7.2
       '@expo/ws-tunnel': 1.0.6
       '@expo/xcpretty': 4.3.2
-      '@react-native/dev-middleware': 0.79.2
+      '@react-native/dev-middleware': 0.79.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@urql/core': 5.1.1
       '@urql/exchange-retry': 1.3.1(@urql/core@5.1.1)
       accepts: 1.3.8
@@ -9960,7 +9963,7 @@ snapshots:
       terminal-link: 2.1.1
       undici: 6.21.3
       wrap-ansi: 7.0.0
-      ws: 8.18.2
+      ws: 8.18.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - graphql
@@ -10128,11 +10131,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@14.1.0(expo-font@13.3.1)(react-native@0.79.2)(react@18.3.1)':
+  '@expo/vector-icons@14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)':
     dependencies:
-      expo-font: 13.3.1(expo@53.0.9)(react@18.3.1)
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
       react: 18.3.1
-      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(react@18.3.1)
+      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
 
   '@expo/websql@1.0.1':
     dependencies:
@@ -10315,10 +10318,10 @@ snapshots:
       '@libsql/core': 0.10.0
       js-base64: 3.7.7
 
-  '@libsql/client@0.10.0':
+  '@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
       '@libsql/core': 0.10.0
-      '@libsql/hrana-client': 0.6.2
+      '@libsql/hrana-client': 0.6.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       js-base64: 3.7.7
       libsql: 0.4.7
       promise-limit: 2.7.0
@@ -10336,10 +10339,10 @@ snapshots:
   '@libsql/darwin-x64@0.4.7':
     optional: true
 
-  '@libsql/hrana-client@0.6.2':
+  '@libsql/hrana-client@0.6.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
       '@libsql/isomorphic-fetch': 0.2.5
-      '@libsql/isomorphic-ws': 0.1.5
+      '@libsql/isomorphic-ws': 0.1.5(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       js-base64: 3.7.7
       node-fetch: 3.3.2
     transitivePeerDependencies:
@@ -10348,10 +10351,12 @@ snapshots:
 
   '@libsql/isomorphic-fetch@0.2.5': {}
 
-  '@libsql/isomorphic-ws@0.1.5':
+  '@libsql/isomorphic-fetch@0.3.1': {}
+
+  '@libsql/isomorphic-ws@0.1.5(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
       '@types/ws': 8.18.1
-      ws: 8.18.2
+      ws: 8.18.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10458,10 +10463,10 @@ snapshots:
       rimraf: 3.0.2
     optional: true
 
-  '@op-engineering/op-sqlite@2.0.22(react-native@0.79.2)(react@18.3.1)':
+  '@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(react@18.3.1)
+      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -10490,7 +10495,7 @@ snapshots:
       prettier: 3.5.3
 
   '@prisma/client@5.14.0(prisma@5.14.0)':
-    dependencies:
+    optionalDependencies:
       prisma: 5.14.0
 
   '@prisma/debug@5.14.0': {}
@@ -10612,14 +10617,14 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.79.2':
+  '@react-native/community-cli-plugin@0.79.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
-      '@react-native/dev-middleware': 0.79.2
+      '@react-native/dev-middleware': 0.79.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       chalk: 4.1.2
       debug: 2.6.9
       invariant: 2.2.4
-      metro: 0.82.4
-      metro-config: 0.82.4
+      metro: 0.82.4(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      metro-config: 0.82.4(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       metro-core: 0.82.4
       semver: 7.7.2
     transitivePeerDependencies:
@@ -10629,7 +10634,7 @@ snapshots:
 
   '@react-native/debugger-frontend@0.79.2': {}
 
-  '@react-native/dev-middleware@0.79.2':
+  '@react-native/dev-middleware@0.79.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.79.2
@@ -10641,7 +10646,7 @@ snapshots:
       nullthrows: 1.1.1
       open: 7.4.2
       serve-static: 1.16.2
-      ws: 6.2.3
+      ws: 6.2.3(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -10653,34 +10658,38 @@ snapshots:
 
   '@react-native/normalize-colors@0.79.2': {}
 
-  '@react-native/virtualized-lists@0.79.2(@types/react@18.3.23)(react-native@0.79.2)(react@18.3.1)':
+  '@react-native/virtualized-lists@0.79.2(@types/react@18.3.23)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)':
     dependencies:
-      '@types/react': 18.3.23
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 18.3.1
-      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(react@18.3.1)
+      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+    optionalDependencies:
+      '@types/react': 18.3.23
 
   '@rollup/plugin-terser@0.4.4(rollup@3.29.5)':
     dependencies:
-      rollup: 3.29.5
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.40.0
+    optionalDependencies:
+      rollup: 3.29.5
 
   '@rollup/plugin-typescript@11.1.6(rollup@3.29.5)(tslib@2.8.1)(typescript@5.6.3)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@3.29.5)
       resolve: 1.22.10
+      typescript: 5.6.3
+    optionalDependencies:
       rollup: 3.29.5
       tslib: 2.8.1
-      typescript: 5.6.3
 
   '@rollup/pluginutils@5.1.4(rollup@3.29.5)':
     dependencies:
       '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 4.0.2
+    optionalDependencies:
       rollup: 3.29.5
 
   '@rollup/rollup-android-arm-eabi@4.41.1':
@@ -11225,7 +11234,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.6.3)
@@ -11240,11 +11249,12 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.7.2
       ts-api-utils: 1.4.3(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.6.3)
@@ -11257,6 +11267,7 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       ts-api-utils: 1.4.3(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -11277,6 +11288,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.1
       eslint: 8.57.1
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -11289,6 +11301,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.1
       eslint: 8.57.1
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -11328,6 +11341,7 @@ snapshots:
       debug: 4.4.1
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -11339,6 +11353,7 @@ snapshots:
       debug: 4.4.1
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -11358,6 +11373,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.7.2
       tsutils: 3.21.0(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -11372,6 +11388,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.7.2
       ts-api-utils: 1.4.3(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -11386,6 +11403,7 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.7.2
       ts-api-utils: 1.4.3(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -11495,12 +11513,29 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(vite@5.4.19)':
+  '@vitest/mocker@3.1.4(vite@5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0))':
     dependencies:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
-      vite: 5.4.19(@types/node@18.19.108)
+    optionalDependencies:
+      vite: 5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
+
+  '@vitest/mocker@3.1.4(vite@5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0))':
+    dependencies:
+      '@vitest/spy': 3.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0)
+
+  '@vitest/mocker@3.1.4(vite@5.4.19(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0))':
+    dependencies:
+      '@vitest/spy': 3.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0)
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -11530,7 +11565,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1)
+      vitest: 3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1)(lightningcss@1.27.0)(terser@5.40.0)
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -12684,9 +12719,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.27.2(bun-types@1.2.15):
-    dependencies:
+  drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.10.0)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7):
+    optionalDependencies:
+      '@aws-sdk/client-rds-data': 3.817.0
+      '@cloudflare/workers-types': 4.20250529.0
+      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@neondatabase/serverless': 0.10.0
+      '@opentelemetry/api': 1.9.0
+      '@planetscale/database': 1.19.0
+      '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.15.2
+      '@types/sql.js': 1.4.9
+      '@vercel/postgres': 0.8.0
+      better-sqlite3: 11.10.0
       bun-types: 1.2.15
+      knex: 2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7)
+      kysely: 0.25.0
+      mysql2: 3.14.1
+      pg: 8.16.0
+      postgres: 3.4.7
+      sql.js: 1.13.0
+      sqlite3: 5.1.7
 
   drizzle-prisma-generator@0.1.7:
     dependencies:
@@ -13095,19 +13148,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.6.3)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.6.3)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
@@ -13116,7 +13169,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13127,6 +13180,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.6.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -13134,13 +13189,14 @@ snapshots:
 
   eslint-plugin-no-instanceof@1.0.1: {}
 
-  eslint-plugin-prettier@5.4.1(eslint-config-prettier@9.1.0)(eslint@8.57.1)(prettier@3.5.3):
+  eslint-plugin-prettier@5.4.1(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3):
     dependencies:
       eslint: 8.57.1
-      eslint-config-prettier: 9.1.0(eslint@8.57.1)
       prettier: 3.5.3
       prettier-linter-helpers: 1.0.0
       synckit: 0.11.8
+    optionalDependencies:
+      eslint-config-prettier: 9.1.0(eslint@8.57.1)
 
   eslint-plugin-unicorn@48.0.1(eslint@8.57.1):
     dependencies:
@@ -13161,11 +13217,12 @@ snapshots:
       semver: 7.7.2
       strip-indent: 3.0.0
 
-  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.57.1):
+  eslint-plugin-unused-imports@3.2.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-rule-composer: 0.3.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
 
   eslint-rule-composer@0.3.0: {}
 
@@ -13318,39 +13375,39 @@ snapshots:
 
   expect-type@1.2.1: {}
 
-  expo-asset@11.1.5(expo@53.0.9)(react-native@0.79.2)(react@18.3.1):
+  expo-asset@11.1.5(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
     dependencies:
       '@expo/image-utils': 0.7.4
-      expo: 53.0.9(@babel/core@7.27.3)(react-native@0.79.2)(react@18.3.1)
-      expo-constants: 17.1.6(expo@53.0.9)(react-native@0.79.2)
+      expo: 53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))
       react: 18.3.1
-      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(react@18.3.1)
+      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@17.1.6(expo@53.0.9)(react-native@0.79.2):
+  expo-constants@17.1.6(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)):
     dependencies:
       '@expo/config': 11.0.10
       '@expo/env': 1.0.5
-      expo: 53.0.9(@babel/core@7.27.3)(react-native@0.79.2)(react@18.3.1)
-      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(react@18.3.1)
+      expo: 53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  expo-file-system@18.1.10(expo@53.0.9)(react-native@0.79.2):
+  expo-file-system@18.1.10(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)):
     dependencies:
-      expo: 53.0.9(@babel/core@7.27.3)(react-native@0.79.2)(react@18.3.1)
-      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(react@18.3.1)
+      expo: 53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
 
-  expo-font@13.3.1(expo@53.0.9)(react@18.3.1):
+  expo-font@13.3.1(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
     dependencies:
-      expo: 53.0.9(@babel/core@7.27.3)(react-native@0.79.2)(react@18.3.1)
+      expo: 53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
       fontfaceobserver: 2.3.0
       react: 18.3.1
 
-  expo-keep-awake@14.1.4(expo@53.0.9)(react@18.3.1):
+  expo-keep-awake@14.1.4(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
     dependencies:
-      expo: 53.0.9(@babel/core@7.27.3)(react-native@0.79.2)(react@18.3.1)
+      expo: 53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
       react: 18.3.1
 
   expo-modules-autolinking@2.1.10:
@@ -13367,31 +13424,31 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-sqlite@14.0.6(expo@53.0.9):
+  expo-sqlite@14.0.6(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)):
     dependencies:
       '@expo/websql': 1.0.1
-      expo: 53.0.9(@babel/core@7.27.3)(react-native@0.79.2)(react@18.3.1)
+      expo: 53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
 
-  expo@53.0.9(@babel/core@7.27.3)(react-native@0.79.2)(react@18.3.1):
+  expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3):
     dependencies:
       '@babel/runtime': 7.27.3
-      '@expo/cli': 0.24.13
+      '@expo/cli': 0.24.13(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@expo/config': 11.0.10
       '@expo/config-plugins': 10.0.2
       '@expo/fingerprint': 0.12.4
       '@expo/metro-config': 0.20.14
-      '@expo/vector-icons': 14.1.0(expo-font@13.3.1)(react-native@0.79.2)(react@18.3.1)
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
       babel-preset-expo: 13.1.11(@babel/core@7.27.3)
-      expo-asset: 11.1.5(expo@53.0.9)(react-native@0.79.2)(react@18.3.1)
-      expo-constants: 17.1.6(expo@53.0.9)(react-native@0.79.2)
-      expo-file-system: 18.1.10(expo@53.0.9)(react-native@0.79.2)
-      expo-font: 13.3.1(expo@53.0.9)(react@18.3.1)
-      expo-keep-awake: 14.1.4(expo@53.0.9)(react@18.3.1)
+      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))
+      expo-file-system: 18.1.10(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      expo-keep-awake: 14.1.4(expo@53.0.9(@babel/core@7.27.3)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
       expo-modules-autolinking: 2.1.10
       expo-modules-core: 2.3.13
       react: 18.3.1
-      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(react@18.3.1)
-      react-native-edge-to-edge: 1.6.0(react-native@0.79.2)(react@18.3.1)
+      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
       - '@babel/core'
@@ -13480,7 +13537,7 @@ snapshots:
       bser: 2.1.1
 
   fdir@6.4.5(picomatch@4.0.2):
-    dependencies:
+    optionalDependencies:
       picomatch: 4.0.2
 
   fetch-blob@3.2.0:
@@ -14327,7 +14384,6 @@ snapshots:
 
   knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7):
     dependencies:
-      better-sqlite3: 11.10.0
       colorette: 2.0.19
       commander: 10.0.1
       debug: 4.3.4
@@ -14337,14 +14393,16 @@ snapshots:
       getopts: 2.3.0
       interpret: 2.2.0
       lodash: 4.17.21
-      mysql2: 3.14.1
-      pg: 8.16.0
       pg-connection-string: 2.6.1
       rechoir: 0.8.0
       resolve-from: 5.0.0
-      sqlite3: 5.1.7
       tarn: 3.0.2
       tildify: 2.0.0
+    optionalDependencies:
+      better-sqlite3: 11.10.0
+      mysql2: 3.14.1
+      pg: 8.16.0
+      sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
 
@@ -14618,13 +14676,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.82.4:
+  metro-config@0.82.4(bufferutil@4.0.8)(utf-8-validate@6.0.3):
     dependencies:
       connect: 3.7.0
       cosmiconfig: 5.2.1
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.82.4
+      metro: 0.82.4(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       metro-cache: 0.82.4
       metro-core: 0.82.4
       metro-runtime: 0.82.4
@@ -14704,14 +14762,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-worker@0.82.4:
+  metro-transform-worker@0.82.4(bufferutil@4.0.8)(utf-8-validate@6.0.3):
     dependencies:
       '@babel/core': 7.27.3
       '@babel/generator': 7.27.3
       '@babel/parser': 7.27.3
       '@babel/types': 7.27.3
       flow-enums-runtime: 0.0.6
-      metro: 0.82.4
+      metro: 0.82.4(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       metro-babel-transformer: 0.82.4
       metro-cache: 0.82.4
       metro-cache-key: 0.82.4
@@ -14724,7 +14782,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.82.4:
+  metro@0.82.4(bufferutil@4.0.8)(utf-8-validate@6.0.3):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.27.3
@@ -14750,7 +14808,7 @@ snapshots:
       metro-babel-transformer: 0.82.4
       metro-cache: 0.82.4
       metro-cache-key: 0.82.4
-      metro-config: 0.82.4
+      metro-config: 0.82.4(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       metro-core: 0.82.4
       metro-file-map: 0.82.4
       metro-resolver: 0.82.4
@@ -14758,13 +14816,13 @@ snapshots:
       metro-source-map: 0.82.4
       metro-symbolicate: 0.82.4
       metro-transform-plugins: 0.82.4
-      metro-transform-worker: 0.82.4
+      metro-transform-worker: 0.82.4(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       mime-types: 2.1.35
       nullthrows: 1.1.1
       serialize-error: 2.1.0
       source-map: 0.5.7
       throat: 5.0.0
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -15382,15 +15440,21 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(tsx@3.14.0):
+  postcss-load-config@6.0.1(postcss@8.5.4)(tsx@3.14.0)(yaml@2.8.0):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.4
       tsx: 3.14.0
+      yaml: 2.8.0
 
-  postcss-load-config@6.0.1(tsx@4.19.4):
+  postcss-load-config@6.0.1(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.4
       tsx: 4.19.4
+      yaml: 2.8.0
 
   postcss@8.4.49:
     dependencies:
@@ -15562,32 +15626,31 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-devtools-core@6.1.2:
+  react-devtools-core@6.1.2(bufferutil@4.0.8)(utf-8-validate@6.0.3):
     dependencies:
       shell-quote: 1.8.2
-      ws: 7.5.10
+      ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
   react-is@18.3.1: {}
 
-  react-native-edge-to-edge@1.6.0(react-native@0.79.2)(react@18.3.1):
+  react-native-edge-to-edge@1.6.0(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(react@18.3.1)
+      react-native: 0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
 
-  react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(react@18.3.1):
+  react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.79.2
       '@react-native/codegen': 0.79.2(@babel/core@7.27.3)
-      '@react-native/community-cli-plugin': 0.79.2
+      '@react-native/community-cli-plugin': 0.79.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@react-native/gradle-plugin': 0.79.2
       '@react-native/js-polyfills': 0.79.2
       '@react-native/normalize-colors': 0.79.2
-      '@react-native/virtualized-lists': 0.79.2(@types/react@18.3.23)(react-native@0.79.2)(react@18.3.1)
-      '@types/react': 18.3.23
+      '@react-native/virtualized-lists': 0.79.2(@types/react@18.3.23)(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -15608,15 +15671,17 @@ snapshots:
       pretty-format: 29.7.0
       promise: 8.3.0
       react: 18.3.1
-      react-devtools-core: 6.1.2
+      react-devtools-core: 6.1.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.25.0
       semver: 7.7.2
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
-      ws: 6.2.3
+      ws: 6.2.3(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       yargs: 17.7.2
+    optionalDependencies:
+      '@types/react': 18.3.23
     transitivePeerDependencies:
       - '@babel/core'
       - '@react-native-community/cli'
@@ -16502,7 +16567,7 @@ snapshots:
       yn: 3.1.1
 
   tsconfck@3.1.6(typescript@5.6.3):
-    dependencies:
+    optionalDependencies:
       typescript: 5.6.3
 
   tsconfig-paths@3.15.0:
@@ -16516,7 +16581,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(tsx@3.14.0)(typescript@5.6.3):
+  tsup@8.5.0(postcss@8.5.4)(tsx@3.14.0)(typescript@5.6.3)(yaml@2.8.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.5)
       cac: 6.7.14
@@ -16527,7 +16592,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(tsx@3.14.0)
+      postcss-load-config: 6.0.1(postcss@8.5.4)(tsx@3.14.0)(yaml@2.8.0)
       resolve-from: 5.0.0
       rollup: 4.41.1
       source-map: 0.8.0-beta.0
@@ -16535,6 +16600,8 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.14
       tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.4
       typescript: 5.6.3
     transitivePeerDependencies:
       - jiti
@@ -16542,7 +16609,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.0(tsx@4.19.4)(typescript@5.6.3):
+  tsup@8.5.0(postcss@8.5.4)(tsx@4.19.4)(typescript@5.6.3)(yaml@2.8.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.5)
       cac: 6.7.14
@@ -16553,7 +16620,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(tsx@4.19.4)
+      postcss-load-config: 6.0.1(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0)
       resolve-from: 5.0.0
       rollup: 4.41.1
       source-map: 0.8.0-beta.0
@@ -16561,6 +16628,8 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.14
       tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.4
       typescript: 5.6.3
     transitivePeerDependencies:
       - jiti
@@ -16791,7 +16860,7 @@ snapshots:
   v8-compile-cache-lib@3.0.1: {}
 
   valibot@1.0.0-beta.7(typescript@5.6.3):
-    dependencies:
+    optionalDependencies:
       typescript: 5.6.3
 
   validate-npm-package-license@3.0.4:
@@ -16807,13 +16876,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.1.4(@types/node@18.19.108):
+  vite-node@3.1.4(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.19(@types/node@18.19.108)
+      vite: 5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16825,13 +16894,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.1.4(@types/node@20.17.55):
+  vite-node@3.1.4(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.19(@types/node@20.17.55)
+      vite: 5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16843,13 +16912,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.1.4(@types/node@22.15.27):
+  vite-node@3.1.4(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.19(@types/node@22.15.27)
+      vite: 5.4.19(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16861,47 +16930,65 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.3.2(typescript@5.6.3):
+  vite-tsconfig-paths@4.3.2(typescript@5.6.3)(vite@5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.6.3)
+    optionalDependencies:
+      vite: 5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.19(@types/node@18.19.108):
+  vite-tsconfig-paths@4.3.2(typescript@5.6.3)(vite@5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0)):
     dependencies:
-      '@types/node': 18.19.108
+      debug: 4.4.1
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.6.3)
+    optionalDependencies:
+      vite: 5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite@5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0):
+    dependencies:
       esbuild: 0.21.5
       postcss: 8.5.4
       rollup: 4.41.1
     optionalDependencies:
+      '@types/node': 18.19.108
       fsevents: 2.3.3
+      lightningcss: 1.27.0
+      terser: 5.40.0
 
-  vite@5.4.19(@types/node@20.17.55):
+  vite@5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0):
     dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.4
+      rollup: 4.41.1
+    optionalDependencies:
       '@types/node': 20.17.55
+      fsevents: 2.3.3
+      lightningcss: 1.27.0
+      terser: 5.40.0
+
+  vite@5.4.19(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0):
+    dependencies:
       esbuild: 0.21.5
       postcss: 8.5.4
       rollup: 4.41.1
     optionalDependencies:
-      fsevents: 2.3.3
-
-  vite@5.4.19(@types/node@22.15.27):
-    dependencies:
       '@types/node': 22.15.27
-      esbuild: 0.21.5
-      postcss: 8.5.4
-      rollup: 4.41.1
-    optionalDependencies:
       fsevents: 2.3.3
+      lightningcss: 1.27.0
+      terser: 5.40.0
 
-  vitest@3.1.4(@types/node@18.19.108):
+  vitest@3.1.4(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0):
     dependencies:
-      '@types/node': 18.19.108
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@5.4.19)
+      '@vitest/mocker': 3.1.4(vite@5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -16918,9 +17005,11 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.19(@types/node@18.19.108)
-      vite-node: 3.1.4(@types/node@18.19.108)
+      vite: 5.4.19(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
+      vite-node: 3.1.4(@types/node@18.19.108)(lightningcss@1.27.0)(terser@5.40.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 18.19.108
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -16932,31 +17021,32 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1):
+  vitest@3.1.4(@types/node@20.17.55)(@vitest/ui@1.6.1)(lightningcss@1.27.0)(terser@5.40.0):
     dependencies:
-      '@types/node': 20.17.55
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@5.4.19)
+      '@vitest/mocker': 3.1.4(vite@5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
       '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 5.4.19(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0)
+      vite-node: 3.1.4(@types/node@20.17.55)(lightningcss@1.27.0)(terser@5.40.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.17.55
       '@vitest/ui': 1.6.1(vitest@3.1.4)
-      '@vitest/utils': 3.1.4
-      chai: 5.2.0
-      debug: 4.4.1
-      expect-type: 1.2.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.0.2
-      tinyrainbow: 2.0.0
-      vite: 5.4.19(@types/node@20.17.55)
-      vite-node: 3.1.4(@types/node@20.17.55)
-      why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -16968,11 +17058,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.1.4(@types/node@22.15.27):
+  vitest@3.1.4(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0):
     dependencies:
-      '@types/node': 22.15.27
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@5.4.19)
+      '@vitest/mocker': 3.1.4(vite@5.4.19(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -16989,9 +17078,11 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.19(@types/node@22.15.27)
-      vite-node: 3.1.4(@types/node@22.15.27)
+      vite: 5.4.19(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0)
+      vite-node: 3.1.4(@types/node@22.15.27)(lightningcss@1.27.0)(terser@5.40.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.27
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -17130,18 +17221,27 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@6.2.3:
+  ws@6.2.3(bufferutil@4.0.8)(utf-8-validate@6.0.3):
     dependencies:
       async-limiter: 1.0.1
-
-  ws@7.5.10: {}
-
-  ws@8.14.2(bufferutil@4.0.8)(utf-8-validate@6.0.3):
-    dependencies:
+    optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 6.0.3
 
-  ws@8.18.2: {}
+  ws@7.5.10(bufferutil@4.0.8)(utf-8-validate@6.0.3):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 6.0.3
+
+  ws@8.14.2(bufferutil@4.0.8)(utf-8-validate@6.0.3):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 6.0.3
+
+  ws@8.18.2(bufferutil@4.0.8)(utf-8-validate@6.0.3):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 6.0.3
 
   xcode@3.0.1:
     dependencies:


### PR DESCRIPTION
When self-hosting libSQL, namespaces can now be accessed via the `x-namespace` header.
<img width="499" height="302" alt="image" src="https://github.com/user-attachments/assets/abc458fc-2dc4-4e03-a226-5c90c78d50e7" />
