### PR TITLE
[SQLite, Pg, MySQL]: Fix RQBv2 findFirst null handling when no results found

### DIFF
--- a/drizzle-orm/src/bun-sql/mysql/session.ts
+++ b/drizzle-orm/src/bun-sql/mysql/session.ts
@@ -126,6 +126,8 @@ export class BunMySqlPreparedQuery<T extends MySqlPreparedQueryConfig, TIsRqbV2 
 		const { client, query, customResultMapper } = this;
 		const rows = await client.unsafe(query, params);
 
+		if (!rows[0]) return;
+
 		return (customResultMapper as (rows: Record<string, unknown>[]) => T['execute'])(rows);
 	}
 

--- a/drizzle-orm/src/bun-sql/postgres/session.ts
+++ b/drizzle-orm/src/bun-sql/postgres/session.ts
@@ -106,6 +106,8 @@ export class BunSQLPreparedQuery<T extends PreparedQueryConfig, TIsRqbV2 extends
 				return client.unsafe(query, params as any[]);
 			});
 
+			if (!rows[0]) return;
+
 			return tracer.startActiveSpan('drizzle.mapResponse', () => {
 				return (customResultMapper as (rows: Record<string, unknown>[]) => T['execute'])(rows);
 			});

--- a/drizzle-orm/src/bun-sql/sqlite/session.ts
+++ b/drizzle-orm/src/bun-sql/sqlite/session.ts
@@ -292,7 +292,7 @@ export class BunSQLitePreparedQuery<
 		const rows = await client.unsafe(query.sql, params);
 		const row = rows[0];
 
-		if (row === undefined) return row;
+		if (!row) return;
 
 		return (customResultMapper as (
 			rows: unknown[][],

--- a/drizzle-orm/src/bun-sqlite/session.ts
+++ b/drizzle-orm/src/bun-sqlite/session.ts
@@ -220,7 +220,7 @@ export class PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig, 
 		const { stmt, customResultMapper } = this;
 
 		const row = stmt.get(...params) as Record<string, unknown>;
-		if (row === undefined) return row;
+		if (!row) return;
 
 		return (customResultMapper as (rows: Record<string, unknown>[]) => unknown)(
 			[row],


### PR DESCRIPTION
Fix RQBv2 findFirst null handling when no results found

When findFirst returns no results, Bun's database drivers return null instead of undefined. The existing code only checked for undefined, causing null values to be passed to mapRelationalRow, which resulted in TypeError when accessing properties of null.

Fixes https://github.com/drizzle-team/drizzle-orm/issues/5189