### PR TITLE
fix(kit-pg): handle empty string defaults in PostgreSQL introspection

### DIFF
--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -366,6 +366,10 @@ export function escapeSingleQuotes(str: string) {
 }
 
 export function unescapeSingleQuotes(str: string, ignoreFirstAndLastChar: boolean) {
+	// Handle empty string case: '' from PostgreSQL should become empty string
+	if (ignoreFirstAndLastChar && str === "''") {
+		return '';
+	}
 	const regex = ignoreFirstAndLastChar ? /(?<!^)'(?!$)/g : /'/g;
 	return str.replace(/''/g, "'").replace(regex, "\\'");
 }

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -479,6 +479,27 @@ test('instrospect strings with single quotes', async () => {
 	expect(sqlStatements.length).toBe(0);
 });
 
+test('introspect empty string defaults', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		t: pgTable('t', {
+			a: text('a').default(''),
+			b: varchar('b', { length: 10 }).default(''),
+			c: char('c', { length: 1 }).default(''),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'introspect-empty-string-defaults',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
 test('introspect checks', async () => {
 	const client = new PGlite();
 

--- a/drizzle-kit/tests/utils/unescapeSingleQuotes.test.ts
+++ b/drizzle-kit/tests/utils/unescapeSingleQuotes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest';
+import { unescapeSingleQuotes } from '../../src/utils';
+
+describe('unescapeSingleQuotes', () => {
+  test("returns empty string for SQL literal '' when ignoring first/last", () => {
+    // Before the fix, this incorrectly returned "'"
+    const input = "''";
+    const out = unescapeSingleQuotes(input, true);
+    expect(out).toBe('');
+  });
+
+  test("keeps non-empty strings intact (ignoring first/last)", () => {
+    const input = "'queued'";
+    const out = unescapeSingleQuotes(input, true);
+    expect(out).toBe("'queued'");
+  });
+
+  test("escapes internal single quotes when not ignoring first/last", () => {
+    const input = "it''s"; // SQL escaped: it''s
+    const out = unescapeSingleQuotes(input, false);
+    expect(out).toBe("it's");
+  });
+});


### PR DESCRIPTION
Fixes #3887

I understand you expect this to be fixed in a future v1, but this has been a long-standing user-impacting bug; I suggest we also patch v0 so users aren’t blocked while waiting for v1.

## Summary
- drizzle-kit pull/introspect emitted `.default(')` for columns with DEFAULT '' (empty string), producing invalid TS.

## Fix
- utils.ts: special-case SQL empty-string literal ("''") in unescapeSingleQuotes when ignoring first/last.

## Tests
- Unit: unescapeSingleQuotes('' , true) → ''.
- PG introspect (minimal): text/varchar/char with default('') round-trips with zero diff.

