### PR TITLE
fix(drizzle-zod): apply ZodOptional for insert schema refinements on nullable/default columns

### DIFF
--- a/drizzle-zod/src/schema.types.internal.ts
+++ b/drizzle-zod/src/schema.types.internal.ts
@@ -26,7 +26,12 @@ type HandleRefinement<
 	TColumn extends Column,
 > = TRefinement extends (schema: any) => z.ZodType ? (TColumn['_']['notNull'] extends true ? ReturnType<TRefinement>
 		: z.ZodNullable<ReturnType<TRefinement>>) extends infer TSchema extends z.ZodType
-		? TType extends 'update' ? z.ZodOptional<TSchema> : TSchema
+		? TType extends 'update' ? z.ZodOptional<TSchema>
+		: TType extends 'insert'
+			? TColumn['_']['notNull'] extends true
+				? TColumn['_']['hasDefault'] extends true ? z.ZodOptional<TSchema> : TSchema
+				: z.ZodOptional<TSchema>
+			: TSchema
 	: z.ZodType
 	: TRefinement;
 


### PR DESCRIPTION
## Problem

When using function refinements in `createInsertSchema`, the type inference was not correctly applying `ZodOptional` for:
- Nullable columns (should be optional since they can be omitted)
- NotNull columns with defaults (should be optional since defaults will be used)

This caused a type mismatch where the inferred type was `string | null` but the runtime schema correctly produced `string | null | undefined`.

### Example

```typescript
const blogPost = pgTable("blog_post", {
  id: uuid("id").primaryKey().defaultRandom(),
  title: text("title").notNull(),
  metaTitle: text("meta_title"), // nullable, no default
});

const insertSchema = createInsertSchema(blogPost, {
  metaTitle: (schema) => schema.max(60, "Too long"),
});

// Before fix: metaTitle inferred as `string | null` (missing undefined)
// After fix: metaTitle inferred as `string | null | undefined`
```

## Solution

The fix aligns `HandleRefinement` type with `HandleInsertColumn` logic:
- For nullable columns: `z.ZodOptional<z.ZodNullable<TSchema>>`
- For notNull with default: `z.ZodOptional<TSchema>`
- For notNull without default: `TSchema` (required)

## Changes

- Updated `HandleRefinement` type in `drizzle-zod/src/schema.types.internal.ts`

## Testing

All 70 existing drizzle-zod tests pass.