### PR TITLE
fix(drizzle-zod): use dataType for Buffer type detection

### DIFF
--- a/drizzle-zod/src/column.types.ts
+++ b/drizzle-zod/src/column.types.ts
@@ -19,7 +19,7 @@ export type GetZodType<
 	: TColumn['_']['columnType'] extends 'PgGeometry' | 'PgPointTuple' ? z.ZodTuple<[z.ZodNumber, z.ZodNumber], null>
 	: TColumn['_']['columnType'] extends 'PgLine' ? z.ZodTuple<[z.ZodNumber, z.ZodNumber, z.ZodNumber], null>
 	: TColumn['_']['data'] extends Date ? CanCoerce<TCoerce, 'date'> extends true ? z.coerce.ZodCoercedDate : z.ZodDate
-	: TColumn['_']['data'] extends Buffer ? z.ZodType<Buffer>
+	: TColumn['_']['dataType'] extends 'buffer' ? z.ZodType<Buffer>
 	: TColumn['_']['dataType'] extends 'array'
 		? z.ZodArray<GetZodPrimitiveType<Assume<TColumn['_']['data'], any[]>[number], '', TCoerce>>
 	: TColumn['_']['data'] extends Record<string, any>


### PR DESCRIPTION
Closes #4705

## Problem
The type-level condition `TColumn['_']['data'] extends Buffer` can produce false positives in environments where the `Buffer` type is declared differently (e.g. Cloudflare Workers), causing non-buffer columns to be inferred as `Buffer`.

## Solution
Switch the check to `TColumn['_']['dataType'] extends 'buffer'` to match the runtime logic that treats `dataType === 'buffer'` as a Buffer column.

## Testing
- All existing tests pass (70 tests)
- Type tests pass

## Acknowledgments
Thanks to @stefnba for testing and confirming this fix works in a Hono + React (Vite) setup:
https://github.com/drizzle-team/drizzle-orm/issues/4705#issuecomment-2543891610

---

> **Note**: The beta branch addresses this with a different approach (`TType['constraint']`). This PR keeps the 0.8.x line aligned with the runtime behavior.