### PR TITLE
Refactor Array.prototype.random to use Object.defineProperty to be no…

### DIFF
--- a/drizzle-kit/src/@types/utils.ts
+++ b/drizzle-kit/src/@types/utils.ts
@@ -51,8 +51,13 @@ String.prototype.snake_case = function() {
 	return this && this.length > 0 ? `${this.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)}` : String(this);
 };
 
-Array.prototype.random = function() {
-	return this[~~(Math.random() * this.length)];
-};
+Object.defineProperty(Array.prototype, "random", {
+	function() {
+		return this[~~(Math.random() * this.length)];,
+	},
+	writable: true,
+	enumerable: false,
+	configurable: true
+});
 
 export {};


### PR DESCRIPTION
…n-enumerable

We dont want this property to be enumerable because it shows up in for loops if thats the case.