### PR TITLE
Fix Drizzle crashing on empty query result with batch

### DIFF
--- a/drizzle-orm/src/d1/session.ts
+++ b/drizzle-orm/src/d1/session.ts
@@ -329,6 +329,10 @@ export class D1PreparedQuery<T extends PreparedQueryConfig = PreparedQueryConfig
 			result = this.isRqbV2Query ? (result as D1Result).results[0] : d1ToRawMapping((result as D1Result).results)[0];
 		}
 
+		if (!result) {
+			return undefined;
+		}
+
 		if (!this.fields && !this.customResultMapper) {
 			return result;
 		}


### PR DESCRIPTION
Fix when D1 relational queries in a batch has empty result, Drizzle crashes when trying to map undefined value.

Fixes #2721 for beta, but main seems to need the fix too.