### PR TITLE
[SQLite-kit]: Fix SQLite partial index where inspection

### DIFF
--- a/drizzle-kit/tests/push/sqlite.test.ts
+++ b/drizzle-kit/tests/push/sqlite.test.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import chalk from 'chalk';
-import { sql } from 'drizzle-orm';
+import { sql, isNotNull } from 'drizzle-orm';
 import {
 	blob,
 	check,
@@ -59,7 +59,13 @@ test('nothing changed in schema', async (t) => {
 			id: integer('id').primaryKey(),
 			content: text('content'),
 			authorId: integer('author_id'),
-		}),
+			},
+			(table) => [
+				uniqueIndex('content_unique_author_nonnull_idx')
+					.on(table.content)
+					.where(isNotNull(table.authorId)),
+			],
+		),
 	};
 
 	const {


### PR DESCRIPTION
Fix Drizzle Kit failing to detect SQLite partial index 'WHERE' clauses during remote introspection phase, which caused infinite drop/recreate cycles.

Changed:

drizzle-kit/src/serializer/sqliteSerializer.ts: add way to recognize if an index is a partial index, and if so then introspect its "where" part
Added partial index test to sqlite "nothing changed in schema" part

Fixes #4688 