### PR TITLE
[drizzle-valibot] include generatedAlwaysAs columns in select schemas

### DIFF
--- a/drizzle-valibot/src/schema.types.internal.ts
+++ b/drizzle-valibot/src/schema.types.internal.ts
@@ -54,7 +54,7 @@ export type BuildSchema<
 > = v.ObjectSchema<
 	Simplify<
 		{
-			readonly [K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? never : K]:
+			readonly [K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? TType extends 'select' ? K : never : K]:
 				TColumns[K] extends infer TColumn extends Column
 					? IsRefinementDefined<TRefinements, Assume<K, string>> extends true
 						? Assume<HandleRefinement<TType, TRefinements[K & keyof TRefinements], TColumn>, v.GenericSchema>

--- a/drizzle-valibot/tests/mysql.test.ts
+++ b/drizzle-valibot/tests/mysql.test.ts
@@ -25,11 +25,12 @@ const textSchema = v.pipe(v.string(), v.maxLength(CONSTANTS.INT16_UNSIGNED_MAX a
 test('table - select', (t) => {
 	const table = mysqlTable('test', {
 		id: serial().primaryKey(),
+		generated: int().generatedAlwaysAs(1).notNull(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = v.object({ id: serialNumberModeSchema, name: textSchema });
+	const expected = v.object({ id: serialNumberModeSchema, generated: intSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });

--- a/drizzle-valibot/tests/pg.test.ts
+++ b/drizzle-valibot/tests/pg.test.ts
@@ -26,11 +26,12 @@ const textSchema = v.string();
 test('table - select', (t) => {
 	const table = pgTable('test', {
 		id: serial().primaryKey(),
+		generated: integer().generatedAlwaysAsIdentity(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = v.object({ id: integerSchema, name: textSchema });
+	const expected = v.object({ id: integerSchema, generated: integerSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });

--- a/drizzle-valibot/tests/singlestore.test.ts
+++ b/drizzle-valibot/tests/singlestore.test.ts
@@ -25,11 +25,12 @@ const textSchema = v.pipe(v.string(), v.maxLength(CONSTANTS.INT16_UNSIGNED_MAX a
 test('table - select', (t) => {
 	const table = singlestoreTable('test', {
 		id: serial().primaryKey(),
+		generated: int().generatedAlwaysAs(1).notNull(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = v.object({ id: serialNumberModeSchema, name: textSchema });
+	const expected = v.object({ id: serialNumberModeSchema, generated: intSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });

--- a/drizzle-valibot/tests/sqlite.test.ts
+++ b/drizzle-valibot/tests/sqlite.test.ts
@@ -19,11 +19,12 @@ const textSchema = v.string();
 test('table - select', (t) => {
 	const table = sqliteTable('test', {
 		id: int().primaryKey({ autoIncrement: true }),
+		generated: int().generatedAlwaysAs(1).notNull(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = v.object({ id: intSchema, name: textSchema });
+	const expected = v.object({ id: intSchema, generated: intSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });


### PR DESCRIPTION
Updates the schema generation logic to include 'generatedAlwaysAs' columns in select schemas. Previously, these columns were incorrectly excluded, leading to incomplete schemas for select operations where these generated values are always present.

Close [#4556](https://github.com/drizzle-team/drizzle-orm/issues/4556).

Duplicated to [#4592](https://github.com/drizzle-team/drizzle-orm/pull/4592)

related to [#4553](https://github.com/drizzle-team/drizzle-orm/issues/4553), [#4554](https://github.com/drizzle-team/drizzle-orm/pull/4554).

big thanks to @valerii15298