### PR TITLE
[SQLite]: Fix imports for sqlite migrator

### DIFF
--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -1,7 +1,7 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { SQLiteCloudRowset } from '@sqlitecloud/drivers';
 import type { AwsDataApiPgQueryResult, AwsDataApiSessionOptions } from 'drizzle-orm/aws-data-api/pg';
-import type { MigrationConfig, MigratorInitFailResponse } from 'drizzle-orm/migrator';
+import type { MigrationConfig, MigratorInitFailResponse } from 'drizzle-orm/migrator-utils';
 import type { PreparedQueryConfig } from 'drizzle-orm/pg-core';
 import type { config } from 'mssql';
 import type { Connection, ConnectionConfig, Query } from 'mysql2';

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -5,7 +5,7 @@ import { mkdirSync } from 'fs';
 import { renderWithTask } from 'hanji';
 import { dialects } from 'src/utils/schemaValidator';
 import '../@types/utils';
-import type { MigrationConfig, MigratorInitFailResponse } from 'drizzle-orm/migrator';
+import type { MigrationConfig, MigratorInitFailResponse } from 'drizzle-orm/migrator-utils';
 import { assertUnreachable } from '../utils';
 import { assertV3OutFolder } from '../utils/utils-node';
 import { checkHandler } from './commands/check';

--- a/drizzle-orm/src/aws-data-api/pg/migrator.ts
+++ b/drizzle-orm/src/aws-data-api/pg/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { AwsDataApiPgDatabase } from './driver.ts';

--- a/drizzle-orm/src/better-sqlite3/migrator.ts
+++ b/drizzle-orm/src/better-sqlite3/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { BetterSQLite3Database } from './driver.ts';

--- a/drizzle-orm/src/bun-sql/migrator.ts
+++ b/drizzle-orm/src/bun-sql/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { BunMySqlDatabase } from './mysql/driver.ts';
 import { migrate as mysqlMigrator } from './mysql/migrator.ts';

--- a/drizzle-orm/src/bun-sql/mysql/migrator.ts
+++ b/drizzle-orm/src/bun-sql/mysql/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { BunMySqlDatabase } from './driver.ts';

--- a/drizzle-orm/src/bun-sql/postgres/migrator.ts
+++ b/drizzle-orm/src/bun-sql/postgres/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { BunSQLDatabase } from './driver.ts';

--- a/drizzle-orm/src/bun-sql/sqlite/migrator.ts
+++ b/drizzle-orm/src/bun-sql/sqlite/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { BunSQLiteDatabase } from './driver.ts';

--- a/drizzle-orm/src/bun-sqlite/migrator.ts
+++ b/drizzle-orm/src/bun-sqlite/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations, EmptyRelations } from '~/relations.ts';
 import type { SQLiteBunDatabase } from './driver.ts';

--- a/drizzle-orm/src/cockroach-core/dialect.ts
+++ b/drizzle-orm/src/cockroach-core/dialect.ts
@@ -20,7 +20,7 @@ import { CockroachTable } from '~/cockroach-core/table.ts';
 import { Column } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
-import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import { and, eq, View } from '~/sql/index.ts';
 import { type Name, Param, type QueryWithTypings, SQL, sql, type SQLChunk } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';

--- a/drizzle-orm/src/cockroach/migrator.ts
+++ b/drizzle-orm/src/cockroach/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { NodeCockroachDatabase } from './driver.ts';
 

--- a/drizzle-orm/src/d1/migrator.ts
+++ b/drizzle-orm/src/d1/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';

--- a/drizzle-orm/src/durable-sqlite/migrator.ts
+++ b/drizzle-orm/src/durable-sqlite/migrator.ts
@@ -1,4 +1,4 @@
-import { formatToMillis, type MigrationMeta, type MigratorInitFailResponse } from '~/migrator.ts';
+import { formatToMillis, type MigrationMeta, type MigratorInitFailResponse } from '~/migrator-utils.ts';
 import type { AnyRelations } from '~/relations.ts';
 import { sql } from '~/sql/index.ts';
 import type { DrizzleSqliteDODatabase } from './driver.ts';

--- a/drizzle-orm/src/expo-sqlite/migrator.ts
+++ b/drizzle-orm/src/expo-sqlite/migrator.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import { formatToMillis, type MigrationMeta } from '~/migrator.ts';
+import { formatToMillis, type MigrationMeta } from '~/migrator-utils.ts';
 import type { AnyRelations, EmptyRelations } from '~/relations.ts';
 import type { ExpoSQLiteDatabase } from './driver.ts';
 

--- a/drizzle-orm/src/libsql/migrator.ts
+++ b/drizzle-orm/src/libsql/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';

--- a/drizzle-orm/src/migrator-utils.ts
+++ b/drizzle-orm/src/migrator-utils.ts
@@ -1,0 +1,40 @@
+export interface KitConfig {
+	out: string;
+	schema: string;
+}
+
+export interface MigrationConfig {
+	migrationsFolder: string;
+	migrationsTable?: string;
+	migrationsSchema?: string;
+	/** @internal */
+	init?: boolean;
+}
+
+export interface MigrationMeta {
+	sql: string[];
+	folderMillis: number;
+	hash: string;
+	bps: boolean;
+}
+
+/** Only gets returned if migrator failed with `init: true` used by `drizzle-kit pull --init`*/
+export interface MigratorInitFailResponse {
+	exitCode: 'databaseMigrations' | 'localMigrations';
+}
+
+/** Only gets returned if migrator failed with `init: true` used by `drizzle-kit pull --init`*/
+export interface MigratorInitFailResponse {
+	exitCode: 'databaseMigrations' | 'localMigrations';
+}
+
+export function formatToMillis(dateStr: string): number {
+	const year = parseInt(dateStr.slice(0, 4), 10);
+	const month = parseInt(dateStr.slice(4, 6), 10) - 1;
+	const day = parseInt(dateStr.slice(6, 8), 10);
+	const hour = parseInt(dateStr.slice(8, 10), 10);
+	const minute = parseInt(dateStr.slice(10, 12), 10);
+	const second = parseInt(dateStr.slice(12, 14), 10);
+
+	return Date.UTC(year, month, day, hour, minute, second);
+}

--- a/drizzle-orm/src/migrator.ts
+++ b/drizzle-orm/src/migrator.ts
@@ -1,47 +1,7 @@
 import crypto from 'node:crypto';
 import fs, { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-
-export interface KitConfig {
-	out: string;
-	schema: string;
-}
-
-export interface MigrationConfig {
-	migrationsFolder: string;
-	migrationsTable?: string;
-	migrationsSchema?: string;
-	/** @internal */
-	init?: boolean;
-}
-
-export interface MigrationMeta {
-	sql: string[];
-	folderMillis: number;
-	hash: string;
-	bps: boolean;
-}
-
-/** Only gets returned if migrator failed with `init: true` used by `drizzle-kit pull --init`*/
-export interface MigratorInitFailResponse {
-	exitCode: 'databaseMigrations' | 'localMigrations';
-}
-
-/** Only gets returned if migrator failed with `init: true` used by `drizzle-kit pull --init`*/
-export interface MigratorInitFailResponse {
-	exitCode: 'databaseMigrations' | 'localMigrations';
-}
-
-export function formatToMillis(dateStr: string): number {
-	const year = parseInt(dateStr.slice(0, 4), 10);
-	const month = parseInt(dateStr.slice(4, 6), 10) - 1;
-	const day = parseInt(dateStr.slice(6, 8), 10);
-	const hour = parseInt(dateStr.slice(8, 10), 10);
-	const minute = parseInt(dateStr.slice(10, 12), 10);
-	const second = parseInt(dateStr.slice(12, 14), 10);
-
-	return Date.UTC(year, month, day, hour, minute, second);
-}
+import { formatToMillis, type MigrationConfig, type MigrationMeta } from './migrator-utils.ts';
 
 function readMigrationFilesOLD(config: MigrationConfig): MigrationMeta[] {
 	const migrationFolderTo = config.migrationsFolder;

--- a/drizzle-orm/src/mssql-core/dialect.ts
+++ b/drizzle-orm/src/mssql-core/dialect.ts
@@ -9,7 +9,7 @@ import {
 import { CasingCache } from '~/casing.ts';
 import { Column } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
-import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import { Param, type QueryWithTypings, SQL, sql, type SQLChunk, View } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -10,7 +10,7 @@ import { CasingCache } from '~/casing.ts';
 import { Column } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
-import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import type {
 	AnyOne,
 	BuildRelationalQueryResult,

--- a/drizzle-orm/src/mysql-proxy/migrator.ts
+++ b/drizzle-orm/src/mysql-proxy/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';

--- a/drizzle-orm/src/mysql2/migrator.ts
+++ b/drizzle-orm/src/mysql2/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { MySql2Database } from './driver.ts';

--- a/drizzle-orm/src/neon-http/migrator.ts
+++ b/drizzle-orm/src/neon-http/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import { type SQL, sql } from '~/sql/sql.ts';

--- a/drizzle-orm/src/neon-serverless/migrator.ts
+++ b/drizzle-orm/src/neon-serverless/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { NeonDatabase } from './driver.ts';

--- a/drizzle-orm/src/node-mssql/migrator.ts
+++ b/drizzle-orm/src/node-mssql/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { NodeMsSqlDatabase } from './driver.ts';
 

--- a/drizzle-orm/src/node-postgres/migrator.ts
+++ b/drizzle-orm/src/node-postgres/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { NodePgDatabase } from './driver.ts';

--- a/drizzle-orm/src/op-sqlite/migrator.ts
+++ b/drizzle-orm/src/op-sqlite/migrator.ts
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import { formatToMillis, type MigrationMeta } from '~/migrator.ts';
+import { formatToMillis, type MigrationMeta } from '~/migrator-utils.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { OPSQLiteDatabase } from './driver.ts';
 

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -10,7 +10,7 @@ import { CasingCache } from '~/casing.ts';
 import { Column } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
-import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import {
 	PgArray,
 	PgColumn,

--- a/drizzle-orm/src/pg-proxy/migrator.ts
+++ b/drizzle-orm/src/pg-proxy/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';

--- a/drizzle-orm/src/pglite/migrator.ts
+++ b/drizzle-orm/src/pglite/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { PgliteDatabase } from './driver.ts';

--- a/drizzle-orm/src/planetscale-serverless/migrator.ts
+++ b/drizzle-orm/src/planetscale-serverless/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { PlanetScaleDatabase } from './driver.ts';

--- a/drizzle-orm/src/postgres-js/migrator.ts
+++ b/drizzle-orm/src/postgres-js/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { PostgresJsDatabase } from './driver.ts';

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -10,7 +10,7 @@ import { CasingCache } from '~/casing.ts';
 import { Column } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
-import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import type {
 	AnyOne,
 	BuildRelationalQueryResult,

--- a/drizzle-orm/src/singlestore-proxy/migrator.ts
+++ b/drizzle-orm/src/singlestore-proxy/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';

--- a/drizzle-orm/src/singlestore/migrator.ts
+++ b/drizzle-orm/src/singlestore/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { SingleStoreDriverDatabase } from './driver.ts';

--- a/drizzle-orm/src/sql-js/migrator.ts
+++ b/drizzle-orm/src/sql-js/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations, EmptyRelations } from '~/relations.ts';
 import type { SQLJsDatabase } from './driver.ts';

--- a/drizzle-orm/src/sqlite-cloud/migrator.ts
+++ b/drizzle-orm/src/sqlite-cloud/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import { type SQL, sql } from '~/sql/sql.ts';

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -11,7 +11,7 @@ import type { AnyColumn } from '~/column.ts';
 import { Column } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
-import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator.ts';
+import type { MigrationConfig, MigrationMeta, MigratorInitFailResponse } from '~/migrator-utils.ts';
 import {
 	type AnyOne,
 	// AggregatedField,

--- a/drizzle-orm/src/sqlite-proxy/migrator.ts
+++ b/drizzle-orm/src/sqlite-proxy/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';

--- a/drizzle-orm/src/tidb-serverless/migrator.ts
+++ b/drizzle-orm/src/tidb-serverless/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { TiDBServerlessDatabase } from './driver.ts';

--- a/drizzle-orm/src/tursodatabase/migrator.ts
+++ b/drizzle-orm/src/tursodatabase/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { TursoDatabaseDatabase } from './driver-core.ts';

--- a/drizzle-orm/src/vercel-postgres/migrator.ts
+++ b/drizzle-orm/src/vercel-postgres/migrator.ts
@@ -1,4 +1,4 @@
-import type { MigrationConfig } from '~/migrator.ts';
+import type { MigrationConfig } from '~/migrator-utils.ts';
 import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations } from '~/relations.ts';
 import type { VercelPgDatabase } from './driver.ts';

--- a/drizzle-orm/src/xata-http/migrator.ts
+++ b/drizzle-orm/src/xata-http/migrator.ts
@@ -1,4 +1,5 @@
-import { type MigratorInitFailResponse, readMigrationFiles } from '~/migrator.ts';
+import type { MigratorInitFailResponse } from '~/migrator-utils.ts';
+import { readMigrationFiles } from '~/migrator.ts';
 import type { AnyRelations, EmptyRelations } from '~/relations.ts';
 import { sql } from '~/sql/sql.ts';
 import type { XataHttpDatabase } from './driver.ts';


### PR DESCRIPTION
Fixes issue when sqlite is being used in non node environments, where importing from migrator.ts causes issues because of the node:crypto, node:fs and node:path.

Moved interfaces and formatToMillis into a seperate file where there are no "node:"  imports.

Fixes:
https://github.com/drizzle-team/drizzle-orm/issues/5126
https://github.com/drizzle-team/drizzle-orm/issues/5183