### PR TITLE
fix(drizzle-kit): fix empty string default generating invalid TypeScript during introspect

### DIFF
--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -366,6 +366,9 @@ export function escapeSingleQuotes(str: string) {
 }
 
 export function unescapeSingleQuotes(str: string, ignoreFirstAndLastChar: boolean) {
-	const regex = ignoreFirstAndLastChar ? /(?<!^)'(?!$)/g : /'/g;
-	return str.replace(/''/g, "'").replace(regex, "\\'");
+	if (ignoreFirstAndLastChar) {
+		const inner = str.slice(1, -1).replace(/''/g, "'").replace(/'/g, "\\'");
+		return `'${inner}'`;
+	}
+	return str.replace(/''/g, "'").replace(/'/g, "\\'");
 }


### PR DESCRIPTION
## Summary

- Fix `drizzle-kit pull` generating `.default(')` instead of `.default('')` when a column has an empty string default — producing a syntax error in the output schema file
- The bug is in `unescapeSingleQuotes` in `drizzle-kit/src/utils.ts`: the regex-based approach to skip first/last quote characters fails when the input is `''` (two quotes representing an empty string)
- Fix: when `ignoreFirstAndLastChar` is true, strip wrapping quotes first, process inner content, then re-wrap — instead of relying on regex boundary assertions

## Test plan

- [x] Added unit test for `unescapeSingleQuotes` covering empty string, normal string, and escaped quote cases
- [x] Added integration test with PGlite: introspects a table with `text`, `varchar`, and `char` columns that have empty string defaults, verifying round-trip produces matching schema


🤖 Generated with [Claude Code](https://claude.com/claude-code)