### PR TITLE
Normalize seq_name in pgSerializer getColumnsInfoQuery

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -2056,7 +2056,12 @@ const getColumnsInfoQuery = ({ schema, table, db }: { schema: string; table: str
         ELSE format_type(a.atttypid, a.atttypmod)
     END AS data_type,  -- Column data type
 --    ns.nspname AS type_schema,  -- Schema name
-    pg_get_serial_sequence('"${schema}"."${table}"', a.attname)::regclass AS seq_name,  -- Serial sequence (if any)
+    CASE
+        WHEN pg_get_serial_sequence('"${schema}"."${table}"', a.attname) LIKE '%.%' THEN
+            split_part(pg_get_serial_sequence('"${schema}"."${table}"', a.attname), '.', 2)::regclass
+        ELSE
+            pg_get_serial_sequence('"${schema}"."${table}"', a.attname)::regclass
+    END AS seq_name,  -- Serial sequence (if any)
     c.column_default,  -- Column default value
     c.data_type AS additional_dt,  -- Data type from information_schema
     c.udt_name AS enum_name,  -- Enum type (if applicable)

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -2058,9 +2058,9 @@ const getColumnsInfoQuery = ({ schema, table, db }: { schema: string; table: str
 --    ns.nspname AS type_schema,  -- Schema name
     CASE
         WHEN pg_get_serial_sequence('"${schema}"."${table}"', a.attname) LIKE '%.%' THEN
-            split_part(pg_get_serial_sequence('"${schema}"."${table}"', a.attname), '.', 2)::regclass
+            split_part(pg_get_serial_sequence('"${schema}"."${table}"', a.attname), '.', 2)
         ELSE
-            pg_get_serial_sequence('"${schema}"."${table}"', a.attname)::regclass
+            pg_get_serial_sequence('"${schema}"."${table}"', a.attname)
     END AS seq_name,  -- Serial sequence (if any)
     c.column_default,  -- Column default value
     c.data_type AS additional_dt,  -- Data type from information_schema


### PR DESCRIPTION
Prevents a failure to match sequences when introspecting non-default schemas by normalzing the `seq_name` column.

The `seq_name`, assigned as [`identityName`](https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-kit/src/serializer/pgSerializer.ts#L1398) in the Postgres introspection is treated as though it is an unqualified column name in [multiple](https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-kit/src/serializer/pgSerializer.ts#L1517-L1518) [locations](https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-kit/src/serializer/pgSerializer.ts#L1526-L1534) in the code. 

This leads to several bugs when using a non-default schema, notably, any `push` to a database after the first `push` will generate a bad change set that attempts to alter the schema, often by trying to drop the sequence which failed these checks.

Concretely, given a `push` for `my-schema.todo`, the `seq_name` for an `id` column returned from the introspection query would be `"my-schema".todo_id_seq`, whereas a default `public.todo` table would return the unqualified  `todo_id_seq`. All of the code is expecting and handling the default case only, for instance, concatenating the schema name with the `seq_name` generating keys like `my-schema."my-schema".todo_id_seq` and testing those against sequences that would have the key `my-schema.todo_id_seq`.