### PR TITLE
fix(cache): Allow `hashQuery` to deal with bigint

### DIFF
--- a/drizzle-orm/src/cache/core/cache.ts
+++ b/drizzle-orm/src/cache/core/cache.ts
@@ -103,7 +103,7 @@ export const strategyFor = async (
 export type MutationOption = { tags?: string | string[]; tables?: Table<any> | Table<any>[] | string | string[] };
 
 export async function hashQuery(sql: string, params?: any[]) {
-	const dataToHash = `${sql}-${JSON.stringify(params)}`;
+	const dataToHash = `${sql}-${JSON.stringify(params, (_, v) => typeof v === 'bigint' ? v.toString() : v)}`;
 	const encoder = new TextEncoder();
 	const data = encoder.encode(dataToHash);
 	const hashBuffer = await crypto.subtle.digest('SHA-256', data);

--- a/drizzle-orm/src/cache/core/cache.ts
+++ b/drizzle-orm/src/cache/core/cache.ts
@@ -103,7 +103,7 @@ export const strategyFor = async (
 export type MutationOption = { tags?: string | string[]; tables?: Table<any> | Table<any>[] | string | string[] };
 
 export async function hashQuery(sql: string, params?: any[]) {
-	const dataToHash = `${sql}-${JSON.stringify(params, (_, v) => typeof v === 'bigint' ? v.toString() : v)}`;
+	const dataToHash = `${sql}-${JSON.stringify(params, (_, v) => typeof v === 'bigint' ? `${v}n` : v)}`;
 	const encoder = new TextEncoder();
 	const data = encoder.encode(dataToHash);
 	const hashBuffer = await crypto.subtle.digest('SHA-256', data);


### PR DESCRIPTION
Update hashQuery to handle bigint parameters correctly.

closes https://github.com/drizzle-team/drizzle-orm/issues/5227