### PR TITLE
fix: validate column names in relational query column selections

### DIFF
--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -1201,12 +1201,16 @@ export class GelDialect {
 						continue;
 					}
 
-					if (field in tableConfig.columns) {
-						if (!isIncludeMode && value === true) {
-							isIncludeMode = true;
-						}
-						selectedColumns.push(field);
+					if (!(field in tableConfig.columns)) {
+						throw new DrizzleError({
+							message: `Column "${field}" not found in table "${tableConfig.tsName}"`,
+						});
 					}
+
+					if (!isIncludeMode && value === true) {
+						isIncludeMode = true;
+					}
+					selectedColumns.push(field);
 				}
 
 				if (selectedColumns.length > 0) {

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -635,12 +635,16 @@ export class MySqlDialect {
 						continue;
 					}
 
-					if (field in tableConfig.columns) {
-						if (!isIncludeMode && value === true) {
-							isIncludeMode = true;
-						}
-						selectedColumns.push(field);
+					if (!(field in tableConfig.columns)) {
+						throw new DrizzleError({
+							message: `Column "${field}" not found in table "${tableConfig.tsName}"`,
+						});
 					}
+
+					if (!isIncludeMode && value === true) {
+						isIncludeMode = true;
+					}
+					selectedColumns.push(field);
 				}
 
 				if (selectedColumns.length > 0) {
@@ -932,12 +936,16 @@ export class MySqlDialect {
 						continue;
 					}
 
-					if (field in tableConfig.columns) {
-						if (!isIncludeMode && value === true) {
-							isIncludeMode = true;
-						}
-						selectedColumns.push(field);
+					if (!(field in tableConfig.columns)) {
+						throw new DrizzleError({
+							message: `Column "${field}" not found in table "${tableConfig.tsName}"`,
+						});
 					}
+
+					if (!isIncludeMode && value === true) {
+						isIncludeMode = true;
+					}
+					selectedColumns.push(field);
 				}
 
 				if (selectedColumns.length > 0) {

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -1210,12 +1210,16 @@ export class PgDialect {
 						continue;
 					}
 
-					if (field in tableConfig.columns) {
-						if (!isIncludeMode && value === true) {
-							isIncludeMode = true;
-						}
-						selectedColumns.push(field);
+					if (!(field in tableConfig.columns)) {
+						throw new DrizzleError({
+							message: `Column "${field}" not found in table "${tableConfig.tsName}"`,
+						});
 					}
+
+					if (!isIncludeMode && value === true) {
+						isIncludeMode = true;
+					}
+					selectedColumns.push(field);
 				}
 
 				if (selectedColumns.length > 0) {

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -595,12 +595,16 @@ export class SingleStoreDialect {
 						continue;
 					}
 
-					if (field in tableConfig.columns) {
-						if (!isIncludeMode && value === true) {
-							isIncludeMode = true;
-						}
-						selectedColumns.push(field);
+					if (!(field in tableConfig.columns)) {
+						throw new DrizzleError({
+							message: `Column "${field}" not found in table "${tableConfig.tsName}"`,
+						});
 					}
+
+					if (!isIncludeMode && value === true) {
+						isIncludeMode = true;
+					}
+					selectedColumns.push(field);
 				}
 
 				if (selectedColumns.length > 0) {

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -597,12 +597,16 @@ export abstract class SQLiteDialect {
 						continue;
 					}
 
-					if (field in tableConfig.columns) {
-						if (!isIncludeMode && value === true) {
-							isIncludeMode = true;
-						}
-						selectedColumns.push(field);
+					if (!(field in tableConfig.columns)) {
+						throw new DrizzleError({
+							message: `Column "${field}" not found in table "${tableConfig.tsName}"`,
+						});
 					}
+
+					if (!isIncludeMode && value === true) {
+						isIncludeMode = true;
+					}
+					selectedColumns.push(field);
 				}
 
 				if (selectedColumns.length > 0) {


### PR DESCRIPTION
## Summary
  - Add explicit validation of `config.columns` keys in relational query builders.
  - Raise a targeted `DrizzleError` when a column key is not part of the table config.
  - Apply the same guard across pg/mysql/sqlite/singlestore/gel dialects for consistent behavior.

## Rationale
  Previously, an unknown column in a nested `with` selection could fall through and surface a misleading error about “views nested selections”. This change fails fast with a precise message, improving debugging and UX for dynamic or loosely typed selection objects.

## Behavior Change
  Before:
  - Unknown nested column could throw a generic or misleading error.

  After:
  - Unknown column throws: `Column "<name>" not found in table "<tableTsName>"`.

 ## Related
  Fixes #5367