### PR TITLE
fix(drizzle-kit): exclude new columns from INSERT INTO SELECT during SQLite table rebuild

### DIFF
--- a/drizzle-kit/src/jsonStatements.ts
+++ b/drizzle-kit/src/jsonStatements.ts
@@ -72,6 +72,7 @@ export interface JsonRecreateTableStatement {
 	compositePKs: string[][];
 	uniqueConstraints?: string[];
 	checkConstraints: string[];
+	addedColumns?: string[];
 }
 
 export interface JsonRecreateSingleStoreTableStatement {

--- a/drizzle-kit/src/snapshotsDiffer.ts
+++ b/drizzle-kit/src/snapshotsDiffer.ts
@@ -3768,7 +3768,7 @@ export const applySqliteSnapshotsDiff = async (
 	jsonStatements.push(...dropViews);
 	jsonStatements.push(...createViews);
 
-	const combinedJsonStatements = sqliteCombineStatements(jsonStatements, json2, action);
+	const combinedJsonStatements = sqliteCombineStatements(jsonStatements, json2, action, columnsPatchedSnap1);
 	const sqlStatements = fromJson(combinedJsonStatements, 'sqlite');
 
 	const uniqueSqlStatements: string[] = [];
@@ -4304,7 +4304,7 @@ export const applyLibSQLSnapshotsDiff = async (
 
 	jsonStatements.push(...jsonAlteredUniqueConstraints);
 
-	const combinedJsonStatements = libSQLCombineStatements(jsonStatements, json2, action);
+	const combinedJsonStatements = libSQLCombineStatements(jsonStatements, json2, action, columnsPatchedSnap1);
 
 	const sqlStatements = fromJson(
 		combinedJsonStatements,

--- a/drizzle-kit/tests/push/libsql.test.ts
+++ b/drizzle-kit/tests/push/libsql.test.ts
@@ -867,6 +867,7 @@ test('recreate table with added column not null and without default', async (t) 
 		type: 'recreate_table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		addedColumns: ['new_column'],
 	});
 
 	expect(sqlStatements!.length).toBe(4);


### PR DESCRIPTION
Fixes https://github.com/drizzle-team/drizzle-orm/issues/5360

## What

Fixes SQLite table rebuild (`INSERT INTO ... SELECT`) treating new column names as string literals instead of using default values, causing data corruption and UNIQUE constraint failures.

## Why

When `drizzle-kit push` or `drizzle-kit generate` triggers a table rebuild (due to autoincrement changes, foreign key additions, etc.) and the schema also includes newly added columns, the generated `INSERT INTO ... SELECT` statement includes **all** columns from the new table — including ones that don't exist in the old table. In SQLite, a double-quoted identifier in a `SELECT` that doesn't match an existing column is treated as a **string literal**, so every row gets the column name as its value (e.g. `"referral_code"` instead of `NULL`). When the new column has a `UNIQUE` constraint, this immediately fails with `SQLITE_CONSTRAINT`.

## How

The fix threads "added column" information through the full migration pipeline so that the SQL generators can exclude new columns from the `SELECT` clause:

1. **`jsonStatements.ts`** — Added optional `addedColumns?: string[]` to `JsonRecreateTableStatement`
2. **`statementCombiner.ts`** — `prepareSQLiteRecreateTable` / `prepareLibSQLRecreateTable` now accept the old table schema and compute which columns are new
3. **`snapshotsDiffer.ts`** — Passes the column-rename-aware snapshot (`columnsPatchedSnap1`) to the combiner so renamed columns are not misidentified as new
4. **`sqlgenerator.ts`** — `SQLiteRecreateTableConvertor` and `LibSQLRecreateTableConvertor` filter the `SELECT` columns to exclude `addedColumns`
5. **`sqlitePushUtils.ts` / `libSqlPushUtils.ts`** — Push path now uses the statement's `addedColumns` (which accounts for column renames) rather than re-computing from the raw schema diff

### Before (buggy)
```sql
INSERT INTO `__new_user`("id", "email", "referral_code")
SELECT "id", "email", "referral_code" FROM `user`;
-- SQLite treats "referral_code" as the string literal 'referral_code'
```

### After (fixed)
```sql
INSERT INTO `__new_user`("id", "email")
SELECT "id", "email" FROM `user`;
-- referral_code gets its DEFAULT (NULL) from the new table definition
```

## Testing

- Added test in `tests/libsql-statements.test.ts` — validates the migration path generates correct SQL excluding new columns
- Added test in `tests/push/sqlite.test.ts` — validates the push path generates correct INSERT for a table rebuild with a new nullable unique column
- Updated existing tests to expect the new `addedColumns` field in `recreate_table` statements
- All 57 existing + new tests pass
