### PR TITLE
[Pg-kit]: Fix unique constraint introspection returning zero rows

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1228,12 +1228,18 @@ WHERE
 					const tableResponse = await getColumnsInfoQuery({ schema: tableSchema, table: tableName, db });
 
 					const tableConstraints = await db.query(
-						`SELECT c.column_name, c.data_type, constraint_type, constraint_name, constraint_schema
+					`SELECT kcu.column_name, c.data_type, tc.constraint_type, tc.constraint_name, tc.constraint_schema
       FROM information_schema.table_constraints tc
-      JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name)
-      JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema
-        AND tc.table_name = c.table_name AND ccu.column_name = c.column_name
-      WHERE tc.table_name = '${tableName}' and constraint_schema = '${tableSchema}';`,
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+        AND tc.constraint_schema = kcu.constraint_schema
+        AND tc.table_name = kcu.table_name
+      JOIN information_schema.columns AS c
+        ON c.table_schema = tc.constraint_schema
+        AND c.table_name = tc.table_name
+        AND c.column_name = kcu.column_name
+      WHERE tc.table_name = '${tableName}' and tc.constraint_schema = '${tableSchema}'
+      ORDER BY tc.constraint_name, kcu.ordinal_position;`,
 					);
 
 					const tableChecks = await db.query(`SELECT 


### PR DESCRIPTION
## Description

Fixes a critical bug in PostgreSQL unique constraint introspection that causes `drizzle-kit push` to falsely detect missing constraints even when they exist in the database.

## Problem

The current introspection query at `pgSerializer.ts:1230-1236` uses `information_schema.constraint_column_usage` which creates a **Cartesian product** when joined with the `columns` table:

```sql
JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name)
JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema
  AND tc.table_name = c.table_name AND ccu.column_name = c.column_name
```

This returns **zero rows** for multi-column unique constraints, causing `drizzle-kit push` to prompt users to add constraints that already exist.

## Solution

Replace `constraint_column_usage` with `key_column_usage` (the standard PostgreSQL information_schema table for PRIMARY KEY and UNIQUE constraints) and properly join on:
- `constraint_name`
- `constraint_schema`
- `table_name`

Added `ORDER BY kcu.ordinal_position` to preserve column order in multi-column constraints.

## Testing

### Before Fix
```sql
-- Returns 0 rows for multi-column unique constraint
SELECT c.column_name FROM information_schema.table_constraints tc
JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name)
JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema
  AND tc.table_name = c.table_name AND ccu.column_name = c.column_name
WHERE tc.table_name = 'address' AND tc.constraint_type = 'UNIQUE';
-- Result: 0 rows
```

### After Fix
```sql
-- Returns all columns in the constraint
SELECT kcu.column_name FROM information_schema.table_constraints tc
JOIN information_schema.key_column_usage kcu
  ON tc.constraint_name = kcu.constraint_name
  AND tc.constraint_schema = kcu.constraint_schema
  AND tc.table_name = kcu.table_name
WHERE tc.table_name = 'address' AND tc.constraint_type = 'UNIQUE'
ORDER BY kcu.ordinal_position;
-- Result: 5 rows (all columns in the unique constraint)
```

## Impact

- ✅ Fixes constraint detection for ALL multi-column unique constraints
- ✅ Eliminates false "add constraint" prompts in `drizzle-kit push`
- ✅ No breaking changes - only fixes broken introspection
- ✅ Compatible with all PostgreSQL versions

## Related Issues

Closes #4490
Closes #4531
Closes #4921

## Checklist

- [x] Bug fix in drizzle-kit introspection
- [x] Tested with real PostgreSQL database
- [x] No breaking changes
- [x] Commit signed

---

**Disclaimer**: This PR was created with assistance from AI tools for bug diagnosis and documentation.