### PR TITLE
Autogenerated `name` for prepared queries

### DIFF
--- a/drizzle-orm/src/cockroach-core/query-builders/count.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/count.ts
@@ -1,6 +1,5 @@
 import { entityKind } from '~/entity.ts';
 import { SQL, sql, type SQLWrapper } from '~/sql/sql.ts';
-import type { NeonAuthToken } from '~/utils.ts';
 import type { CockroachSession } from '../session.ts';
 import type { CockroachTable } from '../table.ts';
 import type { CockroachViewBase } from '../view-base.ts';
@@ -9,7 +8,6 @@ export class CockroachCountBuilder<
 	TSession extends CockroachSession<any, any, any>,
 > extends SQL<number> implements Promise<number>, SQLWrapper {
 	private sql: SQL<number>;
-	private token?: NeonAuthToken;
 
 	static override readonly [entityKind]: string = 'CockroachCountBuilder';
 	[Symbol.toStringTag] = 'CockroachCountBuilder';
@@ -49,17 +47,11 @@ export class CockroachCountBuilder<
 		);
 	}
 
-	/** @intrnal */
-	setToken(token?: NeonAuthToken) {
-		this.token = token;
-		return this;
-	}
-
 	then<TResult1 = number, TResult2 = never>(
 		onfulfilled?: ((value: number) => TResult1 | PromiseLike<TResult1>) | null | undefined,
 		onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined,
 	): Promise<TResult1 | TResult2> {
-		return Promise.resolve(this.session.count(this.sql, this.token))
+		return Promise.resolve(this.session.count(this.sql))
 			.then(
 				onfulfilled,
 				onrejected,

--- a/drizzle-orm/src/cockroach-core/query-builders/delete.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/delete.ts
@@ -254,7 +254,7 @@ export class CockroachDeleteBase<
 		});
 	}
 
-	prepare(name: string): CockroachDeletePrepare<this> {
+	prepare(name?: string): CockroachDeletePrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/cockroach-core/query-builders/insert.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/insert.ts
@@ -408,7 +408,7 @@ export class CockroachInsertBase<
 		});
 	}
 
-	prepare(name: string): CockroachInsertPrepare<this> {
+	prepare(name?: string): CockroachInsertPrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/cockroach-core/query-builders/query.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/query.ts
@@ -109,7 +109,7 @@ export class CockroachRelationalQuery<TResult> extends QueryPromise<TResult>
 		});
 	}
 
-	prepare(name: string): CockroachPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
+	prepare(name?: string): CockroachPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/cockroach-core/query-builders/refresh-materialized-view.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/refresh-materialized-view.ts
@@ -8,7 +8,7 @@ import type {
 } from '~/cockroach-core/session.ts';
 import type { CockroachMaterializedView } from '~/cockroach-core/view.ts';
 import { entityKind } from '~/entity.ts';
-import { preparedStatementName } from '~/query-name-generator';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';

--- a/drizzle-orm/src/cockroach-core/query-builders/refresh-materialized-view.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/refresh-materialized-view.ts
@@ -85,7 +85,7 @@ export class CockroachRefreshMaterializedView<TQueryResult extends CockroachQuer
 		});
 	}
 
-	prepare(name: string): CockroachPreparedQuery<
+	prepare(name?: string): CockroachPreparedQuery<
 		PreparedQueryConfig & {
 			execute: CockroachQueryResultKind<TQueryResult, never>;
 		}

--- a/drizzle-orm/src/cockroach-core/query-builders/refresh-materialized-view.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/refresh-materialized-view.ts
@@ -8,11 +8,11 @@ import type {
 } from '~/cockroach-core/session.ts';
 import type { CockroachMaterializedView } from '~/cockroach-core/view.ts';
 import { entityKind } from '~/entity.ts';
+import { preparedStatementName } from '~/query-name-generator';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
 import { tracer } from '~/tracing.ts';
-import type { NeonAuthToken } from '~/utils.ts';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CockroachRefreshMaterializedView<TQueryResult extends CockroachQueryResultHKT>
@@ -75,13 +75,19 @@ export class CockroachRefreshMaterializedView<TQueryResult extends CockroachQuer
 	}
 
 	/** @internal */
-	_prepare(name?: string): CockroachPreparedQuery<
+	_prepare(name?: string, generateName = false): CockroachPreparedQuery<
 		PreparedQueryConfig & {
 			execute: CockroachQueryResultKind<TQueryResult, never>;
 		}
 	> {
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
-			return this.session.prepareQuery(this.dialect.sqlToQuery(this.getSQL()), undefined, name, true);
+			const query = this.dialect.sqlToQuery(this.getSQL());
+			return this.session.prepareQuery(
+				query,
+				undefined,
+				name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+				true,
+			);
 		});
 	}
 
@@ -90,19 +96,12 @@ export class CockroachRefreshMaterializedView<TQueryResult extends CockroachQuer
 			execute: CockroachQueryResultKind<TQueryResult, never>;
 		}
 	> {
-		return this._prepare(name);
-	}
-
-	private authToken?: NeonAuthToken;
-	/** @internal */
-	setToken(token: NeonAuthToken) {
-		this.authToken = token;
-		return this;
+		return this._prepare(name, true);
 	}
 
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {
 		return tracer.startActiveSpan('drizzle.operation', () => {
-			return this._prepare().execute(placeholderValues, this.authToken);
+			return this._prepare().execute(placeholderValues);
 		});
 	};
 }

--- a/drizzle-orm/src/cockroach-core/query-builders/select.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/select.ts
@@ -1070,7 +1070,7 @@ export class CockroachSelectBase<
 	 *
 	 * {@link https://www.postgresql.org/docs/current/sql-prepare.html | Postgres prepare documentation}
 	 */
-	prepare(name: string): CockroachSelectPrepare<this> {
+	prepare(name?: string): CockroachSelectPrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/cockroach-core/query-builders/update.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/update.ts
@@ -598,7 +598,7 @@ export class CockroachUpdateBase<
 		return query;
 	}
 
-	prepare(name: string): CockroachUpdatePrepare<this> {
+	prepare(name?: string): CockroachUpdatePrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/gel-core/query-builders/_query.ts
+++ b/drizzle-orm/src/gel-core/query-builders/_query.ts
@@ -105,7 +105,7 @@ export class GelRelationalQuery<TResult> extends QueryPromise<TResult>
 		});
 	}
 
-	prepare(name: string): GelPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
+	prepare(name?: string): GelPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/gel-core/query-builders/_query.ts
+++ b/drizzle-orm/src/gel-core/query-builders/_query.ts
@@ -1,5 +1,6 @@
 import * as V1 from '~/_relations.ts';
 import { entityKind } from '~/entity.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, QueryWithTypings, SQL, SQLWrapper } from '~/sql/sql.ts';
@@ -83,14 +84,14 @@ export class GelRelationalQuery<TResult> extends QueryPromise<TResult>
 	}
 
 	/** @internal */
-	_prepare(name?: string): GelPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
+	_prepare(name?: string, generateName = false): GelPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
 			const { query, builtQuery } = this._toSQL();
 
 			return this.session.prepareQuery<PreparedQueryConfig & { execute: TResult }>(
 				builtQuery,
 				undefined,
-				name,
+				name ?? (generateName ? preparedStatementName(builtQuery.sql, builtQuery.params) : name),
 				true,
 				(rawRows, mapColumnValue) => {
 					const rows = rawRows.map((row) =>
@@ -106,7 +107,7 @@ export class GelRelationalQuery<TResult> extends QueryPromise<TResult>
 	}
 
 	prepare(name?: string): GelPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	private _getQuery() {

--- a/drizzle-orm/src/gel-core/query-builders/delete.ts
+++ b/drizzle-orm/src/gel-core/query-builders/delete.ts
@@ -232,7 +232,7 @@ export class GelDeleteBase<
 		});
 	}
 
-	prepare(name: string): GelDeletePrepare<this> {
+	prepare(name?: string): GelDeletePrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/gel-core/query-builders/delete.ts
+++ b/drizzle-orm/src/gel-core/query-builders/delete.ts
@@ -9,6 +9,7 @@ import type {
 } from '~/gel-core/session.ts';
 import type { GelTable } from '~/gel-core/table.ts';
 import type { SelectResultFields } from '~/query-builders/select.types.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
@@ -219,21 +220,29 @@ export class GelDeleteBase<
 	}
 
 	/** @internal */
-	_prepare(name?: string): GelDeletePrepare<this> {
+	_prepare(name?: string, generateName = false): GelDeletePrepare<this> {
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
+			const query = this.dialect.sqlToQuery(this.getSQL());
 			return this.session.prepareQuery<
 				PreparedQueryConfig & {
 					execute: TReturning extends undefined ? GelQueryResultKind<TQueryResult, never> : TReturning[];
 				}
-			>(this.dialect.sqlToQuery(this.getSQL()), this.config.returning, name, true, undefined, {
-				type: 'delete',
-				tables: extractUsedTable(this.config.table),
-			});
+			>(
+				query,
+				this.config.returning,
+				name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+				true,
+				undefined,
+				{
+					type: 'delete',
+					tables: extractUsedTable(this.config.table),
+				},
+			);
 		});
 	}
 
 	prepare(name?: string): GelDeletePrepare<this> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	override execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {

--- a/drizzle-orm/src/gel-core/query-builders/insert.ts
+++ b/drizzle-orm/src/gel-core/query-builders/insert.ts
@@ -401,7 +401,7 @@ export class GelInsertBase<
 		});
 	}
 
-	prepare(name: string): GelInsertPrepare<this> {
+	prepare(name?: string): GelInsertPrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/gel-core/query-builders/query.ts
+++ b/drizzle-orm/src/gel-core/query-builders/query.ts
@@ -103,7 +103,7 @@ export class PgRelationalQuery<TResult> extends QueryPromise<TResult>
 		});
 	}
 
-	prepare(name: string): GelPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
+	prepare(name?: string): GelPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/gel-core/query-builders/refresh-materialized-view.ts
+++ b/drizzle-orm/src/gel-core/query-builders/refresh-materialized-view.ts
@@ -8,7 +8,7 @@ import type {
 	PreparedQueryConfig,
 } from '~/gel-core/session.ts';
 import type { GelMaterializedView } from '~/gel-core/view.ts';
-import { preparedStatementName } from '~/query-name-generator';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';

--- a/drizzle-orm/src/gel-core/query-builders/refresh-materialized-view.ts
+++ b/drizzle-orm/src/gel-core/query-builders/refresh-materialized-view.ts
@@ -84,7 +84,7 @@ export class GelRefreshMaterializedView<TQueryResult extends GelQueryResultHKT>
 		});
 	}
 
-	prepare(name: string): GelPreparedQuery<
+	prepare(name?: string): GelPreparedQuery<
 		PreparedQueryConfig & {
 			execute: GelQueryResultKind<TQueryResult, never>;
 		}

--- a/drizzle-orm/src/gel-core/query-builders/refresh-materialized-view.ts
+++ b/drizzle-orm/src/gel-core/query-builders/refresh-materialized-view.ts
@@ -8,6 +8,7 @@ import type {
 	PreparedQueryConfig,
 } from '~/gel-core/session.ts';
 import type { GelMaterializedView } from '~/gel-core/view.ts';
+import { preparedStatementName } from '~/query-name-generator';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, SQL, SQLWrapper } from '~/sql/sql.ts';
@@ -74,13 +75,19 @@ export class GelRefreshMaterializedView<TQueryResult extends GelQueryResultHKT>
 	}
 
 	/** @internal */
-	_prepare(name?: string): GelPreparedQuery<
+	_prepare(name?: string, generateName = false): GelPreparedQuery<
 		PreparedQueryConfig & {
 			execute: GelQueryResultKind<TQueryResult, never>;
 		}
 	> {
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
-			return this.session.prepareQuery(this.dialect.sqlToQuery(this.getSQL()), undefined, name, true);
+			const query = this.dialect.sqlToQuery(this.getSQL());
+			return this.session.prepareQuery(
+				query,
+				undefined,
+				name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+				true,
+			);
 		});
 	}
 
@@ -89,7 +96,7 @@ export class GelRefreshMaterializedView<TQueryResult extends GelQueryResultHKT>
 			execute: GelQueryResultKind<TQueryResult, never>;
 		}
 	> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {

--- a/drizzle-orm/src/gel-core/query-builders/select.ts
+++ b/drizzle-orm/src/gel-core/query-builders/select.ts
@@ -1095,7 +1095,7 @@ export class GelSelectBase<
 	 *
 	 * {@link https://www.postgresql.org/docs/current/sql-prepare.html | Postgres prepare documentation}
 	 */
-	prepare(name: string): GelSelectPrepare<this> {
+	prepare(name?: string): GelSelectPrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/gel-core/query-builders/select.ts
+++ b/drizzle-orm/src/gel-core/query-builders/select.ts
@@ -17,6 +17,7 @@ import type {
 	SelectResult,
 	SetOperator,
 } from '~/query-builders/select.types.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import { SelectionProxyHandler } from '~/selection-proxy.ts';
@@ -30,7 +31,6 @@ import {
 	getTableColumns,
 	getTableLikeName,
 	haveSameKeys,
-	type NeonAuthToken,
 	orderSelectedFields,
 	type ValueOrArray,
 } from '~/utils.ts';
@@ -89,13 +89,6 @@ export class GelSelectBuilder<
 			this.withList = config.withList;
 		}
 		this.distinct = config.distinct;
-	}
-
-	private authToken?: NeonAuthToken;
-	/** @internal */
-	setToken(token?: NeonAuthToken) {
-		this.authToken = token;
-		return this;
 	}
 
 	/**
@@ -1060,22 +1053,31 @@ export class GelSelectBase<
 	static override readonly [entityKind]: string = 'GelSelect';
 
 	/** @internal */
-	_prepare(name?: string): GelSelectPrepare<this> {
+	_prepare(name?: string, generateName = false): GelSelectPrepare<this> {
 		const { session, config, dialect, joinsNotNullableMap, cacheConfig, usedTables } = this;
 		if (!session) {
 			throw new Error('Cannot execute a query on a query builder. Please use a database instance instead.');
 		}
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
 			const fieldsList = orderSelectedFields<GelColumn>(config.fields);
-			const query = session.prepareQuery<
+			const query = dialect.sqlToQuery(this.getSQL());
+			const preparedQuery = session.prepareQuery<
 				PreparedQueryConfig & { execute: TResult }
-			>(dialect.sqlToQuery(this.getSQL()), fieldsList, name, true, undefined, {
-				type: 'select',
-				tables: [...usedTables],
-			}, cacheConfig);
-			query.joinsNotNullableMap = joinsNotNullableMap;
+			>(
+				query,
+				fieldsList,
+				name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+				true,
+				undefined,
+				{
+					type: 'select',
+					tables: [...usedTables],
+				},
+				cacheConfig,
+			);
+			preparedQuery.joinsNotNullableMap = joinsNotNullableMap;
 
-			return query;
+			return preparedQuery;
 		});
 	}
 
@@ -1096,7 +1098,7 @@ export class GelSelectBase<
 	 * {@link https://www.postgresql.org/docs/current/sql-prepare.html | Postgres prepare documentation}
 	 */
 	prepare(name?: string): GelSelectPrepare<this> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {

--- a/drizzle-orm/src/gel-core/query-builders/update.ts
+++ b/drizzle-orm/src/gel-core/query-builders/update.ts
@@ -552,7 +552,7 @@ export class GelUpdateBase<
 		return query;
 	}
 
-	prepare(name: string): GelUpdatePrepare<this> {
+	prepare(name?: string): GelUpdatePrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/gel-core/query-builders/update.ts
+++ b/drizzle-orm/src/gel-core/query-builders/update.ts
@@ -19,20 +19,14 @@ import type {
 	SelectMode,
 	SelectResult,
 } from '~/query-builders/select.types.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import { SelectionProxyHandler } from '~/selection-proxy.ts';
 import { type ColumnsSelection, type Placeholder, type Query, SQL, type SQLWrapper } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { type InferInsertModel, Table } from '~/table.ts';
-import {
-	type Assume,
-	getTableLikeName,
-	mapUpdateSet,
-	type NeonAuthToken,
-	orderSelectedFields,
-	type UpdateSet,
-} from '~/utils.ts';
+import { type Assume, getTableLikeName, mapUpdateSet, orderSelectedFields, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type { GelColumn } from '../columns/common.ts';
 import { extractUsedTable } from '../utils.ts';
@@ -76,12 +70,6 @@ export class GelUpdateBuilder<TTable extends GelTable, TQueryResult extends GelQ
 		private dialect: GelDialect,
 		private withList?: Subquery[],
 	) {}
-
-	private authToken?: NeonAuthToken;
-	setToken(token: NeonAuthToken) {
-		this.authToken = token;
-		return this;
-	}
 
 	set(
 		values: GelUpdateSetSource<TTable>,
@@ -541,19 +529,27 @@ export class GelUpdateBase<
 	}
 
 	/** @internal */
-	_prepare(name?: string): GelUpdatePrepare<this> {
-		const query = this.session.prepareQuery<
+	_prepare(name?: string, generateName = false): GelUpdatePrepare<this> {
+		const query = this.dialect.sqlToQuery(this.getSQL());
+		const preparedQuery = this.session.prepareQuery<
 			PreparedQueryConfig & { execute: TReturning[] }
-		>(this.dialect.sqlToQuery(this.getSQL()), this.config.returning, name, true, undefined, {
-			type: 'update',
-			tables: extractUsedTable(this.config.table),
-		});
-		query.joinsNotNullableMap = this.joinsNotNullableMap;
-		return query;
+		>(
+			query,
+			this.config.returning,
+			name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+			true,
+			undefined,
+			{
+				type: 'update',
+				tables: extractUsedTable(this.config.table),
+			},
+		);
+		preparedQuery.joinsNotNullableMap = this.joinsNotNullableMap;
+		return preparedQuery;
 	}
 
 	prepare(name?: string): GelUpdatePrepare<this> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	override execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {

--- a/drizzle-orm/src/pg-core/async/delete.ts
+++ b/drizzle-orm/src/pg-core/async/delete.ts
@@ -86,7 +86,7 @@ export class PgAsyncDeleteBase<
 		});
 	}
 
-	prepare(name: string): PgAsyncDeletePrepare<this> {
+	prepare(name?: string): PgAsyncDeletePrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/async/insert.ts
+++ b/drizzle-orm/src/pg-core/async/insert.ts
@@ -1,6 +1,7 @@
 import { entityKind } from '~/entity.ts';
 import type { PgQueryResultHKT, PgQueryResultKind, PreparedQueryConfig } from '~/pg-core/session.ts';
 import type { PgTable } from '~/pg-core/table.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { ColumnsSelection } from '~/sql/sql.ts';
@@ -74,21 +75,30 @@ export class PgAsyncInsertBase<
 	declare protected session: PgAsyncSession;
 
 	/** @internal */
-	_prepare(name?: string): PgInsertPrepare<this> {
+	_prepare(name?: string, generateName = false): PgInsertPrepare<this> {
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
+			const query = this.dialect.sqlToQuery(this.getSQL());
 			return this.session.prepareQuery<
 				PreparedQueryConfig & {
 					execute: TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[];
 				}
-			>(this.dialect.sqlToQuery(this.getSQL()), this.config.returning, name, true, undefined, {
-				type: 'insert',
-				tables: extractUsedTable(this.config.table),
-			}, this.cacheConfig).setToken(this.authToken);
+			>(
+				query,
+				this.config.returning,
+				name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+				true,
+				undefined,
+				{
+					type: 'insert',
+					tables: extractUsedTable(this.config.table),
+				},
+				this.cacheConfig,
+			).setToken(this.authToken);
 		});
 	}
 
 	prepare(name?: string): PgInsertPrepare<this> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	/** @internal */

--- a/drizzle-orm/src/pg-core/async/insert.ts
+++ b/drizzle-orm/src/pg-core/async/insert.ts
@@ -87,7 +87,7 @@ export class PgAsyncInsertBase<
 		});
 	}
 
-	prepare(name: string): PgInsertPrepare<this> {
+	prepare(name?: string): PgInsertPrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/async/query.ts
+++ b/drizzle-orm/src/pg-core/async/query.ts
@@ -42,7 +42,7 @@ export class PgAsyncRelationalQuery<TResult> extends PgRelationalQuery<PgAsyncRe
 		});
 	}
 
-	prepare(name: string): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
+	prepare(name?: string): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/async/query.ts
+++ b/drizzle-orm/src/pg-core/async/query.ts
@@ -1,4 +1,5 @@
 import { entityKind } from '~/entity.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import { mapRelationalRow } from '~/relations.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
@@ -23,14 +24,14 @@ export class PgAsyncRelationalQuery<TResult> extends PgRelationalQuery<PgAsyncRe
 	declare protected session: PgAsyncSession;
 
 	/** @internal */
-	_prepare(name?: string): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
+	_prepare(name?: string, generateName = false): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
 			const { query, builtQuery } = this._toSQL();
 
 			return this.session.prepareRelationalQuery<PreparedQueryConfig & { execute: TResult }>(
 				builtQuery,
 				undefined,
-				name,
+				name ?? (generateName ? preparedStatementName(builtQuery.sql, builtQuery.params) : name),
 				(rawRows, mapColumnValue) => {
 					const rows = rawRows.map((row) => mapRelationalRow(row, query.selection, mapColumnValue, this.parseJson));
 					if (this.mode === 'first') {
@@ -43,7 +44,7 @@ export class PgAsyncRelationalQuery<TResult> extends PgRelationalQuery<PgAsyncRe
 	}
 
 	prepare(name?: string): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	/** @internal */

--- a/drizzle-orm/src/pg-core/async/refresh-materialized-view.ts
+++ b/drizzle-orm/src/pg-core/async/refresh-materialized-view.ts
@@ -33,7 +33,7 @@ export class PgAsyncRefreshMaterializedView<TQueryResult extends PgQueryResultHK
 		});
 	}
 
-	prepare(name: string): PgAsyncPreparedQuery<
+	prepare(name?: string): PgAsyncPreparedQuery<
 		PreparedQueryConfig & {
 			execute: PgQueryResultKind<TQueryResult, never>;
 		}

--- a/drizzle-orm/src/pg-core/async/refresh-materialized-view.ts
+++ b/drizzle-orm/src/pg-core/async/refresh-materialized-view.ts
@@ -1,5 +1,6 @@
 import { entityKind } from '~/entity.ts';
 import type { PgQueryResultHKT, PgQueryResultKind, PreparedQueryConfig } from '~/pg-core/session.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import { tracer } from '~/tracing.ts';
@@ -21,13 +22,19 @@ export class PgAsyncRefreshMaterializedView<TQueryResult extends PgQueryResultHK
 	declare protected session: PgAsyncSession;
 
 	/** @internal */
-	_prepare(name?: string): PgAsyncPreparedQuery<
+	_prepare(name?: string, generateName = false): PgAsyncPreparedQuery<
 		PreparedQueryConfig & {
 			execute: PgQueryResultKind<TQueryResult, never>;
 		}
 	> {
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
-			return this.session.prepareQuery(this.dialect.sqlToQuery(this.getSQL()), undefined, name, true).setToken(
+			const query = this.dialect.sqlToQuery(this.getSQL());
+			return this.session.prepareQuery(
+				query,
+				undefined,
+				name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+				true,
+			).setToken(
 				this.authToken,
 			);
 		});
@@ -38,7 +45,7 @@ export class PgAsyncRefreshMaterializedView<TQueryResult extends PgQueryResultHK
 			execute: PgQueryResultKind<TQueryResult, never>;
 		}
 	> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	/** @internal */

--- a/drizzle-orm/src/pg-core/async/select.ts
+++ b/drizzle-orm/src/pg-core/async/select.ts
@@ -129,7 +129,7 @@ export class PgAsyncSelectBase<
 	 * {@link https://www.postgresql.org/docs/current/sql-prepare.html | Postgres prepare documentation}
 	 */
 	prepare(
-		name: string,
+		name?: string,
 	): PgAsyncSelectPrepare<this> {
 		return this._prepare(name);
 	}

--- a/drizzle-orm/src/pg-core/async/update.ts
+++ b/drizzle-orm/src/pg-core/async/update.ts
@@ -2,11 +2,12 @@ import { entityKind } from '~/entity.ts';
 import type { PgQueryResultHKT, PgQueryResultKind, PreparedQueryConfig } from '~/pg-core/session.ts';
 import type { PgTable } from '~/pg-core/table.ts';
 import type { JoinNullability } from '~/query-builders/select.types.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { ColumnsSelection, SQL } from '~/sql/sql.ts';
 import type { Subquery } from '~/subquery.ts';
-import { applyMixins, type Assume } from '~/utils.ts';
+import { applyMixins, type Assume, type NeonAuthToken } from '~/utils.ts';
 import { type Join, PgUpdateBase, type PgUpdateHKTBase } from '../query-builders/update.ts';
 import { extractUsedTable } from '../utils.ts';
 import type { PgViewBase } from '../view-base.ts';
@@ -100,19 +101,36 @@ export class PgAsyncUpdateBase<
 	declare protected session: PgAsyncSession;
 
 	/** @internal */
-	_prepare(name?: string): PgAsyncUpdatePrepare<this> {
-		const query = this.session.prepareQuery<
+	_prepare(name?: string, generateName = false): PgAsyncUpdatePrepare<this> {
+		const query = this.dialect.sqlToQuery(this.getSQL());
+		const preparedQuery = this.session.prepareQuery<
 			PreparedQueryConfig & { execute: TReturning[] }
-		>(this.dialect.sqlToQuery(this.getSQL()), this.config.returning, name, true, undefined, {
-			type: 'insert',
-			tables: extractUsedTable(this.config.table),
-		}, this.cacheConfig);
-		query.joinsNotNullableMap = this.joinsNotNullableMap;
-		return query;
+		>(
+			query,
+			this.config.returning,
+			name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+			true,
+			undefined,
+			{
+				type: 'insert',
+				tables: extractUsedTable(this.config.table),
+			},
+			this.cacheConfig,
+		);
+		preparedQuery.joinsNotNullableMap = this.joinsNotNullableMap;
+		return preparedQuery.setToken(this.authToken);
 	}
 
 	prepare(name?: string): PgAsyncUpdatePrepare<this> {
-		return this._prepare(name);
+		return this._prepare(name, true);
+	}
+
+	/** @internal */
+	private authToken?: NeonAuthToken;
+	/** @internal */
+	setToken(token?: NeonAuthToken) {
+		this.authToken = token;
+		return this;
 	}
 
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues: Record<string, unknown> = {}) => {

--- a/drizzle-orm/src/pg-core/async/update.ts
+++ b/drizzle-orm/src/pg-core/async/update.ts
@@ -111,7 +111,7 @@ export class PgAsyncUpdateBase<
 		return query;
 	}
 
-	prepare(name: string): PgAsyncUpdatePrepare<this> {
+	prepare(name?: string): PgAsyncUpdatePrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/effect/delete.ts
+++ b/drizzle-orm/src/pg-core/effect/delete.ts
@@ -3,6 +3,7 @@ import { entityKind } from '~/entity.ts';
 import type { PgQueryResultHKT, PgQueryResultKind, PreparedQueryConfig } from '~/pg-core/session.ts';
 import type { PgTable } from '~/pg-core/table.ts';
 import type { TypedQueryBuilder } from '~/query-builders/query-builder.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { ColumnsSelection, SQLWrapper } from '~/sql/sql.ts';
 import { tracer } from '~/tracing.ts';
@@ -73,21 +74,30 @@ export class PgEffectDeleteBase<
 	declare protected session: PgEffectSession;
 
 	/** @internal */
-	_prepare(name?: string): PgEffectDeletePrepare<this> {
+	_prepare(name?: string, generateName = false): PgEffectDeletePrepare<this> {
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
+			const query = this.dialect.sqlToQuery(this.getSQL());
 			return this.session.prepareQuery<
 				PreparedQueryConfig & {
 					execute: TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[];
 				}
-			>(this.dialect.sqlToQuery(this.getSQL()), this.config.returning, name, true, undefined, {
-				type: 'delete',
-				tables: extractUsedTable(this.config.table),
-			}, this.cacheConfig);
+			>(
+				query,
+				this.config.returning,
+				name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+				true,
+				undefined,
+				{
+					type: 'delete',
+					tables: extractUsedTable(this.config.table),
+				},
+				this.cacheConfig,
+			);
 		});
 	}
 
 	prepare(name?: string): PgEffectDeletePrepare<this> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {

--- a/drizzle-orm/src/pg-core/effect/delete.ts
+++ b/drizzle-orm/src/pg-core/effect/delete.ts
@@ -86,7 +86,7 @@ export class PgEffectDeleteBase<
 		});
 	}
 
-	prepare(name: string): PgEffectDeletePrepare<this> {
+	prepare(name?: string): PgEffectDeletePrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/effect/insert.ts
+++ b/drizzle-orm/src/pg-core/effect/insert.ts
@@ -2,6 +2,7 @@ import { applyEffectWrapper, type QueryEffect } from '~/effect-core/query-effect
 import { entityKind } from '~/entity.ts';
 import type { PgQueryResultHKT, PgQueryResultKind, PreparedQueryConfig } from '~/pg-core/session.ts';
 import type { PgTable } from '~/pg-core/table.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { ColumnsSelection } from '~/sql/sql.ts';
 import { tracer } from '~/tracing.ts';
@@ -68,19 +69,28 @@ export class PgEffectInsertBase<
 	declare protected session: PgEffectSession;
 
 	/** @internal */
-	_prepare(name?: string): PgInsertPrepare<this> {
+	_prepare(name?: string, generateName = false): PgInsertPrepare<this> {
+		const query = this.dialect.sqlToQuery(this.getSQL());
 		return this.session.prepareQuery<
 			PreparedQueryConfig & {
 				execute: TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[];
 			}
-		>(this.dialect.sqlToQuery(this.getSQL()), this.config.returning, name, true, undefined, {
-			type: 'insert',
-			tables: extractUsedTable(this.config.table),
-		}, this.cacheConfig);
+		>(
+			query,
+			this.config.returning,
+			name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+			true,
+			undefined,
+			{
+				type: 'insert',
+				tables: extractUsedTable(this.config.table),
+			},
+			this.cacheConfig,
+		);
 	}
 
 	prepare(name?: string): PgInsertPrepare<this> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {

--- a/drizzle-orm/src/pg-core/effect/insert.ts
+++ b/drizzle-orm/src/pg-core/effect/insert.ts
@@ -79,7 +79,7 @@ export class PgEffectInsertBase<
 		}, this.cacheConfig);
 	}
 
-	prepare(name: string): PgInsertPrepare<this> {
+	prepare(name?: string): PgInsertPrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/effect/query.ts
+++ b/drizzle-orm/src/pg-core/effect/query.ts
@@ -41,7 +41,7 @@ export class PgEffectRelationalQuery<TResult> extends PgRelationalQuery<PgEffect
 		});
 	}
 
-	prepare(name: string): PgEffectPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
+	prepare(name?: string): PgEffectPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/effect/refresh-materialized-view.ts
+++ b/drizzle-orm/src/pg-core/effect/refresh-materialized-view.ts
@@ -30,7 +30,7 @@ export class PgEffectRefreshMaterializedView<TQueryResult extends PgQueryResultH
 		});
 	}
 
-	prepare(name: string): PgEffectPreparedQuery<
+	prepare(name?: string): PgEffectPreparedQuery<
 		PreparedQueryConfig & {
 			execute: PgQueryResultKind<TQueryResult, never>;
 		}

--- a/drizzle-orm/src/pg-core/effect/select.ts
+++ b/drizzle-orm/src/pg-core/effect/select.ts
@@ -123,7 +123,7 @@ export class PgEffectSelectBase<
 	 *
 	 * {@link https://www.postgresql.org/docs/current/sql-prepare.html | Postgres prepare documentation}
 	 */
-	prepare(name: string): PgEffectSelectPrepare<this> {
+	prepare(name?: string): PgEffectSelectPrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/effect/select.ts
+++ b/drizzle-orm/src/pg-core/effect/select.ts
@@ -6,6 +6,7 @@ import type {
 	SelectMode,
 	SelectResult,
 } from '~/query-builders/select.types.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import type { ColumnsSelection } from '~/sql/sql.ts';
 import { type Assume, orderSelectedFields } from '~/utils.ts';
 import type { PgColumn } from '../columns/index.ts';
@@ -100,20 +101,29 @@ export class PgEffectSelectBase<
 	declare protected session: PgEffectSession;
 
 	/** @internal */
-	_prepare(name?: string): PgEffectSelectPrepare<this> {
+	_prepare(name?: string, generateName = false): PgEffectSelectPrepare<this> {
 		const { session, config, dialect, joinsNotNullableMap, cacheConfig, usedTables } = this;
 		const { fields } = config;
 
+		const query = dialect.sqlToQuery(this.getSQL());
 		const fieldsList = orderSelectedFields<PgColumn>(fields);
-		const query = session.prepareQuery<
+		const preparedQUery = session.prepareQuery<
 			PreparedQueryConfig & { execute: TResult }
-		>(dialect.sqlToQuery(this.getSQL()), fieldsList, name, true, undefined, {
-			type: 'select',
-			tables: [...usedTables],
-		}, cacheConfig);
-		query.joinsNotNullableMap = joinsNotNullableMap;
+		>(
+			query,
+			fieldsList,
+			name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+			true,
+			undefined,
+			{
+				type: 'select',
+				tables: [...usedTables],
+			},
+			cacheConfig,
+		);
+		preparedQUery.joinsNotNullableMap = joinsNotNullableMap;
 
-		return query;
+		return preparedQUery;
 	}
 
 	/**
@@ -124,7 +134,7 @@ export class PgEffectSelectBase<
 	 * {@link https://www.postgresql.org/docs/current/sql-prepare.html | Postgres prepare documentation}
 	 */
 	prepare(name?: string): PgEffectSelectPrepare<this> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues?: Record<string, unknown>) => {

--- a/drizzle-orm/src/pg-core/effect/update.ts
+++ b/drizzle-orm/src/pg-core/effect/update.ts
@@ -3,6 +3,7 @@ import { entityKind } from '~/entity.ts';
 import type { PgQueryResultHKT, PgQueryResultKind, PreparedQueryConfig } from '~/pg-core/session.ts';
 import type { PgTable } from '~/pg-core/table.ts';
 import type { JoinNullability } from '~/query-builders/select.types.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { ColumnsSelection, SQL } from '~/sql/sql.ts';
 import type { Subquery } from '~/subquery.ts';
@@ -100,19 +101,28 @@ export class PgEffectUpdateBase<
 	declare protected session: PgEffectSession;
 
 	/** @internal */
-	_prepare(name?: string): PgEffectUpdatePrepare<this> {
-		const query = this.session.prepareQuery<
+	_prepare(name?: string, generateName = false): PgEffectUpdatePrepare<this> {
+		const query = this.dialect.sqlToQuery(this.getSQL());
+		const preparedQuery = this.session.prepareQuery<
 			PreparedQueryConfig & { execute: TReturning[] }
-		>(this.dialect.sqlToQuery(this.getSQL()), this.config.returning, name, true, undefined, {
-			type: 'insert',
-			tables: extractUsedTable(this.config.table),
-		}, this.cacheConfig);
-		query.joinsNotNullableMap = this.joinsNotNullableMap;
-		return query;
+		>(
+			query,
+			this.config.returning,
+			name ?? (generateName ? preparedStatementName(query.sql, query.params) : name),
+			true,
+			undefined,
+			{
+				type: 'insert',
+				tables: extractUsedTable(this.config.table),
+			},
+			this.cacheConfig,
+		);
+		preparedQuery.joinsNotNullableMap = this.joinsNotNullableMap;
+		return preparedQuery;
 	}
 
 	prepare(name?: string): PgEffectUpdatePrepare<this> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	execute: ReturnType<this['prepare']>['execute'] = (placeholderValues: Record<string, unknown> = {}) => {

--- a/drizzle-orm/src/pg-core/effect/update.ts
+++ b/drizzle-orm/src/pg-core/effect/update.ts
@@ -111,7 +111,7 @@ export class PgEffectUpdateBase<
 		return query;
 	}
 
-	prepare(name: string): PgEffectUpdatePrepare<this> {
+	prepare(name?: string): PgEffectUpdatePrepare<this> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/query-builders/_query.ts
+++ b/drizzle-orm/src/pg-core/query-builders/_query.ts
@@ -106,7 +106,7 @@ export class _PgRelationalQuery<TResult> extends QueryPromise<TResult>
 		});
 	}
 
-	prepare(name: string): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
+	prepare(name?: string): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
 		return this._prepare(name);
 	}
 

--- a/drizzle-orm/src/pg-core/query-builders/_query.ts
+++ b/drizzle-orm/src/pg-core/query-builders/_query.ts
@@ -1,5 +1,6 @@
 import * as V1 from '~/_relations.ts';
 import { entityKind } from '~/entity.ts';
+import { preparedStatementName } from '~/query-name-generator.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import type { Query, QueryWithTypings, SQL, SQLWrapper } from '~/sql/sql.ts';
@@ -84,14 +85,14 @@ export class _PgRelationalQuery<TResult> extends QueryPromise<TResult>
 	}
 
 	/** @internal */
-	_prepare(name?: string): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
+	_prepare(name?: string, generateName = false): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
 		return tracer.startActiveSpan('drizzle.prepareQuery', () => {
 			const { query, builtQuery } = this._toSQL();
 
 			return this.session.prepareQuery<PreparedQueryConfig & { execute: TResult }>(
 				builtQuery,
 				undefined,
-				name,
+				name ?? (generateName ? preparedStatementName(builtQuery.sql, builtQuery.params) : name),
 				true,
 				(rawRows, mapColumnValue) => {
 					const rows = rawRows.map((row) =>
@@ -107,7 +108,7 @@ export class _PgRelationalQuery<TResult> extends QueryPromise<TResult>
 	}
 
 	prepare(name?: string): PgAsyncPreparedQuery<PreparedQueryConfig & { execute: TResult }> {
-		return this._prepare(name);
+		return this._prepare(name, true);
 	}
 
 	private _getQuery() {

--- a/drizzle-orm/src/query-name-generator.ts
+++ b/drizzle-orm/src/query-name-generator.ts
@@ -1,0 +1,94 @@
+import { is } from './entity.ts';
+import { Placeholder } from './sql/sql.ts';
+
+function isBinary(value: unknown): boolean {
+	if (
+		typeof Buffer !== 'undefined'
+		&& typeof Buffer.isBuffer === 'function'
+		&& Buffer.isBuffer(value)
+	) return true;
+	// oxlint-disable-next-line drizzle-internal/no-instanceof
+	if (value instanceof ArrayBuffer) return true;
+	if (ArrayBuffer.isView(value)) return true;
+	return false;
+}
+
+function arrayTypeId(arr: readonly unknown[]) {
+	if (!arr.length) return 'array<void>';
+	let elementId: string | undefined;
+	for (let i = 0; i < arr.length; i++) {
+		const id = jsTypeId(arr[i]);
+
+		if (!elementId) {
+			elementId = id;
+			continue;
+		}
+
+		if (elementId !== id) {
+			elementId = `${elementId},${id}`;
+			continue;
+		}
+
+		elementId = id;
+	}
+	return `array<${elementId}>`;
+}
+
+// replacement for type OID
+function jsTypeId(value: unknown): string {
+	if (value === null) return 'null';
+	if (is(value, Placeholder)) return 'placeholder';
+	// oxlint-disable-next-line drizzle-internal/no-instanceof
+	if (value instanceof Date) return 'date';
+	if (Array.isArray(value)) return arrayTypeId(value);
+	if (isBinary(value)) return 'binary';
+	return typeof value;
+}
+
+function hash(str: string, seed = 5381): number {
+	let h = seed;
+	for (let i = 0; i < str.length; i++) {
+		h = ((h << 5) + h) ^ str.charCodeAt(i);
+	}
+	return h >>> 0;
+}
+
+const safeChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_';
+function stringify(hash: number, length: number, startWithLetter = false): string {
+	let result = '';
+	let h = hash;
+
+	if (startWithLetter) {
+		result += safeChars[h % 52];
+		h = h >>> 6;
+		--length;
+	}
+
+	while (result.length < length) {
+		result += safeChars[h % safeChars.length];
+		h = h >>> 6;
+		if (h === 0) break;
+	}
+
+	return result;
+}
+
+export function preparedStatementName(
+	sql: string,
+	params: readonly unknown[] = [],
+): string {
+	let hash1 = hash(sql);
+	let hash2 = hash(sql, 5381 ^ 0xdeadbeef);
+
+	const paramIds = params.map(jsTypeId).join(',');
+	for (let ti = 0; ti < paramIds.length; ti++) {
+		hash1 = ((hash1 << 5) + hash1) ^ paramIds.charCodeAt(ti);
+		hash2 = ((hash2 << 5) + hash2) ^ paramIds.charCodeAt(ti);
+	}
+
+	const part1 = stringify(hash1, 31, true);
+	const part2 = stringify(hash2, 32);
+
+	// Max out allowed name length to prevent collisions
+	return part1 + part2;
+}

--- a/integration-tests/tests/cockroach/common.ts
+++ b/integration-tests/tests/cockroach/common.ts
@@ -1253,6 +1253,24 @@ export function tests() {
 			expect(result).toEqual([{ id: 1, name: 'John' }]);
 		});
 
+		test('nameless prepared statement', async (ctx) => {
+			const { db } = ctx.cockroach;
+
+			await db.insert(usersTable).values({ name: 'John' });
+			const statement = db
+				.select({
+					id: usersTable.id,
+					name: usersTable.name,
+				})
+				.from(usersTable)
+				.prepare();
+			const result1 = await statement.execute();
+			const result2 = await statement.execute();
+
+			expect(result1).toEqual([{ id: 1, name: 'John' }]);
+			expect(result2).toEqual([{ id: 1, name: 'John' }]);
+		});
+
 		test('insert: placeholders on columns with encoder', async (ctx) => {
 			const { db } = ctx.cockroach;
 

--- a/integration-tests/tests/gel/gel.test.ts
+++ b/integration-tests/tests/gel/gel.test.ts
@@ -1347,6 +1347,23 @@ describe('some', async () => {
 		expect(result).toEqual([{ name: 'John' }]);
 	});
 
+	test('nameless prepared statement', async (ctx) => {
+		const { db } = ctx.gel;
+
+		await db.insert(usersTable).values({ id1: 1, name: 'John' });
+		const statement = db
+			.select({
+				name: usersTable.name,
+			})
+			.from(usersTable)
+			.prepare();
+		const result1 = await statement.execute();
+		const result2 = await statement.execute();
+
+		expect(result1).toEqual([{ name: 'John' }]);
+		expect(result2).toEqual([{ name: 'John' }]);
+	});
+
 	test('insert: placeholders on columns with encoder', async (ctx) => {
 		const { db } = ctx.gel;
 

--- a/integration-tests/tests/pg/common-pt1.ts
+++ b/integration-tests/tests/pg/common-pt1.ts
@@ -853,6 +853,29 @@ export function tests(test: Test) {
 			expect(result).toEqual([{ id: 1, name: 'John' }]);
 		});
 
+		test.concurrent('nameless prepared statement', async ({ db, push }) => {
+			const usersTable = pgTable('users_33_nmls', {
+				id: serial('id').primaryKey(),
+				name: text('name').notNull(),
+			});
+
+			await push({ usersTable });
+
+			await db.insert(usersTable).values({ name: 'John' });
+			const statement = db
+				.select({
+					id: usersTable.id,
+					name: usersTable.name,
+				})
+				.from(usersTable)
+				.prepare();
+			const result1 = await statement.execute();
+			const result2 = await statement.execute();
+
+			expect(result1).toEqual([{ id: 1, name: 'John' }]);
+			expect(result2).toEqual([{ id: 1, name: 'John' }]);
+		});
+
 		test.concurrent('insert: placeholders on columns with encoder', async ({ db, push }) => {
 			const usersTable = pgTable('users_34', {
 				id: serial('id').primaryKey(),


### PR DESCRIPTION
- Made `name` argument in `prepare(name)` optional in `Gel`, `Postgres`, `Cockroach` dialects (generated automatically if not passed)