### PR TITLE
[drizzle-zod] Add unified createSchema API with pick/omit and modifiers

### DIFF
--- a/drizzle-zod/src/schema.ts
+++ b/drizzle-zod/src/schema.ts
@@ -7,13 +7,81 @@ import type { Conditions } from './schema.types.internal.ts';
 import type {
 	CreateInsertSchema,
 	CreateSchemaFactoryOptions,
+	CreateSchemaOptions,
 	CreateSelectSchema,
 	CreateUpdateSchema,
+	SchemaType,
 } from './schema.types.ts';
 import { isPgEnum } from './utils.ts';
 
+/** Map of schema type to conditions */
+const conditionsMap: Record<SchemaType, Conditions> = {
+	select: {
+		never: () => false,
+		optional: () => false,
+		nullable: (column) => !column.notNull,
+	},
+	insert: {
+		never: (column) => column?.generated?.type === 'always' || column?.generatedIdentity?.type === 'always',
+		optional: (column) => !column.notNull || (column.notNull && column.hasDefault),
+		nullable: (column) => !column.notNull,
+	},
+	update: {
+		never: (column) => column?.generated?.type === 'always' || column?.generatedIdentity?.type === 'always',
+		optional: () => true,
+		nullable: (column) => !column.notNull,
+	},
+};
+
 function getColumns(tableLike: Table | View) {
 	return isTable(tableLike) ? getTableColumns(tableLike) : getViewSelectedFields(tableLike);
+}
+
+/**
+ * Filter columns based on pick/omit options.
+ * Throws error if both pick and omit are provided.
+ */
+function filterColumns(
+	columns: Record<string, any>,
+	options?: { pick?: string[]; omit?: string[] },
+): Record<string, any> {
+	if (!options) return columns;
+
+	const hasPick = options.pick && options.pick.length > 0;
+	const hasOmit = options.omit && options.omit.length > 0;
+
+	if (hasPick && hasOmit) {
+		throw new Error('Cannot use both "pick" and "omit" options together. Use one or the other.');
+	}
+
+	if (hasPick) {
+		const picked: Record<string, any> = {};
+		for (const key of options.pick!) {
+			if (key in columns) {
+				picked[key] = columns[key];
+			}
+		}
+		return picked;
+	}
+
+	if (hasOmit) {
+		const result: Record<string, any> = {};
+		const omitSet = new Set(options.omit!);
+		for (const [key, value] of Object.entries(columns)) {
+			if (!omitSet.has(key)) {
+				result[key] = value;
+			}
+		}
+		return result;
+	}
+
+	return columns;
+}
+
+/** Schema-level options for allOptional/allNullable */
+interface SchemaLevelOptions {
+	allOptional?: boolean;
+	allNullable?: boolean;
 }
 
 function handleColumns(
@@ -23,13 +91,14 @@ function handleColumns(
 	factory?: CreateSchemaFactoryOptions<
 		Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined
 	>,
+	schemaOptions?: SchemaLevelOptions,
 ): z.ZodType {
 	const columnSchemas: Record<string, z.ZodType> = {};
 
 	for (const [key, selected] of Object.entries(columns)) {
 		if (!is(selected, Column) && !is(selected, SQL) && !is(selected, SQL.Aliased) && typeof selected === 'object') {
 			const columns = isTable(selected) || isView(selected) ? getColumns(selected) : selected;
-			columnSchemas[key] = handleColumns(columns, refinements[key] ?? {}, conditions, factory);
+			columnSchemas[key] = handleColumns(columns, refinements[key] ?? {}, conditions, factory, schemaOptions);
 			continue;
 		}
 
@@ -49,14 +118,16 @@ function handleColumns(
 			columnSchemas[key] = refined;
 		}
 
-		if (column) {
-			if (conditions.nullable(column)) {
-				columnSchemas[key] = columnSchemas[key]!.nullable();
-			}
+		// Apply nullable: schemaOptions.allNullable overrides, or use condition check
+		const shouldBeNullable = schemaOptions?.allNullable || (column && conditions.nullable(column));
+		if (shouldBeNullable) {
+			columnSchemas[key] = columnSchemas[key]!.nullable();
+		}
 
-			if (conditions.optional(column)) {
-				columnSchemas[key] = columnSchemas[key]!.optional();
-			}
+		// Apply optional: schemaOptions.allOptional overrides, or use condition check
+		const shouldBeOptional = schemaOptions?.allOptional || (column && conditions.optional(column));
+		if (shouldBeOptional) {
+			columnSchemas[key] = columnSchemas[key]!.optional();
 		}
 	}
 
@@ -148,5 +219,48 @@ export function createSchemaFactory<
 		return handleColumns(columns, refine ?? {}, updateConditions, options) as any;
 	};
 
-	return { createSelectSchema, createInsertSchema, createUpdateSchema };
+	/**
+	 * Unified schema creation function with pick/omit support.
+	 *
+	 * @example
+	 * ```ts
+	 * // Create an insert schema with only specific columns
+	 * const schema = createSchema(users, {
+	 *   type: 'insert',
+	 *   pick: ['name', 'email'],
+	 * });
+	 *
+	 * // Create an update schema excluding certain columns
+	 * const schema = createSchema(users, {
+	 *   type: 'update',
+	 *   omit: ['id', 'createdAt'],
+	 * });
+	 *
+	 * // Make all fields optional (useful for PATCH operations)
+	 * const schema = createSchema(users, {
+	 *   type: 'update',
+	 *   allOptional: true,
+	 * });
+	 * ```
+	 */
+	const createSchema = <TTable extends Table>(
+		table: TTable,
+		schemaOptions: CreateSchemaOptions<keyof TTable['$inferSelect'] & string>,
+	): z.ZodType => {
+		const conditions = conditionsMap[schemaOptions.type];
+		let columns = getColumns(table);
+
+		// Apply pick/omit filtering
+		columns = filterColumns(columns, {
+			pick: schemaOptions.pick as string[] | undefined,
+			omit: schemaOptions.omit as string[] | undefined,
+		});
+
+		return handleColumns(columns, {}, conditions, options, {
+			allOptional: schemaOptions.allOptional,
+			allNullable: schemaOptions.allNullable,
+		}) as any;
+	};
+
+	return { createSelectSchema, createInsertSchema, createUpdateSchema, createSchema };
 }

--- a/drizzle-zod/src/schema.types.ts
+++ b/drizzle-zod/src/schema.types.ts
@@ -3,59 +3,90 @@ import type { PgEnum } from 'drizzle-orm/pg-core';
 import type { z } from 'zod/v4';
 import type { BuildRefine, BuildSchema, NoUnknownKeys } from './schema.types.internal.ts';
 
-/** Type representing a Zod-compatible library instance */
 export type ZodInstance = typeof z;
 
-/** Schema type for unified createSchema function */
 export type SchemaType = 'select' | 'insert' | 'update';
 
-/** Options with pick (mutually exclusive with omit) */
-interface CreateSchemaOptionsWithPick<TColumns extends string> {
-	/** Schema type: 'select', 'insert', or 'update' */
+type GetColumnsForRefine<
+	TTable extends Table,
+	TType extends SchemaType,
+	TPick extends string | undefined,
+	TOmit extends string | undefined,
+> = TPick extends string ? Pick<TTable['_']['columns'], TPick & keyof TTable['_']['columns']>
+	: TOmit extends string ? Omit<TTable['_']['columns'], TOmit & keyof TTable['_']['columns']>
+	: TType extends 'select' ? TTable['_']['columns']
+	: Pick<TTable['_']['columns'], keyof TTable['$inferInsert']>;
+
+interface CreateSchemaOptionsBase<
+	TColumns extends Record<string, any>,
+	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
+	TRefine extends BuildRefine<TColumns, TCoerce>,
+> {
 	type: SchemaType;
-	/** Columns to include in the schema */
+	allOptional?: boolean;
+	allNullable?: boolean;
+	refine?: NoUnknownKeys<TRefine, { [K in keyof TColumns]: any }>;
+}
+
+interface CreateSchemaOptionsWithPick<
+	TColumns extends string,
+	TAllColumns extends Record<string, any>,
+	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
+	TRefine extends BuildRefine<Pick<TAllColumns, TColumns & keyof TAllColumns>, TCoerce>,
+> extends CreateSchemaOptionsBase<Pick<TAllColumns, TColumns & keyof TAllColumns>, TCoerce, TRefine> {
 	pick: TColumns[];
-	/** Cannot be used together with pick */
 	omit?: never;
-	/** Make all fields optional */
-	allOptional?: boolean;
-	/** Make all fields nullable */
-	allNullable?: boolean;
 }
 
-/** Options with omit (mutually exclusive with pick) */
-interface CreateSchemaOptionsWithOmit<TColumns extends string> {
-	/** Schema type: 'select', 'insert', or 'update' */
-	type: SchemaType;
-	/** Cannot be used together with omit */
+interface CreateSchemaOptionsWithOmit<
+	TColumns extends string,
+	TAllColumns extends Record<string, any>,
+	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
+	TRefine extends BuildRefine<Omit<TAllColumns, TColumns & keyof TAllColumns>, TCoerce>,
+> extends CreateSchemaOptionsBase<Omit<TAllColumns, TColumns & keyof TAllColumns>, TCoerce, TRefine> {
 	pick?: never;
-	/** Columns to exclude from the schema */
 	omit: TColumns[];
-	/** Make all fields optional */
-	allOptional?: boolean;
-	/** Make all fields nullable */
-	allNullable?: boolean;
 }
 
-/** Options without filtering */
-interface CreateSchemaOptionsNoFilter {
-	/** Schema type: 'select', 'insert', or 'update' */
-	type: SchemaType;
-	/** Not using pick/omit */
+interface CreateSchemaOptionsNoFilter<
+	TAllColumns extends Record<string, any>,
+	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
+	TRefine extends BuildRefine<TAllColumns, TCoerce>,
+> extends CreateSchemaOptionsBase<TAllColumns, TCoerce, TRefine> {
 	pick?: never;
-	/** Not using pick/omit */
 	omit?: never;
-	/** Make all fields optional */
-	allOptional?: boolean;
-	/** Make all fields nullable */
-	allNullable?: boolean;
 }
 
-/** Options for unified createSchema function */
-export type CreateSchemaOptions<TColumns extends string = string> =
-	| CreateSchemaOptionsWithPick<TColumns>
-	| CreateSchemaOptionsWithOmit<TColumns>
-	| CreateSchemaOptionsNoFilter;
+export type CreateTableSchemaOptions<
+	TTable extends Table,
+	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
+> =
+	| CreateSchemaOptionsWithPick<
+		keyof TTable['$inferSelect'] & string,
+		TTable['_']['columns'],
+		TCoerce,
+		BuildRefine<TTable['_']['columns'], TCoerce>
+	>
+	| CreateSchemaOptionsWithOmit<
+		keyof TTable['$inferSelect'] & string,
+		TTable['_']['columns'],
+		TCoerce,
+		BuildRefine<TTable['_']['columns'], TCoerce>
+	>
+	| CreateSchemaOptionsNoFilter<TTable['_']['columns'], TCoerce, BuildRefine<TTable['_']['columns'], TCoerce>>;
+
+export interface CreateViewSchemaOptions<
+	TView extends View,
+	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
+> {
+	type?: 'select';
+	allOptional?: boolean;
+	allNullable?: boolean;
+	refine?: NoUnknownKeys<
+		BuildRefine<TView['_']['selectedFields'], TCoerce>,
+		{ [K in keyof TView['$inferSelect']]: any }
+	>;
+}
 
 export interface CreateSelectSchema<
 	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,

--- a/drizzle-zod/src/schema.types.ts
+++ b/drizzle-zod/src/schema.types.ts
@@ -3,6 +3,60 @@ import type { PgEnum } from 'drizzle-orm/pg-core';
 import type { z } from 'zod/v4';
 import type { BuildRefine, BuildSchema, NoUnknownKeys } from './schema.types.internal.ts';
 
+/** Type representing a Zod-compatible library instance */
+export type ZodInstance = typeof z;
+
+/** Schema type for unified createSchema function */
+export type SchemaType = 'select' | 'insert' | 'update';
+
+/** Options with pick (mutually exclusive with omit) */
+interface CreateSchemaOptionsWithPick<TColumns extends string> {
+	/** Schema type: 'select', 'insert', or 'update' */
+	type: SchemaType;
+	/** Columns to include in the schema */
+	pick: TColumns[];
+	/** Cannot be used together with pick */
+	omit?: never;
+	/** Make all fields optional */
+	allOptional?: boolean;
+	/** Make all fields nullable */
+	allNullable?: boolean;
+}
+
+/** Options with omit (mutually exclusive with pick) */
+interface CreateSchemaOptionsWithOmit<TColumns extends string> {
+	/** Schema type: 'select', 'insert', or 'update' */
+	type: SchemaType;
+	/** Cannot be used together with omit */
+	pick?: never;
+	/** Columns to exclude from the schema */
+	omit: TColumns[];
+	/** Make all fields optional */
+	allOptional?: boolean;
+	/** Make all fields nullable */
+	allNullable?: boolean;
+}
+
+/** Options without filtering */
+interface CreateSchemaOptionsNoFilter {
+	/** Schema type: 'select', 'insert', or 'update' */
+	type: SchemaType;
+	/** Not using pick/omit */
+	pick?: never;
+	/** Not using pick/omit */
+	omit?: never;
+	/** Make all fields optional */
+	allOptional?: boolean;
+	/** Make all fields nullable */
+	allNullable?: boolean;
+}
+
+/** Options for unified createSchema function */
+export type CreateSchemaOptions<TColumns extends string = string> =
+	| CreateSchemaOptionsWithPick<TColumns>
+	| CreateSchemaOptionsWithOmit<TColumns>
+	| CreateSchemaOptionsNoFilter;
+
 export interface CreateSelectSchema<
 	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
 > {


### PR DESCRIPTION
## Summary
Adds a unified `createSchema()` function with powerful filtering and modifier options:

- **Unified API**: Single function with `type` parameter instead of three separate functions
- **`pick`/`omit`**: Filter columns to include or exclude
- **`allOptional`**: Make all fields optional (useful for PATCH endpoints)
- **`allNullable`**: Make all fields nullable

## Motivation

### Repetitive Schema Definitions
Currently, creating variations of schemas requires manual work:
```ts
// Want only name and email for registration
const registerSchema = z.object({
  name: z.string(),
  email: z.string().email(),
});

// Want everything except id for updates
const updateSchema = createUpdateSchema(users); // still includes id
```

### With This PR
```ts
const { createSchema } = createSchemaFactory();

// Pick specific columns
const registerSchema = createSchema(users, {
  type: 'insert',
  pick: ['name', 'email'],
});

// Omit specific columns
const updateSchema = createSchema(users, {
  type: 'update',
  omit: ['id', 'createdAt'],
});

// PATCH endpoint - all fields optional
const patchSchema = createSchema(users, {
  type: 'update',
  allOptional: true,
});

// Nullable response schema
const responseSchema = createSchema(users, {
  type: 'select',
  allNullable: true,
});
```

## Type Safety
- `pick` and `omit` are fully typed - only valid column names accepted
- `pick` and `omit` are mutually exclusive at both **type level** and **runtime**:

```ts
// TypeScript error: Type 'string[]' is not assignable to type 'never'
createSchema(users, {
  type: 'insert',
  pick: ['name'],
  omit: ['id'],  // ❌ Type error!
});

// Runtime error if somehow bypassed
// Error: Cannot use both "pick" and "omit" options together
```

## API Design
```ts
interface CreateSchemaOptions<TColumns> {
  type: 'select' | 'insert' | 'update';
  pick?: TColumns[];      // Cannot use with omit
  omit?: TColumns[];      // Cannot use with pick
  allOptional?: boolean;  // Make all fields optional
  allNullable?: boolean;  // Make all fields nullable
}
```

## Changes
- `src/schema.types.ts`: Add `SchemaType`, `CreateSchemaOptions` with discriminated unions
- `src/schema.ts`: Add `conditionsMap`, `filterColumns()`, `createSchema()` to factory
- `tests/pg.test.ts`: Add 10 comprehensive tests

## Test plan
- [x] All 80 tests pass (70 existing + 10 new)
- [x] Basic select/insert/update types work
- [x] pick filters to only specified columns
- [x] omit excludes specified columns
- [x] pick + omit throws error
- [x] allOptional makes all fields optional
- [x] allNullable makes all fields nullable
- [x] Modifiers combine correctly with pick/omit