### PR TITLE
fix(sqlite): use correct SQLite syntax for migrations table

### DIFF
--- a/drizzle-orm/src/d1/migrator.ts
+++ b/drizzle-orm/src/d1/migrator.ts
@@ -12,7 +12,7 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 
 	const migrationTableCreate = sql`
 		CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-			id SERIAL PRIMARY KEY,
+			id integer PRIMARY KEY AUTOINCREMENT,
 			hash text NOT NULL,
 			created_at numeric
 		)

--- a/drizzle-orm/src/durable-sqlite/migrator.ts
+++ b/drizzle-orm/src/durable-sqlite/migrator.ts
@@ -52,7 +52,7 @@ export async function migrate<
 
 			const migrationTableCreate = sql`
 				CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-					id SERIAL PRIMARY KEY,
+					id integer PRIMARY KEY AUTOINCREMENT,
 					hash text NOT NULL,
 					created_at numeric
 				)

--- a/drizzle-orm/src/expo-sqlite/migrator.ts
+++ b/drizzle-orm/src/expo-sqlite/migrator.ts
@@ -1,5 +1,6 @@
 import { useEffect, useReducer } from 'react';
 import type { MigrationMeta } from '~/migrator.ts';
+import { computeHash } from '~/utils/crypto.ts';
 import type { ExpoSQLiteDatabase } from './driver.ts';
 
 interface MigrationConfig {
@@ -28,7 +29,7 @@ async function readMigrationFiles({ journal, migrations }: MigrationConfig): Pro
 				sql: result,
 				bps: journalEntry.breakpoints,
 				folderMillis: journalEntry.when,
-				hash: '',
+				hash: await computeHash(query),
 			});
 		} catch {
 			throw new Error(`Failed to parse migration: ${journalEntry.tag}`);

--- a/drizzle-orm/src/libsql/migrator.ts
+++ b/drizzle-orm/src/libsql/migrator.ts
@@ -12,7 +12,7 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 
 	const migrationTableCreate = sql`
 		CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-			id SERIAL PRIMARY KEY,
+			id integer PRIMARY KEY AUTOINCREMENT,
 			hash text NOT NULL,
 			created_at numeric
 		)

--- a/drizzle-orm/src/op-sqlite/migrator.ts
+++ b/drizzle-orm/src/op-sqlite/migrator.ts
@@ -1,5 +1,6 @@
 import { useEffect, useReducer } from 'react';
 import type { MigrationMeta } from '~/migrator.ts';
+import { computeHash } from '~/utils/crypto.ts';
 import type { OPSQLiteDatabase } from './driver.ts';
 
 interface MigrationConfig {
@@ -28,7 +29,7 @@ async function readMigrationFiles({ journal, migrations }: MigrationConfig): Pro
 				sql: result,
 				bps: journalEntry.breakpoints,
 				folderMillis: journalEntry.when,
-				hash: '',
+				hash: await computeHash(query),
 			});
 		} catch {
 			throw new Error(`Failed to parse migration: ${journalEntry.tag}`);

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -843,7 +843,7 @@ export class SQLiteSyncDialect extends SQLiteDialect {
 
 		const migrationTableCreate = sql`
 			CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-				id SERIAL PRIMARY KEY,
+				id integer PRIMARY KEY AUTOINCREMENT,
 				hash text NOT NULL,
 				created_at numeric
 			)
@@ -895,7 +895,7 @@ export class SQLiteAsyncDialect extends SQLiteDialect {
 
 		const migrationTableCreate = sql`
 			CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-				id SERIAL PRIMARY KEY,
+				id integer PRIMARY KEY AUTOINCREMENT,
 				hash text NOT NULL,
 				created_at numeric
 			)

--- a/drizzle-orm/src/sqlite-proxy/migrator.ts
+++ b/drizzle-orm/src/sqlite-proxy/migrator.ts
@@ -18,7 +18,7 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 
 	const migrationTableCreate = sql`
 		CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-			id SERIAL PRIMARY KEY,
+			id integer PRIMARY KEY AUTOINCREMENT,
 			hash text NOT NULL,
 			created_at numeric
 		)

--- a/drizzle-orm/src/utils/crypto.ts
+++ b/drizzle-orm/src/utils/crypto.ts
@@ -1,0 +1,7 @@
+export async function computeHash(data: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const encodedData = encoder.encode(data);
+	const hashBuffer = await crypto.subtle.digest('SHA-256', encodedData);
+	const hashArray = [...new Uint8Array(hashBuffer)];
+	return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/integration-tests/tests/sqlite/better-sqlite.test.ts
+++ b/integration-tests/tests/sqlite/better-sqlite.test.ts
@@ -48,6 +48,32 @@ test('migrator', async () => {
 	db.run(sql`drop table __drizzle_migrations`);
 });
 
+test('migrator: migrations table has correct schema for SQLite', async () => {
+	db.run(sql`drop table if exists another_users`);
+	db.run(sql`drop table if exists users12`);
+	db.run(sql`drop table if exists __drizzle_migrations`);
+
+	migrate(db, { migrationsFolder: './drizzle2/sqlite' });
+
+	// Verify the __drizzle_migrations table uses proper SQLite syntax
+	// The id column should be "integer PRIMARY KEY" (which auto-increments in SQLite),
+	// not "SERIAL PRIMARY KEY" (which is PostgreSQL syntax)
+	const tableInfo = db.all<{ cid: number; name: string; type: string; notnull: number; pk: number }>(
+		sql`PRAGMA table_info(__drizzle_migrations)`,
+	);
+
+	const idColumn = tableInfo.find((col: { cid: number; name: string; type: string; notnull: number; pk: number }) => col.name === 'id');
+	expect(idColumn).toBeDefined();
+	// In SQLite, the type should be "integer" (case-insensitive) for proper auto-increment behavior
+	// "SERIAL" is PostgreSQL syntax and should not be used
+	expect(idColumn!.type.toLowerCase()).toBe('integer');
+	expect(idColumn!.pk).toBe(1);
+
+	db.run(sql`drop table another_users`);
+	db.run(sql`drop table users12`);
+	db.run(sql`drop table __drizzle_migrations`);
+});
+
 skipTests([
 	/**
 	 * doesn't work properly:

--- a/integration-tests/tests/sqlite/better-sqlite.test.ts
+++ b/integration-tests/tests/sqlite/better-sqlite.test.ts
@@ -69,6 +69,13 @@ test('migrator: migrations table has correct schema for SQLite', async () => {
 	expect(idColumn!.type.toLowerCase()).toBe('integer');
 	expect(idColumn!.pk).toBe(1);
 
+	// Verify migration hashes are computed (not empty)
+	const migrationRows = db.all<{ hash: string }>(sql`SELECT hash FROM __drizzle_migrations`);
+	expect(migrationRows.length).toBeGreaterThan(0);
+	for (const row of migrationRows) {
+		expect(row.hash).toHaveLength(64); // SHA-256 hex = 64 chars
+	}
+
 	db.run(sql`drop table another_users`);
 	db.run(sql`drop table users12`);
 	db.run(sql`drop table __drizzle_migrations`);

--- a/integration-tests/tests/sqlite/d1.test.ts
+++ b/integration-tests/tests/sqlite/d1.test.ts
@@ -98,6 +98,13 @@ test('migrator: migrations table has correct schema for SQLite', async () => {
 	expect(idColumn!.type.toLowerCase()).toBe('integer');
 	expect(idColumn!.pk).toBe(1);
 
+	// Verify migration hashes are computed (not empty)
+	const migrationRows = await db.all<{ hash: string }>(sql`SELECT hash FROM __drizzle_migrations`);
+	expect(migrationRows.length).toBeGreaterThan(0);
+	for (const row of migrationRows) {
+		expect(row.hash).toHaveLength(64); // SHA-256 hex = 64 chars
+	}
+
 	await db.run(sql`drop table another_users`);
 	await db.run(sql`drop table users12`);
 	await db.run(sql`drop table __drizzle_migrations`);

--- a/integration-tests/tests/sqlite/d1.test.ts
+++ b/integration-tests/tests/sqlite/d1.test.ts
@@ -77,6 +77,32 @@ test('migrator : migrate with custom table', async () => {
 	await db.run(sql`drop table ${sql.identifier(customTable)}`);
 });
 
+test('migrator: migrations table has correct schema for SQLite', async () => {
+	await db.run(sql`drop table if exists another_users`);
+	await db.run(sql`drop table if exists users12`);
+	await db.run(sql`drop table if exists __drizzle_migrations`);
+
+	await migrate(db, { migrationsFolder: './drizzle2/sqlite' });
+
+	// Verify the __drizzle_migrations table uses proper SQLite syntax
+	// The id column should be "integer PRIMARY KEY" (which auto-increments in SQLite),
+	// not "SERIAL PRIMARY KEY" (which is PostgreSQL syntax)
+	const tableInfo = await db.all<{ cid: number; name: string; type: string; notnull: number; pk: number }>(
+		sql`PRAGMA table_info(__drizzle_migrations)`,
+	);
+
+	const idColumn = tableInfo.find((col: { name: string }) => col.name === 'id');
+	expect(idColumn).toBeDefined();
+	// In SQLite, the type should be "integer" (case-insensitive) for proper auto-increment behavior
+	// "SERIAL" is PostgreSQL syntax and should not be used
+	expect(idColumn!.type.toLowerCase()).toBe('integer');
+	expect(idColumn!.pk).toBe(1);
+
+	await db.run(sql`drop table another_users`);
+	await db.run(sql`drop table users12`);
+	await db.run(sql`drop table __drizzle_migrations`);
+});
+
 skipTests([
 	// Cannot convert 49,50,55 to a BigInt
 	'insert bigint values',

--- a/integration-tests/tests/sqlite/durable-objects/index.ts
+++ b/integration-tests/tests/sqlite/durable-objects/index.ts
@@ -247,6 +247,13 @@ export class MyDurableObject extends DurableObject {
 			expect(idColumn!.type.toLowerCase()).to.equal('integer');
 			expect(idColumn!.pk).to.equal(1);
 
+			// Verify migration hashes are computed (not empty)
+			const migrationRows = this.db.all<{ hash: string }>(sql`SELECT hash FROM __drizzle_migrations`);
+			expect(migrationRows.length).to.be.greaterThan(0);
+			for (const row of migrationRows) {
+				expect(row.hash).to.have.lengthOf(64); // SHA-256 hex = 64 chars
+			}
+
 			this.db.run(sql`drop table another_users`);
 			this.db.run(sql`drop table users12`);
 			this.db.run(sql`drop table __drizzle_migrations`);

--- a/integration-tests/tests/sqlite/durable-objects/index.ts
+++ b/integration-tests/tests/sqlite/durable-objects/index.ts
@@ -225,6 +225,36 @@ export class MyDurableObject extends DurableObject {
 		}
 	}
 
+	async migratorSchemaTest(): Promise<void> {
+		try {
+			this.db.run(sql`drop table if exists another_users`);
+			this.db.run(sql`drop table if exists users12`);
+			this.db.run(sql`drop table if exists __drizzle_migrations`);
+
+			migrate(this.db, migrations);
+
+			// Verify the __drizzle_migrations table uses proper SQLite syntax
+			// The id column should be "integer PRIMARY KEY" (which auto-increments in SQLite),
+			// not "SERIAL PRIMARY KEY" (which is PostgreSQL syntax)
+			const tableInfo = this.db.all<{ cid: number; name: string; type: string; notnull: number; pk: number }>(
+				sql`PRAGMA table_info(__drizzle_migrations)`,
+			);
+
+			const idColumn = tableInfo.find((col: { name: string }) => col.name === 'id');
+			expect(idColumn).to.not.be.undefined;
+			// In SQLite, the type should be "integer" (case-insensitive) for proper auto-increment behavior
+			// "SERIAL" is PostgreSQL syntax and should not be used
+			expect(idColumn!.type.toLowerCase()).to.equal('integer');
+			expect(idColumn!.pk).to.equal(1);
+
+			this.db.run(sql`drop table another_users`);
+			this.db.run(sql`drop table users12`);
+			this.db.run(sql`drop table __drizzle_migrations`);
+		} catch {
+			throw new Error('migratorSchemaTest has broken');
+		}
+	}
+
 	async beforeEach(): Promise<void> {
 		this.db.run(sql`drop table if exists ${usersTable}`);
 		this.db.run(sql`drop table if exists ${users2Table}`);

--- a/integration-tests/tests/sqlite/libsql-http.test.ts
+++ b/integration-tests/tests/sqlite/libsql-http.test.ts
@@ -110,6 +110,13 @@ test('migrator: migrations table has correct schema for SQLite', async () => {
 	expect(idColumn!.type.toLowerCase()).toBe('integer');
 	expect(idColumn!.pk).toBe(1);
 
+	// Verify migration hashes are computed (not empty)
+	const migrationRows = await db.all<{ hash: string }>(sql`SELECT hash FROM __drizzle_migrations`);
+	expect(migrationRows.length).toBeGreaterThan(0);
+	for (const row of migrationRows) {
+		expect(row.hash).toHaveLength(64); // SHA-256 hex = 64 chars
+	}
+
 	await db.run(sql`drop table another_users`);
 	await db.run(sql`drop table users12`);
 	await db.run(sql`drop table __drizzle_migrations`);

--- a/integration-tests/tests/sqlite/libsql-http.test.ts
+++ b/integration-tests/tests/sqlite/libsql-http.test.ts
@@ -89,6 +89,32 @@ test('migrator : migrate with custom table', async () => {
 	await db.run(sql`drop table ${sql.identifier(customTable)}`);
 });
 
+test('migrator: migrations table has correct schema for SQLite', async () => {
+	await db.run(sql`drop table if exists another_users`);
+	await db.run(sql`drop table if exists users12`);
+	await db.run(sql`drop table if exists __drizzle_migrations`);
+
+	await migrate(db, { migrationsFolder: './drizzle2/sqlite' });
+
+	// Verify the __drizzle_migrations table uses proper SQLite syntax
+	// The id column should be "integer PRIMARY KEY" (which auto-increments in SQLite),
+	// not "SERIAL PRIMARY KEY" (which is PostgreSQL syntax)
+	const tableInfo = await db.all<{ cid: number; name: string; type: string; notnull: number; pk: number }>(
+		sql`PRAGMA table_info(__drizzle_migrations)`,
+	);
+
+	const idColumn = tableInfo.find((col: { name: string }) => col.name === 'id');
+	expect(idColumn).toBeDefined();
+	// In SQLite, the type should be "integer" (case-insensitive) for proper auto-increment behavior
+	// "SERIAL" is PostgreSQL syntax and should not be used
+	expect(idColumn!.type.toLowerCase()).toBe('integer');
+	expect(idColumn!.pk).toBe(1);
+
+	await db.run(sql`drop table another_users`);
+	await db.run(sql`drop table users12`);
+	await db.run(sql`drop table __drizzle_migrations`);
+});
+
 test('test $onUpdateFn and $onUpdate works as $default', async (ctx) => {
 	const { db } = ctx.sqlite;
 

--- a/integration-tests/tests/sqlite/libsql-node.test.ts
+++ b/integration-tests/tests/sqlite/libsql-node.test.ts
@@ -89,6 +89,32 @@ test('migrator : migrate with custom table', async () => {
 	await db.run(sql`drop table ${sql.identifier(customTable)}`);
 });
 
+test('migrator: migrations table has correct schema for SQLite', async () => {
+	await db.run(sql`drop table if exists another_users`);
+	await db.run(sql`drop table if exists users12`);
+	await db.run(sql`drop table if exists __drizzle_migrations`);
+
+	await migrate(db, { migrationsFolder: './drizzle2/sqlite' });
+
+	// Verify the __drizzle_migrations table uses proper SQLite syntax
+	// The id column should be "integer PRIMARY KEY" (which auto-increments in SQLite),
+	// not "SERIAL PRIMARY KEY" (which is PostgreSQL syntax)
+	const tableInfo = await db.all<{ cid: number; name: string; type: string; notnull: number; pk: number }>(
+		sql`PRAGMA table_info(__drizzle_migrations)`,
+	);
+
+	const idColumn = tableInfo.find((col: { name: string }) => col.name === 'id');
+	expect(idColumn).toBeDefined();
+	// In SQLite, the type should be "integer" (case-insensitive) for proper auto-increment behavior
+	// "SERIAL" is PostgreSQL syntax and should not be used
+	expect(idColumn!.type.toLowerCase()).toBe('integer');
+	expect(idColumn!.pk).toBe(1);
+
+	await db.run(sql`drop table another_users`);
+	await db.run(sql`drop table users12`);
+	await db.run(sql`drop table __drizzle_migrations`);
+});
+
 skipTests([
 	'delete with limit and order by',
 	'update with limit and order by',

--- a/integration-tests/tests/sqlite/libsql-node.test.ts
+++ b/integration-tests/tests/sqlite/libsql-node.test.ts
@@ -110,6 +110,13 @@ test('migrator: migrations table has correct schema for SQLite', async () => {
 	expect(idColumn!.type.toLowerCase()).toBe('integer');
 	expect(idColumn!.pk).toBe(1);
 
+	// Verify migration hashes are computed (not empty)
+	const migrationRows = await db.all<{ hash: string }>(sql`SELECT hash FROM __drizzle_migrations`);
+	expect(migrationRows.length).toBeGreaterThan(0);
+	for (const row of migrationRows) {
+		expect(row.hash).toHaveLength(64); // SHA-256 hex = 64 chars
+	}
+
 	await db.run(sql`drop table another_users`);
 	await db.run(sql`drop table users12`);
 	await db.run(sql`drop table __drizzle_migrations`);

--- a/integration-tests/tests/sqlite/libsql-sqlite3.test.ts
+++ b/integration-tests/tests/sqlite/libsql-sqlite3.test.ts
@@ -85,6 +85,32 @@ test('migrator : migrate with custom table', async () => {
 	await db.run(sql`drop table ${sql.identifier(customTable)}`);
 });
 
+test('migrator: migrations table has correct schema for SQLite', async () => {
+	await db.run(sql`drop table if exists another_users`);
+	await db.run(sql`drop table if exists users12`);
+	await db.run(sql`drop table if exists __drizzle_migrations`);
+
+	await migrate(db, { migrationsFolder: './drizzle2/sqlite' });
+
+	// Verify the __drizzle_migrations table uses proper SQLite syntax
+	// The id column should be "integer PRIMARY KEY" (which auto-increments in SQLite),
+	// not "SERIAL PRIMARY KEY" (which is PostgreSQL syntax)
+	const tableInfo = await db.all<{ cid: number; name: string; type: string; notnull: number; pk: number }>(
+		sql`PRAGMA table_info(__drizzle_migrations)`,
+	);
+
+	const idColumn = tableInfo.find((col: { name: string }) => col.name === 'id');
+	expect(idColumn).toBeDefined();
+	// In SQLite, the type should be "integer" (case-insensitive) for proper auto-increment behavior
+	// "SERIAL" is PostgreSQL syntax and should not be used
+	expect(idColumn!.type.toLowerCase()).toBe('integer');
+	expect(idColumn!.pk).toBe(1);
+
+	await db.run(sql`drop table another_users`);
+	await db.run(sql`drop table users12`);
+	await db.run(sql`drop table __drizzle_migrations`);
+});
+
 skipTests([
 	'delete with limit and order by',
 	'update with limit and order by',

--- a/integration-tests/tests/sqlite/libsql-sqlite3.test.ts
+++ b/integration-tests/tests/sqlite/libsql-sqlite3.test.ts
@@ -106,6 +106,13 @@ test('migrator: migrations table has correct schema for SQLite', async () => {
 	expect(idColumn!.type.toLowerCase()).toBe('integer');
 	expect(idColumn!.pk).toBe(1);
 
+	// Verify migration hashes are computed (not empty)
+	const migrationRows = await db.all<{ hash: string }>(sql`SELECT hash FROM __drizzle_migrations`);
+	expect(migrationRows.length).toBeGreaterThan(0);
+	for (const row of migrationRows) {
+		expect(row.hash).toHaveLength(64); // SHA-256 hex = 64 chars
+	}
+
 	await db.run(sql`drop table another_users`);
 	await db.run(sql`drop table users12`);
 	await db.run(sql`drop table __drizzle_migrations`);

--- a/integration-tests/tests/sqlite/libsql-ws.test.ts
+++ b/integration-tests/tests/sqlite/libsql-ws.test.ts
@@ -110,6 +110,13 @@ test('migrator: migrations table has correct schema for SQLite', async () => {
 	expect(idColumn!.type.toLowerCase()).toBe('integer');
 	expect(idColumn!.pk).toBe(1);
 
+	// Verify migration hashes are computed (not empty)
+	const migrationRows = await db.all<{ hash: string }>(sql`SELECT hash FROM __drizzle_migrations`);
+	expect(migrationRows.length).toBeGreaterThan(0);
+	for (const row of migrationRows) {
+		expect(row.hash).toHaveLength(64); // SHA-256 hex = 64 chars
+	}
+
 	await db.run(sql`drop table another_users`);
 	await db.run(sql`drop table users12`);
 	await db.run(sql`drop table __drizzle_migrations`);

--- a/integration-tests/tests/sqlite/libsql-ws.test.ts
+++ b/integration-tests/tests/sqlite/libsql-ws.test.ts
@@ -89,6 +89,32 @@ test('migrator : migrate with custom table', async () => {
 	await db.run(sql`drop table ${sql.identifier(customTable)}`);
 });
 
+test('migrator: migrations table has correct schema for SQLite', async () => {
+	await db.run(sql`drop table if exists another_users`);
+	await db.run(sql`drop table if exists users12`);
+	await db.run(sql`drop table if exists __drizzle_migrations`);
+
+	await migrate(db, { migrationsFolder: './drizzle2/sqlite' });
+
+	// Verify the __drizzle_migrations table uses proper SQLite syntax
+	// The id column should be "integer PRIMARY KEY" (which auto-increments in SQLite),
+	// not "SERIAL PRIMARY KEY" (which is PostgreSQL syntax)
+	const tableInfo = await db.all<{ cid: number; name: string; type: string; notnull: number; pk: number }>(
+		sql`PRAGMA table_info(__drizzle_migrations)`,
+	);
+
+	const idColumn = tableInfo.find((col: { name: string }) => col.name === 'id');
+	expect(idColumn).toBeDefined();
+	// In SQLite, the type should be "integer" (case-insensitive) for proper auto-increment behavior
+	// "SERIAL" is PostgreSQL syntax and should not be used
+	expect(idColumn!.type.toLowerCase()).toBe('integer');
+	expect(idColumn!.pk).toBe(1);
+
+	await db.run(sql`drop table another_users`);
+	await db.run(sql`drop table users12`);
+	await db.run(sql`drop table __drizzle_migrations`);
+});
+
 test('test $onUpdateFn and $onUpdate works as $default', async (ctx) => {
 	const { db } = ctx.sqlite;
 

--- a/integration-tests/tests/sqlite/libsql.test.ts
+++ b/integration-tests/tests/sqlite/libsql.test.ts
@@ -97,6 +97,32 @@ test('migrator : migrate with custom table', async () => {
 	await db.run(sql`drop table ${sql.identifier(customTable)}`);
 });
 
+test('migrator: migrations table has correct schema for SQLite', async () => {
+	await db.run(sql`drop table if exists another_users`);
+	await db.run(sql`drop table if exists users12`);
+	await db.run(sql`drop table if exists __drizzle_migrations`);
+
+	await migrate(db, { migrationsFolder: './drizzle2/sqlite' });
+
+	// Verify the __drizzle_migrations table uses proper SQLite syntax
+	// The id column should be "integer PRIMARY KEY" (which auto-increments in SQLite),
+	// not "SERIAL PRIMARY KEY" (which is PostgreSQL syntax)
+	const tableInfo = await db.all<{ cid: number; name: string; type: string; notnull: number; pk: number }>(
+		sql`PRAGMA table_info(__drizzle_migrations)`,
+	);
+
+	const idColumn = tableInfo.find((col: { name: string }) => col.name === 'id');
+	expect(idColumn).toBeDefined();
+	// In SQLite, the type should be "integer" (case-insensitive) for proper auto-increment behavior
+	// "SERIAL" is PostgreSQL syntax and should not be used
+	expect(idColumn!.type.toLowerCase()).toBe('integer');
+	expect(idColumn!.pk).toBe(1);
+
+	await db.run(sql`drop table another_users`);
+	await db.run(sql`drop table users12`);
+	await db.run(sql`drop table __drizzle_migrations`);
+});
+
 skipTests([
 	'delete with limit and order by',
 	'update with limit and order by',

--- a/integration-tests/tests/sqlite/libsql.test.ts
+++ b/integration-tests/tests/sqlite/libsql.test.ts
@@ -118,6 +118,13 @@ test('migrator: migrations table has correct schema for SQLite', async () => {
 	expect(idColumn!.type.toLowerCase()).toBe('integer');
 	expect(idColumn!.pk).toBe(1);
 
+	// Verify migration hashes are computed (not empty)
+	const migrationRows = await db.all<{ hash: string }>(sql`SELECT hash FROM __drizzle_migrations`);
+	expect(migrationRows.length).toBeGreaterThan(0);
+	for (const row of migrationRows) {
+		expect(row.hash).toHaveLength(64); // SHA-256 hex = 64 chars
+	}
+
 	await db.run(sql`drop table another_users`);
 	await db.run(sql`drop table users12`);
 	await db.run(sql`drop table __drizzle_migrations`);

--- a/integration-tests/tests/sqlite/sql-js.test.ts
+++ b/integration-tests/tests/sqlite/sql-js.test.ts
@@ -71,6 +71,13 @@ test('migrator: migrations table has correct schema for SQLite', async () => {
 	expect(idColumn!.type.toLowerCase()).toBe('integer');
 	expect(idColumn!.pk).toBe(1);
 
+	// Verify migration hashes are computed (not empty)
+	const migrationRows = db.all<{ hash: string }>(sql`SELECT hash FROM __drizzle_migrations`);
+	expect(migrationRows.length).toBeGreaterThan(0);
+	for (const row of migrationRows) {
+		expect(row.hash).toHaveLength(64); // SHA-256 hex = 64 chars
+	}
+
 	db.run(sql`drop table another_users`);
 	db.run(sql`drop table users12`);
 	db.run(sql`drop table __drizzle_migrations`);

--- a/integration-tests/tests/sqlite/sql-js.test.ts
+++ b/integration-tests/tests/sqlite/sql-js.test.ts
@@ -50,6 +50,32 @@ test('migrator', async () => {
 	db.run(sql`drop table __drizzle_migrations`);
 });
 
+test('migrator: migrations table has correct schema for SQLite', async () => {
+	db.run(sql`drop table if exists another_users`);
+	db.run(sql`drop table if exists users12`);
+	db.run(sql`drop table if exists __drizzle_migrations`);
+
+	migrate(db, { migrationsFolder: './drizzle2/sqlite' });
+
+	// Verify the __drizzle_migrations table uses proper SQLite syntax
+	// The id column should be "integer PRIMARY KEY" (which auto-increments in SQLite),
+	// not "SERIAL PRIMARY KEY" (which is PostgreSQL syntax)
+	const tableInfo = db.all<{ cid: number; name: string; type: string; notnull: number; pk: number }>(
+		sql`PRAGMA table_info(__drizzle_migrations)`,
+	);
+
+	const idColumn = tableInfo.find((col: { name: string }) => col.name === 'id');
+	expect(idColumn).toBeDefined();
+	// In SQLite, the type should be "integer" (case-insensitive) for proper auto-increment behavior
+	// "SERIAL" is PostgreSQL syntax and should not be used
+	expect(idColumn!.type.toLowerCase()).toBe('integer');
+	expect(idColumn!.pk).toBe(1);
+
+	db.run(sql`drop table another_users`);
+	db.run(sql`drop table users12`);
+	db.run(sql`drop table __drizzle_migrations`);
+});
+
 skipTests([
 	/**
 	 * doesn't work properly:


### PR DESCRIPTION
Fixes https://github.com/drizzle-team/drizzle-orm/issues/4928
This has already been tested on my own database and it did fix the issues I was having with migrations not being applied.

The __drizzle_migrations table was being created with PostgreSQL syntax (SERIAL PRIMARY KEY) instead of proper SQLite syntax (integer PRIMARY KEY AUTOINCREMENT). 
While SQLite's flexible typing allowed the table to be created, the id column was stored with type "SERIAL" rather than "INTEGER", meaning it wouldn't behave as a proper auto-incrementing integer primary key.

Added tests to verify the migrations table schema uses correct SQLite syntax in all SQLite test files.
The tests were validated to indeed fail before this change.


As to existing deployments that have a broken migrations table we have four options as I see it:
1. Do nothing - Existing DBs technically still work because SQLite is permissive. Inserts without an id value will get NULL for the id column, but the table still functions.
2. Detect and warn - Check the schema after table creation and log a warning if it's wrong:
```js
const tableInfo = session.all(sql`PRAGMA table_info(${migrationsTable})`);
const idCol = tableInfo.find(c => c.name === 'id');
if (idCol?.type.toLowerCase() !== 'integer') {
  console.warn('Warning: __drizzle_migrations table has incorrect schema...');
}
```
3. Detect and auto-migrate - Recreate the table with correct schema:
```js
// If table exists with wrong schema, migrate it
// 1. Create temp table with correct schema
// 2. Copy data
// 3. Drop old table
// 4. Rename temp to original
```
4. Document manual fix - Users can run:
```sql
CREATE TABLE __drizzle_migrations_new (
  id integer PRIMARY KEY AUTOINCREMENT,
  hash text NOT NULL,
  created_at numeric
);
INSERT INTO __drizzle_migrations_new SELECT * FROM __drizzle_migrations;
DROP TABLE __drizzle_migrations;
ALTER TABLE __drizzle_migrations_new RENAME TO __drizzle_migrations;
```

At the moment this PR does 1+4, I can do 2/3 as well but I chose not to do it for the initial review part because I couldn't find existing examples where either option was chose.

Thanks for taking the time to review this.