### PR TITLE
fix(drizzle-kit): fix silent failure when schema has duplicate entities

### DIFF
--- a/drizzle-kit/src/cli/commands/generate-mssql.ts
+++ b/drizzle-kit/src/cli/commands/generate-mssql.ts
@@ -101,7 +101,7 @@ export const handleExport = async (config: ExportConfig) => {
 
 	const { ddl, errors: errors2 } = interimToDDL(schema);
 	if (errors2.length > 0) {
-		console.log(errors.map((it) => mssqlSchemaError(it)).join('\n'));
+		console.log(errors2.map((it) => mssqlSchemaError(it)).join('\n'));
 		process.exit(1);
 	}
 

--- a/drizzle-kit/src/cli/commands/push-mssql.ts
+++ b/drizzle-kit/src/cli/commands/push-mssql.ts
@@ -67,12 +67,12 @@ export const handle = async (
 	const { ddl: ddl2, errors: errors2 } = interimToDDL(schemaTo);
 
 	if (errors1.length > 0) {
-		console.log(errors.map((it) => mssqlSchemaError(it)).join('\n'));
+		console.log(errors1.map((it) => mssqlSchemaError(it)).join('\n'));
 		process.exit(1);
 	}
 
 	if (errors2.length > 0) {
-		console.log(errors.map((it) => mssqlSchemaError(it)).join('\n'));
+		console.log(errors2.map((it) => mssqlSchemaError(it)).join('\n'));
 		process.exit(1);
 	}
 

--- a/drizzle-kit/src/cli/views.ts
+++ b/drizzle-kit/src/cli/views.ts
@@ -923,6 +923,42 @@ export const postgresSchemaError = (error: PostgresSchemaError): string => {
 		return withStyle.errorWarning(`There's a sequence name duplicate '${error.name}' in '${error.schema}' schema`);
 	}
 
+	if (error.type === 'table_name_duplicate') {
+		const { schema, name } = error;
+		return withStyle.errorWarning(
+			`There's a duplicate table name '${name}' in '${schema}' schema. This can happen if you export the same table under multiple names.`,
+		);
+	}
+
+	if (error.type === 'column_name_duplicate') {
+		const { schema, table, name } = error;
+		return withStyle.errorWarning(
+			`There's a duplicate column name '${name}' in '${schema}.${table}' table.`,
+		);
+	}
+
+	if (error.type === 'schema_name_duplicate') {
+		return withStyle.errorWarning(`There's a duplicate schema name '${error.name}'.`);
+	}
+
+	if (error.type === 'enum_name_duplicate') {
+		const { schema, name } = error;
+		return withStyle.errorWarning(`There's a duplicate enum name '${name}' in '${schema}' schema.`);
+	}
+
+	if (error.type === 'enum_values_duplicate') {
+		const { schema, name } = error;
+		return withStyle.errorWarning(`There are duplicate values in enum '${name}' in '${schema}' schema.`);
+	}
+
+	if (error.type === 'role_duplicate') {
+		return withStyle.errorWarning(`There's a duplicate role name '${error.name}'.`);
+	}
+
+	if (error.type === 'privilege_duplicate') {
+		return withStyle.errorWarning(`There's a duplicate privilege '${error.name}'.`);
+	}
+
 	// assertUnreachable(error);
 	return '';
 };

--- a/drizzle-kit/src/dialects/cockroach/serializer.ts
+++ b/drizzle-kit/src/dialects/cockroach/serializer.ts
@@ -49,7 +49,7 @@ export const prepareSnapshot = async (
 	const { ddl: ddlCur, errors: errors2 } = interimToDDL(schema);
 
 	if (errors2.length > 0) {
-		console.log(errors.map((it) => postgresSchemaError(it)).join('\n'));
+		console.log(errors2.map((it) => postgresSchemaError(it)).join('\n'));
 		process.exit(1);
 	}
 

--- a/drizzle-kit/src/dialects/postgres/serializer.ts
+++ b/drizzle-kit/src/dialects/postgres/serializer.ts
@@ -49,7 +49,7 @@ export const prepareSnapshot = async (
 	const { ddl: ddlCur, errors: errors2 } = interimToDDL(schema);
 
 	if (errors2.length > 0) {
-		console.log(errors.map((it) => postgresSchemaError(it)).join('\n'));
+		console.log(errors2.map((it) => postgresSchemaError(it)).join('\n'));
 		process.exit(1);
 	}
 


### PR DESCRIPTION
- Fixed wrong variable (errors vs errors2) being logged in error handlers
  - postgres/serializer.ts: errors -> errors2
  - cockroach/serializer.ts: errors -> errors2
  - generate-mssql.ts: errors -> errors2
  - push-mssql.ts: errors -> errors1/errors2
- Added missing error type handlers in postgresSchemaError():
  - table_name_duplicate
  - column_name_duplicate
  - schema_name_duplicate
  - enum_name_duplicate
  - enum_values_duplicate
  - role_duplicate
  - privilege_duplicate
  
  
  Closes #5263 