### PR TITLE
[MySQL-kit]: Add table name to push warning messages

### DIFF
--- a/drizzle-kit/src/cli/commands/mysqlPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/mysqlPushUtils.ts
@@ -173,17 +173,17 @@ export const logSuggestionsAndReturn = async (
 			);
 			const count = Number(res[0].count);
 			if (count > 0) {
-			infoToPrint.push(
-				`· You're about to change ${
-					chalk.underline(
-						statement.columnName,
-					)
-				} column type from ${
-					chalk.underline(
-						statement.oldDataType,
-					)
-				} to ${chalk.underline(statement.newDataType)} in ${statement.tableName} table with ${count} items`,
-			);
+				infoToPrint.push(
+					`· You're about to change ${
+						chalk.underline(
+							statement.columnName,
+						)
+					} column type from ${
+						chalk.underline(
+							statement.oldDataType,
+						)
+					} to ${chalk.underline(statement.newDataType)} in ${statement.tableName} table with ${count} items`,
+				);
 				statementsToExecute.push(`truncate table ${statement.tableName};`);
 				tablesToTruncate.push(statement.tableName);
 				shouldAskForApprove = true;
@@ -196,13 +196,13 @@ export const logSuggestionsAndReturn = async (
 
 				const count = Number(res[0].count);
 				if (count > 0) {
-				infoToPrint.push(
-					`· You're about to remove default value from ${
-						chalk.underline(
-							statement.columnName,
-						)
-					} not-null column in ${statement.tableName} table with ${count} items`,
-				);
+					infoToPrint.push(
+						`· You're about to remove default value from ${
+							chalk.underline(
+								statement.columnName,
+							)
+						} not-null column in ${statement.tableName} table with ${count} items`,
+					);
 
 					tablesToTruncate.push(statement.tableName);
 					statementsToExecute.push(`truncate table ${statement.tableName};`);
@@ -219,13 +219,13 @@ export const logSuggestionsAndReturn = async (
 
 				const count = Number(res[0].count);
 				if (count > 0) {
-				infoToPrint.push(
-					`· You're about to set not-null constraint to ${
-						chalk.underline(
-							statement.columnName,
-						)
-					} column without default in ${statement.tableName} table, which contains ${count} items`,
-				);
+					infoToPrint.push(
+						`· You're about to set not-null constraint to ${
+							chalk.underline(
+								statement.columnName,
+							)
+						} column without default in ${statement.tableName} table, which contains ${count} items`,
+					);
 
 					tablesToTruncate.push(statement.tableName);
 					statementsToExecute.push(`truncate table ${statement.tableName};`);

--- a/drizzle-kit/src/cli/commands/mysqlPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/mysqlPushUtils.ts
@@ -173,17 +173,17 @@ export const logSuggestionsAndReturn = async (
 			);
 			const count = Number(res[0].count);
 			if (count > 0) {
-				infoToPrint.push(
-					`· You're about to change ${
-						chalk.underline(
-							statement.columnName,
-						)
-					} column type from ${
-						chalk.underline(
-							statement.oldDataType,
-						)
-					} to ${chalk.underline(statement.newDataType)} with ${count} items`,
-				);
+			infoToPrint.push(
+				`· You're about to change ${
+					chalk.underline(
+						statement.columnName,
+					)
+				} column type from ${
+					chalk.underline(
+						statement.oldDataType,
+					)
+				} to ${chalk.underline(statement.newDataType)} in ${statement.tableName} table with ${count} items`,
+			);
 				statementsToExecute.push(`truncate table ${statement.tableName};`);
 				tablesToTruncate.push(statement.tableName);
 				shouldAskForApprove = true;
@@ -196,13 +196,13 @@ export const logSuggestionsAndReturn = async (
 
 				const count = Number(res[0].count);
 				if (count > 0) {
-					infoToPrint.push(
-						`· You're about to remove default value from ${
-							chalk.underline(
-								statement.columnName,
-							)
-						} not-null column with ${count} items`,
-					);
+				infoToPrint.push(
+					`· You're about to remove default value from ${
+						chalk.underline(
+							statement.columnName,
+						)
+					} not-null column in ${statement.tableName} table with ${count} items`,
+				);
 
 					tablesToTruncate.push(statement.tableName);
 					statementsToExecute.push(`truncate table ${statement.tableName};`);
@@ -219,13 +219,13 @@ export const logSuggestionsAndReturn = async (
 
 				const count = Number(res[0].count);
 				if (count > 0) {
-					infoToPrint.push(
-						`· You're about to set not-null constraint to ${
-							chalk.underline(
-								statement.columnName,
-							)
-						} column without default, which contains ${count} items`,
-					);
+				infoToPrint.push(
+					`· You're about to set not-null constraint to ${
+						chalk.underline(
+							statement.columnName,
+						)
+					} column without default in ${statement.tableName} table, which contains ${count} items`,
+				);
 
 					tablesToTruncate.push(statement.tableName);
 					statementsToExecute.push(`truncate table ${statement.tableName};`);
@@ -298,7 +298,7 @@ export const logSuggestionsAndReturn = async (
 							chalk.underline(
 								statement.column.name,
 							)
-						} column without default value, which contains ${count} items`,
+						} column without default value to ${statement.tableName} table, which contains ${count} items`,
 					);
 
 					tablesToTruncate.push(statement.tableName);


### PR DESCRIPTION

Added table name to warning messages for:
- alter_table_alter_column_set_type
- alter_table_alter_column_drop_default
- alter_table_alter_column_set_notnull  
- alter_table_add_column

This improves clarity to if someone wants to truncate the table on alter or set. 