### PR TITLE
Fix unique statement formatting in MSSQL dialect

### DIFF
--- a/drizzle-kit/src/dialects/mssql/typescript.ts
+++ b/drizzle-kit/src/dialects/mssql/typescript.ts
@@ -480,7 +480,7 @@ const createTableUniques = (
 		statement += '\tunique(';
 		statement += it.nameExplicit ? `"${it.name}")` : ')';
 		statement += `.on(${it.columns.map((it) => `table.${withCasing(it, casing)}`).join(', ')})`;
-		statement += index === unqs.length - 1 ? `\n` : ',\n';
+		statement += ',\n';
 	});
 
 	return statement;


### PR DESCRIPTION
This pull request introduces a small change to the formatting of unique constraint statements in the `createTableUniques` function. The change ensures that each unique constraint statement ends with a comma and newline, rather than conditionally ending with only a newline for the last item.

Due to the ordering of the statements, there would be a syntax error if a "check" is present in the table. Removing the index check aligns the behavior with the other statements.

* Formatting update: Modified the logic in the `createTableUniques` function in `drizzle-kit/src/dialects/mssql/typescript.ts` so that each unique constraint statement ends with `,\n` regardless of its position in the list.