### PR TITLE
[drizzle-zod] Add security features: mode, trim, and defaultTextMaxLength

### DIFF
--- a/drizzle-zod/src/schema.ts
+++ b/drizzle-zod/src/schema.ts
@@ -9,11 +9,31 @@ import type {
 	CreateSchemaFactoryOptions,
 	CreateSelectSchema,
 	CreateUpdateSchema,
+	SchemaMode,
 } from './schema.types.ts';
 import { isPgEnum } from './utils.ts';
 
+/** Secure defaults for createSchemaFactory - prevents common security issues */
+const SECURE_DEFAULTS = {
+	mode: 'strict' as const,
+	trim: true,
+	defaultTextMaxLength: 65535,
+};
+
 function getColumns(tableLike: Table | View) {
 	return isTable(tableLike) ? getTableColumns(tableLike) : getViewSelectedFields(tableLike);
+}
+
+function applySchemaMode(schema: z.ZodObject<any>, mode: SchemaMode | undefined): z.ZodType {
+	switch (mode) {
+		case 'strict':
+			return schema.strict();
+		case 'passthrough':
+			return schema.passthrough();
+		case 'strip':
+		default:
+			return schema.strip();
+	}
 }
 
 function handleColumns(
@@ -23,13 +43,14 @@ function handleColumns(
 	factory?: CreateSchemaFactoryOptions<
 		Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined
 	>,
+	isTopLevel = false,
 ): z.ZodType {
 	const columnSchemas: Record<string, z.ZodType> = {};
 
 	for (const [key, selected] of Object.entries(columns)) {
 		if (!is(selected, Column) && !is(selected, SQL) && !is(selected, SQL.Aliased) && typeof selected === 'object') {
 			const columns = isTable(selected) || isView(selected) ? getColumns(selected) : selected;
-			columnSchemas[key] = handleColumns(columns, refinements[key] ?? {}, conditions, factory);
+			columnSchemas[key] = handleColumns(columns, refinements[key] ?? {}, conditions, factory, false);
 			continue;
 		}
 
@@ -60,7 +81,9 @@ function handleColumns(
 		}
 	}
 
-	return z.object(columnSchemas) as any;
+	const objectSchema = z.object(columnSchemas);
+	// Apply mode only at top level to avoid nested strict/strip issues
+	return isTopLevel ? applySchemaMode(objectSchema, factory?.mode) : objectSchema;
 }
 
 function handleEnum(
@@ -99,7 +122,7 @@ export const createSelectSchema: CreateSelectSchema<undefined> = (
 		return handleEnum(entity);
 	}
 	const columns = getColumns(entity);
-	return handleColumns(columns, refine ?? {}, selectConditions) as any;
+	return handleColumns(columns, refine ?? {}, selectConditions, undefined, true) as any;
 };
 
 export const createInsertSchema: CreateInsertSchema<undefined> = (
@@ -107,7 +130,7 @@ export const createInsertSchema: CreateInsertSchema<undefined> = (
 	refine?: Record<string, any>,
 ) => {
 	const columns = getColumns(entity);
-	return handleColumns(columns, refine ?? {}, insertConditions) as any;
+	return handleColumns(columns, refine ?? {}, insertConditions, undefined, true) as any;
 };
 
 export const createUpdateSchema: CreateUpdateSchema<undefined> = (
@@ -115,21 +138,24 @@ export const createUpdateSchema: CreateUpdateSchema<undefined> = (
 	refine?: Record<string, any>,
 ) => {
 	const columns = getColumns(entity);
-	return handleColumns(columns, refine ?? {}, updateConditions) as any;
+	return handleColumns(columns, refine ?? {}, updateConditions, undefined, true) as any;
 };
 
 export function createSchemaFactory<
 	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
 >(options?: CreateSchemaFactoryOptions<TCoerce>) {
+	// Merge secure defaults with user options (user options take precedence)
+	const secureOptions = { ...SECURE_DEFAULTS, ...options } as CreateSchemaFactoryOptions<TCoerce>;
+
 	const createSelectSchema: CreateSelectSchema<TCoerce> = (
 		entity: Table | View | PgEnum<[string, ...string[]]>,
 		refine?: Record<string, any>,
 	) => {
 		if (isPgEnum(entity)) {
-			return handleEnum(entity, options);
+			return handleEnum(entity, secureOptions);
 		}
 		const columns = getColumns(entity);
-		return handleColumns(columns, refine ?? {}, selectConditions, options) as any;
+		return handleColumns(columns, refine ?? {}, selectConditions, secureOptions, true) as any;
 	};
 
 	const createInsertSchema: CreateInsertSchema<TCoerce> = (
@@ -137,7 +163,7 @@ export function createSchemaFactory<
 		refine?: Record<string, any>,
 	) => {
 		const columns = getColumns(entity);
-		return handleColumns(columns, refine ?? {}, insertConditions, options) as any;
+		return handleColumns(columns, refine ?? {}, insertConditions, secureOptions, true) as any;
 	};
 
 	const createUpdateSchema: CreateUpdateSchema<TCoerce> = (
@@ -145,7 +171,7 @@ export function createSchemaFactory<
 		refine?: Record<string, any>,
 	) => {
 		const columns = getColumns(entity);
-		return handleColumns(columns, refine ?? {}, updateConditions, options) as any;
+		return handleColumns(columns, refine ?? {}, updateConditions, secureOptions, true) as any;
 	};
 
 	return { createSelectSchema, createInsertSchema, createUpdateSchema };

--- a/drizzle-zod/src/schema.types.ts
+++ b/drizzle-zod/src/schema.types.ts
@@ -3,6 +3,12 @@ import type { PgEnum } from 'drizzle-orm/pg-core';
 import type { z } from 'zod/v4';
 import type { BuildRefine, BuildSchema, NoUnknownKeys } from './schema.types.internal.ts';
 
+/** Type representing a Zod-compatible library instance */
+export type ZodInstance = typeof z;
+
+/** Mode for handling unknown keys in the schema */
+export type SchemaMode = 'strip' | 'strict' | 'passthrough';
+
 export interface CreateSelectSchema<
 	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
 > {
@@ -56,6 +62,27 @@ export interface CreateUpdateSchema<
 export interface CreateSchemaFactoryOptions<
 	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
 > {
-	zodInstance?: any;
+	/** Custom Zod instance to use for schema generation (useful for custom Zod extensions) */
+	zodInstance?: ZodInstance;
+	/** Enable type coercion for specific types or all types */
 	coerce?: TCoerce;
+	/**
+	 * Mode for handling unknown keys in the schema.
+	 * - 'strip': Remove unknown keys (default for standalone functions)
+	 * - 'strict': Reject unknown keys - prevents mass assignment attacks (default for factory)
+	 * - 'passthrough': Allow unknown keys
+	 */
+	mode?: SchemaMode;
+	/**
+	 * Apply .trim() to string schemas to prevent whitespace bypass attacks.
+	 * When enabled, also trims enum values before validation.
+	 * @default true when using createSchemaFactory
+	 */
+	trim?: boolean;
+	/**
+	 * Default max length for unbounded text columns (prevents DoS via large payloads).
+	 * Set to `false` to disable. Only applies to columns without explicit length.
+	 * @default 65535 when using createSchemaFactory
+	 */
+	defaultTextMaxLength?: number | false;
 }


### PR DESCRIPTION
## Summary
Adds opt-in security features to protect against common web application vulnerabilities:

- **`mode`**: Control how unknown keys are handled (`'strip'` | `'strict'` | `'passthrough'`)
- **`trim`**: Automatically trim whitespace from strings and enums
- **`defaultTextMaxLength`**: Limit unbounded text columns to prevent DoS attacks

When using `createSchemaFactory()`, secure defaults are applied automatically. Standalone functions remain backward compatible.

## Motivation

### Mass Assignment Attacks
Without strict mode, attackers can inject extra fields like `isAdmin: true`:
```ts
// Vulnerable: unknown keys are silently stripped
const schema = createInsertSchema(users);
schema.parse({ name: "hacker", isAdmin: true }); // isAdmin passes through!

// Protected: strict mode rejects unknown keys
const { createInsertSchema } = createSchemaFactory({ mode: 'strict' });
```

### Whitespace Bypass Attacks
Attackers can bypass validation with whitespace:
```ts
// Vulnerable: " admin " !== "admin"
const schema = createInsertSchema(users);

// Protected: trim normalizes input
const { createInsertSchema } = createSchemaFactory({ trim: true });
```

### DoS via Large Payloads
Unbounded text columns can accept gigabytes of data:
```ts
// Vulnerable: no limit on text size
const schema = createInsertSchema(posts);

// Protected: default 64KB limit
const { createInsertSchema } = createSchemaFactory({ defaultTextMaxLength: 65535 });
```

## Secure Defaults
`createSchemaFactory()` now applies secure defaults:
- `mode: 'strict'` - Reject unknown keys
- `trim: true` - Trim whitespace
- `defaultTextMaxLength: 65535` - 64KB limit

Users can override any default:
```ts
const { createInsertSchema } = createSchemaFactory({
  mode: 'strip',  // opt-out of strict
  defaultTextMaxLength: 1024 * 1024,  // 1MB limit
});
```

## Backward Compatibility
- Standalone `createInsertSchema()`, `createSelectSchema()`, `createUpdateSchema()` are unchanged
- Only `createSchemaFactory()` applies secure defaults
- All defaults can be overridden

## Changes
- `src/schema.types.ts`: Add `SchemaMode`, security options to factory
- `src/schema.ts`: Add `applySchemaMode()`, secure defaults
- `src/column.ts`: Add trim/maxLength support with `z.preprocess()`
- `tests/pg.test.ts`: Add 10 comprehensive security tests

## Test plan
- [x] All 80 tests pass (70 existing + 10 new)
- [x] Mode strict/strip/passthrough verified
- [x] Trim works on strings and enums
- [x] defaultTextMaxLength limits unbounded text
- [x] Columns with explicit length are not affected
- [x] Standalone functions unchanged (backward compatible)