### PR TITLE
fix(drizzle-kit): prevent duplicate CREATE INDEX on table recreation

### DIFF
--- a/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
+++ b/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
@@ -140,6 +140,9 @@ export const logSuggestionsAndReturn = async (
 	const schemasToRemove: string[] = [];
 	const tablesToTruncate: string[] = [];
 
+	// Track tables that have been recreated to avoid duplicate index creation
+	const recreatedTables = new Set<string>();
+
 	for (const statement of statements) {
 		if (statement.type === 'drop_table') {
 			const res = await connection.query<{ count: string }>(
@@ -217,6 +220,8 @@ export const logSuggestionsAndReturn = async (
 			);
 		} else if (statement.type === 'recreate_table') {
 			const tableName = statement.tableName;
+			// Mark table as recreated to skip duplicate index creation later
+			recreatedTables.add(tableName);
 			const oldTableName = getOldTableName(tableName, meta);
 
 			let dataLoss = false;
@@ -302,6 +307,9 @@ export const logSuggestionsAndReturn = async (
 			if (pragmaState) {
 				statementsToExecute.push(`PRAGMA foreign_keys=ON;`);
 			}
+		} else if (statement.type === 'create_index' && recreatedTables.has(statement.tableName)) {
+			// Skip create_index for recreated tables - indexes are already created in _moveDataStatements
+			continue;
 		} else {
 			const fromJsonStatement = fromJson([statement], 'sqlite', 'push');
 			statementsToExecute.push(


### PR DESCRIPTION
## Summary

- Fix duplicate CREATE INDEX statements when a table with indexes needs recreation
- Track recreated tables and skip separate create_index statements (indexes already created in `_moveDataStatements()`)
- Add regression test with composite PK, uniqueIndex, and regular index

## Problem

When running `drizzle-kit push` on a table that requires recreation (e.g., composite primary key changes), CREATE INDEX statements were emitted twice:

```sql
CREATE TABLE `__new_UserSlugBindings` (...);
INSERT INTO `__new_UserSlugBindings`(...) SELECT ... FROM `UserSlugBindings`;
DROP TABLE `UserSlugBindings`;
ALTER TABLE `__new_UserSlugBindings` RENAME TO `UserSlugBindings`;
CREATE UNIQUE INDEX `UserSlug_userSlug` ON `UserSlugBindings` (`userSlug`);
PRAGMA foreign_keys=ON;
CREATE UNIQUE INDEX `UserSlug_userSlug` ON `UserSlugBindings` (`userSlug`);  <-- duplicate!
```

## Root Cause

Indexes were being generated from two separate places:
1. `_moveDataStatements()` in libSqlPushUtils.ts/sqlitePushUtils.ts - generates index SQL during table recreation
2. Separate `create_index` JSON statements from `prepareLibSQLRecreateTable()` that were also converted to SQL

## Fix

Track which tables have been recreated using a `Set<string>` and skip `create_index` statements for those tables.

## Test plan

- [x] All existing libsql push tests pass (19 tests)
- [x] All existing sqlite push tests pass (21 tests)
- [x] Added regression test that verifies:
  - First push: clean CREATE TABLE and CREATE INDEX (no ALTER/recreate)
  - Second push: no duplicate CREATE INDEX statements