### PR TITLE
feat(pg): add virtual generated columns support for pg 18

### DIFF
--- a/drizzle-kit/src/serializer/pgSchema.ts
+++ b/drizzle-kit/src/serializer/pgSchema.ts
@@ -183,7 +183,7 @@ const column = object({
 	uniqueName: string().optional(),
 	nullsNotDistinct: boolean().optional(),
 	generated: object({
-		type: literal('stored'),
+		type: enumType(['virtual', 'stored']),
 		as: string(),
 	}).optional(),
 	identity: sequenceSchema
@@ -207,7 +207,7 @@ const columnSquashed = object({
 	uniqueName: string().optional(),
 	nullsNotDistinct: boolean().optional(),
 	generated: object({
-		type: literal('stored'),
+		type: enumType(['virtual', 'stored']),
 		as: string(),
 	}).optional(),
 	identity: string().optional(),

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -192,7 +192,7 @@ export const generatePgSnapshot = (
 							: typeof generated.as === 'function'
 							? dialect.sqlToQuery(generated.as() as SQL).sql
 							: (generated.as as any),
-						type: 'stored',
+						type: generated.mode ?? 'stored',
 					}
 					: undefined,
 				identity: identity
@@ -780,7 +780,7 @@ export const generatePgSnapshot = (
 								: typeof generated.as === 'function'
 								? dialect.sqlToQuery(generated.as() as SQL).sql
 								: (generated.as as any),
-							type: 'stored',
+							type: generated.mode ?? 'stored',
 						}
 						: undefined,
 					identity: identity

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -413,7 +413,9 @@ class PgCreateTableConvertor extends Convertor {
 			const type = parseType(schemaPrefix, column.type);
 			const generated = column.generated;
 
-			const generatedStatement = generated ? ` GENERATED ALWAYS AS (${generated?.as}) STORED` : '';
+			const generatedStatement = generated
+				? ` GENERATED ALWAYS AS (${generated?.as}) ${generated?.type.toUpperCase()}`
+				: '';
 
 			const unsquashedIdentity = column.identity
 				? PgSquasher.unsquashIdentity(column.identity)
@@ -1793,7 +1795,9 @@ class PgAlterTableAddColumnConvertor extends Convertor {
 			})`
 			: '';
 
-		const generatedStatement = generated ? ` GENERATED ALWAYS AS (${generated?.as}) STORED` : '';
+		const generatedStatement = generated
+			? ` GENERATED ALWAYS AS (${generated?.as}) ${generated?.type.toUpperCase()}`
+			: '';
 
 		return `ALTER TABLE ${tableNameWithSchema} ADD COLUMN "${name}" ${fixedType}${primaryKeyStatement}${defaultStatement}${generatedStatement}${notNullStatement}${identityStatement};`;
 	}

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -30,6 +30,10 @@ export interface ReferenceConfig {
 	};
 }
 
+export interface PgGeneratedColumnConfig {
+	mode?: 'virtual' | 'stored';
+}
+
 export interface PgColumnBuilderBase<
 	T extends ColumnBuilderBaseConfig<ColumnDataType, string> = ColumnBuilderBaseConfig<ColumnDataType, string>,
 	TTypeConfig extends object = object,
@@ -83,13 +87,13 @@ export abstract class PgColumnBuilder<
 		return this;
 	}
 
-	generatedAlwaysAs(as: SQL | T['data'] | (() => SQL)): HasGenerated<this, {
+	generatedAlwaysAs(as: SQL | T['data'] | (() => SQL), config?: PgGeneratedColumnConfig): HasGenerated<this, {
 		type: 'always';
 	}> {
 		this.config.generated = {
 			as,
 			type: 'always',
-			mode: 'stored',
+			mode: config?.mode ?? 'stored',
 		};
 		return this as HasGenerated<this, {
 			type: 'always';


### PR DESCRIPTION
- Add virtual mode support for PostgreSQL generated columns
- Update schema serializer to handle both virtual and stored generated columns
- Modify SQL generator to support VIRTUAL keyword in generated column statements
- Add comprehensive tests for virtual generated columns
- Update type definitions and interfaces for virtual generated column configuration
- Ensure backward compatibility with existing stored generated columns