### PR TITLE
fix(bun-sql): preserve json/jsonb params when using Bun SQL

### DIFF
--- a/integration-tests/tests/bun/bun-sql.test.ts
+++ b/integration-tests/tests/bun/bun-sql.test.ts
@@ -913,6 +913,23 @@ test('json insert', async () => {
 	expect(result).toEqual([{ id: 1, name: 'John', jsonb: ['foo', 'bar'] }]);
 });
 
+test('jsonb empty array insert preserves jsonb type', async () => {
+	await db.insert(usersTable).values({ name: 'John', jsonb: [] });
+
+	const result = await db
+		.select({
+			id: usersTable.id,
+			jsonb: usersTable.jsonb,
+			jsonbType: sql<string>`jsonb_typeof(${usersTable.jsonb})`,
+			jsonbText: sql<string>`${usersTable.jsonb}::text`,
+		})
+		.from(usersTable);
+
+	expect(result).toEqual([
+		{ id: 1, jsonb: [], jsonbType: 'array', jsonbText: '[]' },
+	]);
+});
+
 test('char insert', async () => {
 	await db.insert(citiesTable).values({ name: 'Austin', state: 'TX' });
 	const result = await db


### PR DESCRIPTION
## Summary
- normalize `json`-typed prepared query params in the Bun SQL adapter before passing them to `Bun.SQL`
- avoid double-serialized JSON values being stored in Postgres `json/jsonb` columns
- add a Bun integration regression test that verifies inserting an empty JSONB array persists as `jsonb_typeof(...) = 'array'` and `::text = '[]'`

## Context
`PgJson/PgJsonb` encoders map to JSON strings. For the Bun SQL driver, passing those strings as params causes Bun to serialize them as JSON strings again, which stores values like `"[]"` in JSONB columns instead of `[]`.