### PR TITLE
Fix bug in mysql-proxy for empty results on execute path

### DIFF
--- a/drizzle-orm/src/mysql-proxy/session.ts
+++ b/drizzle-orm/src/mysql-proxy/session.ts
@@ -136,12 +136,9 @@ export class PreparedQuery<T extends MySqlPreparedQueryConfig> extends PreparedQ
 		logger.logQuery(queryString, params);
 
 		if (!fields && !customResultMapper) {
-			const { rows: data } = await this.queryWithCache(queryString, params, async () => {
+			const { rows, insertId, affectedRows } = await this.queryWithCache(queryString, params, async () => {
 				return await client(queryString, params, 'execute');
 			});
-
-			const insertId = data[0].insertId as number;
-			const affectedRows = data[0].affectedRows;
 
 			if (returningIds) {
 				const returningResponse = [];
@@ -166,7 +163,7 @@ export class PreparedQuery<T extends MySqlPreparedQueryConfig> extends PreparedQ
 				return returningResponse;
 			}
 
-			return data;
+			return rows;
 		}
 
 		const { rows } = await this.queryWithCache(queryString, params, async () => {


### PR DESCRIPTION
I am debugging an issue with the Drizzle MySQL proxy. The callback is expected to return a object with three fields:
- rows
- insertId
- affectedRows

However, the code handling the callback here destructures the rows field and then expects the insertID and affectedRows field on that.

This throws.

The doc seem out of date here as well:
https://orm.drizzle.team/docs/connect-drizzle-proxy

It does mention that on certain `method` a different response is expected. However, I can't validate this in the code and the mode `execute` here is never mentioned in the docs.