### PR TITLE
Change Durable Object SQLite migrate function to be sync

### DIFF
--- a/drizzle-orm/src/durable-sqlite/migrator.ts
+++ b/drizzle-orm/src/durable-sqlite/migrator.ts
@@ -38,12 +38,12 @@ function readMigrationFiles({ journal, migrations }: MigrationConfig): Migration
 	return migrationQueries;
 }
 
-export async function migrate<
+export function migrate<
 	TSchema extends Record<string, unknown>,
 >(
 	db: DrizzleSqliteDODatabase<TSchema>,
 	config: MigrationConfig,
-): Promise<void> {
+) {
 	const migrations = readMigrationFiles(config);
 
 	db.transaction((tx) => {


### PR DESCRIPTION
Change DO SQLite `migrate` function to be in line with other existing sync SQL adapters

This change was motivated by noticing that the setup in Durable Objects was more complicated than required as seen in [the docs](https://orm.drizzle.team/docs/get-started/do-new#step-8---migrate-and-query-the-database).

Since `migrate` is currently async, it seems to require the usage of `ctx.blockConcurrencyWhile` in the setup step of the object, which introduces more things the user has to understand before using the drizzle with Durable Objects.
(In reality, I believe no microtasks are actually ever scheduled since no await is encountered inside migrate, so you wouldn't need to use ctx.blockConcurrencyWhile to guarentee the setup working, but the function being async makes it seem like you do)

I also intend to make a PR on the docs to simplify the setup for new users of Drizzle + Cloudflare Durable Objects.

