### PR TITLE
[Pg, Sqlite] Add enum support for integer columns

### DIFF
--- a/drizzle-orm/src/column-builder.ts
+++ b/drizzle-orm/src/column-builder.ts
@@ -166,7 +166,7 @@ export type MakeColumnConfig<
 	isPrimaryKey: T extends { isPrimaryKey: true } ? true : false;
 	isAutoincrement: T extends { isAutoincrement: true } ? true : false;
 	hasRuntimeDefault: T extends { hasRuntimeDefault: true } ? true : false;
-	enumValues: T extends { enumValues: [string, ...string[]] } ? T['enumValues'] : undefined;
+	enumValues: T extends { enumValues: [any, ...any[]] } ? T['enumValues'] : undefined;
 	baseColumn: T extends { baseBuilder: infer U extends ColumnBuilderBase } ? BuildColumn<TTableName, U, TDialect>
 		: never;
 	identity: T extends { identity: 'always' } ? 'always' : T extends { identity: 'byDefault' } ? 'byDefault' : undefined;

--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -1,6 +1,8 @@
 import type {
 	ColumnBuilderRuntimeConfig,
+	ColumnDataType,
 	ColumnType,
+	ExtractColumnTypeData,
 	GeneratedColumnConfig,
 	GeneratedIdentityConfig,
 } from './column-builder.ts';
@@ -11,6 +13,9 @@ import type { Table } from './table.ts';
 import type { Update } from './utils.ts';
 
 export type Columns = Record<string, Column<any>>;
+export type ColumnDataTypeToEnumValues<T extends ColumnDataType> = T extends 'string' ? string[]
+	: T extends 'number' ? number[]
+	: never;
 
 export interface ColumnBaseConfig<TDataType extends ColumnType> {
 	name: string;
@@ -23,7 +28,7 @@ export interface ColumnBaseConfig<TDataType extends ColumnType> {
 	hasRuntimeDefault: boolean;
 	data: unknown;
 	driverParam: unknown;
-	enumValues: string[] | undefined;
+	enumValues: ColumnDataTypeToEnumValues<ExtractColumnTypeData<TDataType>['type']> | undefined;
 }
 
 export interface Column<

--- a/drizzle-orm/src/pg-core/columns/int.common.ts
+++ b/drizzle-orm/src/pg-core/columns/int.common.ts
@@ -4,10 +4,13 @@ import type { PgSequenceOptions } from '../sequence.ts';
 import { PgColumnBuilder } from './common.ts';
 
 export abstract class PgIntColumnBaseBuilder<
-	T extends ColumnBuilderBaseConfig<ColumnType>,
+	T extends ColumnBuilderBaseConfig<ColumnType> = ColumnBuilderBaseConfig<ColumnType>,
+	TRuntimeConfig extends object = object,
 > extends PgColumnBuilder<
 	T,
-	{ generatedIdentity: GeneratedIdentityConfig }
+	TRuntimeConfig & {
+		generatedIdentity: GeneratedIdentityConfig;
+	}
 > {
 	static override readonly [entityKind]: string = 'PgIntColumnBaseBuilder';
 

--- a/drizzle-orm/src/pg-core/columns/integer.ts
+++ b/drizzle-orm/src/pg-core/columns/integer.ts
@@ -1,28 +1,45 @@
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
+import { getColumnNameAndConfig, type Writable } from '~/utils.ts';
 import type { PgTable } from '../table.ts';
 import { PgColumn } from './common.ts';
 import { PgIntColumnBaseBuilder } from './int.common.ts';
 
-export class PgIntegerBuilder extends PgIntColumnBaseBuilder<{
-	dataType: 'number int32';
-	data: number;
-	driverParam: number | string;
-}> {
+export class PgIntegerBuilder<TEnum extends [number, ...number[]] = [number, ...number[]]>
+	extends PgIntColumnBaseBuilder<{
+		dataType: 'number int32';
+		data: TEnum[number];
+		enumValues: TEnum;
+		driverParam: number | string;
+	}, { enumValues: TEnum | undefined }>
+{
 	static override readonly [entityKind]: string = 'PgIntegerBuilder';
 
-	constructor(name: string) {
+	constructor(name: string, config: PgIntegerConfig<TEnum>) {
 		super(name, 'number int32', 'PgInteger');
+		this.config.enumValues = config.enum;
 	}
 
 	/** @internal */
 	override build(table: PgTable<any>) {
-		return new PgInteger(table, this.config as any);
+		return new PgInteger(table, this.config as any, this.config.enumValues);
 	}
 }
 
-export class PgInteger<T extends ColumnBaseConfig<'number int32'>> extends PgColumn<T> {
+export class PgInteger<T extends ColumnBaseConfig<'number int32'>>
+	extends PgColumn<T, { enumValues: T['enumValues'] }>
+{
 	static override readonly [entityKind]: string = 'PgInteger';
+	override readonly enumValues;
+
+	constructor(
+		table: PgTable<any>,
+		config: any,
+		enumValues?: number[],
+	) {
+		super(table, config);
+		this.enumValues = enumValues;
+	}
 
 	getSQLType(): string {
 		return 'integer';
@@ -35,6 +52,21 @@ export class PgInteger<T extends ColumnBaseConfig<'number int32'>> extends PgCol
 		return value;
 	}
 }
-export function integer(name?: string): PgIntegerBuilder {
-	return new PgIntegerBuilder(name ?? '');
+
+export interface PgIntegerConfig<
+	TEnum extends readonly number[] | undefined = readonly number[] | undefined,
+> {
+	enum?: TEnum;
+}
+
+export function integer<U extends number, T extends Readonly<[U, ...U[]]>>(
+	config?: PgIntegerConfig<T | Writable<T>>,
+): PgIntegerBuilder<Writable<T>>;
+export function integer<U extends number, T extends Readonly<[U, ...U[]]>>(
+	name: string,
+	config?: PgIntegerConfig<T | Writable<T>>,
+): PgIntegerBuilder<Writable<T>>;
+export function integer(a?: string | PgIntegerConfig, b: PgIntegerConfig = {}): PgIntegerBuilder {
+	const { name, config } = getColumnNameAndConfig<PgIntegerConfig>(a, b);
+	return new PgIntegerBuilder(name, config as any);
 }

--- a/drizzle-orm/src/sqlite-core/columns/integer.ts
+++ b/drizzle-orm/src/sqlite-core/columns/integer.ts
@@ -3,7 +3,7 @@ import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import { sql } from '~/sql/sql.ts';
 import type { OnConflict } from '~/sqlite-core/utils.ts';
-import { type Equal, getColumnNameAndConfig, type Or } from '~/utils.ts';
+import { type Equal, getColumnNameAndConfig, type Or, type Writable } from '~/utils.ts';
 import type { SQLiteTable } from '../table.ts';
 import { SQLiteColumn, SQLiteColumnBuilder } from './common.ts';
 
@@ -27,7 +27,9 @@ export abstract class SQLiteBaseIntegerBuilder<
 		this.config.autoIncrement = false;
 	}
 
-	override primaryKey(config?: PrimaryKeyConfig): IsPrimaryKey<HasDefault<NotNull<this>>> {
+	override primaryKey(
+		config?: PrimaryKeyConfig,
+	): IsPrimaryKey<HasDefault<NotNull<this>>> {
 		if (config?.autoIncrement) {
 			this.config.autoIncrement = true;
 		}
@@ -49,34 +51,49 @@ export abstract class SQLiteBaseInteger<
 	}
 }
 
-export class SQLiteIntegerBuilder extends SQLiteBaseIntegerBuilder<{
-	dataType: 'number int53';
-	data: number;
-	driverParam: number;
-}> {
+export class SQLiteIntegerBuilder<
+	TEnum extends [number, ...number[]] = [number, ...number[]],
+> extends SQLiteBaseIntegerBuilder<
+	{
+		dataType: 'number int53';
+		data: TEnum[number];
+		driverParam: number;
+		enumValues: TEnum;
+	},
+	{ enumValues: TEnum | undefined }
+> {
 	static override readonly [entityKind]: string = 'SQLiteIntegerBuilder';
 
-	constructor(name: string) {
+	constructor(name: string, config: IntegerConfig<'number', TEnum>) {
 		super(name, 'number int53', 'SQLiteInteger');
+		this.config.enumValues = config.enum;
 	}
 
 	override build(table: SQLiteTable) {
-		return new SQLiteInteger(
-			table,
-			this.config as any,
-		);
+		return new SQLiteInteger(table, this.config as any);
 	}
 }
 
-export class SQLiteInteger<T extends ColumnBaseConfig<'number int53'>> extends SQLiteBaseInteger<T> {
+export class SQLiteInteger<
+	T extends ColumnBaseConfig<'number int53'>,
+> extends SQLiteBaseInteger<T, { enumValues: T['enumValues'] }> {
 	static override readonly [entityKind]: string = 'SQLiteInteger';
+	override readonly enumValues;
+
+	constructor(table: SQLiteTable<any>, config: any, enumValues?: number[]) {
+		super(table, config);
+		this.enumValues = enumValues;
+	}
 }
 
-export class SQLiteTimestampBuilder extends SQLiteBaseIntegerBuilder<{
-	dataType: 'object date';
-	data: Date;
-	driverParam: number;
-}, { mode: 'timestamp' | 'timestamp_ms' }> {
+export class SQLiteTimestampBuilder extends SQLiteBaseIntegerBuilder<
+	{
+		dataType: 'object date';
+		data: Date;
+		driverParam: number;
+	},
+	{ mode: 'timestamp' | 'timestamp_ms' }
+> {
 	static override readonly [entityKind]: string = 'SQLiteTimestampBuilder';
 
 	constructor(name: string, mode: 'timestamp' | 'timestamp_ms') {
@@ -90,20 +107,19 @@ export class SQLiteTimestampBuilder extends SQLiteBaseIntegerBuilder<{
 	 * Adds `DEFAULT (cast((julianday('now') - 2440587.5)*86400000 as integer))` to the column, which is the current epoch timestamp in milliseconds.
 	 */
 	defaultNow(): HasDefault<this> {
-		return this.default(sql`(cast((julianday('now') - 2440587.5)*86400000 as integer))`) as any;
+		return this.default(
+			sql`(cast((julianday('now') - 2440587.5)*86400000 as integer))`,
+		) as any;
 	}
 
 	override build(table: SQLiteTable) {
-		return new SQLiteTimestamp(
-			table,
-			this.config as any,
-		);
+		return new SQLiteTimestamp(table, this.config as any);
 	}
 }
 
-export class SQLiteTimestamp<T extends ColumnBaseConfig<'object date'>>
-	extends SQLiteBaseInteger<T, { mode: 'timestamp' | 'timestamp_ms' }>
-{
+export class SQLiteTimestamp<
+	T extends ColumnBaseConfig<'object date'>,
+> extends SQLiteBaseInteger<T, { mode: 'timestamp' | 'timestamp_ms' }> {
 	static override readonly [entityKind]: string = 'SQLiteTimestamp';
 
 	readonly mode: 'timestamp' | 'timestamp_ms' = this.config.mode;
@@ -125,11 +141,14 @@ export class SQLiteTimestamp<T extends ColumnBaseConfig<'object date'>>
 	}
 }
 
-export class SQLiteBooleanBuilder extends SQLiteBaseIntegerBuilder<{
-	dataType: 'boolean';
-	data: boolean;
-	driverParam: number;
-}, { mode: 'boolean' }> {
+export class SQLiteBooleanBuilder extends SQLiteBaseIntegerBuilder<
+	{
+		dataType: 'boolean';
+		data: boolean;
+		driverParam: number;
+	},
+	{ mode: 'boolean' }
+> {
 	static override readonly [entityKind]: string = 'SQLiteBooleanBuilder';
 
 	constructor(name: string, mode: 'boolean') {
@@ -138,14 +157,13 @@ export class SQLiteBooleanBuilder extends SQLiteBaseIntegerBuilder<{
 	}
 
 	override build(table: SQLiteTable) {
-		return new SQLiteBoolean(
-			table,
-			this.config as any,
-		);
+		return new SQLiteBoolean(table, this.config as any);
 	}
 }
 
-export class SQLiteBoolean<T extends ColumnBaseConfig<'boolean'>> extends SQLiteBaseInteger<T, { mode: 'boolean' }> {
+export class SQLiteBoolean<
+	T extends ColumnBaseConfig<'boolean'>,
+> extends SQLiteBaseInteger<T, { mode: 'boolean' }> {
 	static override readonly [entityKind]: string = 'SQLiteBoolean';
 
 	readonly mode: 'boolean' = this.config.mode;
@@ -159,36 +177,53 @@ export class SQLiteBoolean<T extends ColumnBaseConfig<'boolean'>> extends SQLite
 	}
 }
 
-export interface IntegerConfig<
+export type IntegerConfig<
 	TMode extends 'number' | 'timestamp' | 'timestamp_ms' | 'boolean' =
 		| 'number'
 		| 'timestamp'
 		| 'timestamp_ms'
 		| 'boolean',
-> {
-	mode: TMode;
-}
+	TEnum extends readonly number[] | undefined = readonly number[] | undefined,
+> = TMode extends 'number' ? {
+		mode: TMode;
+		enum?: TEnum;
+	}
+	: {
+		mode: TMode;
+	};
 
-export function integer<TMode extends IntegerConfig['mode']>(
-	config?: IntegerConfig<TMode>,
+export function integer<
+	TMode extends IntegerConfig['mode'],
+	U extends number,
+	T extends Readonly<[U, ...U[]]>,
+>(
+	config?: IntegerConfig<TMode, T | Writable<T>>,
 ): Or<Equal<TMode, 'timestamp'>, Equal<TMode, 'timestamp_ms'>> extends true ? SQLiteTimestampBuilder
 	: Equal<TMode, 'boolean'> extends true ? SQLiteBooleanBuilder
-	: SQLiteIntegerBuilder;
-export function integer<TMode extends IntegerConfig['mode']>(
+	: SQLiteIntegerBuilder<Writable<T>>;
+export function integer<
+	TMode extends IntegerConfig['mode'],
+	U extends number,
+	T extends Readonly<[U, ...U[]]>,
+>(
 	name: string,
-	config?: IntegerConfig<TMode>,
+	config?: IntegerConfig<TMode, T | Writable<T>>,
 ): Or<Equal<TMode, 'timestamp'>, Equal<TMode, 'timestamp_ms'>> extends true ? SQLiteTimestampBuilder
 	: Equal<TMode, 'boolean'> extends true ? SQLiteBooleanBuilder
-	: SQLiteIntegerBuilder;
+	: SQLiteIntegerBuilder<Writable<T>>;
 export function integer(a?: string | IntegerConfig, b?: IntegerConfig) {
-	const { name, config } = getColumnNameAndConfig<IntegerConfig | undefined>(a, b);
+	const { name, config } = getColumnNameAndConfig<IntegerConfig | undefined>(
+		a,
+		b,
+	);
 	if (config?.mode === 'timestamp' || config?.mode === 'timestamp_ms') {
 		return new SQLiteTimestampBuilder(name, config.mode);
 	}
 	if (config?.mode === 'boolean') {
 		return new SQLiteBooleanBuilder(name, config.mode);
 	}
-	return new SQLiteIntegerBuilder(name);
+	return new SQLiteIntegerBuilder(
+		name,
+		config as any,
+	) as SQLiteIntegerBuilder<any>;
 }
-
-export const int = integer;

--- a/drizzle-orm/type-tests/pg/tables.ts
+++ b/drizzle-orm/type-tests/pg/tables.ts
@@ -1475,3 +1475,24 @@ await db.refreshMaterializedView(newYorkers2).withNoData().concurrently();
 
 	Expect<Equal<{ enum: Role | null }[], typeof schemaRes>>;
 }
+
+{
+	const table = pgTable('test_enum', {
+		stockWithEnum: integer('stock', { enum: [1, 2, 3, 4, 5] as const }),
+		stockWithoutEnum: integer('stock2'),
+		varcharWithEnum: varchar('varchar', { enum: ['a', 'b', 'c'] as const }),
+	});
+
+	type SelectType = typeof table.$inferSelect;
+	Expect<Equal<SelectType['stockWithEnum'], 1 | 2 | 3 | 4 | 5 | null>>;
+	Expect<Equal<SelectType['stockWithoutEnum'], number | null>>;
+	Expect<Equal<SelectType['varcharWithEnum'], 'a' | 'b' | 'c' | null>>;
+
+	type IntegerEnumValues = typeof table.stockWithEnum._.enumValues;
+	type IntegerNoEnumValues = typeof table.stockWithoutEnum._.enumValues;
+	type VarcharEnumValues = typeof table.varcharWithEnum._.enumValues;
+
+	Expect<Equal<IntegerEnumValues, [1, 2, 3, 4, 5]>>;
+	Expect<Equal<IntegerNoEnumValues, [number, ...number[]]>>;
+	Expect<Equal<VarcharEnumValues, ['a', 'b', 'c']>>;
+}

--- a/drizzle-orm/type-tests/sqlite/tables.ts
+++ b/drizzle-orm/type-tests/sqlite/tables.ts
@@ -582,3 +582,20 @@ Expect<
 		textdef: text().default(''),
 	});
 }
+
+{
+	const table = sqliteTable('test_enum', {
+		stockWithEnum: integer('stock', { mode: 'number', enum: [1, 2, 3, 4, 5] }),
+		stockWithoutEnum: integer('stock2'),
+	});
+
+	type SelectType = typeof table.$inferSelect;
+	Expect<Equal<SelectType['stockWithEnum'], 1 | 2 | 3 | 4 | 5 | null>>;
+	Expect<Equal<SelectType['stockWithoutEnum'], number | null>>;
+
+	type IntegerEnumValues = typeof table.stockWithEnum._.enumValues;
+	type IntegerNoEnumValues = typeof table.stockWithoutEnum._.enumValues;
+
+	Expect<Equal<IntegerEnumValues, [1, 2, 3, 4, 5]>>;
+	Expect<Equal<IntegerNoEnumValues, [number, ...number[]]>>;
+}

--- a/drizzle-seed/package.json
+++ b/drizzle-seed/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drizzle-seed",
-	"version": "1.0.0-beta.2",
+	"version": "1.0.0-beta.4",
 	"main": "index.cjs",
 	"module": "index.mjs",
 	"type": "module",

--- a/drizzle-seed/package.json
+++ b/drizzle-seed/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "drizzle-seed",
-	"version": "1.0.0-beta.4",
-	"main": "index.js",
+	"version": "1.0.0-beta.2",
+	"main": "index.cjs",
+	"module": "index.mjs",
 	"type": "module",
 	"scripts": {
 		"build": "tsc -p ./tsconfig.json && tsx scripts/build.ts",

--- a/drizzle-seed/src/types/tables.ts
+++ b/drizzle-seed/src/types/tables.ts
@@ -26,7 +26,7 @@ export type Column = {
 	size?: number;
 	default?: any;
 	hasDefault: boolean;
-	enumValues?: string[];
+	enumValues?: string[] | number[];
 	isUnique: boolean;
 	notNull: boolean;
 	primary: boolean;

--- a/drizzle-typebox/src/column.ts
+++ b/drizzle-typebox/src/column.ts
@@ -19,7 +19,7 @@ export const jsonSchema: JsonSchema = t.Union([literalSchema, t.Array(t.Any()), 
 TypeRegistry.Set('Buffer', (_, value) => value instanceof Buffer);
 export const bufferSchema: BufferSchema = { [Kind]: 'Buffer', type: 'buffer' } as any;
 
-export function mapEnumValues(values: string[]) {
+export function mapEnumValues(values: string[] | number[]) {
 	return Object.fromEntries(values.map((value) => [value, value]));
 }
 

--- a/drizzle-valibot/src/column.ts
+++ b/drizzle-valibot/src/column.ts
@@ -21,7 +21,7 @@ export const jsonSchema: v.GenericSchema<Json> = v.union([
 ]);
 export const bufferSchema: v.GenericSchema<Buffer> = v.custom<Buffer>((v) => v instanceof Buffer);
 
-export function mapEnumValues(values: string[]) {
+export function mapEnumValues(values: string[] | number[]) {
 	return Object.fromEntries(values.map((value) => [value, value]));
 }
 

--- a/drizzle-valibot/src/column.types.ts
+++ b/drizzle-valibot/src/column.types.ts
@@ -46,7 +46,7 @@ export type GetValibotType<
 	TData,
 	TColumnType extends ColumnDataType,
 	TConstraint extends ColumnDataConstraint | undefined,
-	TEnum extends string[] | undefined,
+	TEnum extends string[] | number[] | undefined,
 	TBaseColumn extends Column | undefined,
 	TAdditionalProperties extends Record<string, any>,
 > = TColumnType extends 'array'


### PR DESCRIPTION
# Summary
Closes #4138

This PR implements enum value support for PostgreSQL integer columns, following the same pattern as existing text and varchar enum support.

```ts
import { pgTable, integer, serial } from 'drizzle-orm/pg-core';
const ratingsTable = pgTable('ratings', {
  id: serial('id').primaryKey(),
  rating: integer('rating', { enum: [1, 2, 3, 4, 5] as const }),
});

await db.insert(ratingsTable).values({
  id: 1,
  rating: 5,  // ✅
});

await db.insert(ratingsTable).values({
  id: 2,
  rating: 6,  // ❌ Type '6' is not assignable to type '1 | 2 | 3 | 4 | 5'
});
```