### PR TITLE
[Pg-kit] Add pg_stat_statements extension support

### DIFF
--- a/drizzle-kit/src/cli/validations/cli.ts
+++ b/drizzle-kit/src/cli/validations/cli.ts
@@ -23,7 +23,7 @@ export const pushParams = object({
 	schemaFilter: union([string(), string().array()])
 		.optional()
 		.default(['public']),
-	extensionsFilters: literal('postgis').array().optional(),
+	extensionsFilters: union([literal('postgis'), literal('pg_stat_statements')]).array().optional(),
 	verbose: boolean().optional(),
 	strict: boolean().optional(),
 	entities: object({
@@ -45,7 +45,7 @@ export const pullParams = object({
 	schemaFilter: union([string(), string().array()])
 		.optional()
 		.default(['public']),
-	extensionsFilters: literal('postgis').array().optional(),
+	extensionsFilters: union([literal('postgis'), literal('pg_stat_statements')]).array().optional(),
 	casing,
 	breakpoints: boolean().optional().default(true),
 	migrations: object({

--- a/drizzle-kit/src/extensions/getTablesFilterByExtensions.ts
+++ b/drizzle-kit/src/extensions/getTablesFilterByExtensions.ts
@@ -4,13 +4,16 @@ export const getTablesFilterByExtensions = ({
 	extensionsFilters,
 	dialect,
 }: Pick<Config, 'extensionsFilters' | 'dialect'>): string[] => {
-	if (extensionsFilters) {
-		if (
-			extensionsFilters.includes('postgis')
-			&& dialect === 'postgresql'
-		) {
-			return ['!geography_columns', '!geometry_columns', '!spatial_ref_sys'];
+	const filters: string[] = [];
+
+	if (extensionsFilters && dialect === 'postgresql') {
+		if (extensionsFilters.includes('postgis')) {
+			filters.push('!geography_columns', '!geometry_columns', '!spatial_ref_sys');
+		}
+		if (extensionsFilters.includes('pg_stat_statements')) {
+			filters.push('!pg_stat_*');
 		}
 	}
-	return [];
+
+	return filters;
 };

--- a/drizzle-kit/src/index.ts
+++ b/drizzle-kit/src/index.ts
@@ -80,6 +80,18 @@ type Verify<T, U extends T> = U;
  *
  * ---
  *
+ * `extensionsFilters` - parameter allows you to filter out tables created by PostgreSQL extensions.
+ * This parameter accepts an array of extension names. Currently supported extensions:
+ * - 'postgis' - filters out geography_columns, geometry_columns, and spatial_ref_sys tables
+ * - 'pg_stat_statements' - filters out all pg_stat_* tables
+ *
+ * For example, having extensionsFilters: ["postgis", "pg_stat_statements"] will automatically filter out
+ * all extension-related tables from introspect and push operations.
+ *
+ * See https://orm.drizzle.team/kit-docs/config-reference#extensionsfilters
+ *
+ * ---
+ *
  * `schemaFilter` - parameter allows you to define which schema in PostgreSQL should be used for either introspect or push commands.
  * This parameter accepts a single schema as a string or an array of schemas as strings.
  * No glob pattern is supported here. By default, drizzle will use the public schema for both commands,
@@ -112,7 +124,7 @@ export type Config =
 		out?: string;
 		breakpoints?: boolean;
 		tablesFilter?: string | string[];
-		extensionsFilters?: 'postgis'[];
+		extensionsFilters?: ('postgis' | 'pg_stat_statements')[];
 		schemaFilter?: string | string[];
 		schema?: string | string[];
 		verbose?: boolean;
@@ -315,6 +327,18 @@ export type Config =
  * How to define multi-project tables with Drizzle ORM — see https://orm.drizzle.team/docs/goodies#multi-project-schema
  *
  * See https://orm.drizzle.team/kit-docs/config-reference#tablesfilters
+ *
+ * ---
+ *
+ * `extensionsFilters` - parameter allows you to filter out tables created by PostgreSQL extensions.
+ * This parameter accepts an array of extension names. Currently supported extensions:
+ * - 'postgis' - filters out geography_columns, geometry_columns, and spatial_ref_sys tables
+ * - 'pg_stat_statements' - filters out all pg_stat_* tables
+ *
+ * For example, having extensionsFilters: ["postgis", "pg_stat_statements"] will automatically filter out
+ * all extension-related tables from introspect and push operations.
+ *
+ * See https://orm.drizzle.team/kit-docs/config-reference#extensionsfilters
  *
  * ---
  *

--- a/drizzle-kit/tests/extensions.test.ts
+++ b/drizzle-kit/tests/extensions.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from 'vitest';
+import { getTablesFilterByExtensions } from '../src/extensions/getTablesFilterByExtensions';
+
+test('postgis extension filters', () => {
+	const filters = getTablesFilterByExtensions({
+		extensionsFilters: ['postgis'],
+		dialect: 'postgresql',
+	});
+
+	expect(filters).toEqual([
+		'!geography_columns',
+		'!geometry_columns',
+		'!spatial_ref_sys',
+	]);
+});
+
+test('pg_stat_statements extension filters', () => {
+	const filters = getTablesFilterByExtensions({
+		extensionsFilters: ['pg_stat_statements'],
+		dialect: 'postgresql',
+	});
+
+	expect(filters).toEqual(['!pg_stat_*']);
+});
+
+test('multiple extensions filters', () => {
+	const filters = getTablesFilterByExtensions({
+		extensionsFilters: ['postgis', 'pg_stat_statements'],
+		dialect: 'postgresql',
+	});
+
+	expect(filters).toEqual([
+		'!geography_columns',
+		'!geometry_columns',
+		'!spatial_ref_sys',
+		'!pg_stat_*',
+	]);
+});
+
+test('no extension filters', () => {
+	const filters = getTablesFilterByExtensions({
+		extensionsFilters: undefined,
+		dialect: 'postgresql',
+	});
+
+	expect(filters).toEqual([]);
+});
+
+test('extension filters only for postgresql', () => {
+	const filters = getTablesFilterByExtensions({
+		extensionsFilters: ['postgis', 'pg_stat_statements'],
+		dialect: 'mysql',
+	});
+
+	expect(filters).toEqual([]);
+});


### PR DESCRIPTION
## Summary
Add support for `pg_stat_statements` extension filter in drizzle-kit to automatically exclude pg_stat_* tables from introspect and push operations.

## Changes
- Extended `extensionsFilters` type to accept `'pg_stat_statements'`
- Updated `getTablesFilterByExtensions()` to filter `!pg_stat_*` tables
- Updated Zod validation schemas to accept the new extension type
- Refactored extension filter logic to support multiple extensions simultaneously
- Added comprehensive unit tests covering all scenarios
- Added TSDoc documentation for the feature

## Usage Example
```ts
import { defineConfig } from 'drizzle-kit'

export default defineConfig({
  dialect: "postgresql",
  extensionsFilters: ["postgis", "pg_stat_statements"],
})
```

## Testing
Created new test file `drizzle-kit/tests/extensions.test.ts` with tests for:
- Individual extension filters (postgis, pg_stat_statements)
- Multiple extensions combined
- No extension filters
- PostgreSQL-only dialect behavior

---

⚠️ **Note**: This commit is not GPG signed yet. Will need to be signed before merging per CONTRIBUTING.md guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)