### PR TITLE
ci(turbo): use $TURBO_ROOT$ for root file references and add transit node

### DIFF
--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -1,10 +1,24 @@
 name: Release (feature branch)
 
 on:
-  push:
-    branches-ignore:
-      - main
-  pull_request: {}
+  workflow_call:
+    secrets:
+      PLANETSCALE_CONNECTION_STRING:
+        required: true
+      NEON_CONNECTION_STRING:
+        required: true
+      NEON_HTTP_CONNECTION_STRING:
+        required: true
+      TIDB_CONNECTION_STRING:
+        required: true
+      XATA_API_KEY:
+        required: true
+      XATA_BRANCH:
+        required: true
+      LIBSQL_REMOTE_URL:
+        required: true
+      LIBSQL_REMOTE_TOKEN:
+        required: true
 
 jobs:
   test:
@@ -329,7 +343,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-       # force empty so npm can use OIDC
+    # force empty so npm can use OIDC
     env:
       NODE_AUTH_TOKEN: ""   
       NPM_TOKEN: ""

--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -328,8 +328,8 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      id-token: write
-       # force empty so npm can use OIDC
+      id-token: write # for OIDC
+    # force empty so npm can use OIDC
     env:
       NODE_AUTH_TOKEN: ""   
       NPM_TOKEN: ""

--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -7,8 +7,8 @@ on:
         required: true
       NEON_CONNECTION_STRING:
         required: true
-      NEON_HTTP_CONNECTION_STRING:
-        required: true
+      # NEON_HTTP_CONNECTION_STRING:
+      #   required: true
       TIDB_CONNECTION_STRING:
         required: true
       XATA_API_KEY:

--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -342,7 +342,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      id-token: write
+      id-token: write # for OIDC
     # force empty so npm can use OIDC
     env:
       NODE_AUTH_TOKEN: ""   

--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -305,8 +305,8 @@ jobs:
 
   release:
     permissions:
-      contents: write
-      id-token: write
+      contents: write # for creating GitHub releases
+      id-token: write # for OIDC
     needs:
       - test
       - attw

--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -7,8 +7,8 @@ on:
         required: true
       NEON_CONNECTION_STRING:
         required: true
-      NEON_HTTP_CONNECTION_STRING:
-        required: true
+      # NEON_HTTP_CONNECTION_STRING:
+      #   required: true
       TIDB_CONNECTION_STRING:
         required: true
       XATA_API_KEY:

--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -287,8 +287,8 @@ jobs:
 
   release:
     permissions:
-      contents: read
-      id-token: write
+      contents: write # for creating GitHub releases
+      id-token: write # for OIDC
     needs:
       - test
       - attw

--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -1,6 +1,24 @@
 name: Release (latest)
 
-on: workflow_dispatch
+on:
+  workflow_call:
+    secrets:
+      PLANETSCALE_CONNECTION_STRING:
+        required: true
+      NEON_CONNECTION_STRING:
+        required: true
+      NEON_HTTP_CONNECTION_STRING:
+        required: true
+      TIDB_CONNECTION_STRING:
+        required: true
+      XATA_API_KEY:
+        required: true
+      XATA_BRANCH:
+        required: true
+      LIBSQL_REMOTE_URL:
+        required: true
+      LIBSQL_REMOTE_TOKEN:
+        required: true
 
 jobs:
   test:
@@ -287,7 +305,7 @@ jobs:
 
   release:
     permissions:
-      contents: read
+      contents: write
       id-token: write
     needs:
       - test

--- a/.github/workflows/router.yaml
+++ b/.github/workflows/router.yaml
@@ -8,48 +8,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  switch:
-    runs-on: ubuntu-latest
-    outputs:
-      target: ${{ steps.route.outputs.target }}
-    steps:
-      - name: Route release
-        id: route
-        run: |
-          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "${GITHUB_REF##*/}" == "main" ]]; then
-            echo "target=latest" >> $GITHUB_OUTPUT
-          # only run on all pushes or pull requests from forks
-          elif [[ "$GITHUB_EVENT_NAME" == "push" ]] || [[ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]]; then
-            echo "target=feature" >> $GITHUB_OUTPUT
-          else
-            echo "target=skip" >> $GITHUB_OUTPUT
-          fi
-
   run-feature:
-    needs: switch
-    if: needs.switch.outputs.target == 'feature'
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     uses: ./.github/workflows/release-feature-branch.yaml
-    secrets:
-      PLANETSCALE_CONNECTION_STRING: ${{ secrets.PLANETSCALE_CONNECTION_STRING }}
-      NEON_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}
-      NEON_HTTP_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}
-      TIDB_CONNECTION_STRING: ${{ secrets.TIDB_CONNECTION_STRING }}
-      XATA_API_KEY: ${{ secrets.XATA_API_KEY }}
-      XATA_BRANCH: ${{ secrets.XATA_BRANCH }}
-      LIBSQL_REMOTE_URL: ${{ secrets.LIBSQL_REMOTE_URL }}
-      LIBSQL_REMOTE_TOKEN: ${{ secrets.LIBSQL_REMOTE_TOKEN }}
+    secrets: inherit
 
   run-latest:
-    needs: switch
-    if: needs.switch.outputs.target == 'latest'
+    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
     uses: ./.github/workflows/release-latest.yaml
-    secrets:
-      PLANETSCALE_CONNECTION_STRING: ${{ secrets.PLANETSCALE_CONNECTION_STRING }}
-      NEON_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}
-      NEON_HTTP_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}
-      TIDB_CONNECTION_STRING: ${{ secrets.TIDB_CONNECTION_STRING }}
-      XATA_API_KEY: ${{ secrets.XATA_API_KEY }}
-      XATA_BRANCH: ${{ secrets.XATA_BRANCH }}
-      LIBSQL_REMOTE_URL: ${{ secrets.LIBSQL_REMOTE_URL }}
-      LIBSQL_REMOTE_TOKEN: ${{ secrets.LIBSQL_REMOTE_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/router.yaml
+++ b/.github/workflows/router.yaml
@@ -1,0 +1,55 @@
+name: Release Router
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  switch:
+    runs-on: ubuntu-latest
+    outputs:
+      target: ${{ steps.route.outputs.target }}
+    steps:
+      - name: Route release
+        id: route
+        run: |
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "${GITHUB_REF##*/}" == "main" ]]; then
+            echo "target=latest" >> $GITHUB_OUTPUT
+          # only run on all pushes or pull requests from forks
+          elif [[ "$GITHUB_EVENT_NAME" == "push" ]] || [[ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]]; then
+            echo "target=feature" >> $GITHUB_OUTPUT
+          else
+            echo "target=skip" >> $GITHUB_OUTPUT
+          fi
+
+  run-feature:
+    needs: switch
+    if: needs.switch.outputs.target == 'feature'
+    uses: ./.github/workflows/release-feature-branch.yaml
+    secrets:
+      PLANETSCALE_CONNECTION_STRING: ${{ secrets.PLANETSCALE_CONNECTION_STRING }}
+      NEON_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}
+      NEON_HTTP_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}
+      TIDB_CONNECTION_STRING: ${{ secrets.TIDB_CONNECTION_STRING }}
+      XATA_API_KEY: ${{ secrets.XATA_API_KEY }}
+      XATA_BRANCH: ${{ secrets.XATA_BRANCH }}
+      LIBSQL_REMOTE_URL: ${{ secrets.LIBSQL_REMOTE_URL }}
+      LIBSQL_REMOTE_TOKEN: ${{ secrets.LIBSQL_REMOTE_TOKEN }}
+
+  run-latest:
+    needs: switch
+    if: needs.switch.outputs.target == 'latest'
+    uses: ./.github/workflows/release-latest.yaml
+    secrets:
+      PLANETSCALE_CONNECTION_STRING: ${{ secrets.PLANETSCALE_CONNECTION_STRING }}
+      NEON_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}
+      NEON_HTTP_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}
+      TIDB_CONNECTION_STRING: ${{ secrets.TIDB_CONNECTION_STRING }}
+      XATA_API_KEY: ${{ secrets.XATA_API_KEY }}
+      XATA_BRANCH: ${{ secrets.XATA_BRANCH }}
+      LIBSQL_REMOTE_URL: ${{ secrets.LIBSQL_REMOTE_URL }}
+      LIBSQL_REMOTE_TOKEN: ${{ secrets.LIBSQL_REMOTE_TOKEN }}

--- a/.github/workflows/router.yaml
+++ b/.github/workflows/router.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-feature:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name != 'workflow_dispatch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     uses: ./.github/workflows/release-feature-branch.yaml
     secrets: inherit
 

--- a/changelogs/drizzle-kit/0.31.8.md
+++ b/changelogs/drizzle-kit/0.31.8.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix external dependencies in build configuration.

--- a/changelogs/drizzle-orm/0.45.1.md
+++ b/changelogs/drizzle-orm/0.45.1.md
@@ -1,0 +1,1 @@
+- Fixed pg-native Pool detection in node-postgres transactions breaking in environments with forbidden `require()` ([#5107](https://github.com/drizzle-team/drizzle-orm/issues/5107))  

--- a/drizzle-kit/build.ts
+++ b/drizzle-kit/build.ts
@@ -84,7 +84,11 @@ const main = async () => {
 	await tsup.build({
 		entryPoints: ['./src/index.ts'],
 		outDir: './dist',
-		external: ['bun:sqlite'],
+		external: [
+			'esbuild',
+			'drizzle-orm',
+			...driversPackages,
+		],
 		splitting: false,
 		dts: true,
 		format: ['cjs', 'esm'],
@@ -105,7 +109,11 @@ const main = async () => {
 	await tsup.build({
 		entryPoints: ['./src/api.ts'],
 		outDir: './dist',
-		external: ['bun:sqlite'],
+		external: [
+			'esbuild',
+			'drizzle-orm',
+			...driversPackages,
+		],
 		splitting: false,
 		dts: true,
 		format: ['cjs', 'esm'],

--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drizzle-kit",
-	"version": "0.31.7",
+	"version": "0.31.8",
 	"homepage": "https://orm.drizzle.team",
 	"keywords": [
 		"drizzle",

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drizzle-orm",
-	"version": "0.45.0",
+	"version": "0.45.1",
 	"description": "Drizzle ORM package for SQL databases",
 	"type": "module",
 	"scripts": {

--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -15,7 +15,6 @@ import { tracer } from '~/tracing.ts';
 import { type Assume, mapResultRow } from '~/utils.ts';
 
 const { Pool, types } = pg;
-const NativePool = (<any> pg).native ? (<{ Pool: typeof Pool }> (<any> pg).native).Pool : undefined;
 
 export type NodePgClient = pg.Pool | PoolClient | Client;
 
@@ -250,8 +249,9 @@ export class NodePgSession<
 		transaction: (tx: NodePgTransaction<TFullSchema, TSchema>) => Promise<T>,
 		config?: PgTransactionConfig | undefined,
 	): Promise<T> {
-		const session = (this.client instanceof Pool || (NativePool && this.client instanceof NativePool)) // eslint-disable-line no-instanceof/no-instanceof
-			? new NodePgSession(await this.client.connect(), this.dialect, this.schema, this.options)
+		const isPool = this.client instanceof Pool || Object.getPrototypeOf(this.client).constructor.name.includes('Pool'); // eslint-disable-line no-instanceof/no-instanceof
+		const session = isPool
+			? new NodePgSession(await (<pg.Pool> this.client).connect(), this.dialect, this.schema, this.options)
 			: this;
 		const tx = new NodePgTransaction<TFullSchema, TSchema>(this.dialect, session, this.schema);
 		await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
@@ -263,9 +263,7 @@ export class NodePgSession<
 			await tx.execute(sql`rollback`);
 			throw error;
 		} finally {
-			if (this.client instanceof Pool || (NativePool && this.client instanceof NativePool)) { // eslint-disable-line no-instanceof/no-instanceof
-				(session.client as PoolClient).release();
-			}
+			if (isPool) (session.client as PoolClient).release();
 		}
 	}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,254 +1,191 @@
 {
-	"$schema": "https://turbo.build/schema.json",
-	"tasks": {
-		"//#lint": {
-			"dependsOn": [
-				"^test:types",
-				"drizzle-orm#build"
-			],
-			"inputs": [
-				"**/*.ts",
-				"!**/node_modules",
-				"!**/dist",
-				"!**/dist-dts"
-			],
-			"outputLogs": "new-only"
-		},
-		"test:types": {
-			"dependsOn": [
-				"^test:types",
-				"drizzle-orm#build",
-				"drizzle-seed#build"
-			],
-			"inputs": [
-				"src/**/*.ts",
-				"tests/**/*.ts",
-				"tsconfig.json",
-				"tests/tsconfig.json",
-				"../tsconfig.json"
-			],
-			"outputLogs": "new-only"
-		},
-		"drizzle-orm#build": {
-			"inputs": [
-				"src/**/*.ts",
-				"package.json",
-				"README.md",
-				"../README.md",
-				"tsconfig.json",
-				"tsconfig.*.json",
-				"tsup.config.ts",
-				"scripts/build.ts",
-				"scripts/fix-imports.ts",
-				"../tsconfig.json"
-			],
-			"outputs": [
-				"dist/**",
-				"dist-dts/**"
-			],
-			"outputLogs": "new-only"
-		},
-		"drizzle-kit#build": {
-			"dependsOn": [
-				"drizzle-orm#build"
-			],
-			"inputs": [
-				"src/**/*.ts",
-				"package.json",
-				"README.md",
-				"../README.md",
-				"tsconfig.json",
-				"tsconfig.*.json",
-				"tsup.config.ts",
-				"scripts/build.ts",
-				"scripts/fix-imports.ts",
-				"../tsconfig.json"
-			],
-			"outputs": [
-				"dist/**",
-				"dist-dts/**"
-			],
-			"outputLogs": "new-only"
-		},
-		"drizzle-zod#build": {
-			"dependsOn": [
-				"drizzle-orm#build"
-			],
-			"inputs": [
-				"src/**/*.ts",
-				"package.json",
-				"README.md",
-				"../README.md",
-				"tsconfig.json",
-				"tsconfig.*.json",
-				"tsup.config.ts",
-				"scripts/build.ts",
-				"scripts/fix-imports.ts",
-				"../tsconfig.json"
-			],
-			"outputs": [
-				"dist/**",
-				"dist-dts/**"
-			],
-			"outputLogs": "new-only"
-		},
-		"drizzle-typebox#build": {
-			"dependsOn": [
-				"drizzle-orm#build"
-			],
-			"inputs": [
-				"src/**/*.ts",
-				"package.json",
-				"README.md",
-				"../README.md",
-				"tsconfig.json",
-				"tsconfig.*.json",
-				"tsup.config.ts",
-				"scripts/build.ts",
-				"scripts/fix-imports.ts",
-				"../tsconfig.json"
-			],
-			"outputs": [
-				"dist/**",
-				"dist-dts/**"
-			],
-			"outputLogs": "new-only"
-		},
-		"drizzle-valibot#build": {
-			"dependsOn": [
-				"drizzle-orm#build"
-			],
-			"inputs": [
-				"src/**/*.ts",
-				"package.json",
-				"README.md",
-				"../README.md",
-				"tsconfig.json",
-				"tsconfig.*.json",
-				"tsup.config.ts",
-				"scripts/build.ts",
-				"scripts/fix-imports.ts",
-				"../tsconfig.json"
-			],
-			"outputs": [
-				"dist/**",
-				"dist-dts/**"
-			],
-			"outputLogs": "new-only"
-		},
-		"drizzle-arktype#build": {
-			"dependsOn": [
-				"drizzle-orm#build"
-			],
-			"inputs": [
-				"src/**/*.ts",
-				"package.json",
-				"README.md",
-				"../README.md",
-				"tsconfig.json",
-				"tsconfig.*.json",
-				"tsup.config.ts",
-				"scripts/build.ts",
-				"scripts/fix-imports.ts",
-				"../tsconfig.json"
-			],
-			"outputs": [
-				"dist/**",
-				"dist-dts/**"
-			],
-			"outputLogs": "new-only"
-		},
-		"eslint-plugin-drizzle#build": {
-			"dependsOn": [
-				"drizzle-orm#build"
-			],
-			"inputs": [
-				"src/**/*.ts",
-				"package.json",
-				"README.md",
-				"../README.md",
-				"tsconfig.json",
-				"tsconfig.*.json",
-				"tsup.config.ts",
-				"scripts/build.ts",
-				"scripts/fix-imports.ts",
-				"../tsconfig.json"
-			],
-			"outputs": [
-				"dist/**",
-				"dist-dts/**"
-			],
-			"outputLogs": "new-only"
-		},
-		"drizzle-seed#build": {
-			"dependsOn": [
-				"drizzle-orm#build"
-			],
-			"inputs": [
-				"src/**/*.ts",
-				"package.json",
-				"README.md",
-				"../README.md",
-				"tsconfig.json",
-				"tsconfig.*.json",
-				"tsup.config.ts",
-				"scripts/build.ts",
-				"scripts/fix-imports.ts",
-				"../tsconfig.json"
-			],
-			"outputs": [
-				"dist/**",
-				"dist-dts/**"
-			],
-			"outputLogs": "new-only"
-		},
-		"integration-tests#build": {
-			"dependsOn": [
-				"drizzle-orm#build",
-				"drizzle-seed#build"
-			],
-			"inputs": [
-				"src/**/*.ts",
-				"package.json",
-				"README.md",
-				"../README.md",
-				"tsconfig.json",
-				"tsconfig.*.json",
-				"tsup.config.ts",
-				"scripts/build.ts",
-				"scripts/fix-imports.ts",
-				"../tsconfig.json"
-			],
-			"outputs": [
-				"dist/**",
-				"dist-dts/**"
-			],
-			"outputLogs": "new-only"
-		},
-		"pack": {
-			"dependsOn": [
-				"build",
-				"test:types"
-			],
-			"inputs": [
-				"dist/**"
-			],
-			"outputs": [
-				"package.tgz"
-			],
-			"outputLogs": "new-only"
-		},
-		"test": {
-			"dependsOn": [
-				"build",
-				"test:types"
-			],
-			"inputs": [
-				"tests/**/*.test.ts",
-				"tests/**/*.test.cjs",
-				"tests/**/*.test.mjs"
-			],
-			"outputLogs": "new-only"
-		}
-	}
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "transit": {
+      "dependsOn": ["^transit"]
+    },
+    "//#lint": {
+      "dependsOn": ["^test:types", "drizzle-orm#build"],
+      "inputs": ["**/*.ts", "!**/node_modules", "!**/dist", "!**/dist-dts"],
+      "outputLogs": "new-only"
+    },
+    "test:types": {
+      "dependsOn": ["transit", "drizzle-orm#build", "drizzle-seed#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        "tsconfig.json",
+        "tests/tsconfig.json",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputLogs": "new-only"
+    },
+    "drizzle-orm#build": {
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
+    "drizzle-kit#build": {
+      "dependsOn": ["drizzle-orm#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
+    "drizzle-zod#build": {
+      "dependsOn": ["drizzle-orm#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
+    "drizzle-typebox#build": {
+      "dependsOn": ["drizzle-orm#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
+    "drizzle-valibot#build": {
+      "dependsOn": ["drizzle-orm#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
+    "drizzle-arktype#build": {
+      "dependsOn": ["drizzle-orm#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
+    "eslint-plugin-drizzle#build": {
+      "dependsOn": ["drizzle-orm#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
+    "drizzle-seed#build": {
+      "dependsOn": ["drizzle-orm#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
+    "integration-tests#build": {
+      "dependsOn": ["drizzle-orm#build", "drizzle-seed#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
+    "pack": {
+      "dependsOn": ["build", "test:types"],
+      "inputs": ["dist/**"],
+      "outputs": ["package.tgz"],
+      "outputLogs": "new-only"
+    },
+    "test": {
+      "dependsOn": ["build", "test:types"],
+      "inputs": [
+        "tests/**/*.test.ts",
+        "tests/**/*.test.cjs",
+        "tests/**/*.test.mjs"
+      ],
+      "outputLogs": "new-only"
+    }
+  }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -20,157 +20,28 @@
       ],
       "outputLogs": "new-only"
     },
+    "build": {
+      "dependsOn": ["drizzle-orm#build"],
+      "inputs": [
+        "src/**/*.ts",
+        "package.json",
+        "README.md",
+        "$TURBO_ROOT$/README.md",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "tsup.config.ts",
+        "scripts/build.ts",
+        "scripts/fix-imports.ts",
+        "$TURBO_ROOT$/tsconfig.json"
+      ],
+      "outputs": ["dist/**", "dist-dts/**"],
+      "outputLogs": "new-only"
+    },
     "drizzle-orm#build": {
-      "inputs": [
-        "src/**/*.ts",
-        "package.json",
-        "README.md",
-        "$TURBO_ROOT$/README.md",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "tsup.config.ts",
-        "scripts/build.ts",
-        "scripts/fix-imports.ts",
-        "$TURBO_ROOT$/tsconfig.json"
-      ],
-      "outputs": ["dist/**", "dist-dts/**"],
-      "outputLogs": "new-only"
-    },
-    "drizzle-kit#build": {
-      "dependsOn": ["drizzle-orm#build"],
-      "inputs": [
-        "src/**/*.ts",
-        "package.json",
-        "README.md",
-        "$TURBO_ROOT$/README.md",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "tsup.config.ts",
-        "scripts/build.ts",
-        "scripts/fix-imports.ts",
-        "$TURBO_ROOT$/tsconfig.json"
-      ],
-      "outputs": ["dist/**", "dist-dts/**"],
-      "outputLogs": "new-only"
-    },
-    "drizzle-zod#build": {
-      "dependsOn": ["drizzle-orm#build"],
-      "inputs": [
-        "src/**/*.ts",
-        "package.json",
-        "README.md",
-        "$TURBO_ROOT$/README.md",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "tsup.config.ts",
-        "scripts/build.ts",
-        "scripts/fix-imports.ts",
-        "$TURBO_ROOT$/tsconfig.json"
-      ],
-      "outputs": ["dist/**", "dist-dts/**"],
-      "outputLogs": "new-only"
-    },
-    "drizzle-typebox#build": {
-      "dependsOn": ["drizzle-orm#build"],
-      "inputs": [
-        "src/**/*.ts",
-        "package.json",
-        "README.md",
-        "$TURBO_ROOT$/README.md",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "tsup.config.ts",
-        "scripts/build.ts",
-        "scripts/fix-imports.ts",
-        "$TURBO_ROOT$/tsconfig.json"
-      ],
-      "outputs": ["dist/**", "dist-dts/**"],
-      "outputLogs": "new-only"
-    },
-    "drizzle-valibot#build": {
-      "dependsOn": ["drizzle-orm#build"],
-      "inputs": [
-        "src/**/*.ts",
-        "package.json",
-        "README.md",
-        "$TURBO_ROOT$/README.md",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "tsup.config.ts",
-        "scripts/build.ts",
-        "scripts/fix-imports.ts",
-        "$TURBO_ROOT$/tsconfig.json"
-      ],
-      "outputs": ["dist/**", "dist-dts/**"],
-      "outputLogs": "new-only"
-    },
-    "drizzle-arktype#build": {
-      "dependsOn": ["drizzle-orm#build"],
-      "inputs": [
-        "src/**/*.ts",
-        "package.json",
-        "README.md",
-        "$TURBO_ROOT$/README.md",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "tsup.config.ts",
-        "scripts/build.ts",
-        "scripts/fix-imports.ts",
-        "$TURBO_ROOT$/tsconfig.json"
-      ],
-      "outputs": ["dist/**", "dist-dts/**"],
-      "outputLogs": "new-only"
-    },
-    "eslint-plugin-drizzle#build": {
-      "dependsOn": ["drizzle-orm#build"],
-      "inputs": [
-        "src/**/*.ts",
-        "package.json",
-        "README.md",
-        "$TURBO_ROOT$/README.md",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "tsup.config.ts",
-        "scripts/build.ts",
-        "scripts/fix-imports.ts",
-        "$TURBO_ROOT$/tsconfig.json"
-      ],
-      "outputs": ["dist/**", "dist-dts/**"],
-      "outputLogs": "new-only"
-    },
-    "drizzle-seed#build": {
-      "dependsOn": ["drizzle-orm#build"],
-      "inputs": [
-        "src/**/*.ts",
-        "package.json",
-        "README.md",
-        "$TURBO_ROOT$/README.md",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "tsup.config.ts",
-        "scripts/build.ts",
-        "scripts/fix-imports.ts",
-        "$TURBO_ROOT$/tsconfig.json"
-      ],
-      "outputs": ["dist/**", "dist-dts/**"],
-      "outputLogs": "new-only"
+      "dependsOn": []
     },
     "integration-tests#build": {
-      "dependsOn": ["drizzle-orm#build", "drizzle-seed#build"],
-      "inputs": [
-        "src/**/*.ts",
-        "package.json",
-        "README.md",
-        "$TURBO_ROOT$/README.md",
-        "tsconfig.json",
-        "tsconfig.*.json",
-        "tsup.config.ts",
-        "scripts/build.ts",
-        "scripts/fix-imports.ts",
-        "$TURBO_ROOT$/tsconfig.json"
-      ],
-      "outputs": ["dist/**", "dist-dts/**"],
-      "outputLogs": "new-only"
+      "dependsOn": ["drizzle-orm#build", "drizzle-seed#build"]
     },
     "pack": {
       "dependsOn": ["build", "test:types"],


### PR DESCRIPTION
## Summary

- Replace relative path traversal (`../tsconfig.json`, `../README.md`) with `$TURBO_ROOT$` references in all package build task inputs
- Add a `transit` task to enable parallel execution of `test:types` while maintaining correct cache invalidation
- Simplified configuration by ~190 lines

## Why

**`$TURBO_ROOT$` references**: Using `../` to traverse out of a package in `inputs` is an anti-pattern in Turborepo. The `$TURBO_ROOT$` variable is the recommended way to reference files at the repository root, providing clearer intent and better compatibility with Turborepo's internals.

**Transit node**: The `test:types` task previously used `dependsOn: ["^test:types", ...]` which forces sequential execution across packages. However, type checking doesn't need built output from dependencies - it only needs the source types. The transit node pattern creates the dependency graph relationship for correct cache invalidation without forcing sequential execution, allowing `test:types` tasks to run in parallel.

## Notes
- When reviewing please ensure that all workflows are working as expected. Most importantly, the configuration for `build` has been collapsed into one definition. There were some nuances that the LLM appears to have taken care of, and I've reviewed carefully - but I am paranoid that I may have missed something.
- Chat transcript: https://opncd.ai/share/40HTubnr