### PR TITLE
feat: typed error wrapping for constraint violations

### DIFF
--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -24,6 +24,239 @@ export class DrizzleQueryError extends Error {
 	}
 }
 
+export type ConstraintType = 'unique' | 'not_null' | 'foreign_key' | 'check';
+
+export class DrizzleConstraintError extends DrizzleQueryError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		public readonly constraintType: ConstraintType,
+		public readonly constraintName: string | undefined,
+		public readonly table: string | undefined,
+		public readonly column: string | undefined,
+	) {
+		super(query, params, cause);
+		this.name = 'DrizzleConstraintError';
+		Error.captureStackTrace(this, DrizzleConstraintError);
+	}
+}
+
+export class UniqueConstraintViolationError extends DrizzleConstraintError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		constraintName: string | undefined,
+		table: string | undefined,
+		column: string | undefined,
+	) {
+		super(query, params, cause, 'unique', constraintName, table, column);
+		this.name = 'UniqueConstraintViolationError';
+		Error.captureStackTrace(this, UniqueConstraintViolationError);
+	}
+}
+
+export class NotNullViolationError extends DrizzleConstraintError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		constraintName: string | undefined,
+		table: string | undefined,
+		column: string | undefined,
+	) {
+		super(query, params, cause, 'not_null', constraintName, table, column);
+		this.name = 'NotNullViolationError';
+		Error.captureStackTrace(this, NotNullViolationError);
+	}
+}
+
+export class ForeignKeyViolationError extends DrizzleConstraintError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		constraintName: string | undefined,
+		table: string | undefined,
+		column: string | undefined,
+	) {
+		super(query, params, cause, 'foreign_key', constraintName, table, column);
+		this.name = 'ForeignKeyViolationError';
+		Error.captureStackTrace(this, ForeignKeyViolationError);
+	}
+}
+
+export class CheckConstraintViolationError extends DrizzleConstraintError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		constraintName: string | undefined,
+		table: string | undefined,
+		column: string | undefined,
+	) {
+		super(query, params, cause, 'check', constraintName, table, column);
+		this.name = 'CheckConstraintViolationError';
+		Error.captureStackTrace(this, CheckConstraintViolationError);
+	}
+}
+
+/** @internal */
+export function wrapQueryError(query: string, params: any[], error: Error): DrizzleQueryError {
+	const driverError = error as Record<string, any>;
+
+	// PostgreSQL error codes (pg, postgres.js, neon)
+	const pgCode = driverError['code'] as string | undefined;
+	if (typeof pgCode === 'string') {
+		const table = driverError['table'] as string | undefined;
+		const column = driverError['column'] as string | undefined;
+		const constraint = driverError['constraint'] as string | undefined;
+
+		switch (pgCode) {
+			case '23505': // unique_violation
+				return new UniqueConstraintViolationError(query, params, error, constraint, table, column);
+			case '23502': // not_null_violation
+				return new NotNullViolationError(query, params, error, constraint, table, column);
+			case '23503': // foreign_key_violation
+				return new ForeignKeyViolationError(query, params, error, constraint, table, column);
+			case '23514': // check_violation
+				return new CheckConstraintViolationError(query, params, error, constraint, table, column);
+		}
+	}
+
+	// MySQL error codes (mysql2)
+	const mysqlErrno = driverError['errno'] as number | undefined;
+	if (typeof mysqlErrno === 'number') {
+		const sqlMessage = driverError['sqlMessage'] as string | undefined;
+		const mysqlTable = extractMysqlTable(sqlMessage);
+		const mysqlColumn = extractMysqlColumn(sqlMessage, mysqlErrno);
+		const mysqlConstraint = extractMysqlConstraint(sqlMessage, mysqlErrno);
+
+		switch (mysqlErrno) {
+			case 1062: // ER_DUP_ENTRY (unique constraint)
+				return new UniqueConstraintViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+			case 1048: // ER_BAD_NULL_ERROR (not null)
+				return new NotNullViolationError(query, params, error, undefined, mysqlTable, mysqlColumn);
+			case 1452: // ER_NO_REFERENCED_ROW_2 (foreign key)
+				return new ForeignKeyViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+			case 1216: // ER_NO_REFERENCED_ROW (foreign key, older form)
+				return new ForeignKeyViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+			case 3819: // ER_CHECK_CONSTRAINT_VIOLATED
+				return new CheckConstraintViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+		}
+	}
+
+	// SQLite error codes (better-sqlite3, libsql)
+	// SQLite errors typically have a `code` like 'SQLITE_CONSTRAINT_UNIQUE' or the message contains the constraint type
+	const sqliteCode = driverError['code'] as string | undefined;
+	const message = driverError['message'] as string | undefined ?? '';
+
+	if (typeof sqliteCode === 'string' && sqliteCode.startsWith('SQLITE_CONSTRAINT')) {
+		const sqliteTable = extractSqliteTable(message);
+		const sqliteColumn = extractSqliteColumn(message);
+
+		if (sqliteCode === 'SQLITE_CONSTRAINT_UNIQUE' || sqliteCode === 'SQLITE_CONSTRAINT_PRIMARYKEY') {
+			return new UniqueConstraintViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+		}
+		if (sqliteCode === 'SQLITE_CONSTRAINT_NOTNULL') {
+			return new NotNullViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+		}
+		if (sqliteCode === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
+			return new ForeignKeyViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+		}
+		if (sqliteCode === 'SQLITE_CONSTRAINT_CHECK') {
+			return new CheckConstraintViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+		}
+	}
+
+	// Some SQLite drivers (like libsql) don't set extended error codes but put the info in the message
+	if (typeof message === 'string') {
+		if (message.includes('UNIQUE constraint failed')) {
+			const sqliteTable = extractSqliteTable(message);
+			const sqliteColumn = extractSqliteColumn(message);
+			return new UniqueConstraintViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+		}
+		if (message.includes('NOT NULL constraint failed')) {
+			const sqliteTable = extractSqliteTable(message);
+			const sqliteColumn = extractSqliteColumn(message);
+			return new NotNullViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+		}
+		if (message.includes('FOREIGN KEY constraint failed')) {
+			return new ForeignKeyViolationError(query, params, error, undefined, undefined, undefined);
+		}
+		if (message.includes('CHECK constraint failed')) {
+			const checkName = extractSqliteCheckName(message);
+			return new CheckConstraintViolationError(query, params, error, checkName, undefined, undefined);
+		}
+	}
+
+	return new DrizzleQueryError(query, params, error);
+}
+
+// --- MySQL message parsers ---
+
+function extractMysqlConstraint(message: string | undefined, errno: number): string | undefined {
+	if (!message) return undefined;
+
+	if (errno === 1062) {
+		// "Duplicate entry '...' for key 'constraint_name'"
+		const match = message.match(/for key '([^']+)'/);
+		return match?.[1];
+	}
+	if (errno === 1452 || errno === 1216) {
+		// "CONSTRAINT `fk_name` FOREIGN KEY ..."
+		const match = message.match(/CONSTRAINT `([^`]+)`/);
+		return match?.[1];
+	}
+	if (errno === 3819) {
+		// "Check constraint 'chk_name' is violated"
+		const match = message.match(/Check constraint '([^']+)'/);
+		return match?.[1];
+	}
+	return undefined;
+}
+
+function extractMysqlTable(message: string | undefined): string | undefined {
+	if (!message) return undefined;
+	// "Column 'col' cannot be null" doesn't have table info
+	// FK messages: "... table `schema`.`table_name`, ..."
+	const match = message.match(/table `[^`]*`\.`([^`]+)`/);
+	return match?.[1];
+}
+
+function extractMysqlColumn(message: string | undefined, errno: number): string | undefined {
+	if (!message) return undefined;
+
+	if (errno === 1048) {
+		// "Column 'col_name' cannot be null"
+		const match = message.match(/Column '([^']+)'/);
+		return match?.[1];
+	}
+	return undefined;
+}
+
+// --- SQLite message parsers ---
+
+function extractSqliteTable(message: string): string | undefined {
+	// "UNIQUE constraint failed: table_name.column_name"
+	// "NOT NULL constraint failed: table_name.column_name"
+	const match = message.match(/constraint failed: ([^.]+)\./);
+	return match?.[1];
+}
+
+function extractSqliteColumn(message: string): string | undefined {
+	// "UNIQUE constraint failed: table_name.column_name"
+	const match = message.match(/constraint failed: [^.]+\.(\S+)/);
+	return match?.[1];
+}
+
+function extractSqliteCheckName(message: string): string | undefined {
+	// "CHECK constraint failed: check_name"
+	const match = message.match(/CHECK constraint failed: (\S+)/);
+	return match?.[1];
+}
+
 export class TransactionRollbackError extends DrizzleError {
 	static override readonly [entityKind]: string = 'TransactionRollbackError';
 

--- a/drizzle-orm/src/mysql-core/session.ts
+++ b/drizzle-orm/src/mysql-core/session.ts
@@ -1,7 +1,7 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { DrizzleQueryError, TransactionRollbackError, wrapQueryError } from '~/errors.ts';
 import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
 import { type Query, type SQL, sql } from '~/sql/sql.ts';
 import type { Assume, Equal } from '~/utils.ts';
@@ -76,7 +76,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -85,7 +85,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -103,7 +103,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -112,7 +112,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -128,7 +128,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapQueryError(queryString, params, e as Error);
 				}
 
 				// put actual key
@@ -149,7 +149,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapQueryError(queryString, params, e as Error);
 		}
 	}
 

--- a/drizzle-orm/src/pg-core/session.ts
+++ b/drizzle-orm/src/pg-core/session.ts
@@ -1,7 +1,7 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { DrizzleQueryError, TransactionRollbackError, wrapQueryError } from '~/errors.ts';
 import type { TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
 import { type Query, type SQL, sql } from '~/sql/index.ts';
@@ -70,7 +70,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -79,7 +79,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -97,7 +97,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -106,7 +106,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -122,7 +122,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapQueryError(queryString, params, e as Error);
 				}
 				// put actual key
 				await this.cache.put(
@@ -142,7 +142,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapQueryError(queryString, params, e as Error);
 		}
 	}
 

--- a/drizzle-orm/src/sqlite-core/session.ts
+++ b/drizzle-orm/src/sqlite-core/session.ts
@@ -1,7 +1,7 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleError, DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { DrizzleError, DrizzleQueryError, TransactionRollbackError, wrapQueryError } from '~/errors.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
@@ -77,7 +77,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -86,7 +86,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -104,7 +104,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -113,7 +113,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -129,7 +129,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapQueryError(queryString, params, e as Error);
 				}
 
 				// put actual key
@@ -150,7 +150,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapQueryError(queryString, params, e as Error);
 		}
 	}
 

--- a/drizzle-orm/tests/errors.test.ts
+++ b/drizzle-orm/tests/errors.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from 'vitest';
+import {
+	CheckConstraintViolationError,
+	DrizzleConstraintError,
+	DrizzleQueryError,
+	ForeignKeyViolationError,
+	NotNullViolationError,
+	UniqueConstraintViolationError,
+	wrapQueryError,
+} from '~/errors.ts';
+
+describe('wrapQueryError', () => {
+	const query = 'INSERT INTO users (email) VALUES ($1)';
+	const params = ['test@example.com'];
+
+	describe('PostgreSQL errors', () => {
+		test('wraps unique_violation (23505)', () => {
+			const pgError = Object.assign(new Error('duplicate key value violates unique constraint "users_email_key"'), {
+				code: '23505',
+				table: 'users',
+				column: undefined,
+				constraint: 'users_email_key',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect(wrapped).toBeInstanceOf(DrizzleConstraintError);
+			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
+			expect((wrapped as UniqueConstraintViolationError).constraintType).toBe('unique');
+			expect((wrapped as UniqueConstraintViolationError).constraintName).toBe('users_email_key');
+			expect((wrapped as UniqueConstraintViolationError).table).toBe('users');
+			expect(wrapped.cause).toBe(pgError);
+		});
+
+		test('wraps not_null_violation (23502)', () => {
+			const pgError = Object.assign(new Error('null value in column "name" violates not-null constraint'), {
+				code: '23502',
+				table: 'users',
+				column: 'name',
+				constraint: undefined,
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(NotNullViolationError);
+			expect((wrapped as NotNullViolationError).constraintType).toBe('not_null');
+			expect((wrapped as NotNullViolationError).table).toBe('users');
+			expect((wrapped as NotNullViolationError).column).toBe('name');
+			expect(wrapped.cause).toBe(pgError);
+		});
+
+		test('wraps foreign_key_violation (23503)', () => {
+			const pgError = Object.assign(new Error('insert or update on table "posts" violates foreign key constraint'), {
+				code: '23503',
+				table: 'posts',
+				column: undefined,
+				constraint: 'posts_user_id_fkey',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(ForeignKeyViolationError);
+			expect((wrapped as ForeignKeyViolationError).constraintType).toBe('foreign_key');
+			expect((wrapped as ForeignKeyViolationError).constraintName).toBe('posts_user_id_fkey');
+			expect(wrapped.cause).toBe(pgError);
+		});
+
+		test('wraps check_violation (23514)', () => {
+			const pgError = Object.assign(new Error('new row for relation "users" violates check constraint'), {
+				code: '23514',
+				table: 'users',
+				column: undefined,
+				constraint: 'users_age_check',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(CheckConstraintViolationError);
+			expect((wrapped as CheckConstraintViolationError).constraintType).toBe('check');
+			expect((wrapped as CheckConstraintViolationError).constraintName).toBe('users_age_check');
+			expect(wrapped.cause).toBe(pgError);
+		});
+	});
+
+	describe('MySQL errors', () => {
+		test('wraps ER_DUP_ENTRY (1062)', () => {
+			const mysqlError = Object.assign(new Error("Duplicate entry 'test@example.com' for key 'users_email_unique'"), {
+				errno: 1062,
+				sqlMessage: "Duplicate entry 'test@example.com' for key 'users_email_unique'",
+			});
+
+			const wrapped = wrapQueryError(query, params, mysqlError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect((wrapped as UniqueConstraintViolationError).constraintName).toBe('users_email_unique');
+			expect(wrapped.cause).toBe(mysqlError);
+		});
+
+		test('wraps ER_BAD_NULL_ERROR (1048)', () => {
+			const mysqlError = Object.assign(new Error("Column 'name' cannot be null"), {
+				errno: 1048,
+				sqlMessage: "Column 'name' cannot be null",
+			});
+
+			const wrapped = wrapQueryError(query, params, mysqlError);
+
+			expect(wrapped).toBeInstanceOf(NotNullViolationError);
+			expect((wrapped as NotNullViolationError).column).toBe('name');
+			expect(wrapped.cause).toBe(mysqlError);
+		});
+
+		test('wraps ER_NO_REFERENCED_ROW_2 (1452)', () => {
+			const mysqlError = Object.assign(
+				new Error(
+					"Cannot add or update a child row: a foreign key constraint fails (`db`.`posts`, CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))",
+				),
+				{
+					errno: 1452,
+					sqlMessage:
+						"Cannot add or update a child row: a foreign key constraint fails (`db`.`posts`, CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))",
+				},
+			);
+
+			const wrapped = wrapQueryError(query, params, mysqlError);
+
+			expect(wrapped).toBeInstanceOf(ForeignKeyViolationError);
+			expect((wrapped as ForeignKeyViolationError).constraintName).toBe('posts_user_id_fk');
+			expect(wrapped.cause).toBe(mysqlError);
+		});
+
+		test('wraps ER_CHECK_CONSTRAINT_VIOLATED (3819)', () => {
+			const mysqlError = Object.assign(new Error("Check constraint 'users_age_check' is violated."), {
+				errno: 3819,
+				sqlMessage: "Check constraint 'users_age_check' is violated.",
+			});
+
+			const wrapped = wrapQueryError(query, params, mysqlError);
+
+			expect(wrapped).toBeInstanceOf(CheckConstraintViolationError);
+			expect((wrapped as CheckConstraintViolationError).constraintName).toBe('users_age_check');
+			expect(wrapped.cause).toBe(mysqlError);
+		});
+	});
+
+	describe('SQLite errors', () => {
+		test('wraps SQLITE_CONSTRAINT_UNIQUE via code', () => {
+			const sqliteError = Object.assign(new Error('UNIQUE constraint failed: users.email'), {
+				code: 'SQLITE_CONSTRAINT_UNIQUE',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect((wrapped as UniqueConstraintViolationError).table).toBe('users');
+			expect((wrapped as UniqueConstraintViolationError).column).toBe('email');
+			expect(wrapped.cause).toBe(sqliteError);
+		});
+
+		test('wraps SQLITE_CONSTRAINT_NOTNULL via code', () => {
+			const sqliteError = Object.assign(new Error('NOT NULL constraint failed: users.name'), {
+				code: 'SQLITE_CONSTRAINT_NOTNULL',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(NotNullViolationError);
+			expect((wrapped as NotNullViolationError).table).toBe('users');
+			expect((wrapped as NotNullViolationError).column).toBe('name');
+			expect(wrapped.cause).toBe(sqliteError);
+		});
+
+		test('wraps SQLITE_CONSTRAINT_FOREIGNKEY via code', () => {
+			const sqliteError = Object.assign(new Error('FOREIGN KEY constraint failed'), {
+				code: 'SQLITE_CONSTRAINT_FOREIGNKEY',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(ForeignKeyViolationError);
+			expect(wrapped.cause).toBe(sqliteError);
+		});
+
+		test('wraps SQLITE_CONSTRAINT_CHECK via code', () => {
+			const sqliteError = Object.assign(new Error('CHECK constraint failed: users_age_check'), {
+				code: 'SQLITE_CONSTRAINT_CHECK',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(CheckConstraintViolationError);
+			expect(wrapped.cause).toBe(sqliteError);
+		});
+
+		test('wraps UNIQUE constraint from message (libsql fallback)', () => {
+			const sqliteError = new Error('UNIQUE constraint failed: users.email');
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect((wrapped as UniqueConstraintViolationError).table).toBe('users');
+			expect((wrapped as UniqueConstraintViolationError).column).toBe('email');
+		});
+
+		test('wraps NOT NULL constraint from message (libsql fallback)', () => {
+			const sqliteError = new Error('NOT NULL constraint failed: users.name');
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(NotNullViolationError);
+			expect((wrapped as NotNullViolationError).table).toBe('users');
+			expect((wrapped as NotNullViolationError).column).toBe('name');
+		});
+
+		test('wraps SQLITE_CONSTRAINT_PRIMARYKEY as unique', () => {
+			const sqliteError = Object.assign(new Error('UNIQUE constraint failed: users.id'), {
+				code: 'SQLITE_CONSTRAINT_PRIMARYKEY',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+		});
+	});
+
+	describe('unknown errors', () => {
+		test('falls back to DrizzleQueryError for unknown error codes', () => {
+			const unknownError = Object.assign(new Error('some random error'), {
+				code: '42P01', // relation does not exist
+			});
+
+			const wrapped = wrapQueryError(query, params, unknownError);
+
+			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
+			expect(wrapped).not.toBeInstanceOf(DrizzleConstraintError);
+			expect(wrapped.cause).toBe(unknownError);
+		});
+
+		test('falls back for errors with no recognizable properties', () => {
+			const plainError = new Error('connection refused');
+
+			const wrapped = wrapQueryError(query, params, plainError);
+
+			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
+			expect(wrapped).not.toBeInstanceOf(DrizzleConstraintError);
+		});
+	});
+
+	describe('instanceof chain', () => {
+		test('UniqueConstraintViolationError is instanceof all parent classes', () => {
+			const pgError = Object.assign(new Error('duplicate key'), {
+				code: '23505',
+				table: 'users',
+				constraint: 'users_email_key',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect(wrapped).toBeInstanceOf(DrizzleConstraintError);
+			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
+			expect(wrapped).toBeInstanceOf(Error);
+		});
+
+		test('query and params are accessible on constraint errors', () => {
+			const pgError = Object.assign(new Error('duplicate key'), {
+				code: '23505',
+				table: 'users',
+				constraint: 'users_email_key',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError) as UniqueConstraintViolationError;
+
+			expect(wrapped.query).toBe(query);
+			expect(wrapped.params).toEqual(params);
+			expect(wrapped.constraintType).toBe('unique');
+			expect(wrapped.constraintName).toBe('users_email_key');
+			expect(wrapped.table).toBe('users');
+		});
+	});
+});


### PR DESCRIPTION
Closes #376

Right now if you get a unique constraint violation, foreign key error, etc., drizzle just throws the raw driver error wrapped in `DrizzleQueryError`. There's no way to programmatically catch specific constraint types without parsing error codes yourself, which is different for every driver.

This adds a `DrizzleConstraintError` base class with subclasses for each constraint type:

```
DrizzleQueryError
  └── DrizzleConstraintError
        ├── UniqueConstraintViolationError
        ├── NotNullViolationError
        ├── ForeignKeyViolationError
        └── CheckConstraintViolationError
```

Usage is straightforward:

```ts
import { UniqueConstraintViolationError } from 'drizzle-orm';

try {
  await db.insert(users).values({ email: 'taken@example.com' });
} catch (e) {
  if (e instanceof UniqueConstraintViolationError) {
    console.log(e.constraintName); // 'users_email_key'
    console.log(e.table);          // 'users'
    console.log(e.cause);          // original driver error
  }
}
```

Each error exposes:
- `constraintType` — `'unique' | 'not_null' | 'foreign_key' | 'check'`
- `constraintName` — extracted from the driver error where available
- `table` / `column` — extracted where available
- `cause` — the original driver error, always preserved
- `query` / `params` — inherited from `DrizzleQueryError`

Works across all three database families:
- **PostgreSQL**: error codes `23505`, `23502`, `23503`, `23514`
- **MySQL**: errno `1062`, `1048`, `1452`, `1216`, `3819`
- **SQLite**: extended result codes (`SQLITE_CONSTRAINT_UNIQUE`, etc.) + message-based fallback for drivers like libsql that don't set extended codes

Everything that was a `DrizzleQueryError` before is still a `DrizzleQueryError` — the new classes extend it, so no breaking changes. If the error doesn't match a known constraint code, it falls back to the existing `DrizzleQueryError` behavior.

All existing tests pass, plus 19 new tests covering all the constraint types across PG/MySQL/SQLite error shapes.