### PR TITLE
Run PG migrations in separate transactions

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -92,8 +92,8 @@ export class PgDialect {
 		);
 
 		const lastDbMigration = dbMigrations[0];
-		await session.transaction(async (tx) => {
-			for await (const migration of migrations) {
+		for await (const migration of migrations) {
+			await session.transaction(async (tx) => {
 				if (
 					!lastDbMigration
 					|| Number(lastDbMigration.created_at) < migration.folderMillis
@@ -107,8 +107,8 @@ export class PgDialect {
 						} ("hash", "created_at") values(${migration.hash}, ${migration.folderMillis})`,
 					);
 				}
-			}
-		});
+			});
+		}
 	}
 
 	escapeName(name: string): string {


### PR DESCRIPTION
Some migrations have to happen in different transactions, like adding enums and then using them.

This makes every migration run in its own transaction, allowing them each to be atomic.

Fixes #3249
Fixes #3466