### PR TITLE
feat(pg): add CREATE TRIGGER support

### DIFF
--- a/drizzle-orm/src/pg-core/index.ts
+++ b/drizzle-orm/src/pg-core/index.ts
@@ -6,6 +6,7 @@ export * from './dialect.ts';
 export * from './foreign-keys.ts';
 export * from './indexes.ts';
 export * from './policies.ts';
+export * from './triggers.ts';
 export * from './primary-keys.ts';
 export * from './query-builders/index.ts';
 export * from './roles.ts';

--- a/drizzle-orm/src/pg-core/table.ts
+++ b/drizzle-orm/src/pg-core/table.ts
@@ -7,6 +7,7 @@ import type { ExtraConfigColumn, PgColumn, PgColumnBuilder, PgColumnBuilderBase 
 import type { ForeignKey, ForeignKeyBuilder } from './foreign-keys.ts';
 import type { AnyIndexBuilder } from './indexes.ts';
 import type { PgPolicy } from './policies.ts';
+import type { PgTrigger } from './triggers.ts';
 import type { PrimaryKeyBuilder } from './primary-keys.ts';
 import type { UniqueConstraintBuilder } from './unique-constraint.ts';
 
@@ -16,7 +17,8 @@ export type PgTableExtraConfigValue =
 	| ForeignKeyBuilder
 	| PrimaryKeyBuilder
 	| UniqueConstraintBuilder
-	| PgPolicy;
+	| PgPolicy
+	| PgTrigger;
 
 export type PgTableExtraConfig = Record<
 	string,

--- a/drizzle-orm/src/pg-core/triggers.ts
+++ b/drizzle-orm/src/pg-core/triggers.ts
@@ -1,0 +1,302 @@
+import { entityKind } from '~/entity.ts';
+import type { SQL } from '~/sql/sql.ts';
+import type { PgTable } from './table.ts';
+
+export type PgTriggerEvent = 'INSERT' | 'UPDATE' | 'DELETE' | 'TRUNCATE';
+export type PgTriggerTiming = 'BEFORE' | 'AFTER' | 'INSTEAD OF';
+export type PgTriggerOrientation = 'ROW' | 'STATEMENT';
+
+export interface PgTriggerConfig {
+	/**
+	 * When the trigger fires: BEFORE, AFTER, or INSTEAD OF
+	 */
+	when: PgTriggerTiming;
+
+	/**
+	 * One or more events that fire the trigger
+	 */
+	events: [PgTriggerEvent, ...PgTriggerEvent[]];
+
+	/**
+	 * FOR EACH ROW or FOR EACH STATEMENT
+	 * @default 'STATEMENT'
+	 */
+	forEach?: PgTriggerOrientation;
+
+	/**
+	 * For UPDATE triggers, optionally specify which columns trigger the event
+	 */
+	columns?: string[];
+
+	/**
+	 * Optional WHEN condition for the trigger
+	 */
+	condition?: SQL;
+
+	/**
+	 * The function to execute, e.g. 'my_function()' or sql`my_schema.my_function()`
+	 */
+	execute: SQL;
+
+	/**
+	 * If true, adds OR REPLACE (PostgreSQL 14+)
+	 */
+	replace?: boolean;
+
+	/**
+	 * If true, creates a CONSTRAINT trigger
+	 */
+	isConstraint?: boolean;
+
+	/**
+	 * For CONSTRAINT triggers: DEFERRABLE / NOT DEFERRABLE
+	 */
+	deferrable?: boolean;
+
+	/**
+	 * For CONSTRAINT triggers: INITIALLY IMMEDIATE / INITIALLY DEFERRED
+	 */
+	deferred?: boolean;
+
+	/**
+	 * Referencing clause for transition tables (REFERENCING OLD TABLE AS ... NEW TABLE AS ...)
+	 */
+	referencingOldTableAs?: string;
+	referencingNewTableAs?: string;
+}
+
+export class PgTrigger {
+	static readonly [entityKind]: string = 'PgTrigger';
+
+	/** @internal */
+	_linkedTable?: PgTable;
+
+	readonly when: PgTriggerConfig['when'];
+	readonly events: PgTriggerConfig['events'];
+	readonly forEach: PgTriggerConfig['forEach'];
+	readonly columns: PgTriggerConfig['columns'];
+	readonly condition: PgTriggerConfig['condition'];
+	readonly execute: PgTriggerConfig['execute'];
+	readonly replace: PgTriggerConfig['replace'];
+	readonly isConstraint: PgTriggerConfig['isConstraint'];
+	readonly deferrable: PgTriggerConfig['deferrable'];
+	readonly deferred: PgTriggerConfig['deferred'];
+	readonly referencingOldTableAs: PgTriggerConfig['referencingOldTableAs'];
+	readonly referencingNewTableAs: PgTriggerConfig['referencingNewTableAs'];
+
+	constructor(
+		readonly name: string,
+		config: PgTriggerConfig,
+	) {
+		this.when = config.when;
+		this.events = config.events;
+		this.forEach = config.forEach;
+		this.columns = config.columns;
+		this.condition = config.condition;
+		this.execute = config.execute;
+		this.replace = config.replace;
+		this.isConstraint = config.isConstraint;
+		this.deferrable = config.deferrable;
+		this.deferred = config.deferred;
+		this.referencingOldTableAs = config.referencingOldTableAs;
+		this.referencingNewTableAs = config.referencingNewTableAs;
+	}
+
+	link(table: PgTable): this {
+		this._linkedTable = table;
+		return this;
+	}
+}
+
+/**
+ * Define a PostgreSQL trigger on a table.
+ *
+ * @example
+ * Fluent builder API:
+ * ```ts
+ * import { pgTable, integer, timestamp, pgTrigger } from 'drizzle-orm/pg-core';
+ * import { sql } from 'drizzle-orm';
+ *
+ * export const users = pgTable('users', {
+ *   id: integer().primaryKey(),
+ *   updatedAt: timestamp('updated_at').defaultNow().notNull(),
+ * }, () => [
+ *   pgTrigger('set_updated_at')
+ *     .before()
+ *     .update()
+ *     .forEach('ROW')
+ *     .execute(sql`set_updated_at()`),
+ * ]);
+ * ```
+ *
+ * Config object API:
+ * ```ts
+ * pgTrigger('set_updated_at', {
+ *   when: 'BEFORE',
+ *   events: ['UPDATE'],
+ *   forEach: 'ROW',
+ *   execute: sql`set_updated_at()`,
+ * })
+ * ```
+ *
+ * Multiple events:
+ * ```ts
+ * pgTrigger('audit_changes')
+ *   .after()
+ *   .insert()
+ *   .update()
+ *   .delete()
+ *   .forEach('ROW')
+ *   .execute(sql`audit_trigger_func()`)
+ * ```
+ */
+export function pgTrigger(name: string, config: PgTriggerConfig): PgTrigger;
+export function pgTrigger(name: string): PgTriggerBuilder;
+export function pgTrigger(name: string, config?: PgTriggerConfig): PgTrigger | PgTriggerBuilder {
+	if (config) {
+		return new PgTrigger(name, config);
+	}
+	return new PgTriggerBuilder(name);
+}
+
+/**
+ * Fluent builder for creating PostgreSQL triggers.
+ */
+export class PgTriggerBuilder {
+	static readonly [entityKind]: string = 'PgTriggerBuilder';
+
+	private _when?: PgTriggerTiming;
+	private _events: PgTriggerEvent[] = [];
+	private _forEach?: PgTriggerOrientation;
+	private _columns?: string[];
+	private _condition?: SQL;
+	private _replace?: boolean;
+	private _isConstraint?: boolean;
+	private _deferrable?: boolean;
+	private _deferred?: boolean;
+	private _referencingOldTableAs?: string;
+	private _referencingNewTableAs?: string;
+
+	constructor(private readonly _name: string) {}
+
+	/** Set trigger timing to BEFORE */
+	before(): this {
+		this._when = 'BEFORE';
+		return this;
+	}
+
+	/** Set trigger timing to AFTER */
+	after(): this {
+		this._when = 'AFTER';
+		return this;
+	}
+
+	/** Set trigger timing to INSTEAD OF */
+	insteadOf(): this {
+		this._when = 'INSTEAD OF';
+		return this;
+	}
+
+	/** Add INSERT to trigger events */
+	insert(): this {
+		this._events.push('INSERT');
+		return this;
+	}
+
+	/** Add UPDATE to trigger events */
+	update(...columns: string[]): this {
+		this._events.push('UPDATE');
+		if (columns.length > 0) {
+			this._columns = columns;
+		}
+		return this;
+	}
+
+	/** Add DELETE to trigger events */
+	delete(): this {
+		this._events.push('DELETE');
+		return this;
+	}
+
+	/** Add TRUNCATE to trigger events */
+	truncate(): this {
+		this._events.push('TRUNCATE');
+		return this;
+	}
+
+	/** Set FOR EACH ROW or FOR EACH STATEMENT */
+	forEach(orientation: PgTriggerOrientation): this {
+		this._forEach = orientation;
+		return this;
+	}
+
+	/** Set a WHEN condition */
+	when(condition: SQL): this {
+		this._condition = condition;
+		return this;
+	}
+
+	/** Use CREATE OR REPLACE TRIGGER (PostgreSQL 14+) */
+	orReplace(): this {
+		this._replace = true;
+		return this;
+	}
+
+	/** Create a CONSTRAINT trigger */
+	constraint(): this {
+		this._isConstraint = true;
+		return this;
+	}
+
+	/** Mark trigger as DEFERRABLE */
+	asDeferrable(): this {
+		this._deferrable = true;
+		return this;
+	}
+
+	/** Mark trigger as INITIALLY DEFERRED */
+	initiallyDeferred(): this {
+		this._deferred = true;
+		return this;
+	}
+
+	/** Set REFERENCING OLD TABLE AS */
+	referencingOldTableAs(name: string): this {
+		this._referencingOldTableAs = name;
+		return this;
+	}
+
+	/** Set REFERENCING NEW TABLE AS */
+	referencingNewTableAs(name: string): this {
+		this._referencingNewTableAs = name;
+		return this;
+	}
+
+	/**
+	 * Specify the function to execute and finalize the trigger.
+	 * @param fn - The function call as SQL, e.g. sql`my_function()`
+	 */
+	execute(fn: SQL): PgTrigger {
+		if (!this._when) {
+			throw new Error(`Trigger "${this._name}" must specify timing (before/after/insteadOf)`);
+		}
+		if (this._events.length === 0) {
+			throw new Error(`Trigger "${this._name}" must specify at least one event (insert/update/delete/truncate)`);
+		}
+
+		return new PgTrigger(this._name, {
+			when: this._when,
+			events: this._events as [PgTriggerEvent, ...PgTriggerEvent[]],
+			forEach: this._forEach,
+			columns: this._columns,
+			condition: this._condition,
+			execute: fn,
+			replace: this._replace,
+			isConstraint: this._isConstraint,
+			deferrable: this._deferrable,
+			deferred: this._deferred,
+			referencingOldTableAs: this._referencingOldTableAs,
+			referencingNewTableAs: this._referencingNewTableAs,
+		});
+	}
+}

--- a/drizzle-orm/src/pg-core/utils.ts
+++ b/drizzle-orm/src/pg-core/utils.ts
@@ -10,6 +10,7 @@ import { type ForeignKey, ForeignKeyBuilder } from './foreign-keys.ts';
 import type { Index } from './indexes.ts';
 import { IndexBuilder } from './indexes.ts';
 import { PgPolicy } from './policies.ts';
+import { PgTrigger } from './triggers.ts';
 import { type PrimaryKey, PrimaryKeyBuilder } from './primary-keys.ts';
 import { type UniqueConstraint, UniqueConstraintBuilder } from './unique-constraint.ts';
 import type { PgViewBase } from './view-base.ts';
@@ -26,6 +27,7 @@ export function getTableConfig<TTable extends PgTable>(table: TTable) {
 	const name = table[Table.Symbol.Name];
 	const schema = table[Table.Symbol.Schema];
 	const policies: PgPolicy[] = [];
+	const triggers: PgTrigger[] = [];
 	const enableRLS: boolean = table[PgTable.Symbol.EnableRLS];
 
 	const extraConfigBuilder = table[PgTable.Symbol.ExtraConfigBuilder];
@@ -46,6 +48,8 @@ export function getTableConfig<TTable extends PgTable>(table: TTable) {
 				foreignKeys.push(builder.build(table));
 			} else if (is(builder, PgPolicy)) {
 				policies.push(builder);
+			} else if (is(builder, PgTrigger)) {
+				triggers.push(builder);
 			}
 		}
 	}
@@ -60,6 +64,7 @@ export function getTableConfig<TTable extends PgTable>(table: TTable) {
 		name,
 		schema,
 		policies,
+		triggers,
 		enableRLS,
 	};
 }

--- a/drizzle-orm/tests/pg-trigger.test.ts
+++ b/drizzle-orm/tests/pg-trigger.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { sql } from '~/sql/sql.ts';
+import { pgTable, integer, timestamp, pgTrigger, getTableConfig } from '~/pg-core/index.ts';
+
+describe('pgTrigger', () => {
+	it('creates a trigger with config object API', () => {
+		const trigger = pgTrigger('set_updated_at', {
+			when: 'BEFORE',
+			events: ['UPDATE'],
+			forEach: 'ROW',
+			execute: sql`set_updated_at()`,
+		});
+
+		expect(trigger.name).toBe('set_updated_at');
+		expect(trigger.when).toBe('BEFORE');
+		expect(trigger.events).toEqual(['UPDATE']);
+		expect(trigger.forEach).toBe('ROW');
+	});
+
+	it('creates a trigger with fluent builder API', () => {
+		const trigger = pgTrigger('audit_trigger')
+			.after()
+			.insert()
+			.update()
+			.delete()
+			.forEach('ROW')
+			.execute(sql`audit_func()`);
+
+		expect(trigger.name).toBe('audit_trigger');
+		expect(trigger.when).toBe('AFTER');
+		expect(trigger.events).toEqual(['INSERT', 'UPDATE', 'DELETE']);
+		expect(trigger.forEach).toBe('ROW');
+	});
+
+	it('creates a BEFORE trigger', () => {
+		const trigger = pgTrigger('before_trigger')
+			.before()
+			.insert()
+			.execute(sql`my_func()`);
+
+		expect(trigger.when).toBe('BEFORE');
+	});
+
+	it('creates an INSTEAD OF trigger', () => {
+		const trigger = pgTrigger('instead_trigger')
+			.insteadOf()
+			.insert()
+			.execute(sql`my_func()`);
+
+		expect(trigger.when).toBe('INSTEAD OF');
+	});
+
+	it('supports UPDATE OF columns', () => {
+		const trigger = pgTrigger('col_trigger')
+			.before()
+			.update('name', 'email')
+			.forEach('ROW')
+			.execute(sql`check_cols()`);
+
+		expect(trigger.columns).toEqual(['name', 'email']);
+	});
+
+	it('supports OR REPLACE', () => {
+		const trigger = pgTrigger('replaceable')
+			.before()
+			.insert()
+			.orReplace()
+			.execute(sql`my_func()`);
+
+		expect(trigger.replace).toBe(true);
+	});
+
+	it('supports CONSTRAINT triggers', () => {
+		const trigger = pgTrigger('constraint_trigger')
+			.after()
+			.insert()
+			.constraint()
+			.asDeferrable()
+			.initiallyDeferred()
+			.execute(sql`validate_func()`);
+
+		expect(trigger.isConstraint).toBe(true);
+		expect(trigger.deferrable).toBe(true);
+		expect(trigger.deferred).toBe(true);
+	});
+
+	it('supports REFERENCING clause', () => {
+		const trigger = pgTrigger('ref_trigger')
+			.after()
+			.insert()
+			.forEach('STATEMENT')
+			.referencingNewTableAs('new_rows')
+			.execute(sql`batch_func()`);
+
+		expect(trigger.referencingNewTableAs).toBe('new_rows');
+	});
+
+	it('throws when timing is not specified', () => {
+		expect(() => {
+			pgTrigger('bad_trigger')
+				.insert()
+				.execute(sql`my_func()`);
+		}).toThrow('must specify timing');
+	});
+
+	it('throws when no events are specified', () => {
+		expect(() => {
+			pgTrigger('bad_trigger')
+				.before()
+				.execute(sql`my_func()`);
+		}).toThrow('must specify at least one event');
+	});
+
+	it('works as table extra config', () => {
+		const users = pgTable('users', {
+			id: integer().primaryKey(),
+			updatedAt: timestamp('updated_at').defaultNow().notNull(),
+		}, () => [
+			pgTrigger('set_updated_at', {
+				when: 'BEFORE',
+				events: ['UPDATE'],
+				forEach: 'ROW',
+				execute: sql`set_updated_at()`,
+			}),
+		]);
+
+		const config = getTableConfig(users);
+		expect(config.triggers).toHaveLength(1);
+		expect(config.triggers[0]!.name).toBe('set_updated_at');
+		expect(config.triggers[0]!.when).toBe('BEFORE');
+		expect(config.triggers[0]!.events).toEqual(['UPDATE']);
+		expect(config.triggers[0]!.forEach).toBe('ROW');
+	});
+
+	it('works with fluent builder in table extra config', () => {
+		const orders = pgTable('orders', {
+			id: integer().primaryKey(),
+		}, () => [
+			pgTrigger('audit_orders')
+				.after()
+				.insert()
+				.update()
+				.delete()
+				.forEach('ROW')
+				.execute(sql`audit_func()`),
+		]);
+
+		const config = getTableConfig(orders);
+		expect(config.triggers).toHaveLength(1);
+		expect(config.triggers[0]!.name).toBe('audit_orders');
+		expect(config.triggers[0]!.events).toEqual(['INSERT', 'UPDATE', 'DELETE']);
+	});
+
+	it('supports multiple triggers on the same table', () => {
+		const users = pgTable('users', {
+			id: integer().primaryKey(),
+			updatedAt: timestamp('updated_at').defaultNow().notNull(),
+		}, () => [
+			pgTrigger('set_updated_at')
+				.before()
+				.update()
+				.forEach('ROW')
+				.execute(sql`set_updated_at()`),
+			pgTrigger('audit_users')
+				.after()
+				.insert()
+				.update()
+				.delete()
+				.forEach('ROW')
+				.execute(sql`audit_func()`),
+		]);
+
+		const config = getTableConfig(users);
+		expect(config.triggers).toHaveLength(2);
+		expect(config.triggers[0]!.name).toBe('set_updated_at');
+		expect(config.triggers[1]!.name).toBe('audit_users');
+	});
+});


### PR DESCRIPTION
Adds trigger definition support to `pg-core` schema declarations, addressing #843.

### What's included

- New `PgTrigger` class and `pgTrigger()` factory function in `drizzle-orm/src/pg-core/triggers.ts`
- Two ways to define triggers:
  - **Config object** for straightforward definitions
  - **Fluent builder** for more readable chaining
- Full PostgreSQL trigger syntax coverage (timing, events, UPDATE OF columns, FOR EACH ROW/STATEMENT, WHEN conditions, OR REPLACE, CONSTRAINT triggers, REFERENCING transition tables)
- Triggers integrate into table extra config alongside indexes, checks, policies, etc.
- `getTableConfig()` now returns a `triggers` array

### Usage

```ts
import { pgTable, integer, timestamp, pgTrigger } from 'drizzle-orm/pg-core';
import { sql } from 'drizzle-orm';

// Fluent builder
export const users = pgTable('users', {
  id: integer().primaryKey(),
  updatedAt: timestamp('updated_at').defaultNow().notNull(),
}, () => [
  pgTrigger('set_updated_at')
    .before()
    .update()
    .forEach('ROW')
    .execute(sql`set_updated_at()`),
]);

// Config object
export const orders = pgTable('orders', {
  id: integer().primaryKey(),
}, () => [
  pgTrigger('audit_orders', {
    when: 'AFTER',
    events: ['INSERT', 'UPDATE', 'DELETE'],
    forEach: 'ROW',
    execute: sql`audit_func()`,
  }),
]);
```

### Notes

This PR covers the ORM schema definition side. The corresponding `drizzle-kit` SQL generation (for migrations) and snapshot serialization would be a follow-up, since the kit has its own separate serialization/diffing pipeline. The schema definition API is the foundational piece that everything else builds on.

Tests included covering both APIs, validation, multi-trigger tables, and extra config integration.

Closes #843