### PR TITLE
Beta: fix non-UTC year being used in UTC timestamp

### DIFF
--- a/drizzle-kit/src/cli/commands/generate-common.ts
+++ b/drizzle-kit/src/cli/commands/generate-common.ts
@@ -116,7 +116,7 @@ export const embeddedMigrations = (snapshots: string[], driver?: Driver) => {
 
 export const prepareSnapshotFolderName = (ms?: number) => {
 	const now = ms ? new Date(ms) : new Date();
-	return `${now.getFullYear()}${two(now.getUTCMonth() + 1)}${
+	return `${now.getUTCFullYear()}${two(now.getUTCMonth() + 1)}${
 		two(
 			now.getUTCDate(),
 		)


### PR DESCRIPTION
I generated a migration before midnight in my timezone on Dec 31 and noticed that drizzle-kit generated a migration timestamped before my other migrations with the prefix 20250101. This happened because even though it was 2025 in my timezone, it was 2026 in UTC time, and `prepareSnapshotFolderName` uses `getFullYear` when it should use `getUTCFullYear`. This PR fixes that.

Example: `prepareSnapshotFolderName(1767243310815)`
Returned: `'20250101045510'`
Expected: `'20260101045510'`