### PR TITLE
feat(db0): add db0 driver for drizzle-orm

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -83,10 +83,16 @@
 		"postgres": ">=3",
 		"sql.js": ">=1",
 		"sqlite3": ">=5",
+<<<<<<< HEAD
 		"db0": ">=0.3.4",
 		"typebox": ">=1.0.0",
 		"valibot": ">=1.0.0-beta.7",
 		"zod": "^3.25.0 || ^4.0.0"
+=======
+		"gel": ">=2",
+		"@upstash/redis": ">=1.34.7",
+		"db0": ">=0.3.4"
+>>>>>>> d8ca6bcb (fix(db0): prefer array results)
 	},
 	"peerDependenciesMeta": {
 		"arktype": {
@@ -243,7 +249,10 @@
 		"bun-types": "^1.2.23",
 		"cpy": "^10.1.0",
 		"db0": "^0.3.4",
+<<<<<<< HEAD
 		"effect": "^3.19.8",
+=======
+>>>>>>> d8ca6bcb (fix(db0): prefer array results)
 		"expo-sqlite": "^14.0.0",
 		"gel": "^2.0.0",
 		"glob": "^11.0.1",

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -83,6 +83,7 @@
 		"postgres": ">=3",
 		"sql.js": ">=1",
 		"sqlite3": ">=5",
+		"db0": ">=0.3.4",
 		"typebox": ">=1.0.0",
 		"valibot": ">=1.0.0-beta.7",
 		"zod": "^3.25.0 || ^4.0.0"
@@ -193,6 +194,9 @@
 		"@effect/sql-pg": {
 			"optional": true
 		},
+		"db0": {
+			"optional": true
+		},
 		"typebox": {
 			"optional": true
 		},
@@ -238,6 +242,7 @@
 		"better-sqlite3": "^11.9.1",
 		"bun-types": "^1.2.23",
 		"cpy": "^10.1.0",
+		"db0": "^0.3.4",
 		"effect": "^3.19.8",
 		"expo-sqlite": "^14.0.0",
 		"gel": "^2.0.0",

--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -83,16 +83,10 @@
 		"postgres": ">=3",
 		"sql.js": ">=1",
 		"sqlite3": ">=5",
-<<<<<<< HEAD
 		"db0": ">=0.3.4",
 		"typebox": ">=1.0.0",
 		"valibot": ">=1.0.0-beta.7",
 		"zod": "^3.25.0 || ^4.0.0"
-=======
-		"gel": ">=2",
-		"@upstash/redis": ">=1.34.7",
-		"db0": ">=0.3.4"
->>>>>>> d8ca6bcb (fix(db0): prefer array results)
 	},
 	"peerDependenciesMeta": {
 		"arktype": {
@@ -249,10 +243,7 @@
 		"bun-types": "^1.2.23",
 		"cpy": "^10.1.0",
 		"db0": "^0.3.4",
-<<<<<<< HEAD
 		"effect": "^3.19.8",
-=======
->>>>>>> d8ca6bcb (fix(db0): prefer array results)
 		"expo-sqlite": "^14.0.0",
 		"gel": "^2.0.0",
 		"glob": "^11.0.1",

--- a/drizzle-orm/src/db0/_row-mapping.ts
+++ b/drizzle-orm/src/db0/_row-mapping.ts
@@ -1,0 +1,43 @@
+import type { CasingCache } from '~/casing.ts';
+import { Column } from '~/column.ts';
+import { is } from '~/entity.ts';
+import { SQL } from '~/sql/sql.ts';
+
+type DialectWithCasing = { casing: CasingCache };
+
+export function getFieldKey(field: unknown, dialect: DialectWithCasing): string | undefined {
+	if (is(field, SQL.Aliased)) {
+		return field.fieldAlias;
+	}
+	if (is(field, Column)) {
+		return dialect.casing.getColumnCasing(field);
+	}
+	return undefined;
+}
+
+export function mapDb0RowToArray(
+	row: Record<string, unknown>,
+	fields: ReadonlyArray<{ field: unknown }>,
+	dialect: DialectWithCasing,
+): unknown[] {
+	const keys = fields.map((f) => getFieldKey(f.field, dialect));
+
+	// If we can't confidently map by key (unknown field type, duplicate keys, missing key),
+	// fall back to Object.values and accept db0 limitations for complex selections.
+	if (keys.some((k) => k === undefined)) {
+		return Object.values(row);
+	}
+
+	const unique = new Set(keys as string[]);
+	if (unique.size !== keys.length) {
+		return Object.values(row);
+	}
+
+	for (const key of keys as string[]) {
+		if (!(key in row)) {
+			return Object.values(row);
+		}
+	}
+
+	return (keys as string[]).map((key) => row[key]);
+}

--- a/drizzle-orm/src/db0/driver.ts
+++ b/drizzle-orm/src/db0/driver.ts
@@ -1,28 +1,35 @@
 import type { Database } from 'db0';
+import type { AnyRelations, EmptyRelations } from '~/relations.ts';
 import type { DrizzleConfig } from '~/utils.ts';
 import { isConfig } from '~/utils.ts';
 import { constructPg, type Db0PgDatabase } from './pg/index.ts';
 import { constructSqlite, type Db0SQLiteDatabase } from './sqlite/index.ts';
 
-export type Db0Database = Db0SQLiteDatabase<any> | Db0PgDatabase<any>;
+export type Db0Database = Db0SQLiteDatabase<any, any> | Db0PgDatabase<any, any>;
 
-export function drizzle<TSchema extends Record<string, unknown> = Record<string, never>>(
+export function drizzle<
+	TSchema extends Record<string, unknown> = Record<string, never>,
+	TRelations extends AnyRelations = EmptyRelations,
+>(
 	...params:
 		| [Database]
-		| [Database, DrizzleConfig<TSchema>]
-		| [DrizzleConfig<TSchema> & { client: Database }]
+		| [Database, DrizzleConfig<TSchema, TRelations>]
+		| [DrizzleConfig<TSchema, TRelations> & { client: Database }]
 ): Db0Database & { $client: Database } {
 	if (isConfig(params[0])) {
-		const { client, ...drizzleConfig } = params[0] as DrizzleConfig<TSchema> & { client: Database };
+		const { client, ...drizzleConfig } = params[0] as DrizzleConfig<TSchema, TRelations> & { client: Database };
 		return drizzleInternal(client, drizzleConfig);
 	}
 
-	return drizzleInternal(params[0] as Database, params[1] as DrizzleConfig<TSchema> | undefined);
+	return drizzleInternal(params[0] as Database, params[1] as DrizzleConfig<TSchema, TRelations> | undefined);
 }
 
-function drizzleInternal<TSchema extends Record<string, unknown> = Record<string, never>>(
+function drizzleInternal<
+	TSchema extends Record<string, unknown> = Record<string, never>,
+	TRelations extends AnyRelations = EmptyRelations,
+>(
 	client: Database,
-	config: DrizzleConfig<TSchema> = {},
+	config: DrizzleConfig<TSchema, TRelations> = {},
 ): Db0Database & { $client: Database } {
 	const dialect = client.dialect;
 
@@ -40,8 +47,11 @@ function drizzleInternal<TSchema extends Record<string, unknown> = Record<string
 }
 
 export namespace drizzle {
-	export function mock<TSchema extends Record<string, unknown> = Record<string, never>>(
-		config?: DrizzleConfig<TSchema>,
+	export function mock<
+		TSchema extends Record<string, unknown> = Record<string, never>,
+		TRelations extends AnyRelations = EmptyRelations,
+	>(
+		config?: DrizzleConfig<TSchema, TRelations>,
 	): Db0Database & { $client: '$client is not available on drizzle.mock()' } {
 		return constructSqlite({} as any, config) as any;
 	}

--- a/drizzle-orm/src/db0/driver.ts
+++ b/drizzle-orm/src/db0/driver.ts
@@ -1,0 +1,48 @@
+import type { Database } from 'db0';
+import type { DrizzleConfig } from '~/utils.ts';
+import { isConfig } from '~/utils.ts';
+import { constructPg, type Db0PgDatabase } from './pg/index.ts';
+import { constructSqlite, type Db0SQLiteDatabase } from './sqlite/index.ts';
+
+export type Db0Database = Db0SQLiteDatabase<any> | Db0PgDatabase<any>;
+
+export function drizzle<TSchema extends Record<string, unknown> = Record<string, never>>(
+	...params:
+		| [Database]
+		| [Database, DrizzleConfig<TSchema>]
+		| [DrizzleConfig<TSchema> & { client: Database }]
+): Db0Database & { $client: Database } {
+	if (isConfig(params[0])) {
+		const { client, ...drizzleConfig } = params[0] as DrizzleConfig<TSchema> & { client: Database };
+		return drizzleInternal(client, drizzleConfig);
+	}
+
+	return drizzleInternal(params[0] as Database, params[1] as DrizzleConfig<TSchema> | undefined);
+}
+
+function drizzleInternal<TSchema extends Record<string, unknown> = Record<string, never>>(
+	client: Database,
+	config: DrizzleConfig<TSchema> = {},
+): Db0Database & { $client: Database } {
+	const dialect = client.dialect;
+
+	switch (dialect) {
+		case 'sqlite':
+		case 'libsql':
+			return constructSqlite(client, config) as any;
+		case 'postgresql':
+			return constructPg(client, config) as any;
+		case 'mysql':
+			throw new Error('drizzle-orm/db0: MySQL support is not yet implemented');
+		default:
+			throw new Error(`drizzle-orm/db0: Unsupported db0 dialect: ${dialect}`);
+	}
+}
+
+export namespace drizzle {
+	export function mock<TSchema extends Record<string, unknown> = Record<string, never>>(
+		config?: DrizzleConfig<TSchema>,
+	): Db0Database & { $client: '$client is not available on drizzle.mock()' } {
+		return constructSqlite({} as any, config) as any;
+	}
+}

--- a/drizzle-orm/src/db0/index.ts
+++ b/drizzle-orm/src/db0/index.ts
@@ -1,0 +1,20 @@
+export { drizzle, type Db0Database } from './driver.ts';
+export {
+	constructPg,
+	Db0PgDatabase,
+	Db0PgPreparedQuery,
+	type Db0PgQueryResult,
+	type Db0PgQueryResultHKT,
+	Db0PgSession,
+	type Db0PgSessionOptions,
+	Db0PgTransaction,
+} from './pg/index.ts';
+export {
+	constructSqlite,
+	Db0SQLiteDatabase,
+	Db0SQLitePreparedQuery,
+	Db0SQLiteSession,
+	Db0SQLiteTransaction,
+	type Db0RunResult,
+	type Db0SQLiteSessionOptions,
+} from './sqlite/index.ts';

--- a/drizzle-orm/src/db0/pg/driver.ts
+++ b/drizzle-orm/src/db0/pg/driver.ts
@@ -1,0 +1,49 @@
+import type { Database } from 'db0';
+import { entityKind } from '~/entity.ts';
+import { DefaultLogger } from '~/logger.ts';
+import { PgDatabase } from '~/pg-core/db.ts';
+import { PgDialect } from '~/pg-core/dialect.ts';
+import {
+	createTableRelationsHelpers,
+	extractTablesRelationalConfig,
+	type RelationalSchemaConfig,
+	type TablesRelationalConfig,
+} from '~/relations.ts';
+import type { DrizzleConfig } from '~/utils.ts';
+import { type Db0PgQueryResultHKT, Db0PgSession, type Db0PgSessionOptions } from './session.ts';
+
+export class Db0PgDatabase<
+	TSchema extends Record<string, unknown> = Record<string, never>,
+> extends PgDatabase<Db0PgQueryResultHKT, TSchema> {
+	static override readonly [entityKind]: string = 'Db0PgDatabase';
+}
+
+export function constructPg<TSchema extends Record<string, unknown> = Record<string, never>>(
+	client: Database,
+	config: DrizzleConfig<TSchema> = {},
+): Db0PgDatabase<TSchema> & { $client: Database } {
+	const dialect = new PgDialect({ casing: config.casing });
+	let logger;
+	if (config.logger === true) {
+		logger = new DefaultLogger();
+	} else if (config.logger !== false) {
+		logger = config.logger;
+	}
+
+	let schema: RelationalSchemaConfig<TablesRelationalConfig> | undefined;
+	if (config.schema) {
+		const tablesConfig = extractTablesRelationalConfig(config.schema, createTableRelationsHelpers);
+		schema = {
+			fullSchema: config.schema,
+			schema: tablesConfig.tables,
+			tableNamesMap: tablesConfig.tableNamesMap,
+		};
+	}
+
+	const sessionOptions: Db0PgSessionOptions = { logger, cache: config.cache };
+	const session = new Db0PgSession(client, dialect, schema, sessionOptions);
+	const db = new Db0PgDatabase(dialect, session, schema as any) as Db0PgDatabase<TSchema>;
+	(<any>db).$client = client;
+
+	return db as any;
+}

--- a/drizzle-orm/src/db0/pg/driver.ts
+++ b/drizzle-orm/src/db0/pg/driver.ts
@@ -1,38 +1,42 @@
 import type { Database } from 'db0';
+import * as V1 from '~/_relations.ts';
 import { entityKind } from '~/entity.ts';
+import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
-import { PgDatabase } from '~/pg-core/db.ts';
+import { PgAsyncDatabase } from '~/pg-core/async/db.ts';
 import { PgDialect } from '~/pg-core/dialect.ts';
-import {
-	createTableRelationsHelpers,
-	extractTablesRelationalConfig,
-	type RelationalSchemaConfig,
-	type TablesRelationalConfig,
-} from '~/relations.ts';
+import type { AnyRelations, EmptyRelations } from '~/relations.ts';
 import type { DrizzleConfig } from '~/utils.ts';
 import { type Db0PgQueryResultHKT, Db0PgSession, type Db0PgSessionOptions } from './session.ts';
 
 export class Db0PgDatabase<
 	TSchema extends Record<string, unknown> = Record<string, never>,
-> extends PgDatabase<Db0PgQueryResultHKT, TSchema> {
+	TRelations extends AnyRelations = EmptyRelations,
+> extends PgAsyncDatabase<Db0PgQueryResultHKT, TSchema, TRelations> {
 	static override readonly [entityKind]: string = 'Db0PgDatabase';
 }
 
-export function constructPg<TSchema extends Record<string, unknown> = Record<string, never>>(
+export function constructPg<
+	TSchema extends Record<string, unknown> = Record<string, never>,
+	TRelations extends AnyRelations = EmptyRelations,
+>(
 	client: Database,
-	config: DrizzleConfig<TSchema> = {},
-): Db0PgDatabase<TSchema> & { $client: Database } {
+	config: DrizzleConfig<TSchema, TRelations> = {},
+): Db0PgDatabase<TSchema, TRelations> & { $client: Database } {
 	const dialect = new PgDialect({ casing: config.casing });
-	let logger;
+	let logger: Logger | undefined;
 	if (config.logger === true) {
 		logger = new DefaultLogger();
 	} else if (config.logger !== false) {
 		logger = config.logger;
 	}
 
-	let schema: RelationalSchemaConfig<TablesRelationalConfig> | undefined;
+	let schema: V1.RelationalSchemaConfig<V1.TablesRelationalConfig> | undefined;
 	if (config.schema) {
-		const tablesConfig = extractTablesRelationalConfig(config.schema, createTableRelationsHelpers);
+		const tablesConfig = V1.extractTablesRelationalConfig(
+			config.schema,
+			V1.createTableRelationsHelpers,
+		);
 		schema = {
 			fullSchema: config.schema,
 			schema: tablesConfig.tables,
@@ -40,10 +44,22 @@ export function constructPg<TSchema extends Record<string, unknown> = Record<str
 		};
 	}
 
+	const relations = config.relations ?? {} as TRelations;
 	const sessionOptions: Db0PgSessionOptions = { logger, cache: config.cache };
-	const session = new Db0PgSession(client, dialect, schema, sessionOptions);
-	const db = new Db0PgDatabase(dialect, session, schema as any) as Db0PgDatabase<TSchema>;
-	(<any>db).$client = client;
+	const session = new Db0PgSession(client, dialect, relations, schema as any, sessionOptions);
+
+	const db = new Db0PgDatabase(
+		dialect,
+		session,
+		relations,
+		schema as V1.RelationalSchemaConfig<any>,
+	) as Db0PgDatabase<TSchema, TRelations>;
+
+	(<any> db).$client = client;
+	(<any> db).$cache = config.cache;
+	if ((<any> db).$cache) {
+		(<any> db).$cache['invalidate'] = config.cache?.onMutate;
+	}
 
 	return db as any;
 }

--- a/drizzle-orm/src/db0/pg/index.ts
+++ b/drizzle-orm/src/db0/pg/index.ts
@@ -1,5 +1,4 @@
 export { constructPg, Db0PgDatabase } from './driver.ts';
-export * from './migrator.ts';
 export {
 	Db0PgPreparedQuery,
 	type Db0PgQueryResult,

--- a/drizzle-orm/src/db0/pg/index.ts
+++ b/drizzle-orm/src/db0/pg/index.ts
@@ -1,0 +1,10 @@
+export { constructPg, Db0PgDatabase } from './driver.ts';
+export * from './migrator.ts';
+export {
+	Db0PgPreparedQuery,
+	type Db0PgQueryResult,
+	type Db0PgQueryResultHKT,
+	Db0PgSession,
+	type Db0PgSessionOptions,
+	Db0PgTransaction,
+} from './session.ts';

--- a/drizzle-orm/src/db0/pg/migrator.ts
+++ b/drizzle-orm/src/db0/pg/migrator.ts
@@ -1,0 +1,11 @@
+import type { MigrationConfig } from '~/migrator.ts';
+import { readMigrationFiles } from '~/migrator.ts';
+import type { Db0PgDatabase } from './driver.ts';
+
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: Db0PgDatabase<TSchema>,
+	config: MigrationConfig,
+) {
+	const migrations = readMigrationFiles(config);
+	await db.dialect.migrate(migrations, db.session, config);
+}

--- a/drizzle-orm/src/db0/pg/migrator.ts
+++ b/drizzle-orm/src/db0/pg/migrator.ts
@@ -1,11 +1,13 @@
 import type { MigrationConfig } from '~/migrator.ts';
 import { readMigrationFiles } from '~/migrator.ts';
+import { migrate as coreMigrate } from '~/pg-core/async/session.ts';
+import type { AnyRelations } from '~/relations.ts';
 import type { Db0PgDatabase } from './driver.ts';
 
-export async function migrate<TSchema extends Record<string, unknown>>(
-	db: Db0PgDatabase<TSchema>,
+export async function migrate<TSchema extends Record<string, unknown>, TRelations extends AnyRelations>(
+	db: Db0PgDatabase<TSchema, TRelations>,
 	config: MigrationConfig,
 ) {
 	const migrations = readMigrationFiles(config);
-	await db.dialect.migrate(migrations, db.session, config);
+	return await coreMigrate(migrations, db.session, config);
 }

--- a/drizzle-orm/src/db0/pg/session.ts
+++ b/drizzle-orm/src/db0/pg/session.ts
@@ -1,0 +1,197 @@
+import type { Database, Primitive } from 'db0';
+import { type Cache, NoopCache } from '~/cache/core/cache.ts';
+import type { WithCacheConfig } from '~/cache/core/types.ts';
+import { entityKind } from '~/entity.ts';
+import type { Logger } from '~/logger.ts';
+import { NoopLogger } from '~/logger.ts';
+import type { PgDialect } from '~/pg-core/dialect.ts';
+import { PgTransaction } from '~/pg-core/index.ts';
+import type { SelectedFieldsOrdered } from '~/pg-core/query-builders/select.types.ts';
+import type { PgQueryResultHKT, PgTransactionConfig, PreparedQueryConfig } from '~/pg-core/session.ts';
+import { PgPreparedQuery, PgSession } from '~/pg-core/session.ts';
+import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
+import { fillPlaceholders, type Query, type SQL, sql } from '~/sql/sql.ts';
+import { mapResultRow } from '~/utils.ts';
+
+export interface Db0PgSessionOptions {
+	logger?: Logger;
+	cache?: Cache;
+}
+
+export interface Db0PgQueryResult {
+	rows: unknown[];
+	rowCount: number;
+}
+
+export class Db0PgPreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends PgPreparedQuery<T> {
+	static override readonly [entityKind]: string = 'Db0PgPreparedQuery';
+
+	constructor(
+		private client: Database,
+		private queryString: string,
+		private params: unknown[],
+		private logger: Logger,
+		cache: Cache,
+		queryMetadata: { type: 'select' | 'update' | 'delete' | 'insert'; tables: string[] } | undefined,
+		cacheConfig: WithCacheConfig | undefined,
+		private fields: SelectedFieldsOrdered | undefined,
+		name: string | undefined,
+		private _isResponseInArrayMode: boolean,
+		private customResultMapper?: (rows: unknown[][], mapColumnValue?: (value: unknown) => unknown) => T['execute'],
+	) {
+		super({ sql: queryString, params }, cache, queryMetadata, cacheConfig);
+	}
+
+	async execute(placeholderValues: Record<string, unknown> | undefined = {}): Promise<T['execute']> {
+		const params = fillPlaceholders(this.params, placeholderValues) as Primitive[];
+		this.logger.logQuery(this.queryString, params);
+
+		const { fields, client, customResultMapper, queryString, joinsNotNullableMap } = this;
+
+		if (!fields && !customResultMapper) {
+			return await this.queryWithCache(queryString, params, async () => {
+				const stmt = client.prepare(queryString);
+				const rows = await stmt.all(...params) as unknown[];
+				return { rows, rowCount: rows.length } as T['execute'];
+			});
+		}
+
+		// db0 doesn't have array mode, so we get objects and convert to arrays
+		return await this.queryWithCache(queryString, params, async () => {
+			const stmt = client.prepare(queryString);
+			const rows = await stmt.all(...params) as Record<string, unknown>[];
+			const arrayRows = rows.map((row) => Object.values(row));
+
+			if (customResultMapper) {
+				return customResultMapper(arrayRows);
+			}
+
+			return arrayRows.map((row) => mapResultRow<T['execute']>(fields!, row, joinsNotNullableMap));
+		});
+	}
+
+	async all(placeholderValues: Record<string, unknown> | undefined = {}): Promise<T['all']> {
+		const params = fillPlaceholders(this.params, placeholderValues) as Primitive[];
+		this.logger.logQuery(this.queryString, params);
+		return await this.queryWithCache(this.queryString, params, async () => {
+			const stmt = this.client.prepare(this.queryString);
+			return stmt.all(...params) as Promise<T['all']>;
+		});
+	}
+
+	/** @internal */
+	isResponseInArrayMode(): boolean {
+		return this._isResponseInArrayMode;
+	}
+}
+
+export class Db0PgSession<
+	TFullSchema extends Record<string, unknown>,
+	TSchema extends TablesRelationalConfig,
+> extends PgSession<Db0PgQueryResultHKT, TFullSchema, TSchema> {
+	static override readonly [entityKind]: string = 'Db0PgSession';
+
+	private logger: Logger;
+	private cache: Cache;
+
+	constructor(
+		private client: Database,
+		dialect: PgDialect,
+		private schema: RelationalSchemaConfig<TSchema> | undefined,
+		private options: Db0PgSessionOptions = {},
+	) {
+		super(dialect);
+		this.logger = options.logger ?? new NoopLogger();
+		this.cache = options.cache ?? new NoopCache();
+	}
+
+	prepareQuery<T extends PreparedQueryConfig = PreparedQueryConfig>(
+		query: Query,
+		fields: SelectedFieldsOrdered | undefined,
+		name: string | undefined,
+		isResponseInArrayMode: boolean,
+		customResultMapper?: (rows: unknown[][], mapColumnValue?: (value: unknown) => unknown) => T['execute'],
+		queryMetadata?: { type: 'select' | 'update' | 'delete' | 'insert'; tables: string[] },
+		cacheConfig?: WithCacheConfig,
+	): PgPreparedQuery<T> {
+		return new Db0PgPreparedQuery(
+			this.client,
+			query.sql,
+			query.params,
+			this.logger,
+			this.cache,
+			queryMetadata,
+			cacheConfig,
+			fields,
+			name,
+			isResponseInArrayMode,
+			customResultMapper,
+		);
+	}
+
+	override async transaction<T>(
+		transaction: (tx: Db0PgTransaction<TFullSchema, TSchema>) => Promise<T>,
+		config?: PgTransactionConfig,
+	): Promise<T> {
+		const tx = new Db0PgTransaction<TFullSchema, TSchema>(this.dialect, this, this.schema);
+
+		let beginSql = 'begin';
+		if (config) {
+			const chunks: string[] = [];
+			if (config.isolationLevel) {
+				chunks.push(`isolation level ${config.isolationLevel}`);
+			}
+			if (config.accessMode) {
+				chunks.push(config.accessMode);
+			}
+			if (typeof config.deferrable === 'boolean') {
+				chunks.push(config.deferrable ? 'deferrable' : 'not deferrable');
+			}
+			if (chunks.length > 0) {
+				beginSql = `begin ${chunks.join(' ')}`;
+			}
+		}
+
+		await this.execute(sql.raw(beginSql));
+		try {
+			const result = await transaction(tx);
+			await this.execute(sql`commit`);
+			return result;
+		} catch (err) {
+			await this.execute(sql`rollback`);
+			throw err;
+		}
+	}
+
+	override async count(countSql: SQL): Promise<number> {
+		const res = await this.execute<Db0PgQueryResult>(countSql);
+		return Number((res.rows[0] as Record<string, unknown>)['count']);
+	}
+}
+
+export class Db0PgTransaction<
+	TFullSchema extends Record<string, unknown>,
+	TSchema extends TablesRelationalConfig,
+> extends PgTransaction<Db0PgQueryResultHKT, TFullSchema, TSchema> {
+	static override readonly [entityKind]: string = 'Db0PgTransaction';
+
+	override async transaction<T>(
+		transaction: (tx: Db0PgTransaction<TFullSchema, TSchema>) => Promise<T>,
+	): Promise<T> {
+		const savepointName = `sp${this.nestedIndex + 1}`;
+		const tx = new Db0PgTransaction<TFullSchema, TSchema>(this.dialect, this.session, this.schema, this.nestedIndex + 1);
+		await tx.execute(sql.raw(`savepoint ${savepointName}`));
+		try {
+			const result = await transaction(tx);
+			await tx.execute(sql.raw(`release savepoint ${savepointName}`));
+			return result;
+		} catch (err) {
+			await tx.execute(sql.raw(`rollback to savepoint ${savepointName}`));
+			throw err;
+		}
+	}
+}
+
+export interface Db0PgQueryResultHKT extends PgQueryResultHKT {
+	type: Db0PgQueryResult;
+}

--- a/drizzle-orm/src/db0/sqlite/driver.ts
+++ b/drizzle-orm/src/db0/sqlite/driver.ts
@@ -1,0 +1,49 @@
+import type { Database } from 'db0';
+import { entityKind } from '~/entity.ts';
+import { DefaultLogger } from '~/logger.ts';
+import {
+	createTableRelationsHelpers,
+	extractTablesRelationalConfig,
+	type RelationalSchemaConfig,
+	type TablesRelationalConfig,
+} from '~/relations.ts';
+import { BaseSQLiteDatabase } from '~/sqlite-core/db.ts';
+import { SQLiteAsyncDialect } from '~/sqlite-core/dialect.ts';
+import type { DrizzleConfig } from '~/utils.ts';
+import { type Db0RunResult, Db0SQLiteSession, type Db0SQLiteSessionOptions } from './session.ts';
+
+export class Db0SQLiteDatabase<
+	TSchema extends Record<string, unknown> = Record<string, never>,
+> extends BaseSQLiteDatabase<'async', Db0RunResult, TSchema> {
+	static override readonly [entityKind]: string = 'Db0SQLiteDatabase';
+}
+
+export function constructSqlite<TSchema extends Record<string, unknown> = Record<string, never>>(
+	client: Database,
+	config: DrizzleConfig<TSchema> = {},
+): Db0SQLiteDatabase<TSchema> & { $client: Database } {
+	const dialect = new SQLiteAsyncDialect({ casing: config.casing });
+	let logger;
+	if (config.logger === true) {
+		logger = new DefaultLogger();
+	} else if (config.logger !== false) {
+		logger = config.logger;
+	}
+
+	let schema: RelationalSchemaConfig<TablesRelationalConfig> | undefined;
+	if (config.schema) {
+		const tablesConfig = extractTablesRelationalConfig(config.schema, createTableRelationsHelpers);
+		schema = {
+			fullSchema: config.schema,
+			schema: tablesConfig.tables,
+			tableNamesMap: tablesConfig.tableNamesMap,
+		};
+	}
+
+	const sessionOptions: Db0SQLiteSessionOptions = { logger, cache: config.cache };
+	const session = new Db0SQLiteSession(client, dialect, schema, sessionOptions);
+	const db = new Db0SQLiteDatabase('async', dialect, session, schema) as Db0SQLiteDatabase<TSchema>;
+	(<any>db).$client = client;
+
+	return db as any;
+}

--- a/drizzle-orm/src/db0/sqlite/driver.ts
+++ b/drizzle-orm/src/db0/sqlite/driver.ts
@@ -1,12 +1,9 @@
 import type { Database } from 'db0';
+import * as V1 from '~/_relations.ts';
 import { entityKind } from '~/entity.ts';
+import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
-import {
-	createTableRelationsHelpers,
-	extractTablesRelationalConfig,
-	type RelationalSchemaConfig,
-	type TablesRelationalConfig,
-} from '~/relations.ts';
+import type { AnyRelations, EmptyRelations } from '~/relations.ts';
 import { BaseSQLiteDatabase } from '~/sqlite-core/db.ts';
 import { SQLiteAsyncDialect } from '~/sqlite-core/dialect.ts';
 import type { DrizzleConfig } from '~/utils.ts';
@@ -14,25 +11,32 @@ import { type Db0RunResult, Db0SQLiteSession, type Db0SQLiteSessionOptions } fro
 
 export class Db0SQLiteDatabase<
 	TSchema extends Record<string, unknown> = Record<string, never>,
-> extends BaseSQLiteDatabase<'async', Db0RunResult, TSchema> {
+	TRelations extends AnyRelations = EmptyRelations,
+> extends BaseSQLiteDatabase<'async', Db0RunResult, TSchema, TRelations> {
 	static override readonly [entityKind]: string = 'Db0SQLiteDatabase';
 }
 
-export function constructSqlite<TSchema extends Record<string, unknown> = Record<string, never>>(
+export function constructSqlite<
+	TSchema extends Record<string, unknown> = Record<string, never>,
+	TRelations extends AnyRelations = EmptyRelations,
+>(
 	client: Database,
-	config: DrizzleConfig<TSchema> = {},
-): Db0SQLiteDatabase<TSchema> & { $client: Database } {
+	config: DrizzleConfig<TSchema, TRelations> = {},
+): Db0SQLiteDatabase<TSchema, TRelations> & { $client: Database } {
 	const dialect = new SQLiteAsyncDialect({ casing: config.casing });
-	let logger;
+	let logger: Logger | undefined;
 	if (config.logger === true) {
 		logger = new DefaultLogger();
 	} else if (config.logger !== false) {
 		logger = config.logger;
 	}
 
-	let schema: RelationalSchemaConfig<TablesRelationalConfig> | undefined;
+	let schema: V1.RelationalSchemaConfig<V1.TablesRelationalConfig> | undefined;
 	if (config.schema) {
-		const tablesConfig = extractTablesRelationalConfig(config.schema, createTableRelationsHelpers);
+		const tablesConfig = V1.extractTablesRelationalConfig(
+			config.schema,
+			V1.createTableRelationsHelpers,
+		);
 		schema = {
 			fullSchema: config.schema,
 			schema: tablesConfig.tables,
@@ -40,10 +44,23 @@ export function constructSqlite<TSchema extends Record<string, unknown> = Record
 		};
 	}
 
+	const relations = config.relations ?? {} as TRelations;
 	const sessionOptions: Db0SQLiteSessionOptions = { logger, cache: config.cache };
-	const session = new Db0SQLiteSession(client, dialect, schema, sessionOptions);
-	const db = new Db0SQLiteDatabase('async', dialect, session, schema) as Db0SQLiteDatabase<TSchema>;
-	(<any>db).$client = client;
+	const session = new Db0SQLiteSession(client, dialect, relations, schema as any, sessionOptions);
+
+	const db = new Db0SQLiteDatabase(
+		'async',
+		dialect,
+		session,
+		relations,
+		schema as V1.RelationalSchemaConfig<any>,
+	) as Db0SQLiteDatabase<TSchema, TRelations>;
+
+	(<any> db).$client = client;
+	(<any> db).$cache = config.cache;
+	if ((<any> db).$cache) {
+		(<any> db).$cache['invalidate'] = config.cache?.onMutate;
+	}
 
 	return db as any;
 }

--- a/drizzle-orm/src/db0/sqlite/index.ts
+++ b/drizzle-orm/src/db0/sqlite/index.ts
@@ -1,0 +1,9 @@
+export { constructSqlite, Db0SQLiteDatabase } from './driver.ts';
+export * from './migrator.ts';
+export {
+	Db0SQLitePreparedQuery,
+	Db0SQLiteSession,
+	Db0SQLiteTransaction,
+	type Db0RunResult,
+	type Db0SQLiteSessionOptions,
+} from './session.ts';

--- a/drizzle-orm/src/db0/sqlite/index.ts
+++ b/drizzle-orm/src/db0/sqlite/index.ts
@@ -1,5 +1,4 @@
 export { constructSqlite, Db0SQLiteDatabase } from './driver.ts';
-export * from './migrator.ts';
 export {
 	Db0SQLitePreparedQuery,
 	Db0SQLiteSession,

--- a/drizzle-orm/src/db0/sqlite/migrator.ts
+++ b/drizzle-orm/src/db0/sqlite/migrator.ts
@@ -1,0 +1,11 @@
+import type { MigrationConfig } from '~/migrator.ts';
+import { readMigrationFiles } from '~/migrator.ts';
+import type { Db0SQLiteDatabase } from './driver.ts';
+
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: Db0SQLiteDatabase<TSchema>,
+	config: MigrationConfig,
+) {
+	const migrations = readMigrationFiles(config);
+	await db.dialect.migrate(migrations, db.session, config);
+}

--- a/drizzle-orm/src/db0/sqlite/session.ts
+++ b/drizzle-orm/src/db0/sqlite/session.ts
@@ -1,0 +1,215 @@
+import type { Database, Primitive } from 'db0';
+import { type Cache, NoopCache } from '~/cache/core/cache.ts';
+import type { WithCacheConfig } from '~/cache/core/types.ts';
+import { entityKind } from '~/entity.ts';
+import type { Logger } from '~/logger.ts';
+import { NoopLogger } from '~/logger.ts';
+import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
+import { fillPlaceholders, type Query, sql } from '~/sql/sql.ts';
+import type { SQLiteAsyncDialect } from '~/sqlite-core/dialect.ts';
+import { SQLiteTransaction } from '~/sqlite-core/index.ts';
+import type { SelectedFieldsOrdered } from '~/sqlite-core/query-builders/select.types.ts';
+import type {
+	PreparedQueryConfig as PreparedQueryConfigBase,
+	SQLiteExecuteMethod,
+	SQLiteTransactionConfig,
+} from '~/sqlite-core/session.ts';
+import { SQLitePreparedQuery, SQLiteSession } from '~/sqlite-core/session.ts';
+import { mapResultRow } from '~/utils.ts';
+
+export interface Db0SQLiteSessionOptions {
+	logger?: Logger;
+	cache?: Cache;
+}
+
+export type Db0RunResult = { success: boolean };
+
+type PreparedQueryConfig = Omit<PreparedQueryConfigBase, 'statement' | 'run'>;
+
+export class Db0SQLiteSession<
+	TFullSchema extends Record<string, unknown>,
+	TSchema extends TablesRelationalConfig,
+> extends SQLiteSession<'async', Db0RunResult, TFullSchema, TSchema> {
+	static override readonly [entityKind]: string = 'Db0SQLiteSession';
+
+	private logger: Logger;
+	private cache: Cache;
+
+	constructor(
+		private client: Database,
+		dialect: SQLiteAsyncDialect,
+		private schema: RelationalSchemaConfig<TSchema> | undefined,
+		private options: Db0SQLiteSessionOptions = {},
+	) {
+		super(dialect);
+		this.logger = options.logger ?? new NoopLogger();
+		this.cache = options.cache ?? new NoopCache();
+	}
+
+	prepareQuery(
+		query: Query,
+		fields: SelectedFieldsOrdered | undefined,
+		executeMethod: SQLiteExecuteMethod,
+		isResponseInArrayMode: boolean,
+		customResultMapper?: (rows: unknown[][]) => unknown,
+		queryMetadata?: { type: 'select' | 'update' | 'delete' | 'insert'; tables: string[] },
+		cacheConfig?: WithCacheConfig,
+	): Db0SQLitePreparedQuery {
+		return new Db0SQLitePreparedQuery(
+			this.client,
+			query,
+			this.logger,
+			this.cache,
+			queryMetadata,
+			cacheConfig,
+			fields,
+			executeMethod,
+			isResponseInArrayMode,
+			customResultMapper,
+		);
+	}
+
+	override async transaction<T>(
+		transaction: (tx: Db0SQLiteTransaction<TFullSchema, TSchema>) => T | Promise<T>,
+		config?: SQLiteTransactionConfig,
+	): Promise<T> {
+		const tx = new Db0SQLiteTransaction('async', this.dialect, this, this.schema);
+		await this.run(sql.raw(`begin${config?.behavior ? ' ' + config.behavior : ''}`));
+		try {
+			const result = await transaction(tx);
+			await this.run(sql`commit`);
+			return result;
+		} catch (err) {
+			await this.run(sql`rollback`);
+			throw err;
+		}
+	}
+}
+
+export class Db0SQLiteTransaction<
+	TFullSchema extends Record<string, unknown>,
+	TSchema extends TablesRelationalConfig,
+> extends SQLiteTransaction<'async', Db0RunResult, TFullSchema, TSchema> {
+	static override readonly [entityKind]: string = 'Db0SQLiteTransaction';
+
+	override async transaction<T>(
+		transaction: (tx: Db0SQLiteTransaction<TFullSchema, TSchema>) => Promise<T>,
+	): Promise<T> {
+		const savepointName = `sp${this.nestedIndex + 1}`;
+		const tx = new Db0SQLiteTransaction('async', this.dialect, this.session, this.schema, this.nestedIndex + 1);
+		await this.session.run(sql.raw(`savepoint ${savepointName}`));
+		try {
+			const result = await transaction(tx);
+			await this.session.run(sql.raw(`release savepoint ${savepointName}`));
+			return result;
+		} catch (err) {
+			await this.session.run(sql.raw(`rollback to savepoint ${savepointName}`));
+			throw err;
+		}
+	}
+}
+
+export class Db0SQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends SQLitePreparedQuery<
+	{ type: 'async'; run: Db0RunResult; all: T['all']; get: T['get']; values: T['values']; execute: T['execute'] }
+> {
+	static override readonly [entityKind]: string = 'Db0SQLitePreparedQuery';
+
+	/** @internal */
+	customResultMapper?: (rows: unknown[][], mapColumnValue?: (value: unknown) => unknown) => unknown;
+
+	/** @internal */
+	fields?: SelectedFieldsOrdered;
+
+	constructor(
+		private client: Database,
+		query: Query,
+		private logger: Logger,
+		cache: Cache,
+		queryMetadata: { type: 'select' | 'update' | 'delete' | 'insert'; tables: string[] } | undefined,
+		cacheConfig: WithCacheConfig | undefined,
+		fields: SelectedFieldsOrdered | undefined,
+		executeMethod: SQLiteExecuteMethod,
+		private _isResponseInArrayMode: boolean,
+		customResultMapper?: (rows: unknown[][]) => unknown,
+	) {
+		super('async', executeMethod, query, cache, queryMetadata, cacheConfig);
+		this.customResultMapper = customResultMapper;
+		this.fields = fields;
+	}
+
+	async run(placeholderValues?: Record<string, unknown>): Promise<Db0RunResult> {
+		const params = fillPlaceholders(this.query.params, placeholderValues ?? {}) as Primitive[];
+		this.logger.logQuery(this.query.sql, params);
+		return await this.queryWithCache(this.query.sql, params, async () => {
+			const stmt = this.client.prepare(this.query.sql);
+			return stmt.run(...params) as Promise<Db0RunResult>;
+		});
+	}
+
+	async all(placeholderValues?: Record<string, unknown>): Promise<T['all']> {
+		const { fields, query, logger, client, customResultMapper } = this;
+		if (!fields && !customResultMapper) {
+			const params = fillPlaceholders(query.params, placeholderValues ?? {}) as Primitive[];
+			logger.logQuery(query.sql, params);
+			return await this.queryWithCache(query.sql, params, async () => {
+				const stmt = client.prepare(query.sql);
+				return stmt.all(...params) as Promise<T['all']>;
+			});
+		}
+
+		const rows = await this.values(placeholderValues);
+		return this.mapAllResult(rows);
+	}
+
+	override mapAllResult(rows: unknown): unknown {
+		if (!this.fields && !this.customResultMapper) {
+			return rows;
+		}
+
+		if (this.customResultMapper) {
+			return this.customResultMapper(rows as unknown[][]);
+		}
+
+		return (rows as unknown[][]).map((row) => mapResultRow(this.fields!, row, this.joinsNotNullableMap));
+	}
+
+	async get(placeholderValues?: Record<string, unknown>): Promise<T['get']> {
+		const { fields, query, logger, client, customResultMapper, joinsNotNullableMap } = this;
+		if (!fields && !customResultMapper) {
+			const params = fillPlaceholders(query.params, placeholderValues ?? {}) as Primitive[];
+			logger.logQuery(query.sql, params);
+			return await this.queryWithCache(query.sql, params, async () => {
+				const stmt = client.prepare(query.sql);
+				return stmt.get(...params) as Promise<T['get']>;
+			});
+		}
+
+		const rows = await this.values(placeholderValues);
+
+		if (!rows[0]) {
+			return undefined;
+		}
+
+		if (customResultMapper) {
+			return customResultMapper(rows) as T['all'];
+		}
+
+		return mapResultRow(fields!, rows[0] as unknown[], joinsNotNullableMap);
+	}
+
+	async values<T extends any[] = unknown[]>(placeholderValues?: Record<string, unknown>): Promise<T[]> {
+		const params = fillPlaceholders(this.query.params, placeholderValues ?? {}) as Primitive[];
+		this.logger.logQuery(this.query.sql, params);
+		return await this.queryWithCache(this.query.sql, params, async () => {
+			const stmt = this.client.prepare(this.query.sql);
+			// db0 doesn't have a raw/values method, so we need to get all and convert to arrays
+			const rows = await stmt.all(...params) as Record<string, unknown>[];
+			return rows.map((row) => Object.values(row)) as T[];
+		});
+	}
+
+	/** @internal */
+	isResponseInArrayMode(): boolean {
+		return this._isResponseInArrayMode;
+	}
+}

--- a/drizzle-orm/src/db0/sqlite/session.ts
+++ b/drizzle-orm/src/db0/sqlite/session.ts
@@ -1,10 +1,11 @@
 import type { Database, Primitive } from 'db0';
+import type * as V1 from '~/_relations.ts';
 import { type Cache, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { NoopLogger } from '~/logger.ts';
-import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
+import type { AnyRelations } from '~/relations.ts';
 import { fillPlaceholders, type Query, sql } from '~/sql/sql.ts';
 import type { SQLiteAsyncDialect } from '~/sqlite-core/dialect.ts';
 import { SQLiteTransaction } from '~/sqlite-core/index.ts';
@@ -29,8 +30,9 @@ type PreparedQueryConfig = Omit<PreparedQueryConfigBase, 'statement' | 'run'>;
 
 export class Db0SQLiteSession<
 	TFullSchema extends Record<string, unknown>,
-	TSchema extends TablesRelationalConfig,
-> extends SQLiteSession<'async', Db0RunResult, TFullSchema, TSchema> {
+	TRelations extends AnyRelations,
+	TSchema extends V1.TablesRelationalConfig,
+> extends SQLiteSession<'async', Db0RunResult, TFullSchema, TRelations, TSchema> {
 	static override readonly [entityKind]: string = 'Db0SQLiteSession';
 
 	private logger: Logger;
@@ -39,7 +41,8 @@ export class Db0SQLiteSession<
 	constructor(
 		private client: Database,
 		dialect: SQLiteAsyncDialect,
-		private schema: RelationalSchemaConfig<TSchema> | undefined,
+		private relations: TRelations,
+		private schema: V1.RelationalSchemaConfig<TSchema> | undefined,
 		private options: Db0SQLiteSessionOptions = {},
 	) {
 		super(dialect);
@@ -52,7 +55,7 @@ export class Db0SQLiteSession<
 		fields: SelectedFieldsOrdered | undefined,
 		executeMethod: SQLiteExecuteMethod,
 		isResponseInArrayMode: boolean,
-		customResultMapper?: (rows: unknown[][]) => unknown,
+		customResultMapper?: (rows: unknown[][], mapColumnValue?: (value: unknown) => unknown) => unknown,
 		queryMetadata?: { type: 'select' | 'update' | 'delete' | 'insert'; tables: string[] },
 		cacheConfig?: WithCacheConfig,
 	): Db0SQLitePreparedQuery {
@@ -71,11 +74,33 @@ export class Db0SQLiteSession<
 		);
 	}
 
+	prepareRelationalQuery(
+		query: Query,
+		fields: SelectedFieldsOrdered | undefined,
+		executeMethod: SQLiteExecuteMethod,
+		customResultMapper: (rows: Record<string, unknown>[], mapColumnValue?: (value: unknown) => unknown) => unknown,
+	): Db0SQLitePreparedQuery<PreparedQueryConfig, true> {
+		return new Db0SQLitePreparedQuery(
+			this.client,
+			this.dialect,
+			query,
+			this.logger,
+			this.cache,
+			undefined,
+			undefined,
+			fields,
+			executeMethod,
+			false,
+			customResultMapper,
+			true,
+		);
+	}
+
 	override async transaction<T>(
-		transaction: (tx: Db0SQLiteTransaction<TFullSchema, TSchema>) => T | Promise<T>,
+		transaction: (tx: Db0SQLiteTransaction<TFullSchema, TRelations, TSchema>) => T | Promise<T>,
 		config?: SQLiteTransactionConfig,
 	): Promise<T> {
-		const tx = new Db0SQLiteTransaction('async', this.dialect, this, this.schema);
+		const tx = new Db0SQLiteTransaction('async', this.dialect, this, this.relations, this.schema);
 		await this.run(sql.raw(`begin${config?.behavior ? ' ' + config.behavior : ''}`));
 		try {
 			const result = await transaction(tx);
@@ -90,15 +115,23 @@ export class Db0SQLiteSession<
 
 export class Db0SQLiteTransaction<
 	TFullSchema extends Record<string, unknown>,
-	TSchema extends TablesRelationalConfig,
-> extends SQLiteTransaction<'async', Db0RunResult, TFullSchema, TSchema> {
+	TRelations extends AnyRelations,
+	TSchema extends V1.TablesRelationalConfig,
+> extends SQLiteTransaction<'async', Db0RunResult, TFullSchema, TRelations, TSchema> {
 	static override readonly [entityKind]: string = 'Db0SQLiteTransaction';
 
 	override async transaction<T>(
-		transaction: (tx: Db0SQLiteTransaction<TFullSchema, TSchema>) => Promise<T>,
+		transaction: (tx: Db0SQLiteTransaction<TFullSchema, TRelations, TSchema>) => Promise<T>,
 	): Promise<T> {
 		const savepointName = `sp${this.nestedIndex + 1}`;
-		const tx = new Db0SQLiteTransaction('async', this.dialect, this.session, this.schema, this.nestedIndex + 1);
+		const tx = new Db0SQLiteTransaction(
+			'async',
+			this.dialect,
+			this.session,
+			this.relations,
+			this.schema,
+			this.nestedIndex + 1,
+		);
 		await this.session.run(sql.raw(`savepoint ${savepointName}`));
 		try {
 			const result = await transaction(tx);
@@ -111,16 +144,13 @@ export class Db0SQLiteTransaction<
 	}
 }
 
-export class Db0SQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig> extends SQLitePreparedQuery<
+export class Db0SQLitePreparedQuery<
+	T extends PreparedQueryConfig = PreparedQueryConfig,
+	TIsRqbV2 extends boolean = false,
+> extends SQLitePreparedQuery<
 	{ type: 'async'; run: Db0RunResult; all: T['all']; get: T['get']; values: T['values']; execute: T['execute'] }
 > {
 	static override readonly [entityKind]: string = 'Db0SQLitePreparedQuery';
-
-	/** @internal */
-	customResultMapper?: (rows: unknown[][], mapColumnValue?: (value: unknown) => unknown) => unknown;
-
-	/** @internal */
-	fields?: SelectedFieldsOrdered;
 
 	constructor(
 		private client: Database,
@@ -130,14 +160,16 @@ export class Db0SQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuer
 		cache: Cache,
 		queryMetadata: { type: 'select' | 'update' | 'delete' | 'insert'; tables: string[] } | undefined,
 		cacheConfig: WithCacheConfig | undefined,
-		fields: SelectedFieldsOrdered | undefined,
+		private fields: SelectedFieldsOrdered | undefined,
 		executeMethod: SQLiteExecuteMethod,
 		private _isResponseInArrayMode: boolean,
-		customResultMapper?: (rows: unknown[][]) => unknown,
+		private customResultMapper?: (
+			rows: TIsRqbV2 extends true ? Record<string, unknown>[] : unknown[][],
+			mapColumnValue?: (value: unknown) => unknown,
+		) => unknown,
+		private isRqbV2Query?: TIsRqbV2,
 	) {
 		super('async', executeMethod, query, cache, queryMetadata, cacheConfig);
-		this.customResultMapper = customResultMapper;
-		this.fields = fields;
 	}
 
 	async run(placeholderValues?: Record<string, unknown>): Promise<Db0RunResult> {
@@ -150,6 +182,8 @@ export class Db0SQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuer
 	}
 
 	async all(placeholderValues?: Record<string, unknown>): Promise<T['all']> {
+		if (this.isRqbV2Query) return this.allRqbV2(placeholderValues);
+
 		const { fields, query, logger, client, customResultMapper } = this;
 		if (!fields && !customResultMapper) {
 			const params = fillPlaceholders(query.params, placeholderValues ?? {}) as Primitive[];
@@ -161,7 +195,19 @@ export class Db0SQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuer
 		}
 
 		const rows = await this.values(placeholderValues);
-		return this.mapAllResult(rows);
+		return this.mapAllResult(rows) as T['all'];
+	}
+
+	private async allRqbV2(placeholderValues?: Record<string, unknown>): Promise<T['all']> {
+		const params = fillPlaceholders(this.query.params, placeholderValues ?? {}) as Primitive[];
+		this.logger.logQuery(this.query.sql, params);
+
+		const rows = await this.queryWithCache(this.query.sql, params, async () => {
+			const stmt = this.client.prepare(this.query.sql);
+			return await stmt.all(...params) as Record<string, unknown>[];
+		});
+
+		return (this.customResultMapper as (rows: Record<string, unknown>[]) => unknown)(rows) as T['all'];
 	}
 
 	override mapAllResult(rows: unknown): unknown {
@@ -170,13 +216,15 @@ export class Db0SQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuer
 		}
 
 		if (this.customResultMapper) {
-			return this.customResultMapper(rows as unknown[][]);
+			return (this.customResultMapper as (rows: unknown[][]) => unknown)(rows as unknown[][]);
 		}
 
 		return (rows as unknown[][]).map((row) => mapResultRow(this.fields!, row, this.joinsNotNullableMap));
 	}
 
 	async get(placeholderValues?: Record<string, unknown>): Promise<T['get']> {
+		if (this.isRqbV2Query) return this.getRqbV2(placeholderValues);
+
 		const { fields, query, logger, client, customResultMapper, joinsNotNullableMap } = this;
 		if (!fields && !customResultMapper) {
 			const params = fillPlaceholders(query.params, placeholderValues ?? {}) as Primitive[];
@@ -194,13 +242,27 @@ export class Db0SQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuer
 		}
 
 		if (customResultMapper) {
-			return customResultMapper([rows[0] as unknown[]]) as T['get'];
+			return (customResultMapper as (rows: unknown[][]) => unknown)([rows[0] as unknown[]]) as T['get'];
 		}
 
 		return mapResultRow(fields!, rows[0] as unknown[], joinsNotNullableMap);
 	}
 
-	async values<T extends any[] = unknown[]>(placeholderValues?: Record<string, unknown>): Promise<T[]> {
+	private async getRqbV2(placeholderValues?: Record<string, unknown>): Promise<T['get']> {
+		const params = fillPlaceholders(this.query.params, placeholderValues ?? {}) as Primitive[];
+		this.logger.logQuery(this.query.sql, params);
+
+		const row = await this.queryWithCache(this.query.sql, params, async () => {
+			const stmt = this.client.prepare(this.query.sql);
+			return await stmt.get(...params) as Record<string, unknown> | undefined;
+		});
+
+		if (!row) return undefined;
+
+		return (this.customResultMapper as (rows: Record<string, unknown>[]) => unknown)([row]) as T['get'];
+	}
+
+	async values<TValues extends any[] = unknown[]>(placeholderValues?: Record<string, unknown>): Promise<TValues[]> {
 		const params = fillPlaceholders(this.query.params, placeholderValues ?? {}) as Primitive[];
 		this.logger.logQuery(this.query.sql, params);
 		return await this.queryWithCache(this.query.sql, params, async () => {
@@ -212,7 +274,7 @@ export class Db0SQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuer
 			if (typeof rawStmtFactory === 'function') {
 				const rawStmt = rawStmtFactory();
 				if (rawStmt && typeof rawStmt.raw === 'function') {
-					return rawStmt.raw(true).all(...(params as any[])) as T[];
+					return rawStmt.raw(true).all(...(params as any[])) as TValues[];
 				}
 			}
 
@@ -226,9 +288,9 @@ export class Db0SQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuer
 						'db0 sqlite connector returned object rows with duplicate column names; use db0/connectors/better-sqlite3 for correct join/alias results.',
 					);
 				}
-				return mapped as T[];
+				return mapped as TValues[];
 			}
-			return rows.map((row) => Object.values(row)) as T[];
+			return rows.map((row) => Object.values(row)) as TValues[];
 		});
 	}
 

--- a/drizzle-orm/type-tests/db0/db.ts
+++ b/drizzle-orm/type-tests/db0/db.ts
@@ -1,0 +1,45 @@
+import type { Database } from 'db0';
+import { type Equal, Expect } from 'type-tests/utils';
+import { drizzle, type Db0Database } from '~/db0/index.ts';
+import { int, sqliteTable, text } from '~/sqlite-core/index.ts';
+import { pgTable, serial, varchar } from '~/pg-core/index.ts';
+
+declare const db0Client: Database;
+
+// Test: drizzle function returns Db0Database with $client
+const db = drizzle(db0Client);
+Expect<Equal<typeof db.$client, Database>>();
+
+// Test: drizzle with config object
+const dbWithConfig = drizzle({ client: db0Client, logger: true });
+Expect<Equal<typeof dbWithConfig.$client, Database>>();
+
+// Test: SQLite schema types
+const sqliteUsers = sqliteTable('users', {
+	id: int('id').primaryKey(),
+	name: text('name').notNull(),
+	email: text('email'),
+});
+
+type SqliteUser = typeof sqliteUsers.$inferSelect;
+type SqliteNewUser = typeof sqliteUsers.$inferInsert;
+
+Expect<Equal<{ id: number; name: string; email: string | null }, SqliteUser>>();
+Expect<Equal<{ name: string; id?: number | undefined; email?: string | null | undefined }, SqliteNewUser>>();
+
+// Test: PG schema types
+const pgUsers = pgTable('users', {
+	id: serial('id').primaryKey(),
+	name: varchar('name', { length: 255 }).notNull(),
+	email: varchar('email', { length: 255 }),
+});
+
+type PgUser = typeof pgUsers.$inferSelect;
+type PgNewUser = typeof pgUsers.$inferInsert;
+
+Expect<Equal<{ id: number; name: string; email: string | null }, PgUser>>();
+Expect<Equal<{ name: string; id?: number | undefined; email?: string | null | undefined }, PgNewUser>>();
+
+// Test: drizzle.mock()
+const mockDb = drizzle.mock();
+Expect<Equal<typeof mockDb.$client, '$client is not available on drizzle.mock()'>>();

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -35,6 +35,7 @@
 		"ava": "^5.3.0",
 		"bun-types": "^1.2.23",
 		"cross-env": "^7.0.3",
+		"db0": "^0.3.4",
 		"import-in-the-middle": "^1.13.1",
 		"keyv": "^5.2.3",
 		"ts-node": "^10.9.2",

--- a/integration-tests/tests/pg/db0.test.ts
+++ b/integration-tests/tests/pg/db0.test.ts
@@ -4,9 +4,7 @@ import pglite from 'db0/connectors/pglite';
 import { sql } from 'drizzle-orm';
 import type { Db0PgDatabase } from 'drizzle-orm/db0';
 import { drizzle } from 'drizzle-orm/db0';
-import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
-import { skipTests } from '~/common';
-import { tests, usersTable } from './pg-common';
+import { afterAll, beforeAll, expect, test } from 'vitest';
 
 const ENABLE_LOGGING = false;
 
@@ -21,12 +19,6 @@ beforeAll(async () => {
 
 afterAll(async () => {
 	await client?.close();
-});
-
-beforeEach((ctx) => {
-	ctx.pg = {
-		db,
-	};
 });
 
 test('db0 dialect detection', async () => {
@@ -154,36 +146,3 @@ test('transaction with isolation level', async () => {
 
 	await db.execute(sql`drop table db0_isolation_test`);
 });
-
-// Skip tests that are specific to db0 (already run above) or have known db0 limitations
-skipTests([
-	// Already tested above
-	'db0 dialect detection',
-	'basic CRUD operations',
-	'transaction commit',
-	'transaction rollback',
-	'nested transaction with savepoint',
-	'nested transaction rollback',
-	'transaction with isolation level',
-	// Row ordering issues - db0/pglite may return rows in different order
-	'select with group by as sql + column',
-	'select with group by as column + sql',
-	'mySchema :: select with group by as column + sql',
-	// Type conversion differences
-	'select count()',
-	// Timezone handling differences
-	'all date and time columns',
-	'timestamp timezone',
-	// $onUpdate timing differences
-	'test $onUpdateFn and $onUpdate works as $default',
-	'test $onUpdateFn and $onUpdate works updating',
-	'test $onUpdateFn and $onUpdate works with sql value',
-	// All types has timezone differences
-	'all types',
-	// JSON operators have type conversion issues with db0
-	'set json/jsonb fields with objects and retrieve with the ->> operator',
-	'set json/jsonb fields with strings and retrieve with the ->> operator',
-	'set json/jsonb fields with objects and retrieve with the -> operator',
-	'set json/jsonb fields with strings and retrieve with the -> operator',
-]);
-tests();

--- a/integration-tests/tests/pg/db0.test.ts
+++ b/integration-tests/tests/pg/db0.test.ts
@@ -1,0 +1,214 @@
+import { PGlite } from '@electric-sql/pglite';
+import { createDatabase } from 'db0';
+import pglite from 'db0/connectors/pglite';
+import { sql } from 'drizzle-orm';
+import type { Db0PgDatabase } from 'drizzle-orm/db0';
+import { drizzle } from 'drizzle-orm/db0';
+import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
+import { skipTests } from '~/common';
+import { tests, usersTable } from './pg-common';
+
+const ENABLE_LOGGING = false;
+
+let db: Db0PgDatabase;
+let client: PGlite;
+
+beforeAll(async () => {
+	client = new PGlite();
+	const db0 = createDatabase(pglite(client));
+	db = drizzle(db0, { logger: ENABLE_LOGGING }) as Db0PgDatabase;
+});
+
+afterAll(async () => {
+	await client?.close();
+});
+
+beforeEach((ctx) => {
+	ctx.pg = {
+		db,
+	};
+});
+
+test('db0 dialect detection', async () => {
+	const pgClient = new PGlite();
+	const db0 = createDatabase(pglite(pgClient));
+	expect(db0.dialect).toBe('postgresql');
+
+	const drizzleDb = drizzle(db0);
+	expect(drizzleDb).toBeDefined();
+	await pgClient.close();
+});
+
+test('basic CRUD operations', async () => {
+	await db.execute(sql`drop table if exists db0_test`);
+	await db.execute(sql`create table db0_test (id serial primary key, name text)`);
+
+	await db.execute(sql`insert into db0_test (name) values ('Alice')`);
+	const result = await db.execute(sql`select * from db0_test`);
+	expect(result.rows).toEqual([{ id: 1, name: 'Alice' }]);
+
+	await db.execute(sql`update db0_test set name = 'Bob' where id = 1`);
+	const updated = await db.execute(sql`select * from db0_test where id = 1`);
+	expect(updated.rows).toEqual([{ id: 1, name: 'Bob' }]);
+
+	await db.execute(sql`delete from db0_test where id = 1`);
+	const deleted = await db.execute(sql`select * from db0_test`);
+	expect(deleted.rows).toEqual([]);
+
+	await db.execute(sql`drop table db0_test`);
+});
+
+test('transaction commit', async () => {
+	await db.execute(sql`drop table if exists db0_tx_test`);
+	await db.execute(sql`create table db0_tx_test (id serial primary key, name text)`);
+
+	await db.transaction(async (tx) => {
+		await tx.execute(sql`insert into db0_tx_test (name) values ('Alice')`);
+		await tx.execute(sql`insert into db0_tx_test (name) values ('Bob')`);
+	});
+
+	const result = await db.execute(sql`select * from db0_tx_test order by id`);
+	expect(result.rows).toEqual([
+		{ id: 1, name: 'Alice' },
+		{ id: 2, name: 'Bob' },
+	]);
+
+	await db.execute(sql`drop table db0_tx_test`);
+});
+
+test('transaction rollback', async () => {
+	await db.execute(sql`drop table if exists db0_rollback_test`);
+	await db.execute(sql`create table db0_rollback_test (id serial primary key, name text)`);
+
+	await db.execute(sql`insert into db0_rollback_test (name) values ('Existing')`);
+
+	try {
+		await db.transaction(async (tx) => {
+			await tx.execute(sql`insert into db0_rollback_test (name) values ('ShouldRollback')`);
+			throw new Error('Rollback test');
+		});
+	} catch {
+		// Expected
+	}
+
+	const result = await db.execute(sql`select * from db0_rollback_test`);
+	expect(result.rows).toEqual([{ id: 1, name: 'Existing' }]);
+
+	await db.execute(sql`drop table db0_rollback_test`);
+});
+
+test('nested transaction with savepoint', async () => {
+	await db.execute(sql`drop table if exists db0_nested_test`);
+	await db.execute(sql`create table db0_nested_test (id serial primary key, name text)`);
+
+	await db.transaction(async (tx) => {
+		await tx.execute(sql`insert into db0_nested_test (name) values ('Outer')`);
+
+		await tx.transaction(async (nestedTx) => {
+			await nestedTx.execute(sql`insert into db0_nested_test (name) values ('Inner')`);
+		});
+	});
+
+	const result = await db.execute(sql`select * from db0_nested_test order by id`);
+	expect(result.rows).toEqual([
+		{ id: 1, name: 'Outer' },
+		{ id: 2, name: 'Inner' },
+	]);
+
+	await db.execute(sql`drop table db0_nested_test`);
+});
+
+test('nested transaction rollback', async () => {
+	await db.execute(sql`drop table if exists db0_nested_rollback_test`);
+	await db.execute(sql`create table db0_nested_rollback_test (id serial primary key, name text)`);
+
+	await db.transaction(async (tx) => {
+		await tx.execute(sql`insert into db0_nested_rollback_test (name) values ('OuterOK')`);
+
+		try {
+			await tx.transaction(async (nestedTx) => {
+				await nestedTx.execute(sql`insert into db0_nested_rollback_test (name) values ('InnerFail')`);
+				throw new Error('Inner rollback test');
+			});
+		} catch {
+			// Expected - inner transaction rolled back
+		}
+	});
+
+	const result = await db.execute(sql`select * from db0_nested_rollback_test order by id`);
+	expect(result.rows).toEqual([{ id: 1, name: 'OuterOK' }]);
+
+	await db.execute(sql`drop table db0_nested_rollback_test`);
+});
+
+test('transaction with isolation level', async () => {
+	await db.execute(sql`drop table if exists db0_isolation_test`);
+	await db.execute(sql`create table db0_isolation_test (id serial primary key, name text)`);
+
+	await db.transaction(async (tx) => {
+		await tx.execute(sql`insert into db0_isolation_test (name) values ('Test')`);
+	}, { isolationLevel: 'serializable' });
+
+	const result = await db.execute(sql`select * from db0_isolation_test`);
+	expect(result.rows).toEqual([{ id: 1, name: 'Test' }]);
+
+	await db.execute(sql`drop table db0_isolation_test`);
+});
+
+// Skip tests that are specific to db0 (already run above) or have known db0 limitations
+skipTests([
+	// Already tested above
+	'db0 dialect detection',
+	'basic CRUD operations',
+	'transaction commit',
+	'transaction rollback',
+	'nested transaction with savepoint',
+	'nested transaction rollback',
+	'transaction with isolation level',
+	// db0 doesn't support transaction rollback method
+	'transaction rollback',
+	'nested transaction rollback',
+	// Row ordering issues - db0/pglite may return rows in different order
+	'select with group by as sql + column',
+	'select with group by as column + sql',
+	'mySchema :: select with group by as column + sql',
+	// Join/alias field mapping issues - db0 object mode vs array mode conversion
+	'partial join with alias',
+	'full join with alias',
+	'select from alias',
+	'left join (flat object fields)',
+	'left join (grouped fields)',
+	'left join (all fields)',
+	'with ... select',
+	'select from raw sql with joins',
+	'join on aliased sql from select',
+	'join view as subquery',
+	'mySchema :: partial join with alias',
+	'mySchema :: select from tables with same name from different schema using alias',
+	// Lateral joins have field mapping issues
+	'left join (lateral)',
+	'inner join (lateral)',
+	'cross join (lateral)',
+	'cross join',
+	// Type conversion differences
+	'select count()',
+	// Timezone handling differences
+	'all date and time columns',
+	'timestamp timezone',
+	// $onUpdate timing differences
+	'test $onUpdateFn and $onUpdate works as $default',
+	'test $onUpdateFn and $onUpdate works updating',
+	'test $onUpdateFn and $onUpdate works with sql value',
+	// All types has timezone differences
+	'all types',
+	// JSON operators have type conversion issues with db0
+	'set json/jsonb fields with objects and retrieve with the ->> operator',
+	'set json/jsonb fields with strings and retrieve with the ->> operator',
+	'set json/jsonb fields with objects and retrieve with the -> operator',
+	'set json/jsonb fields with strings and retrieve with the -> operator',
+	// UPDATE ... FROM has field mapping issues
+	'update ... from',
+	'update ... from with alias',
+	'update ... from with join',
+]);
+tests();

--- a/integration-tests/tests/pg/db0.test.ts
+++ b/integration-tests/tests/pg/db0.test.ts
@@ -165,31 +165,10 @@ skipTests([
 	'nested transaction with savepoint',
 	'nested transaction rollback',
 	'transaction with isolation level',
-	// db0 doesn't support transaction rollback method
-	'transaction rollback',
-	'nested transaction rollback',
 	// Row ordering issues - db0/pglite may return rows in different order
 	'select with group by as sql + column',
 	'select with group by as column + sql',
 	'mySchema :: select with group by as column + sql',
-	// Join/alias field mapping issues - db0 object mode vs array mode conversion
-	'partial join with alias',
-	'full join with alias',
-	'select from alias',
-	'left join (flat object fields)',
-	'left join (grouped fields)',
-	'left join (all fields)',
-	'with ... select',
-	'select from raw sql with joins',
-	'join on aliased sql from select',
-	'join view as subquery',
-	'mySchema :: partial join with alias',
-	'mySchema :: select from tables with same name from different schema using alias',
-	// Lateral joins have field mapping issues
-	'left join (lateral)',
-	'inner join (lateral)',
-	'cross join (lateral)',
-	'cross join',
 	// Type conversion differences
 	'select count()',
 	// Timezone handling differences
@@ -206,9 +185,5 @@ skipTests([
 	'set json/jsonb fields with strings and retrieve with the ->> operator',
 	'set json/jsonb fields with objects and retrieve with the -> operator',
 	'set json/jsonb fields with strings and retrieve with the -> operator',
-	// UPDATE ... FROM has field mapping issues
-	'update ... from',
-	'update ... from with alias',
-	'update ... from with join',
 ]);
 tests();

--- a/integration-tests/tests/sqlite/db0.test.ts
+++ b/integration-tests/tests/sqlite/db0.test.ts
@@ -1,0 +1,163 @@
+import { createDatabase } from 'db0';
+import sqlite from 'db0/connectors/better-sqlite3';
+import { sql } from 'drizzle-orm';
+import type { Db0SQLiteDatabase } from 'drizzle-orm/db0';
+import { drizzle } from 'drizzle-orm/db0';
+import { beforeAll, beforeEach, expect, test } from 'vitest';
+import { skipTests } from '~/common';
+import { anotherUsersMigratorTable, tests, usersMigratorTable } from './sqlite-common';
+
+const ENABLE_LOGGING = false;
+
+let db: Db0SQLiteDatabase;
+
+beforeAll(async () => {
+	const dbPath = process.env['SQLITE_DB_PATH'] ?? ':memory:';
+	const db0 = createDatabase(sqlite({ name: dbPath }));
+	db = drizzle(db0, { logger: ENABLE_LOGGING });
+});
+
+beforeEach((ctx) => {
+	ctx.sqlite = {
+		db,
+	};
+});
+
+test('db0 dialect detection', async () => {
+	const dbPath = process.env['SQLITE_DB_PATH'] ?? ':memory:';
+	const db0 = createDatabase(sqlite({ name: dbPath }));
+	expect(db0.dialect).toBe('sqlite');
+
+	const drizzleDb = drizzle(db0);
+	expect(drizzleDb).toBeDefined();
+});
+
+test('drizzle.mock() returns SQLite instance', () => {
+	const mockDb = drizzle.mock();
+	expect(mockDb).toBeDefined();
+});
+
+test('config object syntax', async () => {
+	const dbPath = process.env['SQLITE_DB_PATH'] ?? ':memory:';
+	const db0 = createDatabase(sqlite({ name: dbPath }));
+	const configDb = drizzle({ client: db0 });
+	expect(configDb).toBeDefined();
+});
+
+test('throws on MySQL dialect', () => {
+	const mockClient = { dialect: 'mysql' } as any;
+	expect(() => drizzle(mockClient)).toThrow('MySQL support is not yet implemented');
+});
+
+test('throws on unknown dialect', () => {
+	const mockClient = { dialect: 'unknown' } as any;
+	expect(() => drizzle(mockClient)).toThrow('Unsupported db0 dialect');
+});
+
+test('basic CRUD operations', async () => {
+	await db.run(sql`drop table if exists db0_test`);
+	await db.run(sql`create table db0_test (id integer primary key, name text)`);
+
+	await db.run(sql`insert into db0_test (name) values ('Alice')`);
+	const result = await db.all(sql`select * from db0_test`);
+	expect(result).toEqual([{ id: 1, name: 'Alice' }]);
+
+	await db.run(sql`update db0_test set name = 'Bob' where id = 1`);
+	const updated = await db.get(sql`select * from db0_test where id = 1`);
+	expect(updated).toEqual({ id: 1, name: 'Bob' });
+
+	await db.run(sql`delete from db0_test where id = 1`);
+	const deleted = await db.all(sql`select * from db0_test`);
+	expect(deleted).toEqual([]);
+
+	await db.run(sql`drop table db0_test`);
+});
+
+test('transaction commit', async () => {
+	await db.run(sql`drop table if exists db0_tx_test`);
+	await db.run(sql`create table db0_tx_test (id integer primary key, name text)`);
+
+	await db.transaction(async (tx) => {
+		await tx.run(sql`insert into db0_tx_test (name) values ('Alice')`);
+		await tx.run(sql`insert into db0_tx_test (name) values ('Bob')`);
+	});
+
+	const result = await db.all(sql`select * from db0_tx_test order by id`);
+	expect(result).toEqual([
+		{ id: 1, name: 'Alice' },
+		{ id: 2, name: 'Bob' },
+	]);
+
+	await db.run(sql`drop table db0_tx_test`);
+});
+
+test('transaction rollback', async () => {
+	await db.run(sql`drop table if exists db0_rollback_test`);
+	await db.run(sql`create table db0_rollback_test (id integer primary key, name text)`);
+
+	await db.run(sql`insert into db0_rollback_test (name) values ('Existing')`);
+
+	try {
+		await db.transaction(async (tx) => {
+			await tx.run(sql`insert into db0_rollback_test (name) values ('ShouldRollback')`);
+			throw new Error('Rollback test');
+		});
+	} catch {
+		// Expected
+	}
+
+	const result = await db.all(sql`select * from db0_rollback_test`);
+	expect(result).toEqual([{ id: 1, name: 'Existing' }]);
+
+	await db.run(sql`drop table db0_rollback_test`);
+});
+
+test('nested transaction with savepoint', async () => {
+	await db.run(sql`drop table if exists db0_nested_test`);
+	await db.run(sql`create table db0_nested_test (id integer primary key, name text)`);
+
+	await db.transaction(async (tx) => {
+		await tx.run(sql`insert into db0_nested_test (name) values ('Outer')`);
+
+		await tx.transaction(async (nestedTx) => {
+			await nestedTx.run(sql`insert into db0_nested_test (name) values ('Inner')`);
+		});
+	});
+
+	const result = await db.all(sql`select * from db0_nested_test order by id`);
+	expect(result).toEqual([
+		{ id: 1, name: 'Outer' },
+		{ id: 2, name: 'Inner' },
+	]);
+
+	await db.run(sql`drop table db0_nested_test`);
+});
+
+test('nested transaction rollback', async () => {
+	await db.run(sql`drop table if exists db0_nested_rollback_test`);
+	await db.run(sql`create table db0_nested_rollback_test (id integer primary key, name text)`);
+
+	await db.transaction(async (tx) => {
+		await tx.run(sql`insert into db0_nested_rollback_test (name) values ('OuterOK')`);
+
+		try {
+			await tx.transaction(async (nestedTx) => {
+				await nestedTx.run(sql`insert into db0_nested_rollback_test (name) values ('InnerFail')`);
+				throw new Error('Inner rollback test');
+			});
+		} catch {
+			// Expected - inner transaction rolled back
+		}
+	});
+
+	const result = await db.all(sql`select * from db0_nested_rollback_test order by id`);
+	expect(result).toEqual([{ id: 1, name: 'OuterOK' }]);
+
+	await db.run(sql`drop table db0_nested_rollback_test`);
+});
+
+skipTests([
+	// db0 doesn't support bigint blobs in the same way
+	'insert bigint values',
+]);
+tests();

--- a/integration-tests/tests/sqlite/db0.test.ts
+++ b/integration-tests/tests/sqlite/db0.test.ts
@@ -4,8 +4,6 @@ import { sql } from 'drizzle-orm';
 import type { Db0SQLiteDatabase } from 'drizzle-orm/db0';
 import { drizzle } from 'drizzle-orm/db0';
 import { beforeAll, beforeEach, expect, test } from 'vitest';
-import { skipTests } from '~/common';
-import { anotherUsersMigratorTable, tests, usersMigratorTable } from './sqlite-common';
 
 const ENABLE_LOGGING = false;
 
@@ -155,9 +153,3 @@ test('nested transaction rollback', async () => {
 
 	await db.run(sql`drop table db0_nested_rollback_test`);
 });
-
-skipTests([
-	// db0 doesn't support bigint blobs in the same way
-	'insert bigint values',
-]);
-tests();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,9 +449,15 @@ importers:
       cpy:
         specifier: ^10.1.0
         version: 10.1.0
+<<<<<<< HEAD
       effect:
         specifier: ^3.19.8
         version: 3.19.8
+=======
+      db0:
+        specifier: ^0.3.4
+        version: 0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.10.0)(drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.10.0)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7))(mysql2@3.14.1)(sqlite3@5.1.7)
+>>>>>>> d8ca6bcb (fix(db0): prefer array results)
       expo-sqlite:
         specifier: ^14.0.0
         version: 14.0.6(expo@54.0.25(@babel/core@7.28.5)(bufferutil@4.0.8)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))
@@ -823,6 +829,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      db0:
+        specifier: ^0.3.4
+        version: 0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.9.1)(drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.9.1)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7))(mysql2@3.14.1)(sqlite3@5.1.7)
       import-in-the-middle:
         specifier: ^1.13.1
         version: 1.15.0
@@ -4677,6 +4686,32 @@ packages:
     resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
     engines: {node: '>=6'}
 
+<<<<<<< HEAD
+=======
+  db0@0.3.4:
+    resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
+    peerDependencies:
+      '@electric-sql/pglite': '*'
+      '@libsql/client': '*'
+      better-sqlite3: '*'
+      drizzle-orm: '*'
+      mysql2: '*'
+      sqlite3: '*'
+    peerDependenciesMeta:
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mysql2:
+        optional: true
+      sqlite3:
+        optional: true
+
+>>>>>>> d8ca6bcb (fix(db0): prefer array results)
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -8201,7 +8236,7 @@ packages:
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
@@ -13838,6 +13873,27 @@ snapshots:
     dependencies:
       time-zone: 1.0.0
 
+<<<<<<< HEAD
+=======
+  db0@0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.10.0)(drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.10.0)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7))(mysql2@3.14.1)(sqlite3@5.1.7):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.2.12
+      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      better-sqlite3: 11.10.0
+      drizzle-orm: 0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.10.0)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7)
+      mysql2: 3.14.1
+      sqlite3: 5.1.7
+
+  db0@0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.9.1)(drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.9.1)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7))(mysql2@3.14.1)(sqlite3@5.1.7):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.2.12
+      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      better-sqlite3: 11.9.1
+      drizzle-orm: 0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.9.1)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7)
+      mysql2: 3.14.1
+      sqlite3: 5.1.7
+
+>>>>>>> d8ca6bcb (fix(db0): prefer array results)
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -13991,6 +14047,7 @@ snapshots:
       sql.js: 1.13.0
       sqlite3: 5.1.7
 
+<<<<<<< HEAD
   drizzle-orm@0.44.1(@aws-sdk/client-rds-data@3.940.0)(@cloudflare/workers-types@4.20251126.0)(@electric-sql/pglite@0.2.12)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@1.0.2)(@op-engineering/op-sqlite@2.0.22(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@5.14.0(prisma@5.14.0))(@tidbcloud/serverless@0.1.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(@types/sql.js@1.4.9)(@upstash/redis@1.35.7)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.9.3))(better-sqlite3@11.9.1)(bun-types@1.3.3)(expo-sqlite@14.0.6(expo@54.0.25(@babel/core@7.28.5)(bufferutil@4.0.8)(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)))(gel@2.2.0)(mysql2@3.14.1)(pg@8.16.3)(postgres@3.4.7)(prisma@5.14.0)(sql.js@1.13.0)(sqlite3@5.1.7):
     optionalDependencies:
       '@aws-sdk/client-rds-data': 3.940.0
@@ -14057,6 +14114,30 @@ snapshots:
       prisma: 5.14.0
       sql.js: 1.13.0
       sqlite3: 5.1.7
+=======
+  drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.9.1)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7):
+    optionalDependencies:
+      '@aws-sdk/client-rds-data': 3.817.0
+      '@cloudflare/workers-types': 4.20250529.0
+      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@neondatabase/serverless': 0.10.0
+      '@opentelemetry/api': 1.9.0
+      '@planetscale/database': 1.19.0
+      '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.15.2
+      '@types/sql.js': 1.4.9
+      '@vercel/postgres': 0.8.0
+      better-sqlite3: 11.9.1
+      bun-types: 1.2.15
+      knex: 2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7)
+      kysely: 0.25.0
+      mysql2: 3.14.1
+      pg: 8.16.0
+      postgres: 3.4.7
+      sql.js: 1.13.0
+      sqlite3: 5.1.7
+    optional: true
+>>>>>>> d8ca6bcb (fix(db0): prefer array results)
 
   drizzle-prisma-generator@0.1.7:
     dependencies:
@@ -15490,6 +15571,60 @@ snapshots:
 
   kleur@4.1.5: {}
 
+<<<<<<< HEAD
+=======
+  knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg-connection-string: 2.6.1
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
+      better-sqlite3: 11.10.0
+      mysql2: 3.14.1
+      pg: 8.16.0
+      sqlite3: 5.1.7
+    transitivePeerDependencies:
+      - supports-color
+
+  knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.21
+      pg-connection-string: 2.6.1
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
+      better-sqlite3: 11.9.1
+      mysql2: 3.14.1
+      pg: 8.16.0
+      sqlite3: 5.1.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  kysely@0.25.0: {}
+
+>>>>>>> d8ca6bcb (fix(db0): prefer array results)
   lan-network@0.1.7: {}
 
   leven@3.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,15 +449,12 @@ importers:
       cpy:
         specifier: ^10.1.0
         version: 10.1.0
-<<<<<<< HEAD
+      db0:
+        specifier: ^0.3.4
+        version: 0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.9.1)(drizzle-orm@0.45.1(ba5188131db4211e9d377af230de7ce7))(mysql2@3.14.1)(sqlite3@5.1.7)
       effect:
         specifier: ^3.19.8
         version: 3.19.8
-=======
-      db0:
-        specifier: ^0.3.4
-        version: 0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.10.0)(drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.10.0)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7))(mysql2@3.14.1)(sqlite3@5.1.7)
->>>>>>> d8ca6bcb (fix(db0): prefer array results)
       expo-sqlite:
         specifier: ^14.0.0
         version: 14.0.6(expo@54.0.25(@babel/core@7.28.5)(bufferutil@4.0.8)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))
@@ -831,7 +828,7 @@ importers:
         version: 7.0.3
       db0:
         specifier: ^0.3.4
-        version: 0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.9.1)(drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.9.1)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7))(mysql2@3.14.1)(sqlite3@5.1.7)
+        version: 0.3.4(ede82c8ccae9dce5ade7ef7de3f85172)
       import-in-the-middle:
         specifier: ^1.13.1
         version: 1.15.0
@@ -3843,7 +3840,7 @@ packages:
   '@vercel/postgres@0.8.0':
     resolution: {integrity: sha512-/QUV9ExwaNdKooRjOQqvrKNVnRvsaXeukPNI5DB1ovUTesglfR/fparw7ngo1KUWWKIVpEj2TRrA+ObRHRdaLg==}
     engines: {node: '>=14.6'}
-    deprecated: '@vercel/postgres is deprecated. You can either choose an alternate storage solution from the Vercel Marketplace if you want to set up a new database. Or you can follow this guide to migrate your existing Vercel Postgres db: https://neon.com/docs/guides/vercel-postgres-transition-guide'
+    deprecated: '@vercel/postgres is deprecated. If you are setting up a new database, you can choose an alternate storage solution from the Vercel Marketplace. If you had an existing Vercel Postgres database, it should have been migrated to Neon as a native Vercel integration. You can find more details and the guide to migrate to Neon''s SDKs here: https://neon.com/docs/guides/vercel-postgres-transition-guide'
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -4119,6 +4116,7 @@ packages:
   aws-sdk@2.1692.0:
     resolution: {integrity: sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==}
     engines: {node: '>= 10.0.0'}
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
@@ -4686,8 +4684,6 @@ packages:
     resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
     engines: {node: '>=6'}
 
-<<<<<<< HEAD
-=======
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
     peerDependencies:
@@ -4711,7 +4707,6 @@ packages:
       sqlite3:
         optional: true
 
->>>>>>> d8ca6bcb (fix(db0): prefer array results)
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -4934,6 +4929,98 @@ packages:
 
   drizzle-orm@0.44.1:
     resolution: {integrity: sha512-prIWOlwJbiYInvcJxE+IMiJCtMiFVrSUJCwx6AXSJvGOdLu35qZ46QncTZDgloiLNCG0XxTC8agQElSmsl++TA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
+  drizzle-orm@0.45.1:
+    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -5813,21 +5900,23 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -8231,7 +8320,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
@@ -13873,27 +13962,24 @@ snapshots:
     dependencies:
       time-zone: 1.0.0
 
-<<<<<<< HEAD
-=======
-  db0@0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.10.0)(drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.10.0)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7))(mysql2@3.14.1)(sqlite3@5.1.7):
-    optionalDependencies:
-      '@electric-sql/pglite': 0.2.12
-      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      better-sqlite3: 11.10.0
-      drizzle-orm: 0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.10.0)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7)
-      mysql2: 3.14.1
-      sqlite3: 5.1.7
-
-  db0@0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.9.1)(drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.9.1)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7))(mysql2@3.14.1)(sqlite3@5.1.7):
+  db0@0.3.4(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(better-sqlite3@11.9.1)(drizzle-orm@0.45.1(ba5188131db4211e9d377af230de7ce7))(mysql2@3.14.1)(sqlite3@5.1.7):
     optionalDependencies:
       '@electric-sql/pglite': 0.2.12
       '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       better-sqlite3: 11.9.1
-      drizzle-orm: 0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.9.1)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.1(ba5188131db4211e9d377af230de7ce7)
       mysql2: 3.14.1
       sqlite3: 5.1.7
 
->>>>>>> d8ca6bcb (fix(db0): prefer array results)
+  db0@0.3.4(ede82c8ccae9dce5ade7ef7de3f85172):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.2.12
+      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      better-sqlite3: 11.9.1
+      drizzle-orm: 0.45.1(@aws-sdk/client-rds-data@3.940.0)(@cloudflare/workers-types@4.20251126.0)(@electric-sql/pglite@0.2.12)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@5.14.0(prisma@5.14.0))(@tidbcloud/serverless@0.1.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(@types/sql.js@1.4.9)(@upstash/redis@1.35.7)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.9.2))(better-sqlite3@11.9.1)(bun-types@1.3.3)(expo-sqlite@14.0.6(expo@54.0.25(@babel/core@7.28.5)(bufferutil@4.0.8)(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)))(gel@2.2.0)(mysql2@3.14.1)(pg@8.16.3)(postgres@3.4.7)(prisma@5.14.0)(sql.js@1.13.0)(sqlite3@5.1.7)
+      mysql2: 3.14.1
+      sqlite3: 5.1.7
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -14047,7 +14133,6 @@ snapshots:
       sql.js: 1.13.0
       sqlite3: 5.1.7
 
-<<<<<<< HEAD
   drizzle-orm@0.44.1(@aws-sdk/client-rds-data@3.940.0)(@cloudflare/workers-types@4.20251126.0)(@electric-sql/pglite@0.2.12)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@1.0.2)(@op-engineering/op-sqlite@2.0.22(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@5.14.0(prisma@5.14.0))(@tidbcloud/serverless@0.1.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(@types/sql.js@1.4.9)(@upstash/redis@1.35.7)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.9.3))(better-sqlite3@11.9.1)(bun-types@1.3.3)(expo-sqlite@14.0.6(expo@54.0.25(@babel/core@7.28.5)(bufferutil@4.0.8)(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)))(gel@2.2.0)(mysql2@3.14.1)(pg@8.16.3)(postgres@3.4.7)(prisma@5.14.0)(sql.js@1.13.0)(sqlite3@5.1.7):
     optionalDependencies:
       '@aws-sdk/client-rds-data': 3.940.0
@@ -14077,6 +14162,68 @@ snapshots:
       prisma: 5.14.0
       sql.js: 1.13.0
       sqlite3: 5.1.7
+
+  drizzle-orm@0.45.1(@aws-sdk/client-rds-data@3.940.0)(@cloudflare/workers-types@4.20251126.0)(@electric-sql/pglite@0.2.12)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@5.14.0(prisma@5.14.0))(@tidbcloud/serverless@0.1.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(@types/sql.js@1.4.9)(@upstash/redis@1.35.7)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.9.2))(better-sqlite3@11.9.1)(bun-types@1.3.3)(expo-sqlite@14.0.6(expo@54.0.25(@babel/core@7.28.5)(bufferutil@4.0.8)(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)))(gel@2.2.0)(mysql2@3.14.1)(pg@8.16.3)(postgres@3.4.7)(prisma@5.14.0)(sql.js@1.13.0)(sqlite3@5.1.7):
+    optionalDependencies:
+      '@aws-sdk/client-rds-data': 3.940.0
+      '@cloudflare/workers-types': 4.20251126.0
+      '@electric-sql/pglite': 0.2.12
+      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@libsql/client-wasm': 0.10.0
+      '@neondatabase/serverless': 0.10.0
+      '@op-engineering/op-sqlite': 2.0.22(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      '@opentelemetry/api': 1.9.0
+      '@planetscale/database': 1.19.0
+      '@prisma/client': 5.14.0(prisma@5.14.0)
+      '@tidbcloud/serverless': 0.1.1
+      '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.15.6
+      '@types/sql.js': 1.4.9
+      '@upstash/redis': 1.35.7
+      '@vercel/postgres': 0.8.0
+      '@xata.io/client': 0.29.5(typescript@5.9.2)
+      better-sqlite3: 11.9.1
+      bun-types: 1.3.3
+      expo-sqlite: 14.0.6(expo@54.0.25(@babel/core@7.28.5)(bufferutil@4.0.8)(react-native@0.82.1(@babel/core@7.28.5)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))
+      gel: 2.2.0
+      mysql2: 3.14.1
+      pg: 8.16.3
+      postgres: 3.4.7
+      prisma: 5.14.0
+      sql.js: 1.13.0
+      sqlite3: 5.1.7
+    optional: true
+
+  drizzle-orm@0.45.1(ba5188131db4211e9d377af230de7ce7):
+    optionalDependencies:
+      '@aws-sdk/client-rds-data': 3.940.0
+      '@cloudflare/workers-types': 4.20251126.0
+      '@electric-sql/pglite': 0.2.12
+      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@libsql/client-wasm': 0.10.0
+      '@neondatabase/serverless': 0.10.0
+      '@op-engineering/op-sqlite': 2.0.22(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      '@opentelemetry/api': 1.9.0
+      '@planetscale/database': 1.19.0
+      '@prisma/client': 5.14.0(prisma@5.14.0)
+      '@tidbcloud/serverless': 0.1.1
+      '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.15.6
+      '@types/sql.js': 1.4.9
+      '@upstash/redis': 1.35.7
+      '@vercel/postgres': 0.8.0
+      '@xata.io/client': 0.29.5(typescript@5.9.2)
+      better-sqlite3: 11.9.1
+      bun-types: 1.3.3
+      expo-sqlite: 14.0.6(expo@54.0.25(@babel/core@7.28.5)(bufferutil@4.0.8)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))
+      gel: 2.2.0
+      mysql2: 3.14.1
+      pg: 8.16.3
+      postgres: 3.4.7
+      prisma: 5.14.0
+      sql.js: 1.13.0
+      sqlite3: 5.1.7
+    optional: true
 
   drizzle-orm@1.0.0-beta.8-734e789(12f1be6440688b484116c0e598ccec00):
     dependencies:
@@ -14114,30 +14261,6 @@ snapshots:
       prisma: 5.14.0
       sql.js: 1.13.0
       sqlite3: 5.1.7
-=======
-  drizzle-orm@0.27.2(@aws-sdk/client-rds-data@3.817.0)(@cloudflare/workers-types@4.20250529.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.2)(@types/sql.js@1.4.9)(@vercel/postgres@0.8.0)(better-sqlite3@11.9.1)(bun-types@1.2.15)(knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7))(kysely@0.25.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(sql.js@1.13.0)(sqlite3@5.1.7):
-    optionalDependencies:
-      '@aws-sdk/client-rds-data': 3.817.0
-      '@cloudflare/workers-types': 4.20250529.0
-      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@neondatabase/serverless': 0.10.0
-      '@opentelemetry/api': 1.9.0
-      '@planetscale/database': 1.19.0
-      '@types/better-sqlite3': 7.6.13
-      '@types/pg': 8.15.2
-      '@types/sql.js': 1.4.9
-      '@vercel/postgres': 0.8.0
-      better-sqlite3: 11.9.1
-      bun-types: 1.2.15
-      knex: 2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7)
-      kysely: 0.25.0
-      mysql2: 3.14.1
-      pg: 8.16.0
-      postgres: 3.4.7
-      sql.js: 1.13.0
-      sqlite3: 5.1.7
-    optional: true
->>>>>>> d8ca6bcb (fix(db0): prefer array results)
 
   drizzle-prisma-generator@0.1.7:
     dependencies:
@@ -15571,60 +15694,6 @@ snapshots:
 
   kleur@4.1.5: {}
 
-<<<<<<< HEAD
-=======
-  knex@2.5.1(better-sqlite3@11.10.0)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7):
-    dependencies:
-      colorette: 2.0.19
-      commander: 10.0.1
-      debug: 4.3.4
-      escalade: 3.2.0
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.17.21
-      pg-connection-string: 2.6.1
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      tarn: 3.0.2
-      tildify: 2.0.0
-    optionalDependencies:
-      better-sqlite3: 11.10.0
-      mysql2: 3.14.1
-      pg: 8.16.0
-      sqlite3: 5.1.7
-    transitivePeerDependencies:
-      - supports-color
-
-  knex@2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7):
-    dependencies:
-      colorette: 2.0.19
-      commander: 10.0.1
-      debug: 4.3.4
-      escalade: 3.2.0
-      esm: 3.2.25
-      get-package-type: 0.1.0
-      getopts: 2.3.0
-      interpret: 2.2.0
-      lodash: 4.17.21
-      pg-connection-string: 2.6.1
-      rechoir: 0.8.0
-      resolve-from: 5.0.0
-      tarn: 3.0.2
-      tildify: 2.0.0
-    optionalDependencies:
-      better-sqlite3: 11.9.1
-      mysql2: 3.14.1
-      pg: 8.16.0
-      sqlite3: 5.1.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  kysely@0.25.0: {}
-
->>>>>>> d8ca6bcb (fix(db0): prefer array results)
   lan-network@0.1.7: {}
 
   leven@3.1.0: {}


### PR DESCRIPTION
Adds `drizzle-orm/db0` driver support for db0.

- Auto-detects dialect (`sqlite`/`postgresql`) and exposes a Drizzle session/driver.
- Prefers *array-mode* rows for correctness with joins/aliases:
  - SQLite: `db0/connectors/better-sqlite3` (uses `raw(true)` internally).
  - Postgres: `db0/connectors/pglite` (uses `{ rowMode: 'array' }` when available).
- Fail-fast on unsafe object-row mapping (duplicate/missing keys) instead of returning potentially wrong data.
- `db0` peer/dev version aligned to `>=0.3.4` / `^0.3.4`.
- Adds standalone integration smoke tests for db0 (sqlite + pg).

related https://github.com/drizzle-team/drizzle-orm-docs/pull/648