### PR TITLE
fix(drizzle-kit): MySQL enum changes no longer trigger table truncation

### DIFF
--- a/drizzle-kit/src/cli/commands/mysqlPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/mysqlPushUtils.ts
@@ -168,25 +168,36 @@ export const logSuggestionsAndReturn = async (
 				shouldAskForApprove = true;
 			}
 		} else if (statement.type === 'alter_table_alter_column_set_type') {
-			const res = await db.query(
-				`select count(*) as count from \`${statement.tableName}\``,
-			);
-			const count = Number(res[0].count);
-			if (count > 0) {
-				infoToPrint.push(
-					`· You're about to change ${
-						chalk.underline(
-							statement.columnName,
-						)
-					} column type from ${
-						chalk.underline(
-							statement.oldDataType,
-						)
-					} to ${chalk.underline(statement.newDataType)} with ${count} items`,
+			if (
+				statement.oldDataType.startsWith('enum(')
+				&& statement.newDataType.startsWith('enum(')
+			) {
+				// Enum-to-enum changes are handled safely by ALTER TABLE MODIFY COLUMN.
+				// MySQL will update the enum definition in place without data loss for
+				// added or reordered values. If values were removed, MySQL will reject
+				// the change in strict mode or convert affected rows to '' in non-strict
+				// mode — either way, truncation is not appropriate here.
+			} else {
+				const res = await db.query(
+					`select count(*) as count from \`${statement.tableName}\``,
 				);
-				statementsToExecute.push(`truncate table ${statement.tableName};`);
-				tablesToTruncate.push(statement.tableName);
-				shouldAskForApprove = true;
+				const count = Number(res[0].count);
+				if (count > 0) {
+					infoToPrint.push(
+						`· You're about to change ${
+							chalk.underline(
+								statement.columnName,
+							)
+						} column type from ${
+							chalk.underline(
+								statement.oldDataType,
+							)
+						} to ${chalk.underline(statement.newDataType)} with ${count} items`,
+					);
+					statementsToExecute.push(`truncate table ${statement.tableName};`);
+					tablesToTruncate.push(statement.tableName);
+					shouldAskForApprove = true;
+				}
 			}
 		} else if (statement.type === 'alter_table_alter_column_drop_default') {
 			if (statement.columnNotNull) {

--- a/drizzle-kit/src/jsonDiffer.js
+++ b/drizzle-kit/src/jsonDiffer.js
@@ -576,8 +576,22 @@ const alternationsInColumn = (column) => {
 
 	const result = altered
 		.filter((it) => {
-			if ('type' in it && it.type.__old.replace(' (', '(') === it.type.__new.replace(' (', '(')) {
-				return false;
+			if ('type' in it) {
+				const oldType = it.type.__old.replace(' (', '(');
+				const newType = it.type.__new.replace(' (', '(');
+				if (oldType === newType) return false;
+
+				// For MySQL enum types, compare values as sets (order-insensitive)
+				if (oldType.startsWith('enum(') && newType.startsWith('enum(')) {
+					const oldValues = oldType.substring(5, oldType.length - 1).split(',').sort();
+					const newValues = newType.substring(5, newType.length - 1).split(',').sort();
+					if (
+						oldValues.length === newValues.length
+						&& oldValues.every((v, i) => v === newValues[i])
+					) {
+						return false;
+					}
+				}
 			}
 			return true;
 		})

--- a/drizzle-kit/tests/mysql.test.ts
+++ b/drizzle-kit/tests/mysql.test.ts
@@ -896,3 +896,113 @@ test('add table with ts enum', async () => {
 		checkConstraints: [],
 	});
 });
+
+test('enum column: reordering values should not produce a diff', async () => {
+	const from = {
+		users: mysqlTable('users', {
+			status: mysqlEnum('status', ['active', 'inactive', 'pending']),
+		}),
+	};
+
+	const to = {
+		users: mysqlTable('users', {
+			status: mysqlEnum('status', ['pending', 'active', 'inactive']),
+		}),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasMysql(from, to, []);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
+test('enum column: adding a value should produce an alter statement', async () => {
+	const from = {
+		users: mysqlTable('users', {
+			status: mysqlEnum('status', ['active', 'inactive']),
+		}),
+	};
+
+	const to = {
+		users: mysqlTable('users', {
+			status: mysqlEnum('status', ['active', 'inactive', 'pending']),
+		}),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasMysql(from, to, []);
+
+	expect(statements.length).toBe(1);
+	expect(statements[0]).toStrictEqual({
+		type: 'alter_table_alter_column_set_type',
+		tableName: 'users',
+		columnName: 'status',
+		newDataType: "enum('active','inactive','pending')",
+		oldDataType: "enum('active','inactive')",
+		schema: '',
+		columnDefault: undefined,
+		columnGenerated: undefined,
+		columnAutoIncrement: false,
+		columnNotNull: false,
+		columnOnUpdate: undefined,
+		columnPk: false,
+	});
+	expect(sqlStatements.length).toBe(1);
+	expect(sqlStatements[0]).toBe(
+		"ALTER TABLE `users` MODIFY COLUMN `status` enum('active','inactive','pending');",
+	);
+});
+
+test('enum column: removing a value should produce an alter statement', async () => {
+	const from = {
+		users: mysqlTable('users', {
+			status: mysqlEnum('status', ['active', 'inactive', 'pending']),
+		}),
+	};
+
+	const to = {
+		users: mysqlTable('users', {
+			status: mysqlEnum('status', ['active', 'inactive']),
+		}),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasMysql(from, to, []);
+
+	expect(statements.length).toBe(1);
+	expect(statements[0]).toStrictEqual({
+		type: 'alter_table_alter_column_set_type',
+		tableName: 'users',
+		columnName: 'status',
+		newDataType: "enum('active','inactive')",
+		oldDataType: "enum('active','inactive','pending')",
+		schema: '',
+		columnDefault: undefined,
+		columnGenerated: undefined,
+		columnAutoIncrement: false,
+		columnNotNull: false,
+		columnOnUpdate: undefined,
+		columnPk: false,
+	});
+	expect(sqlStatements.length).toBe(1);
+	expect(sqlStatements[0]).toBe(
+		"ALTER TABLE `users` MODIFY COLUMN `status` enum('active','inactive');",
+	);
+});
+
+test('enum column: identical values should not produce a diff', async () => {
+	const from = {
+		users: mysqlTable('users', {
+			status: mysqlEnum('status', ['active', 'inactive']),
+		}),
+	};
+
+	const to = {
+		users: mysqlTable('users', {
+			status: mysqlEnum('status', ['active', 'inactive']),
+		}),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasMysql(from, to, []);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes two issues with MySQL enum handling in `drizzle-kit push` / `generate`:

- **Enum value reordering produced false diffs:** The diff engine compared enum type strings verbatim, so `enum('a','b')` vs `enum('b','a')` was flagged as a type change even though the values are identical. Now enum values are compared as sets (order-insensitive), so reordering alone produces no diff.

- **Any enum change triggered `TRUNCATE TABLE`:** During `push`, all column type changes — including safe enum modifications like adding a value — went through a code path that prepended `TRUNCATE TABLE` and required approval. Enum-to-enum changes now skip truncation entirely, since MySQL's `ALTER TABLE ... MODIFY COLUMN` handles them safely.

## Changes

| File | What changed |
|---|---|
| `drizzle-kit/src/jsonDiffer.js` | `alternationsInColumn()`: parse enum values, sort, and compare as sets before flagging a type change |
| `drizzle-kit/src/cli/commands/mysqlPushUtils.ts` | `logSuggestionsAndReturn()`: skip truncation logic when both old and new types are enums |
| `drizzle-kit/tests/mysql.test.ts` | 4 new tests: reorder (no diff), add value (alter), remove value (alter), identical (no diff) |

## Test plan

- [x] All 94 existing MySQL tests pass
- [x] All 58 Postgres enum tests pass (no regressions from `jsonDiffer.js` change)
- [x] All 36 SingleStore tests pass
- [x] 4 new enum-specific tests pass

Closes #4884, relates to #2047

🤖 Generated with [Claude Code](https://claude.com/claude-code)