### PR TITLE
fix(drizzle-kit): support top-level await in config and schema files

### DIFF
--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -56,7 +56,7 @@
 		"@drizzle-team/brocli": "^0.11.0",
 		"@js-temporal/polyfill": "^0.5.1",
 		"esbuild": "^0.25.10",
-		"tsx": "^4.20.6"
+		"jiti": "^2.6.1"
 	},
 	"devDependencies": {
 		"@aws-sdk/client-rds-data": "^3.556.0",
@@ -120,6 +120,7 @@
 		"rolldown": "^1.0.0-beta.57",
 		"semver": "^7.7.2",
 		"tsdown": "^0.18.3",
+		"tsx": "^4.20.6",
 		"typescript": "^5.9.3",
 		"uuid": "^9.0.1",
 		"ws": "^8.18.2",

--- a/drizzle-kit/scripts/build.ts
+++ b/drizzle-kit/scripts/build.ts
@@ -29,8 +29,6 @@ const driversPackages = [
 
 const external = [
 	'esbuild',
-	'tsx',
-	/^tsx\//,
 	/^drizzle-orm\/?/,
 	...driversPackages,
 ];

--- a/drizzle-kit/src/cli/commands/studio.ts
+++ b/drizzle-kit/src/cli/commands/studio.ts
@@ -34,8 +34,7 @@ import { z } from 'zod';
 import { getColumnCasing } from '../../dialects/drizzle';
 import type { BenchmarkProxy, Proxy, TransactionProxy } from '../../utils';
 import { assertUnreachable } from '../../utils';
-import { safeRegister } from '../../utils/utils-node';
-import { prepareFilenames } from '../../utils/utils-node';
+import { loadModule, prepareFilenames } from '../../utils/utils-node';
 import { JSONB } from '../../utils/when-json-met-bigint';
 import type { DuckDbCredentials } from '../validations/duckdb';
 import type { MysqlCredentials } from '../validations/mysql';
@@ -108,26 +107,24 @@ export const preparePgSchema = async (path: string | string[]) => {
 		content: fs.readFileSync(it, 'utf-8'),
 	}));
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
 
-			const i0: Record<string, unknown> = require(`${it}`);
-			const i0values = Object.entries(i0);
+		const i0: Record<string, unknown> = await loadModule(it);
+		const i0values = Object.entries(i0);
 
-			i0values.forEach(([k, t]) => {
-				if (is(t, PgTable)) {
-					const schema = pgTableConfig(t).schema || 'public';
-					pgSchema[schema] = pgSchema[schema] || {};
-					pgSchema[schema][k] = t;
-				}
+		i0values.forEach(([k, t]) => {
+			if (is(t, PgTable)) {
+				const schema = pgTableConfig(t).schema || 'public';
+				pgSchema[schema] = pgSchema[schema] || {};
+				pgSchema[schema][k] = t;
+			}
 
-				if (is(t, Relations)) {
-					relations[k] = t;
-				}
-			});
-		}
-	});
+			if (is(t, Relations)) {
+				relations[k] = t;
+			}
+		});
+	}
 
 	return { schema: pgSchema, relations, files };
 };
@@ -146,25 +143,23 @@ export const prepareMySqlSchema = async (path: string | string[]) => {
 		content: fs.readFileSync(it, 'utf-8'),
 	}));
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
 
-			const i0: Record<string, unknown> = require(`${it}`);
-			const i0values = Object.entries(i0);
+		const i0: Record<string, unknown> = await loadModule(it);
+		const i0values = Object.entries(i0);
 
-			i0values.forEach(([k, t]) => {
-				if (is(t, MySqlTable)) {
-					const schema = mysqlTableConfig(t).schema || 'public';
-					mysqlSchema[schema][k] = t;
-				}
+		i0values.forEach(([k, t]) => {
+			if (is(t, MySqlTable)) {
+				const schema = mysqlTableConfig(t).schema || 'public';
+				mysqlSchema[schema][k] = t;
+			}
 
-				if (is(t, Relations)) {
-					relations[k] = t;
-				}
-			});
-		}
-	});
+			if (is(t, Relations)) {
+				relations[k] = t;
+			}
+		});
+	}
 
 	return { schema: mysqlSchema, relations, files };
 };
@@ -183,25 +178,23 @@ export const prepareMsSqlSchema = async (path: string | string[]) => {
 		content: fs.readFileSync(it, 'utf-8'),
 	}));
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
 
-			const i0: Record<string, unknown> = require(`${it}`);
-			const i0values = Object.entries(i0);
+		const i0: Record<string, unknown> = await loadModule(it);
+		const i0values = Object.entries(i0);
 
-			i0values.forEach(([k, t]) => {
-				if (is(t, MsSqlTable)) {
-					const schema = mssqlTableConfig(t).schema || 'public';
-					mssqlSchema[schema][k] = t;
-				}
+		i0values.forEach(([k, t]) => {
+			if (is(t, MsSqlTable)) {
+				const schema = mssqlTableConfig(t).schema || 'public';
+				mssqlSchema[schema][k] = t;
+			}
 
-				if (is(t, Relations)) {
-					relations[k] = t;
-				}
-			});
-		}
-	});
+			if (is(t, Relations)) {
+				relations[k] = t;
+			}
+		});
+	}
 
 	return { schema: mssqlSchema, relations, files };
 };
@@ -220,25 +213,23 @@ export const prepareSQLiteSchema = async (path: string | string[]) => {
 		content: fs.readFileSync(it, 'utf-8'),
 	}));
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
 
-			const i0: Record<string, unknown> = require(`${it}`);
-			const i0values = Object.entries(i0);
+		const i0: Record<string, unknown> = await loadModule(it);
+		const i0values = Object.entries(i0);
 
-			i0values.forEach(([k, t]) => {
-				if (is(t, SQLiteTable)) {
-					const schema = 'public'; // sqlite does not have schemas
-					sqliteSchema[schema][k] = t;
-				}
+		i0values.forEach(([k, t]) => {
+			if (is(t, SQLiteTable)) {
+				const schema = 'public'; // sqlite does not have schemas
+				sqliteSchema[schema][k] = t;
+			}
 
-				if (is(t, Relations)) {
-					relations[k] = t;
-				}
-			});
-		}
-	});
+			if (is(t, Relations)) {
+				relations[k] = t;
+			}
+		});
+	}
 
 	return { schema: sqliteSchema, relations, files };
 };
@@ -260,25 +251,23 @@ export const prepareSingleStoreSchema = async (path: string | string[]) => {
 		content: fs.readFileSync(it, 'utf-8'),
 	}));
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
 
-			const i0: Record<string, unknown> = require(`${it}`);
-			const i0values = Object.entries(i0);
+		const i0: Record<string, unknown> = await loadModule(it);
+		const i0values = Object.entries(i0);
 
-			i0values.forEach(([k, t]) => {
-				if (is(t, SingleStoreTable)) {
-					const schema = singlestoreTableConfig(t).schema || 'public';
-					singlestoreSchema[schema][k] = t;
-				}
+		i0values.forEach(([k, t]) => {
+			if (is(t, SingleStoreTable)) {
+				const schema = singlestoreTableConfig(t).schema || 'public';
+				singlestoreSchema[schema][k] = t;
+			}
 
-				if (is(t, Relations)) {
-					relations[k] = t;
-				}
-			});
-		}
-	});
+			if (is(t, Relations)) {
+				relations[k] = t;
+			}
+		});
+	}
 
 	return { schema: singlestoreSchema, relations, files };
 };

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -6,7 +6,7 @@ import { object, string } from 'zod';
 import { assertUnreachable, type Journal } from '../../utils';
 import { type Dialect, dialect } from '../../utils/schemaValidator';
 import { prepareFilenames } from '../../utils/utils-node';
-import { safeRegister } from '../../utils/utils-node';
+import { loadModule } from '../../utils/utils-node';
 import type { EntitiesFilterConfig } from '../validations/cli';
 import { pullParams, pushParams } from '../validations/cli';
 import type { CockroachCredentials } from '../validations/cockroach';
@@ -1000,11 +1000,7 @@ export const drizzleConfigFromFile = async (
 
 	if (!isExport) console.log(chalk.grey(`Reading config file '${path}'`));
 
-	const content = await safeRegister(async () => {
-		const required = require(`${path}`);
-		const content = required.default ?? required;
-		return content;
-	});
+	const content = await loadModule<any>(path);
 
 	// --- get response and then check by each dialect independently
 	const res = configCommonSchema.safeParse(content);

--- a/drizzle-kit/src/dialects/cockroach/drizzle.ts
+++ b/drizzle-kit/src/dialects/cockroach/drizzle.ts
@@ -29,7 +29,7 @@ import {
 	isCockroachView,
 } from 'drizzle-orm/cockroach-core';
 import type { CasingType } from 'src/cli/validations/common';
-import { safeRegister } from 'src/utils/utils-node';
+import { loadModule } from 'src/utils/utils-node';
 import { assertUnreachable } from '../../utils';
 import { getColumnCasing } from '../drizzle';
 import type { EntityFilter } from '../pull-utils';
@@ -698,24 +698,22 @@ export const prepareFromSchemaFiles = async (imports: string[]) => {
 	const matViews: CockroachMaterializedView[] = [];
 	const relations: Relations[] = [];
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
 
-			const i0: Record<string, unknown> = require(`${it}`);
-			const prepared = fromExports(i0);
+		const i0: Record<string, unknown> = await loadModule(it);
+		const prepared = fromExports(i0);
 
-			tables.push(...prepared.tables);
-			enums.push(...prepared.enums);
-			schemas.push(...prepared.schemas);
-			sequences.push(...prepared.sequences);
-			views.push(...prepared.views);
-			matViews.push(...prepared.matViews);
-			roles.push(...prepared.roles);
-			policies.push(...prepared.policies);
-			relations.push(...prepared.relations);
-		}
-	});
+		tables.push(...prepared.tables);
+		enums.push(...prepared.enums);
+		schemas.push(...prepared.schemas);
+		sequences.push(...prepared.sequences);
+		views.push(...prepared.views);
+		matViews.push(...prepared.matViews);
+		roles.push(...prepared.roles);
+		policies.push(...prepared.policies);
+		relations.push(...prepared.relations);
+	}
 
 	return {
 		tables,

--- a/drizzle-kit/src/dialects/mssql/drizzle.ts
+++ b/drizzle-kit/src/dialects/mssql/drizzle.ts
@@ -12,7 +12,7 @@ import {
 	MsSqlView,
 } from 'drizzle-orm/mssql-core';
 import type { CasingType } from 'src/cli/validations/common';
-import { safeRegister } from 'src/utils/utils-node';
+import { loadModule } from 'src/utils/utils-node';
 import { getColumnCasing, sqlToStr } from '../drizzle';
 import type { EntityFilter } from '../pull-utils';
 import type { DefaultConstraint, InterimSchema, MssqlEntities, Schema, SchemaError } from './ddl';
@@ -359,19 +359,17 @@ export const prepareFromSchemaFiles = async (imports: string[]) => {
 	const views: MsSqlView[] = [];
 	const relations: Relations[] = [];
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
 
-			const i0: Record<string, unknown> = require(`${it}`);
-			const prepared = fromExport(i0);
+		const i0: Record<string, unknown> = await loadModule(it);
+		const prepared = fromExport(i0);
 
-			tables.push(...prepared.tables);
-			schemas.push(...prepared.schemas);
-			views.push(...prepared.views);
-			relations.push(...prepared.relations);
-		}
-	});
+		tables.push(...prepared.tables);
+		schemas.push(...prepared.schemas);
+		views.push(...prepared.views);
+		relations.push(...prepared.relations);
+	}
 
 	return {
 		tables,

--- a/drizzle-kit/src/dialects/mysql/drizzle.ts
+++ b/drizzle-kit/src/dialects/mysql/drizzle.ts
@@ -18,7 +18,7 @@ import {
 	MySqlView,
 } from 'drizzle-orm/mysql-core';
 import type { CasingType } from 'src/cli/validations/common';
-import { safeRegister } from '../../utils/utils-node';
+import { loadModule } from '../../utils/utils-node';
 import { getColumnCasing, sqlToStr } from '../drizzle';
 import type { Column, InterimSchema } from './ddl';
 import { defaultNameForFK, nameForUnique, typeFor } from './grammar';
@@ -296,17 +296,15 @@ export const prepareFromSchemaFiles = async (imports: string[]) => {
 	const views: MySqlView[] = [];
 	const relations: Relations[] = [];
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
-			const i0: Record<string, unknown> = require(`${it}`);
-			const prepared = prepareFromExports(i0);
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
+		const i0: Record<string, unknown> = await loadModule(it);
+		const prepared = prepareFromExports(i0);
 
-			tables.push(...prepared.tables);
-			views.push(...prepared.views);
-			relations.push(...prepared.relations);
-		}
-	});
+		tables.push(...prepared.tables);
+		views.push(...prepared.views);
+		relations.push(...prepared.relations);
+	}
 	return { tables: Array.from(new Set(tables)), views, relations };
 };
 

--- a/drizzle-kit/src/dialects/postgres/drizzle.ts
+++ b/drizzle-kit/src/dialects/postgres/drizzle.ts
@@ -37,7 +37,7 @@ import {
 	uniqueKeyName,
 } from 'drizzle-orm/pg-core';
 import type { CasingType } from 'src/cli/validations/common';
-import { safeRegister } from 'src/utils/utils-node';
+import { loadModule } from 'src/utils/utils-node';
 import { assertUnreachable } from '../../utils';
 import { getColumnCasing } from '../drizzle';
 import type { EntityFilter } from '../pull-utils';
@@ -841,24 +841,22 @@ export const prepareFromSchemaFiles = async (imports: string[]) => {
 	const matViews: PgMaterializedView[] = [];
 	const relations: Relations[] = [];
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
 
-			const i0: Record<string, unknown> = require(`${it}`);
-			const prepared = fromExports(i0);
+		const i0: Record<string, unknown> = await loadModule(it);
+		const prepared = fromExports(i0);
 
-			tables.push(...prepared.tables);
-			enums.push(...prepared.enums);
-			schemas.push(...prepared.schemas);
-			sequences.push(...prepared.sequences);
-			views.push(...prepared.views);
-			matViews.push(...prepared.matViews);
-			roles.push(...prepared.roles);
-			policies.push(...prepared.policies);
-			relations.push(...prepared.relations);
-		}
-	});
+		tables.push(...prepared.tables);
+		enums.push(...prepared.enums);
+		schemas.push(...prepared.schemas);
+		sequences.push(...prepared.sequences);
+		views.push(...prepared.views);
+		matViews.push(...prepared.matViews);
+		roles.push(...prepared.roles);
+		policies.push(...prepared.policies);
+		relations.push(...prepared.relations);
+	}
 
 	return {
 		tables,

--- a/drizzle-kit/src/dialects/singlestore/drizzle.ts
+++ b/drizzle-kit/src/dialects/singlestore/drizzle.ts
@@ -5,7 +5,7 @@ import type { AnySingleStoreColumn, AnySingleStoreTable } from 'drizzle-orm/sing
 import { getTableConfig, SingleStoreDialect, SingleStoreTable, uniqueKeyName } from 'drizzle-orm/singlestore-core';
 import type { CasingType } from 'src/cli/validations/common';
 import { escapeSingleQuotes } from 'src/utils';
-import { safeRegister } from '../../utils/utils-node';
+import { loadModule } from '../../utils/utils-node';
 import { getColumnCasing, sqlToStr } from '../drizzle';
 import type { Column, InterimSchema } from '../mysql/ddl';
 import { typeFor } from '../mysql/grammar';
@@ -182,16 +182,14 @@ export const prepareFromSchemaFiles = async (imports: string[]) => {
 	const tables: AnySingleStoreTable[] = [];
 	const relations: Relations[] = [];
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
-			const i0: Record<string, unknown> = require(`${it}`);
-			const prepared = prepareFromExports(i0);
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
+		const i0: Record<string, unknown> = await loadModule(it);
+		const prepared = prepareFromExports(i0);
 
-			tables.push(...prepared.tables);
-			relations.push(...prepared.relations);
-		}
-	});
+		tables.push(...prepared.tables);
+		relations.push(...prepared.relations);
+	}
 
 	return { tables: Array.from(new Set(tables)), relations };
 };

--- a/drizzle-kit/src/dialects/sqlite/drizzle.ts
+++ b/drizzle-kit/src/dialects/sqlite/drizzle.ts
@@ -10,7 +10,7 @@ import {
 	SQLiteTimestamp,
 	SQLiteView,
 } from 'drizzle-orm/sqlite-core';
-import { safeRegister } from 'src/utils/utils-node';
+import { loadModule } from 'src/utils/utils-node';
 import type { CasingType } from '../../cli/validations/common';
 import { getColumnCasing, sqlToStr } from '../drizzle';
 import type {
@@ -239,18 +239,16 @@ export const prepareFromSchemaFiles = async (imports: string[]) => {
 	const views: SQLiteView[] = [];
 	const relations: Relations[] = [];
 
-	await safeRegister(async () => {
-		for (let i = 0; i < imports.length; i++) {
-			const it = imports[i];
+	for (let i = 0; i < imports.length; i++) {
+		const it = imports[i];
 
-			const i0: Record<string, unknown> = require(`${it}`);
-			const prepared = fromExports(i0);
+		const i0: Record<string, unknown> = await loadModule(it);
+		const prepared = fromExports(i0);
 
-			tables.push(...prepared.tables);
-			views.push(...prepared.views);
-			relations.push(...prepared.relations);
-		}
-	});
+		tables.push(...prepared.tables);
+		views.push(...prepared.views);
+		relations.push(...prepared.relations);
+	}
 
 	return { tables: Array.from(new Set(tables)), views, relations };
 };

--- a/drizzle-kit/src/utils/_es5.ts
+++ b/drizzle-kit/src/utils/_es5.ts
@@ -1,2 +1,0 @@
-const _ = '';
-export default _;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 0.8.23(typescript@5.9.2)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
       tsx:
         specifier: ^4.10.5
         version: 4.20.6
@@ -61,10 +61,10 @@ importers:
         version: 5.9.2
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.9.2)(vite@7.2.4(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.3.2(typescript@5.9.2)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       vitest:
         specifier: 4.0.13
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.13(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   attw-fork:
     dependencies:
@@ -165,9 +165,9 @@ importers:
       esbuild:
         specifier: ^0.25.10
         version: 0.25.12
-      tsx:
-        specifier: ^4.20.6
-        version: 4.20.6
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
     devDependencies:
       '@aws-sdk/client-rds-data':
         specifier: ^3.556.0
@@ -352,6 +352,9 @@ importers:
       tsdown:
         specifier: ^0.18.3
         version: 0.18.4(typescript@5.9.3)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -731,7 +734,7 @@ importers:
         version: 0.49.7(@effect/experimental@0.57.8(@effect/platform@0.93.5(effect@3.19.8))(effect@3.19.8))(@effect/platform@0.93.5(effect@3.19.8))(@effect/sql@0.48.5(@effect/experimental@0.57.8(@effect/platform@0.93.5(effect@3.19.8))(effect@3.19.8))(@effect/platform@0.93.5(effect@3.19.8))(effect@3.19.8))(effect@3.19.8)
       '@effect/vitest':
         specifier: ^0.27.0
-        version: 0.27.0(effect@3.19.8)(vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 0.27.0(effect@3.19.8)(vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@electric-sql/pglite':
         specifier: 0.2.12
         version: 0.2.12
@@ -921,7 +924,7 @@ importers:
         version: 4.20.6
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.9.2)(vite@7.2.4(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.3.2(typescript@5.9.2)(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       zx:
         specifier: ^8.3.2
         version: 8.8.5
@@ -3951,6 +3954,7 @@ packages:
   '@vercel/postgres@0.8.0':
     resolution: {integrity: sha512-/QUV9ExwaNdKooRjOQqvrKNVnRvsaXeukPNI5DB1ovUTesglfR/fparw7ngo1KUWWKIVpEj2TRrA+ObRHRdaLg==}
     engines: {node: '>=14.6'}
+    deprecated: '@vercel/postgres is deprecated. You can either choose an alternate storage solution from the Vercel Marketplace if you want to set up a new database. Or you can follow this guide to migrate your existing Vercel Postgres db: https://neon.com/docs/guides/vercel-postgres-transition-guide'
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -6329,6 +6333,10 @@ packages:
   jimp-compact@0.16.1:
     resolution: {integrity: sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   jmespath@0.16.0:
     resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
     engines: {node: '>= 0.6.0'}
@@ -8355,10 +8363,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
@@ -10667,10 +10677,10 @@ snapshots:
       effect: 3.19.8
       uuid: 11.1.0
 
-  '@effect/vitest@0.27.0(effect@3.19.8)(vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
+  '@effect/vitest@0.27.0(effect@3.19.8)(vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       effect: 3.19.8
-      vitest: 4.0.13(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.13(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@electric-sql/pglite@0.2.12': {}
 
@@ -13013,21 +13023,21 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)
 
-  '@vitest/mocker@4.0.13(vite@7.2.4(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.13(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.13
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.4(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
-  '@vitest/mocker@4.0.13(vite@7.2.4(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.13(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.13
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.4(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -15628,6 +15638,8 @@ snapshots:
 
   jimp-compact@0.16.1: {}
 
+  jiti@2.6.1: {}
+
   jmespath@0.16.0: {}
 
   jose@4.15.9: {}
@@ -17028,10 +17040,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      jiti: 2.6.1
       postcss: 8.5.6
       tsx: 4.20.6
       yaml: 2.8.1
@@ -18298,7 +18311,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.0)
       cac: 6.7.14
@@ -18309,7 +18322,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1)
       resolve-from: 5.0.0
       rollup: 4.53.3
       source-map: 0.7.6
@@ -18550,24 +18563,24 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.2.4(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
+  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 7.2.4(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.2.4(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
+  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 7.2.4(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -18583,7 +18596,7 @@ snapshots:
       lightningcss: 1.30.2
       terser: 5.44.1
 
-  vite@7.2.4(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
+  vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -18594,12 +18607,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.25
       fsevents: 2.3.3
+      jiti: 2.6.1
       lightningcss: 1.30.2
       terser: 5.44.1
       tsx: 4.20.6
       yaml: 2.8.1
 
-  vite@7.2.4(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
+  vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -18610,6 +18624,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
       fsevents: 2.3.3
+      jiti: 2.6.1
       lightningcss: 1.30.2
       terser: 5.44.1
       tsx: 4.20.6
@@ -18650,10 +18665,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.13
-      '@vitest/mocker': 4.0.13(vite@7.2.4(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.13(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.13
       '@vitest/runner': 4.0.13
       '@vitest/snapshot': 4.0.13
@@ -18670,7 +18685,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.2.4(@types/node@20.19.25)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -18689,10 +18704,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@4.0.13(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.13
-      '@vitest/mocker': 4.0.13(vite@7.2.4(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.13(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.13
       '@vitest/runner': 4.0.13
       '@vitest/snapshot': 4.0.13
@@ -18709,7 +18724,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.2.4(@types/node@24.10.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Summary
Enable top-level await in drizzle-kit config and schema files on Node.js by replacing `require()` with async `loadModule()` using jiti.

## Changes
- Add `loadModule()` function using jiti for TypeScript files
- Replace all `require()` calls for user modules with `await loadModule()`
- Add Node version check (requires 18.19+, 20.6+, or 21+)
- Bun/Deno continue using native `import()`

## Test Matrix (all pass)
| Project Type | TLA Location | Result |
|--------------|--------------|--------|
| CJS | Config | ✅ |
| CJS | Schema | ✅ |
| CJS | None | ✅ |
| ESM | Config | ✅ |
| ESM | Schema | ✅ |
| ESM | None | ✅ |