### PR TITLE
Fixed pg-native Pool detection in node-postgres transactions breaking in environments with forbidden `require()` 

### DIFF
--- a/changelogs/drizzle-orm/0.45.1.md
+++ b/changelogs/drizzle-orm/0.45.1.md
@@ -1,0 +1,1 @@
+- Fixed pg-native Pool detection in node-postgres transactions breaking in environments with forbidden `require()` ([#5107](https://github.com/drizzle-team/drizzle-orm/issues/5107))  

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drizzle-orm",
-	"version": "0.45.0",
+	"version": "0.45.1",
 	"description": "Drizzle ORM package for SQL databases",
 	"type": "module",
 	"scripts": {

--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -15,7 +15,6 @@ import { tracer } from '~/tracing.ts';
 import { type Assume, mapResultRow } from '~/utils.ts';
 
 const { Pool, types } = pg;
-const NativePool = (<any> pg).native ? (<{ Pool: typeof Pool }> (<any> pg).native).Pool : undefined;
 
 export type NodePgClient = pg.Pool | PoolClient | Client;
 
@@ -250,8 +249,9 @@ export class NodePgSession<
 		transaction: (tx: NodePgTransaction<TFullSchema, TSchema>) => Promise<T>,
 		config?: PgTransactionConfig | undefined,
 	): Promise<T> {
-		const session = (this.client instanceof Pool || (NativePool && this.client instanceof NativePool)) // eslint-disable-line no-instanceof/no-instanceof
-			? new NodePgSession(await this.client.connect(), this.dialect, this.schema, this.options)
+		const isPool = this.client instanceof Pool || Object.getPrototypeOf(this.client).constructor.name.includes('Pool'); // eslint-disable-line no-instanceof/no-instanceof
+		const session = isPool
+			? new NodePgSession(await (<pg.Pool> this.client).connect(), this.dialect, this.schema, this.options)
 			: this;
 		const tx = new NodePgTransaction<TFullSchema, TSchema>(this.dialect, session, this.schema);
 		await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
@@ -263,9 +263,7 @@ export class NodePgSession<
 			await tx.execute(sql`rollback`);
 			throw error;
 		} finally {
-			if (this.client instanceof Pool || (NativePool && this.client instanceof NativePool)) { // eslint-disable-line no-instanceof/no-instanceof
-				(session.client as PoolClient).release();
-			}
+			if (isPool) (session.client as PoolClient).release();
 		}
 	}
 


### PR DESCRIPTION
fixes #5107