### PR TITLE
feat(pg): add materialized view dependsOn ordering

### DIFF
--- a/drizzle-kit/src/jsonStatements.ts
+++ b/drizzle-kit/src/jsonStatements.ts
@@ -3371,8 +3371,9 @@ export const preparePgCreateViewJson = (
 	withOption?: any,
 	using?: string,
 	tablespace?: string,
+	dependsOn?: string[],
 ): JsonCreatePgViewStatement => {
-	return {
+	const statement: JsonCreatePgViewStatement = {
 		type: 'create_view',
 		name: name,
 		schema: schema,
@@ -3383,6 +3384,10 @@ export const preparePgCreateViewJson = (
 		using,
 		tablespace,
 	};
+	if (dependsOn && dependsOn.length > 0) {
+		statement.dependsOn = dependsOn;
+	}
+	return statement;
 };
 
 export const prepareMySqlCreateViewJson = (

--- a/drizzle-kit/src/serializer/pgSchema.ts
+++ b/drizzle-kit/src/serializer/pgSchema.ts
@@ -287,6 +287,7 @@ export const view = object({
 	withNoData: boolean().optional(),
 	using: string().optional(),
 	tablespace: string().optional(),
+	dependsOn: array(string()).optional(),
 }).strict();
 
 const tableV4 = object({

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -715,11 +715,12 @@ export const generatePgSnapshot = (
 		let using;
 		let withNoData;
 		let materialized: boolean = false;
+		let dependsOn: string[] | undefined;
 
 		if (is(view, PgView)) {
 			({ name: viewName, schema, query, selectedFields, isExisting, with: withOption } = getViewConfig(view));
 		} else {
-			({ name: viewName, schema, query, selectedFields, isExisting, with: withOption, tablespace, using, withNoData } =
+			({ name: viewName, schema, query, selectedFields, isExisting, with: withOption, tablespace, using, withNoData, dependsOn } =
 				getMaterializedViewConfig(view));
 
 			materialized = true;
@@ -866,6 +867,7 @@ export const generatePgSnapshot = (
 			materialized,
 			tablespace,
 			using,
+			dependsOn,
 		};
 	}
 


### PR DESCRIPTION
## Summary
  - Add `.dependsOn()` to `pgMaterializedView` to capture view dependencies.
  - Persist `dependsOn` in snapshots/serialization for PG views.
  - Order CREATE/DROP view statements topologically and recreate dependent views when a base view changes.

  ## Usage
  ```ts
  const baseView = pgMaterializedView('base_view', { id: integer('id') }).as(sql`SELECT "id" FROM ${users}`);
  const aggView = pgMaterializedView('agg_view', { id: integer('id') })
    .dependsOn(baseView)
    .as(sql`SELECT "id" FROM "base_view"`);
```
  ## Tests
```
   ✓ create materialized views in dependency order 1ms
   ✓ drop materialized views in dependency order 1ms
   ✓ recreate dependent materialized views when base changes 2ms
```
  Fixes drizzle-team/drizzle-orm#4520
