### PR TITLE
[Pg-kit]: Fix functional index generation in pull

### DIFF
--- a/drizzle-kit/src/dialects/postgres/typescript.ts
+++ b/drizzle-kit/src/dialects/postgres/typescript.ts
@@ -665,7 +665,7 @@ const createTableIndexes = (tableName: string, idxs: Index[], casing: Casing): s
 			it.columns
 				.map((it) => {
 					if (it.isExpression) {
-						return `sql\`${it.isExpression}\``;
+						return `sql\`${it.value}\``;
 					} else {
 						return `table.${withCasing(it.value, casing)}${it.asc ? '.asc()' : '.desc()'}${
 							it.nullsFirst ? '.nullsFirst()' : '.nullsLast()'


### PR DESCRIPTION
Fixed a bug where `drizzle-kit pull` generated incorrect TypeScript file for functional/computed indexes. The generator was incorrectly using the boolean `isExpression` property instead of the `value` property when creating the `sql` template literal, resulting in `sql`true`` in the output.

Fixes #5224 