### PR TITLE
[Pg[: Add pgEnumCreator function

### DIFF
--- a/drizzle-kit/tests/pg-enums.test.ts
+++ b/drizzle-kit/tests/pg-enums.test.ts
@@ -1,6 +1,13 @@
-import { integer, pgEnum, pgSchema, pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
+import { integer, pgEnum, pgEnumCreator, pgSchema, pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
 import { expect, test } from 'vitest';
 import { diffTestSchemas } from './schemaDiffer';
+
+test('enums creator #1', async () => {
+	const enumCreator = pgEnumCreator((s) => `prefix_${s}`);
+	const createdEnum = enumCreator('enum', ['value']);
+
+	expect(createdEnum.enumName).toBe("prefix_enum");
+});
 
 test('enums #1', async () => {
 	const to = {

--- a/drizzle-orm/src/pg-core/columns/enum.ts
+++ b/drizzle-orm/src/pg-core/columns/enum.ts
@@ -160,6 +160,13 @@ export function pgEnum(
 		: pgEnumObjectWithSchema(enumName, input, undefined);
 }
 
+export function pgEnumCreator(customizeTableName: (name: string) => string): typeof pgEnum {
+	// @ts-ignore
+	return (_enumName: string, input: any) => {
+		return pgEnum(customizeTableName(_enumName), input);
+	};
+}
+
 /** @internal */
 export function pgEnumWithSchema<U extends string, T extends Readonly<[U, ...U[]]>>(
 	enumName: string,


### PR DESCRIPTION
This function allows users to prefix their enums like they do with pgTableCreator.

It also implements a test to make sure that it creates the enum object properly with the correct name.

``pg-core/columns/enum.ts``

```ts
export function pgEnumCreator(customizeTableName: (name: string) => string): typeof pgEnum {
	// @ts-ignore
	return (_enumName: string, input: any) => {
		return pgEnum(customizeTableName(_enumName), input);
	};
}
```

The usecase for this function should be similar for usecases for `pgTableCreator`, which i use in projects so that I can have more than 1 project use the same database in Neon free tier.

Please let me know if there are things that can be improved. I am unsure if the test that I wrote is correct since each test is supposed to be an integration test, what I made is more of a unit test.