### PR TITLE
[MySQL-kit] Fix DateTime toTs missing CURRENT_TIMESTAMP literal check

### DIFF
--- a/drizzle-kit/src/dialects/mysql/grammar.ts
+++ b/drizzle-kit/src/dialects/mysql/grammar.ts
@@ -474,8 +474,14 @@ export const DateTime: SqlType = {
 
 		if (!def) return { options, default: '' };
 		const trimmed = trimChar(def, "'");
+		if (
+			trimmed === 'now()' || trimmed === '(now())' || trimmed === '(CURRENT_TIMESTAMP)'
+			|| trimmed === 'CURRENT_TIMESTAMP'
+		) {
+			return { options, default: '.defaultNow()' };
+		}
 
-		if (trimmed.includes('now') || trimmed.includes('CURRENT_TIMESTAMP')) {
+		if (trimmed.includes('now(') || trimmed.includes('CURRENT_TIMESTAMP(')) {
 			return { options, default: `sql\`${trimmed}\`` };
 		}
 


### PR DESCRIPTION
## What

Fixes `drizzle-kit pull` generating invalid code for MySQL `datetime` columns with `DEFAULT CURRENT_TIMESTAMP`.

## Why

Follow-up to #5212. The fix in beta.11 added a `CURRENT_TIMESTAMP` literal check to `Timestamp.toTs`, but the same check was missing from `DateTime.toTs`. This caused:

```ts
// Generated (broken):
created_at: datetime().default(new Date("CURRENT_TIMESTAMPZ")).notNull(),  // Invalid Date

// Expected:
created_at: datetime().defaultNow().notNull(),
```

## How

Aligned `DateTime.toTs` with the same two-tier default handling as `Timestamp.toTs`:

1. **Exact matches** (`CURRENT_TIMESTAMP`, `now()`, `(now())`, `(CURRENT_TIMESTAMP)`) → `.defaultNow()`
2. **Parameterized variants** (`CURRENT_TIMESTAMP(N)`, `now(N)`) → `` sql`...` ``

The previous `includes('now')` check was also tightened to `includes('now(')` to match the Timestamp pattern and avoid false positives.

Fixes #5342