### PR TITLE
[drizzle-zod] Export CONSTANTS and add ZodInstance type

### DIFF
--- a/drizzle-zod/src/index.ts
+++ b/drizzle-zod/src/index.ts
@@ -1,5 +1,6 @@
 export { bufferSchema, jsonSchema, literalSchema } from './column.ts';
 export * from './column.types.ts';
+export { CONSTANTS } from './constants.ts';
 export * from './schema.ts';
 export * from './schema.types.internal.ts';
 export * from './schema.types.ts';

--- a/drizzle-zod/src/schema.types.ts
+++ b/drizzle-zod/src/schema.types.ts
@@ -3,6 +3,9 @@ import type { PgEnum } from 'drizzle-orm/pg-core';
 import type { z } from 'zod/v4';
 import type { BuildRefine, BuildSchema, NoUnknownKeys } from './schema.types.internal.ts';
 
+/** Type representing a Zod-compatible library instance */
+export type ZodInstance = typeof z;
+
 export interface CreateSelectSchema<
 	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
 > {
@@ -56,6 +59,8 @@ export interface CreateUpdateSchema<
 export interface CreateSchemaFactoryOptions<
 	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
 > {
-	zodInstance?: any;
+	/** Custom Zod instance to use for schema generation (useful for custom Zod extensions) */
+	zodInstance?: ZodInstance;
+	/** Enable type coercion for specific types or all types */
 	coerce?: TCoerce;
 }


### PR DESCRIPTION
## Summary
Small DX improvements that expose existing internals for user convenience:

- **Export `CONSTANTS`**: Users can access integer bounds (INT8_MIN, INT32_MAX, etc.) for custom validation logic without hardcoding values
- **Add `ZodInstance` type**: Provides proper typing for the `zodInstance` option instead of `any`

## Motivation
Currently, users who want to add custom integer validation need to hardcode bounds or import them from elsewhere. Since drizzle-zod already defines these constants internally, exposing them improves DX.

The `zodInstance` option accepts `any`, which loses type safety. Adding a proper type alias improves the developer experience.

## Changes
- `src/index.ts`: Add `export { CONSTANTS } from './constants.ts'`
- `src/schema.types.ts`: Add `ZodInstance` type and update `zodInstance` option type

## Test plan
- [x] All 70 existing tests pass
- [x] No breaking changes - purely additive exports
- [x] Types verified with `pnpm test:types`