### PR TITLE
[kit] sort view creation/drop statements by dependency order

### DIFF
--- a/drizzle-kit/src/snapshotsDiffer.ts
+++ b/drizzle-kit/src/snapshotsDiffer.ts
@@ -143,6 +143,7 @@ import { SingleStoreSchema, SingleStoreSchemaSquashed, SingleStoreSquasher } fro
 import { SQLiteSchema, SQLiteSchemaSquashed, SQLiteSquasher, View as SqliteView } from './serializer/sqliteSchema';
 import { libSQLCombineStatements, singleStoreCombineStatements, sqliteCombineStatements } from './statementCombiner';
 import { copy, prepareMigrationMeta } from './utils';
+import { sortCreateViewStatements, sortDropViewStatements } from './viewDeps';
 
 const makeChanged = <T extends ZodTypeAny>(schema: T) => {
 	return object({
@@ -1966,7 +1967,7 @@ export const applyPgSnapshotsDiff = async (
 
 	jsonStatements.push(...jsonEnableRLSStatements);
 	jsonStatements.push(...jsonDisableRLSStatements);
-	jsonStatements.push(...dropViews);
+	jsonStatements.push(...sortDropViewStatements(dropViews, json1.views, 'pg'));
 	jsonStatements.push(...renameViews);
 	jsonStatements.push(...alterViews);
 
@@ -2005,7 +2006,7 @@ export const applyPgSnapshotsDiff = async (
 
 	jsonStatements.push(...jsonAlteredUniqueConstraints);
 
-	jsonStatements.push(...createViews);
+	jsonStatements.push(...sortCreateViewStatements(createViews, 'pg'));
 
 	jsonStatements.push(...jsonRenamePoliciesStatements);
 	jsonStatements.push(...jsonDropPoliciesStatements);
@@ -2663,7 +2664,7 @@ export const applyMysqlSnapshotsDiff = async (
 	jsonStatements.push(...jsonRenameTables);
 	jsonStatements.push(...jsonRenameColumnsStatements);
 
-	jsonStatements.push(...dropViews);
+	jsonStatements.push(...sortDropViewStatements(dropViews, json1.views, 'mysql'));
 	jsonStatements.push(...renameViews);
 	jsonStatements.push(...alterViews);
 
@@ -2697,7 +2698,7 @@ export const applyMysqlSnapshotsDiff = async (
 	// jsonStatements.push(...jsonAddedCompositePKs);
 	jsonStatements.push(...jsonAlteredCompositePKs);
 
-	jsonStatements.push(...createViews);
+	jsonStatements.push(...sortCreateViewStatements(createViews, 'mysql'));
 
 	jsonStatements.push(...jsonAlteredUniqueConstraints);
 
@@ -3765,8 +3766,8 @@ export const applySqliteSnapshotsDiff = async (
 
 	jsonStatements.push(...jsonAlteredUniqueConstraints);
 
-	jsonStatements.push(...dropViews);
-	jsonStatements.push(...createViews);
+	jsonStatements.push(...sortDropViewStatements(dropViews, json1.views, 'sqlite'));
+	jsonStatements.push(...sortCreateViewStatements(createViews, 'sqlite'));
 
 	const combinedJsonStatements = sqliteCombineStatements(jsonStatements, json2, action);
 	const sqlStatements = fromJson(combinedJsonStatements, 'sqlite');
@@ -4293,8 +4294,8 @@ export const applyLibSQLSnapshotsDiff = async (
 	jsonStatements.push(...jsonCreateIndexesForAllAlteredTables);
 	jsonStatements.push(...jsonCreatedCheckConstraints);
 
-	jsonStatements.push(...dropViews);
-	jsonStatements.push(...createViews);
+	jsonStatements.push(...sortDropViewStatements(dropViews, json1.views, 'sqlite'));
+	jsonStatements.push(...sortCreateViewStatements(createViews, 'sqlite'));
 
 	jsonStatements.push(...jsonCreatedReferencesForAlteredTables);
 

--- a/drizzle-kit/src/viewDeps.ts
+++ b/drizzle-kit/src/viewDeps.ts
@@ -1,0 +1,156 @@
+type ViewWithDefinition = {
+	name: string;
+	definition?: string;
+	schema?: string;
+	[key: string]: unknown;
+};
+
+function extractViewDependencies(
+	definition: string,
+	allViewNames: Set<string>,
+	dialect: 'pg' | 'mysql' | 'sqlite',
+): Set<string> {
+	const deps = new Set<string>();
+	if (!definition) return deps;
+
+	for (const viewName of allViewNames) {
+		let pattern: RegExp;
+		if (dialect === 'mysql') {
+			pattern = new RegExp(`(?:^|[\\s,(\`])` + '`' + escapeRegex(viewName) + '`' + `(?:[\\s,);\`]|$)`);
+		} else {
+			pattern = new RegExp(
+				`(?:^|[\\s,("])` + '"' + escapeRegex(viewName) + '"' + `(?:[\\s,);"]|$)`,
+			);
+		}
+		if (pattern.test(definition)) {
+			deps.add(viewName);
+		}
+	}
+
+	return deps;
+}
+
+function escapeRegex(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function sortCreateViewStatements<T extends ViewWithDefinition>(
+	views: T[],
+	dialect: 'pg' | 'mysql' | 'sqlite',
+): T[] {
+	if (views.length <= 1) return views;
+
+	const allViewNames = new Set(views.map((v) => v.name));
+	const graph = new Map<string, Set<string>>();
+	const viewMap = new Map<string, T>();
+
+	for (const view of views) {
+		viewMap.set(view.name, view);
+		const deps = view.definition
+			? extractViewDependencies(view.definition, allViewNames, dialect)
+			: new Set<string>();
+		deps.delete(view.name);
+		graph.set(view.name, deps);
+	}
+
+	const sorted: T[] = [];
+	const visited = new Set<string>();
+	const visiting = new Set<string>();
+
+	function visit(name: string): void {
+		if (visited.has(name)) return;
+		if (visiting.has(name)) return;
+
+		visiting.add(name);
+
+		const deps = graph.get(name);
+		if (deps) {
+			for (const dep of deps) {
+				if (viewMap.has(dep)) {
+					visit(dep);
+				}
+			}
+		}
+
+		visiting.delete(name);
+		visited.add(name);
+
+		const view = viewMap.get(name);
+		if (view) {
+			sorted.push(view);
+		}
+	}
+
+	for (const view of views) {
+		visit(view.name);
+	}
+
+	return sorted;
+}
+
+export function sortDropViewStatements<T extends ViewWithDefinition>(
+	drops: T[],
+	allViews: Record<string, ViewWithDefinition>,
+	dialect: 'pg' | 'mysql' | 'sqlite',
+): T[] {
+	if (drops.length <= 1) return drops;
+
+	const allViewNames = new Set(Object.values(allViews).map((v) => v.name));
+	const graph = new Map<string, Set<string>>();
+
+	for (const [, view] of Object.entries(allViews)) {
+		const deps = view.definition
+			? extractViewDependencies(view.definition, allViewNames, dialect)
+			: new Set<string>();
+		deps.delete(view.name);
+		graph.set(view.name, deps);
+	}
+
+	const dropNames = new Set(drops.map((d) => d.name));
+	const dropMap = new Map<string, T>();
+	for (const drop of drops) {
+		dropMap.set(drop.name, drop);
+	}
+
+	const dependents = new Map<string, Set<string>>();
+	for (const [name, deps] of graph) {
+		for (const dep of deps) {
+			if (!dependents.has(dep)) dependents.set(dep, new Set());
+			dependents.get(dep)!.add(name);
+		}
+	}
+
+	const sorted: T[] = [];
+	const visited = new Set<string>();
+	const visiting = new Set<string>();
+
+	function visit(name: string): void {
+		if (visited.has(name)) return;
+		if (visiting.has(name)) return;
+
+		visiting.add(name);
+
+		const depsOnThis = dependents.get(name);
+		if (depsOnThis) {
+			for (const dep of depsOnThis) {
+				if (dropNames.has(dep)) {
+					visit(dep);
+				}
+			}
+		}
+
+		visiting.delete(name);
+		visited.add(name);
+
+		const drop = dropMap.get(name);
+		if (drop) {
+			sorted.push(drop);
+		}
+	}
+
+	for (const drop of drops) {
+		visit(drop.name);
+	}
+
+	return sorted;
+}

--- a/drizzle-kit/tests/mysql-views.test.ts
+++ b/drizzle-kit/tests/mysql-views.test.ts
@@ -551,3 +551,36 @@ SQL SECURITY invoker
 VIEW \`new_some_view\` AS (SELECT * FROM \`users\` WHERE \`users\`.\`id\` = 1)
 WITH cascaded CHECK OPTION;`);
 });
+
+test('views with dependencies are created in correct order', async () => {
+	const users = mysqlTable('users', {
+		id: int('id').primaryKey().notNull(),
+		score: int('score'),
+	});
+
+	const userScoresView = mysqlView('user_scores').as((qb) =>
+		qb.select({ id: users.id, score: users.score }).from(users)
+	);
+
+	const topScoresView = mysqlView('top_scores', { id: int('id'), score: int('score') }).as(
+		sql`select \`id\`, \`score\` from \`user_scores\` where \`score\` > 100`,
+	);
+
+	const to = {
+		users,
+		topScoresView,
+		userScoresView,
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasMysql({}, to, []);
+
+	const createViewStatements = statements.filter(
+		(s) => s.type === 'mysql_create_view',
+	);
+	expect(createViewStatements.length).toBe(2);
+
+	const viewNames = createViewStatements.map((s) => s.name);
+	const userScoresIdx = viewNames.indexOf('user_scores');
+	const topScoresIdx = viewNames.indexOf('top_scores');
+	expect(userScoresIdx).toBeLessThan(topScoresIdx);
+});

--- a/drizzle-kit/tests/pg-views.test.ts
+++ b/drizzle-kit/tests/pg-views.test.ts
@@ -1927,3 +1927,105 @@ test('moved schema and alter view', async () => {
 	expect(sqlStatements[0]).toBe(`ALTER VIEW "public"."some_view" SET SCHEMA "my_schema";`);
 	expect(sqlStatements[1]).toBe(`ALTER VIEW "my_schema"."some_view" SET (check_option = cascaded);`);
 });
+
+test('views with dependencies are created in correct order', async () => {
+	const users = pgTable('users', {
+		id: integer('id').primaryKey().notNull(),
+		score: integer('score'),
+	});
+
+	const userScoresView = pgView('user_scores').as((qb) =>
+		qb.select({ id: users.id, score: users.score }).from(users)
+	);
+
+	const topScoresView = pgView('top_scores', { id: integer('id'), score: integer('score') }).as(
+		sql`select "id", "score" from "user_scores" where "score" > 100`,
+	);
+
+	const to = {
+		users,
+		topScoresView,
+		userScoresView,
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemas({}, to, []);
+
+	const createViewStatements = statements.filter((s) => s.type === 'create_view');
+	expect(createViewStatements.length).toBe(2);
+
+	const viewNames = createViewStatements.map((s) => s.name);
+	const userScoresIdx = viewNames.indexOf('user_scores');
+	const topScoresIdx = viewNames.indexOf('top_scores');
+	expect(userScoresIdx).toBeLessThan(topScoresIdx);
+
+	const createViewSql = sqlStatements.filter((s) => s.includes('CREATE VIEW'));
+	expect(createViewSql.length).toBe(2);
+	expect(createViewSql[0]).toContain('user_scores');
+	expect(createViewSql[1]).toContain('top_scores');
+});
+
+test('materialized views with dependencies are created in correct order', async () => {
+	const events = pgTable('events', {
+		id: integer('id').primaryKey().notNull(),
+		amount: integer('amount'),
+	});
+
+	const dailyTotalsView = pgMaterializedView('daily_totals').as((qb) =>
+		qb.select({ id: events.id, amount: events.amount }).from(events)
+	);
+
+	const weeklyTotalsView = pgMaterializedView('weekly_totals', { total: integer('total') }).as(
+		sql`select sum("amount") as "total" from "daily_totals"`,
+	);
+
+	const to = {
+		events,
+		weeklyTotalsView,
+		dailyTotalsView,
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemas({}, to, []);
+
+	const createViewStatements = statements.filter((s) => s.type === 'create_view');
+	expect(createViewStatements.length).toBe(2);
+
+	const viewNames = createViewStatements.map((s) => s.name);
+	const dailyIdx = viewNames.indexOf('daily_totals');
+	const weeklyIdx = viewNames.indexOf('weekly_totals');
+	expect(dailyIdx).toBeLessThan(weeklyIdx);
+});
+
+test('three-level view dependency chain is ordered correctly', async () => {
+	const orders = pgTable('orders', {
+		id: integer('id').primaryKey().notNull(),
+		total: integer('total'),
+	});
+
+	const orderStatsView = pgView('order_stats').as((qb) =>
+		qb.select({ id: orders.id, total: orders.total }).from(orders)
+	);
+
+	const highValueView = pgView('high_value_orders', { id: integer('id'), total: integer('total') }).as(
+		sql`select "id", "total" from "order_stats" where "total" > 1000`,
+	);
+
+	const summaryView = pgView('summary_report', { cnt: integer('cnt') }).as(
+		sql`select count(*) as "cnt" from "high_value_orders"`,
+	);
+
+	const to = {
+		orders,
+		summaryView,
+		highValueView,
+		orderStatsView,
+	};
+
+	const { statements } = await diffTestSchemas({}, to, []);
+
+	const createViewStatements = statements.filter((s) => s.type === 'create_view');
+	expect(createViewStatements.length).toBe(3);
+
+	const viewNames = createViewStatements.map((s) => s.name);
+	expect(viewNames.indexOf('order_stats')).toBeLessThan(viewNames.indexOf('high_value_orders'));
+	expect(viewNames.indexOf('high_value_orders')).toBeLessThan(viewNames.indexOf('summary_report'));
+});

--- a/drizzle-kit/tests/sqlite-views.test.ts
+++ b/drizzle-kit/tests/sqlite-views.test.ts
@@ -216,3 +216,36 @@ test('rename view and alter ".as"', async () => {
 	expect(sqlStatements[0]).toBe('DROP VIEW `view`;');
 	expect(sqlStatements[1]).toBe(`CREATE VIEW \`new_view\` AS SELECT * FROM users WHERE 1=1;`);
 });
+
+test('views with dependencies are created in correct order', async () => {
+	const users = sqliteTable('users', {
+		id: int('id').primaryKey().notNull(),
+		score: int('score'),
+	});
+
+	const userScoresView = sqliteView('user_scores').as((qb) =>
+		qb.select({ id: users.id, score: users.score }).from(users)
+	);
+
+	const topScoresView = sqliteView('top_scores', { id: int('id'), score: int('score') }).as(
+		sql`select "id", "score" from "user_scores" where "score" > 100`,
+	);
+
+	const to = {
+		users,
+		topScoresView,
+		userScoresView,
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasSqlite({}, to, []);
+
+	const createViewStatements = statements.filter(
+		(s) => s.type === 'sqlite_create_view',
+	);
+	expect(createViewStatements.length).toBe(2);
+
+	const viewNames = createViewStatements.map((s) => s.name);
+	const userScoresIdx = viewNames.indexOf('user_scores');
+	const topScoresIdx = viewNames.indexOf('top_scores');
+	expect(userScoresIdx).toBeLessThan(topScoresIdx);
+});

--- a/drizzle-kit/tests/view-deps.test.ts
+++ b/drizzle-kit/tests/view-deps.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest';
+import { sortCreateViewStatements, sortDropViewStatements } from '../src/viewDeps';
+
+describe('sortCreateViewStatements', () => {
+	test('returns empty array for empty input', () => {
+		expect(sortCreateViewStatements([], 'pg')).toEqual([]);
+	});
+
+	test('returns single view unchanged', () => {
+		const views = [{ name: 'v1', definition: 'select 1' }];
+		expect(sortCreateViewStatements(views, 'pg')).toEqual(views);
+	});
+
+	test('sorts pg views by dependency', () => {
+		const views = [
+			{ name: 'dependent', definition: 'select * from "base_view"' },
+			{ name: 'base_view', definition: 'select * from "users"' },
+		];
+		const sorted = sortCreateViewStatements(views, 'pg');
+		expect(sorted.map((v) => v.name)).toEqual(['base_view', 'dependent']);
+	});
+
+	test('sorts mysql views by dependency', () => {
+		const views = [
+			{ name: 'dependent', definition: 'select * from `base_view`' },
+			{ name: 'base_view', definition: 'select * from `users`' },
+		];
+		const sorted = sortCreateViewStatements(views, 'mysql');
+		expect(sorted.map((v) => v.name)).toEqual(['base_view', 'dependent']);
+	});
+
+	test('sorts three-level dependency chain', () => {
+		const views = [
+			{ name: 'level3', definition: 'select * from "level2"' },
+			{ name: 'level1', definition: 'select * from "some_table"' },
+			{ name: 'level2', definition: 'select * from "level1"' },
+		];
+		const sorted = sortCreateViewStatements(views, 'pg');
+		expect(sorted.map((v) => v.name)).toEqual(['level1', 'level2', 'level3']);
+	});
+
+	test('handles independent views without changing order', () => {
+		const views = [
+			{ name: 'view_b', definition: 'select * from "table_b"' },
+			{ name: 'view_a', definition: 'select * from "table_a"' },
+		];
+		const sorted = sortCreateViewStatements(views, 'pg');
+		expect(sorted.map((v) => v.name)).toEqual(['view_b', 'view_a']);
+	});
+
+	test('does not break on circular dependency', () => {
+		const views = [
+			{ name: 'view_a', definition: 'select * from "view_b"' },
+			{ name: 'view_b', definition: 'select * from "view_a"' },
+		];
+		const sorted = sortCreateViewStatements(views, 'pg');
+		expect(sorted.length).toBe(2);
+	});
+
+	test('handles self-referencing view', () => {
+		const views = [
+			{ name: 'recursive', definition: 'select * from "recursive"' },
+			{ name: 'base', definition: 'select 1' },
+		];
+		const sorted = sortCreateViewStatements(views, 'pg');
+		expect(sorted.length).toBe(2);
+	});
+
+	test('ignores references to non-view tables', () => {
+		const views = [
+			{ name: 'top', definition: 'select * from "bottom"' },
+			{ name: 'bottom', definition: 'select * from "users"' },
+		];
+		const sorted = sortCreateViewStatements(views, 'pg');
+		expect(sorted.map((v) => v.name)).toEqual(['bottom', 'top']);
+	});
+});
+
+describe('sortDropViewStatements', () => {
+	test('drops dependent views before their dependencies', () => {
+		const drops = [
+			{ name: 'base_view', definition: 'select 1' },
+			{ name: 'dependent', definition: 'select * from "base_view"' },
+		];
+		const allViews: Record<string, typeof drops[0]> = {
+			base_view: { name: 'base_view', definition: 'select 1' },
+			dependent: { name: 'dependent', definition: 'select * from "base_view"' },
+		};
+		const sorted = sortDropViewStatements(drops, allViews, 'pg');
+		expect(sorted.map((v) => v.name)).toEqual(['dependent', 'base_view']);
+	});
+});


### PR DESCRIPTION
## Problem

#4076

When generating SQL migrations, drizzle-kit creates views in an unpredictable order that does not consider inter-view dependencies. When a view `B` references another view `A` in its definition, the generated migration may emit `CREATE VIEW B` before `CREATE VIEW A`, causing the migration to fail at runtime.

Similarly, `DROP VIEW` statements are not ordered to respect reverse dependencies, so dropping a base view before its dependents can also fail.

This affects all dialects: PostgreSQL, MySQL, SQLite, and LibSQL.



## Solution

Added a `viewDeps.ts` utility that:

1. Extracts view-to-view dependencies by scanning each view's SQL definition for quoted references to other view names (dialect-aware: double-quotes for PG/SQLite, backticks for MySQL).
2. Topologically sorts `CREATE VIEW` statements so dependencies come first.
3. Reverse-topologically sorts `DROP VIEW` statements so dependents are dropped first.
4. Handles edge cases: circular references (no crash), self-references, independent views (stable order preserved).

Applied the sorting in all four dialect functions in `snapshotsDiffer.ts`:
- `applyPgSnapshotsDiff`
- `applyMySqlSnapshotsDiff`
- `applySQLiteSnapshotsDiff`
- `applyLibSQLSnapshotsDiff`

## Tests

- **Unit tests** for `viewDeps.ts`: two-level chains, three-level chains, MySQL vs PG quoting, independent views, circular/self-references, drop ordering (10 tests).
- **Integration tests** added to `pg-views.test.ts` (3 tests), `mysql-views.test.ts` (1 test), `sqlite-views.test.ts` (1 test).
- All 94 existing + new view tests pass.\