### PR TITLE
  [Pg-kit]: Support PostgreSQL schema names starting with numbers

### DIFF
--- a/drizzle-kit/src/jsonDiffer.js
+++ b/drizzle-kit/src/jsonDiffer.js
@@ -88,17 +88,24 @@ const mapArraysDiff = (source, diff) => {
 };
 
 export function diffSchemasOrTables(left, right) {
-	left = JSON.parse(JSON.stringify(left));
-	right = JSON.parse(JSON.stringify(right));
+	// Direct key comparison avoids JSON.parse issues with numeric-prefixed keys
+	const leftKeys = new Set(Object.keys(left));
+	const rightKeys = new Set(Object.keys(right));
 
-	const result = Object.entries(diff(left, right) ?? {});
+	const added = [];
+	const deleted = [];
 
-	const added = result
-		.filter((it) => it[0].endsWith('__added'))
-		.map((it) => it[1]);
-	const deleted = result
-		.filter((it) => it[0].endsWith('__deleted'))
-		.map((it) => it[1]);
+	for (const key of rightKeys) {
+		if (!leftKeys.has(key)) {
+			added.push(right[key]);
+		}
+	}
+
+	for (const key of leftKeys) {
+		if (!rightKeys.has(key)) {
+			deleted.push(left[key]);
+		}
+	}
 
 	return { added, deleted };
 }

--- a/drizzle-kit/tests/pg-schemas.test.ts
+++ b/drizzle-kit/tests/pg-schemas.test.ts
@@ -103,3 +103,35 @@ test('rename schema #2', async () => {
 		to: 'dev2',
 	});
 });
+
+test('add schema with numeric prefix', async () => {
+	const to = {
+		numericSchema: pgSchema('2HrzP19rneClkDSN'),
+	};
+
+	const { statements } = await diffTestSchemas({}, to, []);
+
+	expect(statements.length).toBe(1);
+	expect(statements[0]).toStrictEqual({
+		type: 'create_schema',
+		name: '2HrzP19rneClkDSN',
+	});
+});
+
+test('add schema with numeric prefix alongside regular schema', async () => {
+	const from = {
+		regularSchema: pgSchema('public_schema'),
+	};
+	const to = {
+		regularSchema: pgSchema('public_schema'),
+		numericSchema: pgSchema('2HrzP19rneClkDSN'),
+	};
+
+	const { statements } = await diffTestSchemas(from, to, []);
+
+	expect(statements.length).toBe(1);
+	expect(statements[0]).toStrictEqual({
+		type: 'create_schema',
+		name: '2HrzP19rneClkDSN',
+	});
+});


### PR DESCRIPTION

  Fixes #5283

  This PR fixes an issue where PostgreSQL schema names starting with numbers (e.g., `2HrzP19rneClkDSN`) would fail to be created during migrations, despite the migration reporting success.

  ## Problem

  When using schema names that begin with numbers, the `drizzle-kit generate` command would:
  - Generate correct SQL: `CREATE SCHEMA "2HrzP19rneClkDSN";`
  - Report successful migration
  - But fail to actually create the schema in the database

  The root cause was in the `diffSchemasOrTables()` function in `drizzle-kit/src/jsonDiffer.js`. This function used `JSON.parse(JSON.stringify())` to deep clone objects before comparison, which caused JavaScript to reorder object keys that start with numbers. This led to incorrect schema change detection by the json-diff library.

  ## Solution

  Replaced the JSON serialization approach with a direct Set-based key comparison:
  - Preserves exact key ordering and format
  - Avoids JSON serialization side effects
  - Provides simpler, more predictable behavior
  - Correctly handles schema names starting with any character (numbers, letters, symbols)

  ## Changes

  - **Modified**: `drizzle-kit/src/jsonDiffer.js`
    - Rewrote `diffSchemasOrTables()` to use Set-based comparison instead of relying on json-diff for detecting added/deleted schemas and tables
    - Simplified the logic while maintaining backward compatibility

  - **Added**: `drizzle-kit/tests/pg-schemas.test.ts`
    - Test case: "add schema with numeric prefix"
    - Test case: "add schema with numeric prefix alongside regular schema"

  ## Testing

  Added test cases specifically for numeric-prefixed schema names to ensure they are correctly detected during schema diffing operations.

  The fix also applies to:
  - Tables with numeric-prefixed names
  - Enums, sequences, roles, and views (all use the same `diffSchemasOrTables` function)
