### PR TITLE
Add UNLOGGED table support for PostgreSQL

### DIFF
--- a/drizzle-kit/src/jsonStatements.ts
+++ b/drizzle-kit/src/jsonStatements.ts
@@ -23,6 +23,7 @@ import {
 	View as SqliteView,
 } from './serializer/sqliteSchema';
 import { AlteredColumn, Column, Sequence, Table } from './snapshotsDiffer';
+import { PgTable } from '../../drizzle-orm/src/pg-core/table';
 
 export interface JsonSqliteCreateTableStatement {
 	type: 'sqlite_create_table';
@@ -53,7 +54,8 @@ export interface JsonCreateTableStatement {
 	policies?: string[];
 	checkConstraints?: string[];
 	internals?: MySqlKitInternals | SingleStoreKitInternals;
-	isRLSEnabled?: boolean;
+  isRLSEnabled?: boolean;
+  isUnlogged?: boolean;
 }
 
 export interface JsonRecreateTableStatement {
@@ -912,7 +914,8 @@ export const preparePgCreateTableJson = (
 		uniqueConstraints: Object.values(uniqueConstraints),
 		policies: Object.values(policies),
 		checkConstraints: Object.values(checkConstraints),
-		isRLSEnabled: isRLSEnabled ?? false,
+    isRLSEnabled: isRLSEnabled ?? false,
+		isUnlogged: (table as any)[PgTable.Symbol.Unlogged] ?? false,
 	};
 };
 

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -388,13 +388,15 @@ class PgCreateTableConvertor extends Convertor {
 	}
 
 	convert(st: JsonCreateTableStatement) {
-		const { tableName, schema, columns, compositePKs, uniqueConstraints, checkConstraints, policies, isRLSEnabled } =
+		const { tableName, schema, columns, compositePKs, uniqueConstraints, checkConstraints, policies, isRLSEnabled, isUnlogged } =
 			st;
 
 		let statement = '';
 		const name = schema ? `"${schema}"."${tableName}"` : `"${tableName}"`;
 
-		statement += `CREATE TABLE ${name} (\n`;
+		const createPrefix = isUnlogged ? 'CREATE UNLOGGED TABLE' : 'CREATE TABLE';
+
+		statement += `${createPrefix} ${name} (\n`;
 		for (let i = 0; i < columns.length; i++) {
 			const column = columns[i];
 
@@ -3272,7 +3274,7 @@ class PgAlterTableAlterColumnDropPrimaryKeyConvertor extends Convertor {
 
 	convert(statement: JsonAlterColumnDropPrimaryKeyStatement) {
 		const { tableName, columnName, schema } = statement;
-		return `/* 
+		return `/*
     Unfortunately in current drizzle-kit version we can't automatically get name for primary key.
     We are working on making it available!
 
@@ -3283,7 +3285,7 @@ class PgAlterTableAlterColumnDropPrimaryKeyConvertor extends Convertor {
                 AND table_name = '${tableName}'
                 AND constraint_type = 'PRIMARY KEY';
         2. Uncomment code below and paste pk name manually
-        
+
     Hope to release this update as soon as possible
 */
 

--- a/drizzle-kit/tests/unlogged.test.ts
+++ b/drizzle-kit/tests/unlogged.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest';
+import { pgTable } from '../../drizzle-orm/src/pg-core/table';
+import { uuid } from '../../drizzle-orm/src/pg-core/columns';
+import { diffTestSchemas } from 'tests/schemaDiffer';
+
+test('unlogged table generates correct DDL', async () => {
+    const schema = {
+        logs: pgTable('logs', {
+            id: uuid('id'),
+        }).unlogged(),
+    };
+
+    const { sqlStatements } = await diffTestSchemas({}, schema, []);
+    expect(sqlStatements[0]).toMatch(/^CREATE UNLOGGED TABLE/);
+});


### PR DESCRIPTION
Introduce `isUnlogged` flag in JSON create‑table statements and extend `PgTable` with an internal `UnloggedTable` symbol and `unlogged()` builder.
Update the SQL generator to emit `CREATE UNLOGGED TABLE` when the flag is
set, and add a test that verifies the generated DDL starts with that statement.