### PR TITLE
FEAT(postgres): add `{mode:"virtual"}` option to `.generatedAlwaysAs()` column builder

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -192,7 +192,7 @@ export const generatePgSnapshot = (
 							: typeof generated.as === 'function'
 							? dialect.sqlToQuery(generated.as() as SQL).sql
 							: (generated.as as any),
-						type: 'stored',
+						type: generated.mode ?? 'stored',
 					}
 					: undefined,
 				identity: identity
@@ -780,7 +780,7 @@ export const generatePgSnapshot = (
 								: typeof generated.as === 'function'
 								? dialect.sqlToQuery(generated.as() as SQL).sql
 								: (generated.as as any),
-							type: 'stored',
+							type: generated.mode ?? 'stored',
 						}
 						: undefined,
 					identity: identity

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -413,7 +413,7 @@ class PgCreateTableConvertor extends Convertor {
 			const type = parseType(schemaPrefix, column.type);
 			const generated = column.generated;
 
-			const generatedStatement = generated ? ` GENERATED ALWAYS AS (${generated?.as}) STORED` : '';
+			const generatedStatement = generated ? ` GENERATED ALWAYS AS (${generated?.as}) ${generated?.type.toUpperCase()}` : '';
 
 			const unsquashedIdentity = column.identity
 				? PgSquasher.unsquashIdentity(column.identity)
@@ -1793,7 +1793,7 @@ class PgAlterTableAddColumnConvertor extends Convertor {
 			})`
 			: '';
 
-		const generatedStatement = generated ? ` GENERATED ALWAYS AS (${generated?.as}) STORED` : '';
+		const generatedStatement = generated ? ` GENERATED ALWAYS AS (${generated?.as}) ${generated?.type.toUpperCase()}` : '';
 
 		return `ALTER TABLE ${tableNameWithSchema} ADD COLUMN "${name}" ${fixedType}${primaryKeyStatement}${defaultStatement}${generatedStatement}${notNullStatement}${identityStatement};`;
 	}

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -83,13 +83,13 @@ export abstract class PgColumnBuilder<
 		return this;
 	}
 
-	generatedAlwaysAs(as: SQL | T['data'] | (() => SQL)): HasGenerated<this, {
+	generatedAlwaysAs(as: SQL | T['data'] | (() => SQL), config?: { mode?: 'virtual' | 'stored' }): HasGenerated<this, {
 		type: 'always';
 	}> {
 		this.config.generated = {
 			as,
 			type: 'always',
-			mode: 'stored',
+			mode: config?.mode ?? 'stored',
 		};
 		return this as HasGenerated<this, {
 			type: 'always';

--- a/drizzle-orm/type-tests/pg/generated-columns.ts
+++ b/drizzle-orm/type-tests/pg/generated-columns.ts
@@ -15,6 +15,14 @@ const users = pgTable(
 		upperName: text('upper_name').generatedAlwaysAs(
 			sql` case when first_name is null then null else upper(first_name) end `,
 		),
+		storedGenerated: text('stored_gen').generatedAlwaysAs(
+			sql`first_name || ' ' || last_name`,
+			{ mode: 'stored' }
+		),
+		virtualGenerated: text('virtual_gen').generatedAlwaysAs(
+			sql`first_name || ' [virtual]'`,
+			{ mode: 'virtual' }
+		),
 	},
 );
 {
@@ -30,6 +38,8 @@ const users = pgTable(
 				email: string;
 				fullName: string;
 				upperName: string | null;
+				storedGenerated: string | null;
+				virtualGenerated: string | null;
 			},
 			User
 		>
@@ -61,6 +71,8 @@ const users = pgTable(
 				email: string;
 				fullName: string;
 				upperName: string | null;
+				storedGenerated: string | null;
+				virtualGenerated: string | null;
 			},
 			User
 		>
@@ -91,6 +103,8 @@ const users = pgTable(
 				email: string;
 				fullName: string;
 				upperName: string | null;
+				storedGenerated: string | null;
+				virtualGenerated: string | null;
 			}[],
 			typeof dbUsers
 		>
@@ -111,6 +125,8 @@ const users = pgTable(
 				email: string;
 				fullName: string;
 				upperName: string | null;
+				storedGenerated: string | null;
+				virtualGenerated: string | null;
 			} | undefined,
 			typeof dbUser
 		>
@@ -131,6 +147,8 @@ const users = pgTable(
 				email: string;
 				fullName: string;
 				upperName: string | null;
+				storedGenerated: string | null;
+				virtualGenerated: string | null;
 			}[],
 			typeof dbUser
 		>
@@ -148,12 +166,52 @@ const users = pgTable(
 }
 
 {
+	// @ts-expect-error - Can't use the storedGenerated because it's a generated column
+	await db.insert(users).values({
+		firstName: 'test',
+		lastName: 'test',
+		email: 'test',
+		storedGenerated: 'test',
+	});
+}
+
+{
+	// @ts-expect-error - Can't use the virtualGenerated because it's a generated column
+	await db.insert(users).values({
+		firstName: 'test',
+		lastName: 'test',
+		email: 'test',
+		virtualGenerated: 'test',
+	});
+}
+
+{
 	await db.update(users).set({
 		firstName: 'test',
 		lastName: 'test',
 		email: 'test',
 		// @ts-expect-error - Can't use the fullName because it's a generated column
 		fullName: 'test',
+	});
+}
+
+{
+	await db.update(users).set({
+		firstName: 'test',
+		lastName: 'test',
+		email: 'test',
+		// @ts-expect-error - Can't use the storedGenerated because it's a generated column
+		storedGenerated: 'test',
+	});
+}
+
+{
+	await db.update(users).set({
+		firstName: 'test',
+		lastName: 'test',
+		email: 'test',
+		// @ts-expect-error - Can't use the virtualGenerated because it's a generated column
+		virtualGenerated: 'test',
 	});
 }
 


### PR DESCRIPTION
Originally implemented by copilot in my fork at https://github.com/NickCrews/drizzle-orm/pull/2. copilot wrote all of this code, but it looks pretty good to me, and the tests seem sufficient to me.

Fixes https://github.com/drizzle-team/drizzle-orm/issues/4074

Adds `mode` parameter to PostgreSQL's `generatedAlwaysAs()` method for API consistency with SQLite and MySQL. You would need postgres version 18 in order to actually be able to use this.

## Changes

**Column Builder** (`drizzle-orm/src/pg-core/columns/common.ts`)
- Added optional `config?: { mode?: 'virtual' | 'stored' }` parameter to `generatedAlwaysAs()`
- Defaults to `'stored'` for backward compatibility

**SQL Generator** (`drizzle-kit/src/sqlgenerator.ts`)
- Changed hardcoded `STORED` to dynamic `${generated?.type.toUpperCase()}`
- Applies to both `CREATE TABLE` and `ALTER TABLE ADD COLUMN`

**Schema Serializer** (`drizzle-kit/src/serializer/pgSerializer.ts`)
- Reads `generated.mode` instead of hardcoding `'stored'`
- Applies to both table and view serialization

## Usage

```typescript
export const users = pgTable("users", {
  name: text("name"),
  
  // Defaults to stored (backward compatible)
  gen1: text("gen1").generatedAlwaysAs(sql`name || 'hello'`),
  
  // Explicit modes
  gen2: text("gen2").generatedAlwaysAs(sql`name || 'hello'`, { mode: "stored" }),
  gen3: text("gen3").generatedAlwaysAs(sql`name || 'hello'`, { mode: "virtual" }),
});
```

Once this is merged, we would need to do a followup PR to update [the existing docs page](https://orm.drizzle.team/docs/generated-columns).
