### PR TITLE
[drizzle-kit] Remove infant_terrible from heroes list

### DIFF
--- a/drizzle-kit/src/utils/words.ts
+++ b/drizzle-kit/src/utils/words.ts
@@ -682,7 +682,6 @@ export const heroes = [
 	'imperial_guard',
 	'impossible_man',
 	'inertia',
-	'infant_terrible',
 	'inhumans',
 	'ink',
 	'invaders',


### PR DESCRIPTION
### About
This PR removes the hero `infant_terrible` from the heroes list in drizzle-kit.

### Motivation
I was playing around with creating migrations using drizzle-kit and I ended up with `motionless_infant_terrible.sql`. 

This unfortunate random combination of terms definitely conjures up some brutal imagery 😅