### PR TITLE
fix: allow placeholders in SQLite onConflictDoUpdate set clause

### DIFF
--- a/drizzle-orm/src/sqlite-core/query-builders/update.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/update.ts
@@ -42,6 +42,7 @@ export type SQLiteUpdateSetSource<TTable extends SQLiteTable> =
 			| GetColumnData<TTable['_']['columns'][Key], 'query'>
 			| SQL
 			| SQLiteColumn
+			| Placeholder
 			| undefined;
 	}
 	& {};

--- a/drizzle-orm/type-tests/sqlite/issue-5084.ts
+++ b/drizzle-orm/type-tests/sqlite/issue-5084.ts
@@ -1,0 +1,23 @@
+import { sql } from '~/sql/sql.ts';
+import { integer, sqliteTable, text } from '~/sqlite-core/index.ts';
+import { drizzle } from '~/sqlite-proxy/index.ts';
+
+const table = sqliteTable('table', {
+    id: integer('id').primaryKey(),
+    name: text('name'),
+});
+
+const db = drizzle(async () => ({ rows: [] }));
+
+db.insert(table)
+    .values({
+        id: sql.placeholder('id'),
+        name: sql.placeholder('name'),
+    })
+    .onConflictDoUpdate({
+        target: table.id,
+        set: {
+            id: sql.placeholder('id'),
+            name: sql.placeholder('name'),
+        },
+    });


### PR DESCRIPTION
Fixes #5084

Problem
The TypeScript types for onConflictDoUpdate's set clause did not allow sql.placeholder values, even though they work correctly at runtime. This prevented users from using placeholders in upsert operations with prepared statements.

Solution
Added Placeholder to the SQLiteUpdateSetSource type definition in  src/sqlite-core/query-builders/update.ts

Changes
Modified SQLiteUpdateSetSource type to include | Placeholder in the union type
Added type test type-tests/sqlite/issue-5084.ts to verify the fix

Testing
Created a reproduction test case in type-tests/sqlite/issue-5084.ts that verifies sql.placeholder can now be used in 
onConflictDoUpdate set clause
Verified locally by running npm run test:types
Confirmed the test fails without the fix and passes with the fix
