### PR TITLE
Fix coercion logic for number schema creation

### DIFF
--- a/drizzle-zod/src/column.ts
+++ b/drizzle-zod/src/column.ts
@@ -241,7 +241,7 @@ function numberColumnToSchema(
 	}
 
 	let schema = coerce === true || coerce?.number
-		? integer ? z.coerce.number() : z.coerce.number().int()
+		? integer ? z.coerce.number().int() : z.coerce.number()
 		: integer
 		? z.int()
 		: z.number();


### PR DESCRIPTION
This pull request makes a small fix to the logic for generating Zod schemas for number columns in the `numberColumnToSchema` function. Specifically, it corrects the order of applying the `.int()` method when coercing numbers, ensuring that integer coercion is only applied when appropriate.

- Fixed the logic in `numberColumnToSchema` to apply `.int()` to `z.coerce.number()` only when the column is an integer, preventing unintended integer coercion for non-integer columns.