### PR TITLE
[Sqlite-kit]: Avoid duplicate CREATE INDEX during push table recreation

### DIFF
--- a/drizzle-kit/src/cli/commands/libSqlPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/libSqlPushUtils.ts
@@ -4,7 +4,6 @@ import { JsonStatement } from 'src/jsonStatements';
 import { findAddedAndRemoved, SQLiteDB } from 'src/utils';
 import { SQLiteSchemaInternal, SQLiteSchemaSquashed, SQLiteSquasher } from '../../serializer/sqliteSchema';
 import {
-	CreateSqliteIndexConvertor,
 	fromJson,
 	LibSQLModifyColumn,
 	SQLiteCreateTableConvertor,
@@ -86,28 +85,17 @@ export const _moveDataStatements = (
 		}),
 	);
 
-	// rename table
-	statements.push(
-		new SqliteRenameTableConvertor().convert({
-			fromSchema: '',
-			tableNameFrom: newTableName,
-			tableNameTo: tableName,
-			toSchema: '',
-			type: 'rename_table',
-		}),
-	);
-
-	for (const idx of Object.values(json.tables[tableName].indexes)) {
-		statements.push(
-			new CreateSqliteIndexConvertor().convert({
-				type: 'create_index',
-				tableName: tableName,
-				schema: '',
-				data: idx,
-			}),
-		);
-	}
-	return statements;
+    // rename table
+    statements.push(
+        new SqliteRenameTableConvertor().convert({
+            fromSchema: '',
+            tableNameFrom: newTableName,
+            tableNameTo: tableName,
+            toSchema: '',
+            type: 'rename_table',
+        }),
+    );
+    return statements;
 };
 
 export const libSqlLogSuggestionsAndReturn = async (

--- a/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
+++ b/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 
 import { SQLiteSchemaInternal, SQLiteSchemaSquashed, SQLiteSquasher } from '../../serializer/sqliteSchema';
 import {
-	CreateSqliteIndexConvertor,
 	fromJson,
 	SQLiteCreateTableConvertor,
 	SQLiteDropTableConvertor,
@@ -13,11 +12,11 @@ import type { JsonStatement } from '../../jsonStatements';
 import { findAddedAndRemoved, type SQLiteDB } from '../../utils';
 
 export const _moveDataStatements = (
-	tableName: string,
-	json: SQLiteSchemaSquashed,
-	dataLoss: boolean = false,
+    tableName: string,
+    json: SQLiteSchemaSquashed,
+    dataLoss: boolean = false,
 ) => {
-	const statements: string[] = [];
+    const statements: string[] = [];
 
 	const newTableName = `__new_${tableName}`;
 
@@ -73,29 +72,18 @@ export const _moveDataStatements = (
 		}),
 	);
 
-	// rename table
-	statements.push(
-		new SqliteRenameTableConvertor().convert({
-			fromSchema: '',
-			tableNameFrom: newTableName,
-			tableNameTo: tableName,
-			toSchema: '',
-			type: 'rename_table',
-		}),
-	);
+    // rename table
+    statements.push(
+        new SqliteRenameTableConvertor().convert({
+            fromSchema: '',
+            tableNameFrom: newTableName,
+            tableNameTo: tableName,
+            toSchema: '',
+            type: 'rename_table',
+        }),
+    );
 
-	for (const idx of Object.values(json.tables[tableName].indexes)) {
-		statements.push(
-			new CreateSqliteIndexConvertor().convert({
-				type: 'create_index',
-				tableName: tableName,
-				schema: '',
-				data: idx,
-			}),
-		);
-	}
-
-	return statements;
+    return statements;
 };
 
 export const getOldTableName = (


### PR DESCRIPTION
Fixes #3574

Avoid duplicate CREATE INDEX during SQLite/D1 push table recreation by removing index creation in _moveDataStatements. Indexes are created once from planned create_index statements. Adds a regression test.