### PR TITLE
[beta] Refine RelationsFieldFilter type to prioritize Primitive over Object

### DIFF
--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -920,10 +920,19 @@ export interface RelationFieldsFilterInternals<T> {
 	AND?: RelationsFieldFilter<T>[] | undefined;
 }
 
+type Primitive = 
+	| null
+    | undefined
+    | string
+    | number
+    | boolean
+    | symbol
+    | bigint
+
 export type RelationsFieldFilter<T = unknown> =
 	| RelationFieldsFilterInternals<T>
 	| (
-		unknown extends T ? never : T extends object ? never : T
+		unknown extends T ? never : T extends Primitive ? T : never
 	)
 	// Bleeds into filters - discuss removal
 	| Placeholder;


### PR DESCRIPTION
Branded types may be both Primitive and Object. For example:
```ts
import z from 'zod'

// AppId is both string and object
export type AppId = string & z.$brand<'AppId'>
```

Currently [`RelationsFieldFilter<AppId>`](https://github.com/drizzle-team/drizzle-orm/blob/beta/drizzle-orm/src/relations.ts#L923) results in `never`. It leads to a type error when `$type<AppId>()` is used in the database schema. For example:
```ts
import { db } from '../lib/db'
import { pgTable, uuid } from 'drizzle-orm/pg-core'

export const apps = pgTable('apps', {
  id: uuid().$type<AppId>().primaryKey(),
})

export async function getAppById(appId: AppId) {
  return db.query.apps.findFirst({
    where: {
      id: appId,
    },
  })
}
```

Error:
<img width="1962" height="400" alt="image" src="https://github.com/user-attachments/assets/a2bbe4fb-c665-4af3-89c2-5a9fcd9b1de3" />

Prioritizing [Primitive](https://github.com/sindresorhus/type-fest/blob/main/source/primitive.d.ts) over Object in the `RelationsFieldFilter` definition will fix that
