### PR TITLE
add STRICT table mode support for SQLite

### DIFF
--- a/drizzle-kit/src/jsonStatements.ts
+++ b/drizzle-kit/src/jsonStatements.ts
@@ -40,6 +40,7 @@ export interface JsonSqliteCreateTableStatement {
 	compositePKs: string[][];
 	uniqueConstraints?: string[];
 	checkConstraints?: string[];
+	isStrict?: boolean;
 }
 
 export interface JsonCreateTableStatement {
@@ -72,6 +73,7 @@ export interface JsonRecreateTableStatement {
 	compositePKs: string[][];
 	uniqueConstraints?: string[];
 	checkConstraints: string[];
+	isStrict?: boolean;
 }
 
 export interface JsonRecreateSingleStoreTableStatement {
@@ -912,6 +914,7 @@ export const preparePgCreateTableJson = (
 		uniqueConstraints: Object.values(uniqueConstraints),
 		policies: Object.values(policies),
 		checkConstraints: Object.values(checkConstraints),
+		isStrict,
 		isRLSEnabled: isRLSEnabled ?? false,
 	};
 };
@@ -942,6 +945,7 @@ export const prepareMySqlCreateTableJson = (
 		uniqueConstraints: Object.values(uniqueConstraints),
 		internals,
 		checkConstraints: Object.values(checkConstraints),
+		isStrict,
 	};
 };
 
@@ -977,7 +981,7 @@ export const prepareSQLiteCreateTable = (
 	table: Table,
 	action?: 'push' | undefined,
 ): JsonSqliteCreateTableStatement => {
-	const { name, columns, uniqueConstraints, checkConstraints } = table;
+	const { name, columns, uniqueConstraints, checkConstraints, isStrict } = table;
 
 	const references: string[] = Object.values(table.foreignKeys);
 
@@ -999,6 +1003,7 @@ export const prepareSQLiteCreateTable = (
 		compositePKs: composites,
 		uniqueConstraints: Object.values(uniqueConstraints),
 		checkConstraints: Object.values(checkConstraints),
+		isStrict,
 	};
 };
 

--- a/drizzle-kit/src/jsonStatements.ts
+++ b/drizzle-kit/src/jsonStatements.ts
@@ -914,7 +914,6 @@ export const preparePgCreateTableJson = (
 		uniqueConstraints: Object.values(uniqueConstraints),
 		policies: Object.values(policies),
 		checkConstraints: Object.values(checkConstraints),
-		isStrict,
 		isRLSEnabled: isRLSEnabled ?? false,
 	};
 };
@@ -945,7 +944,6 @@ export const prepareMySqlCreateTableJson = (
 		uniqueConstraints: Object.values(uniqueConstraints),
 		internals,
 		checkConstraints: Object.values(checkConstraints),
-		isStrict,
 	};
 };
 

--- a/drizzle-kit/src/serializer/sqliteSchema.ts
+++ b/drizzle-kit/src/serializer/sqliteSchema.ts
@@ -62,6 +62,7 @@ const table = object({
 	compositePrimaryKeys: record(string(), compositePK),
 	uniqueConstraints: record(string(), uniqueConstraint).default({}),
 	checkConstraints: record(string(), checkConstraint).default({}),
+	isStrict: boolean().default(false),
 }).strict();
 
 export const view = object({
@@ -144,6 +145,7 @@ const tableSquashed = object({
 	compositePrimaryKeys: record(string(), string()),
 	uniqueConstraints: record(string(), string()).default({}),
 	checkConstraints: record(string(), string()).default({}),
+	isStrict: boolean().default(false),
 }).strict();
 
 export const schemaSquashed = object({
@@ -315,6 +317,7 @@ export const squashSqliteScheme = (
 					compositePrimaryKeys: squashedPKs,
 					uniqueConstraints: squashedUniqueConstraints,
 					checkConstraints: squashedCheckConstraints,
+					isStrict: it[1].isStrict ?? false,
 				},
 			];
 		}),

--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -57,6 +57,7 @@ export const generateSqliteSnapshot = (
 			foreignKeys: tableForeignKeys,
 			primaryKeys,
 			uniqueConstraints,
+			isStrict,
 		} = getTableConfig(table);
 
 		columns.forEach((column) => {
@@ -313,6 +314,21 @@ export const generateSqliteSnapshot = (
 			};
 		});
 
+		// Validate column types for STRICT tables
+		if (isStrict) {
+			const validStrictTypes = ['INT', 'INTEGER', 'REAL', 'TEXT', 'BLOB', 'ANY'];
+			for (const column of columns) {
+				const upperType = column.getSQLType().toUpperCase();
+				if (!validStrictTypes.includes(upperType)) {
+					console.log(
+						`\n${withStyle.errorWarning(
+							`Column "${column.name}" in STRICT table "${tableName}" has type "${column.getSQLType()}" which is not a valid STRICT type. Valid types: ${validStrictTypes.join(', ')}`,
+						)}`,
+					);
+				}
+			}
+		}
+
 		result[tableName] = {
 			name: tableName,
 			columns: columnsObject,
@@ -321,6 +337,7 @@ export const generateSqliteSnapshot = (
 			compositePrimaryKeys: primaryKeysObject,
 			uniqueConstraints: uniqueConstraintObject,
 			checkConstraints: checkConstraintObject,
+			isStrict,
 		};
 	}
 
@@ -649,6 +666,12 @@ export const fromDatabase = async (
 				: undefined,
 		};
 
+		// Check if table DDL contains STRICT keyword
+		const isStrict = column.sql
+			? /\)\s*(?:WITHOUT\s+ROWID\s*,\s*)?STRICT\b/i.test(column.sql) ||
+			  /\)\s*STRICT\s*,\s*WITHOUT\s+ROWID\b/i.test(column.sql)
+			: false;
+
 		if (!table) {
 			result[tableName] = {
 				name: tableName,
@@ -660,6 +683,7 @@ export const fromDatabase = async (
 				foreignKeys: {},
 				uniqueConstraints: {},
 				checkConstraints: {},
+				isStrict,
 			};
 		} else {
 			result[tableName]!.columns[columnName] = newColumn;
@@ -929,6 +953,7 @@ export const fromDatabase = async (
 				foreignKeys: {},
 				uniqueConstraints: {},
 				checkConstraints: checkConstraints,
+				isStrict: false,
 			};
 		} else {
 			result[tableName]!.checkConstraints = checkConstraints;

--- a/drizzle-kit/src/snapshotsDiffer.ts
+++ b/drizzle-kit/src/snapshotsDiffer.ts
@@ -269,6 +269,7 @@ const tableScheme = object({
 	policies: record(string(), string()).default({}),
 	checkConstraints: record(string(), string()).default({}),
 	isRLSEnabled: boolean().default(false),
+	isStrict: boolean().default(false),
 }).strict();
 
 export const alteredTableScheme = object({

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -668,6 +668,7 @@ export class SQLiteCreateTableConvertor extends Convertor {
 			compositePKs,
 			uniqueConstraints,
 			checkConstraints,
+			isStrict,
 		} = st;
 
 		let statement = '';
@@ -744,7 +745,7 @@ export class SQLiteCreateTableConvertor extends Convertor {
 		}
 
 		statement += `\n`;
-		statement += `);`;
+		statement += isStrict ? `) STRICT;` : `);`;
 		statement += `\n`;
 		return statement;
 	}
@@ -3769,7 +3770,7 @@ class SQLiteRecreateTableConvertor extends Convertor {
 	}
 
 	convert(statement: JsonRecreateTableStatement): string | string[] {
-		const { tableName, columns, compositePKs, referenceData, checkConstraints } = statement;
+		const { tableName, columns, compositePKs, referenceData, checkConstraints, isStrict } = statement;
 
 		const columnNames = columns.map((it) => `"${it.name}"`).join(', ');
 		const newTableName = `__new_${tableName}`;
@@ -3793,6 +3794,7 @@ class SQLiteRecreateTableConvertor extends Convertor {
 				referenceData,
 				compositePKs,
 				checkConstraints: mappedCheckConstraints,
+				isStrict,
 			}),
 		);
 
@@ -3836,7 +3838,7 @@ class LibSQLRecreateTableConvertor extends Convertor {
 	}
 
 	convert(statement: JsonRecreateTableStatement): string[] {
-		const { tableName, columns, compositePKs, referenceData, checkConstraints } = statement;
+		const { tableName, columns, compositePKs, referenceData, checkConstraints, isStrict } = statement;
 
 		const columnNames = columns.map((it) => `"${it.name}"`).join(', ');
 		const newTableName = `__new_${tableName}`;
@@ -3859,6 +3861,7 @@ class LibSQLRecreateTableConvertor extends Convertor {
 				referenceData,
 				compositePKs,
 				checkConstraints: mappedCheckConstraints,
+				isStrict,
 			}),
 		);
 

--- a/drizzle-kit/src/statementCombiner.ts
+++ b/drizzle-kit/src/statementCombiner.ts
@@ -11,7 +11,7 @@ export const prepareLibSQLRecreateTable = (
 	table: SQLiteSchemaSquashed['tables'][keyof SQLiteSchemaSquashed['tables']],
 	action?: 'push',
 ): (JsonRecreateTableStatement | JsonCreateIndexStatement)[] => {
-	const { name, columns, uniqueConstraints, indexes, checkConstraints } = table;
+	const { name, columns, uniqueConstraints, indexes, checkConstraints, isStrict } = table;
 
 	const composites: string[][] = Object.values(table.compositePrimaryKeys).map(
 		(it) => SQLiteSquasher.unsquashPK(it),
@@ -31,6 +31,7 @@ export const prepareLibSQLRecreateTable = (
 			referenceData: fks,
 			uniqueConstraints: Object.values(uniqueConstraints),
 			checkConstraints: Object.values(checkConstraints),
+			isStrict,
 		},
 	];
 
@@ -44,7 +45,7 @@ export const prepareSQLiteRecreateTable = (
 	table: SQLiteSchemaSquashed['tables'][keyof SQLiteSchemaSquashed['tables']],
 	action?: 'push',
 ): JsonStatement[] => {
-	const { name, columns, uniqueConstraints, indexes, checkConstraints } = table;
+	const { name, columns, uniqueConstraints, indexes, checkConstraints, isStrict } = table;
 
 	const composites: string[][] = Object.values(table.compositePrimaryKeys).map(
 		(it) => SQLiteSquasher.unsquashPK(it),
@@ -64,6 +65,7 @@ export const prepareSQLiteRecreateTable = (
 			referenceData: fks,
 			uniqueConstraints: Object.values(uniqueConstraints),
 			checkConstraints: Object.values(checkConstraints),
+			isStrict,
 		},
 	];
 

--- a/drizzle-kit/tests/libsql-checks.test.ts
+++ b/drizzle-kit/tests/libsql-checks.test.ts
@@ -39,6 +39,7 @@ test('create table with check', async (t) => {
 		checkConstraints: ['some_check_name;"users"."age" > 21'],
 		referenceData: [],
 		uniqueConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(1);
@@ -93,6 +94,7 @@ test('add check contraint to existing table', async (t) => {
 		tableName: 'users',
 		type: 'recreate_table',
 		uniqueConstraints: [],
+		isStrict: false,
 		checkConstraints: ['some_check_name;"users"."age" > 21'],
 	});
 
@@ -153,7 +155,9 @@ test('drop check contraint to existing table', async (t) => {
 		tableName: 'users',
 		type: 'recreate_table',
 		uniqueConstraints: [],
+		isStrict: false,
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(6);
@@ -214,6 +218,7 @@ test('rename check constraint', async (t) => {
 		tableName: 'users',
 		type: 'recreate_table',
 		uniqueConstraints: [],
+		isStrict: false,
 		checkConstraints: [`new_some_check_name;"users"."age" > 21`],
 	});
 
@@ -276,6 +281,7 @@ test('rename check constraint', async (t) => {
 		tableName: 'users',
 		type: 'recreate_table',
 		uniqueConstraints: [],
+		isStrict: false,
 		checkConstraints: [`some_check_name;"users"."age" > 10`],
 	});
 

--- a/drizzle-kit/tests/libsql-checks.test.ts
+++ b/drizzle-kit/tests/libsql-checks.test.ts
@@ -157,7 +157,6 @@ test('drop check contraint to existing table', async (t) => {
 		uniqueConstraints: [],
 		isStrict: false,
 		checkConstraints: [],
-		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(6);

--- a/drizzle-kit/tests/libsql-views.test.ts
+++ b/drizzle-kit/tests/libsql-views.test.ts
@@ -29,6 +29,7 @@ test('create view', async () => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 	expect(statements[1]).toStrictEqual({
 		type: 'sqlite_create_view',

--- a/drizzle-kit/tests/push/libsql.test.ts
+++ b/drizzle-kit/tests/push/libsql.test.ts
@@ -1127,6 +1127,7 @@ test('add check constraint to table', async (t) => {
 		type: 'recreate_table',
 		uniqueConstraints: [],
 		checkConstraints: ['some_check;"users"."age" > 21'],
+		isStrict: false,
 	});
 
 	expect(sqlStatements!.length).toBe(4);

--- a/drizzle-kit/tests/push/sqlite.test.ts
+++ b/drizzle-kit/tests/push/sqlite.test.ts
@@ -384,6 +384,7 @@ test('drop autoincrement. drop column with data', async (t) => {
 		referenceData: [],
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(4);
@@ -501,6 +502,7 @@ test('drop autoincrement. drop column with data with pragma off', async (t) => {
 		],
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(4);
@@ -606,6 +608,7 @@ test('change autoincrement. other table references current', async (t) => {
 		referenceData: [],
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(6);
@@ -726,6 +729,7 @@ test('drop not null, add not null', async (t) => {
 	expect(statements!.length).toBe(2);
 	expect(statements![0]).toStrictEqual({
 		checkConstraints: [],
+		isStrict: false,
 		columns: [
 			{
 				autoincrement: true,
@@ -752,6 +756,7 @@ test('drop not null, add not null', async (t) => {
 	});
 	expect(statements![1]).toStrictEqual({
 		checkConstraints: [],
+		isStrict: false,
 		columns: [
 			{
 				autoincrement: true,
@@ -879,6 +884,7 @@ test('rename table and change data type', async (t) => {
 		type: 'recreate_table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements!.length).toBe(5);
@@ -958,6 +964,7 @@ test('rename column and change data type', async (t) => {
 		type: 'recreate_table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements!.length).toBe(4);
@@ -1066,6 +1073,7 @@ test('recreate table with nested references', async (t) => {
 		type: 'recreate_table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements!.length).toBe(6);
@@ -1175,6 +1183,7 @@ test('recreate table with added column not null and without default with data', 
 		type: 'recreate_table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements!.length).toBe(4);
@@ -1273,6 +1282,7 @@ test('add check constraint to table', async (t) => {
 		type: 'recreate_table',
 		uniqueConstraints: [],
 		checkConstraints: ['some_check;"users"."age" > 21'],
+		isStrict: false,
 	});
 
 	expect(sqlStatements!.length).toBe(4);
@@ -1367,6 +1377,7 @@ test('drop check constraint', async (t) => {
 		type: 'recreate_table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements!.length).toBe(4);
@@ -1569,6 +1580,7 @@ test('create composite primary key', async (t) => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 		columns: [
 			{ name: 'col1', type: 'integer', primaryKey: false, notNull: true, autoincrement: false },
 			{ name: 'col2', type: 'integer', primaryKey: false, notNull: true, autoincrement: false },

--- a/drizzle-kit/tests/sqlite-checks.test.ts
+++ b/drizzle-kit/tests/sqlite-checks.test.ts
@@ -39,6 +39,7 @@ test('create table with check', async (t) => {
 		checkConstraints: ['some_check_name;"users"."age" > 21'],
 		referenceData: [],
 		uniqueConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(1);
@@ -93,6 +94,7 @@ test('add check contraint to existing table', async (t) => {
 		tableName: 'users',
 		type: 'recreate_table',
 		uniqueConstraints: [],
+		isStrict: false,
 		checkConstraints: ['some_check_name;"users"."age" > 21'],
 	});
 
@@ -153,7 +155,9 @@ test('drop check contraint to existing table', async (t) => {
 		tableName: 'users',
 		type: 'recreate_table',
 		uniqueConstraints: [],
+		isStrict: false,
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(6);
@@ -214,6 +218,7 @@ test('rename check constraint', async (t) => {
 		tableName: 'users',
 		type: 'recreate_table',
 		uniqueConstraints: [],
+		isStrict: false,
 		checkConstraints: [`new_some_check_name;"users"."age" > 21`],
 	});
 
@@ -276,6 +281,7 @@ test('rename check constraint', async (t) => {
 		tableName: 'users',
 		type: 'recreate_table',
 		uniqueConstraints: [],
+		isStrict: false,
 		checkConstraints: [`some_check_name;"users"."age" > 10`],
 	});
 

--- a/drizzle-kit/tests/sqlite-checks.test.ts
+++ b/drizzle-kit/tests/sqlite-checks.test.ts
@@ -157,7 +157,6 @@ test('drop check contraint to existing table', async (t) => {
 		uniqueConstraints: [],
 		isStrict: false,
 		checkConstraints: [],
-		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(6);

--- a/drizzle-kit/tests/sqlite-columns.test.ts
+++ b/drizzle-kit/tests/sqlite-columns.test.ts
@@ -38,6 +38,7 @@ test('create table with id', async (t) => {
 		referenceData: [],
 		compositePKs: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -365,6 +366,7 @@ test('add foreign key #1', async (t) => {
 			tableName: 'users',
 			uniqueConstraints: [],
 			checkConstraints: [],
+		isStrict: false,
 		} as JsonRecreateTableStatement,
 	);
 });
@@ -429,6 +431,7 @@ test('add foreign key #2', async (t) => {
 		tableName: 'users',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	} as JsonRecreateTableStatement);
 });
 
@@ -588,6 +591,7 @@ test('alter table add composite pk', async (t) => {
 		tableName: 'table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -626,6 +630,7 @@ test('alter column drop not null', async (t) => {
 		tableName: 'table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -664,6 +669,7 @@ test('alter column add not null', async (t) => {
 		tableName: 'table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -703,6 +709,7 @@ test('alter column add default', async (t) => {
 		tableName: 'table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -741,6 +748,7 @@ test('alter column drop default', async (t) => {
 		tableName: 'table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -780,6 +788,7 @@ test('alter column add default not null', async (t) => {
 		tableName: 'table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -823,6 +832,7 @@ test('alter column add default not null with indexes', async (t) => {
 		tableName: 'table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 	expect(statements[1]).toStrictEqual({
 		data: 'index_name;name;false;',
@@ -880,6 +890,7 @@ test('alter column drop default not null', async (t) => {
 		tableName: 'table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 	expect(sqlStatements.length).toBe(6);
 	expect(sqlStatements[0]).toBe(`PRAGMA foreign_keys=OFF;`);
@@ -1009,6 +1020,7 @@ test('recreate table with nested references', async (t) => {
 		type: 'recreate_table',
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(sqlStatements.length).toBe(6);

--- a/drizzle-kit/tests/sqlite-generated.test.ts
+++ b/drizzle-kit/tests/sqlite-generated.test.ts
@@ -509,6 +509,7 @@ test('generated as callback: add table with column with stored generated constra
 			type: 'sqlite_create_table',
 			uniqueConstraints: [],
 			checkConstraints: [],
+		isStrict: false,
 		},
 	]);
 	expect(sqlStatements).toStrictEqual([
@@ -578,6 +579,7 @@ test('generated as callback: add table with column with virtual generated constr
 			type: 'sqlite_create_table',
 			uniqueConstraints: [],
 			checkConstraints: [],
+		isStrict: false,
 		},
 	]);
 	expect(sqlStatements).toStrictEqual([
@@ -1079,6 +1081,7 @@ test('generated as sql: add table with column with stored generated constraint',
 			type: 'sqlite_create_table',
 			uniqueConstraints: [],
 			checkConstraints: [],
+		isStrict: false,
 		},
 	]);
 	expect(sqlStatements).toStrictEqual([
@@ -1148,6 +1151,7 @@ test('generated as sql: add table with column with virtual generated constraint'
 			type: 'sqlite_create_table',
 			uniqueConstraints: [],
 			checkConstraints: [],
+		isStrict: false,
 		},
 	]);
 	expect(sqlStatements).toStrictEqual([
@@ -1649,6 +1653,7 @@ test('generated as string: add table with column with stored generated constrain
 			type: 'sqlite_create_table',
 			uniqueConstraints: [],
 			checkConstraints: [],
+		isStrict: false,
 		},
 	]);
 	expect(sqlStatements).toStrictEqual([
@@ -1718,6 +1723,7 @@ test('generated as string: add table with column with virtual generated constrai
 			type: 'sqlite_create_table',
 			uniqueConstraints: [],
 			checkConstraints: [],
+		isStrict: false,
 		},
 	]);
 	expect(sqlStatements).toStrictEqual([

--- a/drizzle-kit/tests/sqlite-tables.test.ts
+++ b/drizzle-kit/tests/sqlite-tables.test.ts
@@ -29,6 +29,7 @@ test('add table #1', async () => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -58,6 +59,7 @@ test('add table #2', async () => {
 		referenceData: [],
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -98,6 +100,7 @@ test('add table #3', async () => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -118,6 +121,7 @@ test('add table #4', async () => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 	expect(statements[1]).toStrictEqual({
 		type: 'sqlite_create_table',
@@ -127,6 +131,7 @@ test('add table #4', async () => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -154,6 +159,7 @@ test('add table #6', async () => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 	expect(statements[1]).toStrictEqual({
 		type: 'drop_table',
@@ -193,6 +199,7 @@ test('add table #7', async () => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 });
 
@@ -231,6 +238,7 @@ test('add table #8', async () => {
 		compositePKs: [],
 		uniqueConstraints: [],
 		checkConstraints: [],
+		isStrict: false,
 		referenceData: [
 			{
 				columnsFrom: ['reportee_id'],
@@ -287,6 +295,7 @@ test('add table #9', async () => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 
 	expect(statements[1]).toStrictEqual({

--- a/drizzle-kit/tests/sqlite-views.test.ts
+++ b/drizzle-kit/tests/sqlite-views.test.ts
@@ -29,6 +29,7 @@ test('create view', async () => {
 		uniqueConstraints: [],
 		referenceData: [],
 		checkConstraints: [],
+		isStrict: false,
 	});
 	expect(statements[1]).toStrictEqual({
 		type: 'sqlite_create_view',

--- a/drizzle-orm/src/sqlite-core/table.ts
+++ b/drizzle-orm/src/sqlite-core/table.ts
@@ -25,6 +25,8 @@ export type TableConfig = TableConfigBase<SQLiteColumn<any>>;
 
 /** @internal */
 export const InlineForeignKeys = Symbol.for('drizzle:SQLiteInlineForeignKeys');
+/** @internal */
+export const Strict = Symbol.for('drizzle:SQLiteStrict');
 
 export class SQLiteTable<T extends TableConfig = TableConfig> extends Table<T> {
 	static override readonly [entityKind]: string = 'SQLiteTable';
@@ -32,6 +34,7 @@ export class SQLiteTable<T extends TableConfig = TableConfig> extends Table<T> {
 	/** @internal */
 	static override readonly Symbol = Object.assign({}, Table.Symbol, {
 		InlineForeignKeys: InlineForeignKeys as typeof InlineForeignKeys,
+			Strict: Strict as typeof Strict,
 	});
 
 	/** @internal */
@@ -39,6 +42,9 @@ export class SQLiteTable<T extends TableConfig = TableConfig> extends Table<T> {
 
 	/** @internal */
 	[InlineForeignKeys]: ForeignKey[] = [];
+
+	/** @internal */
+	[Strict]: boolean = false;
 
 	/** @internal */
 	override [Table.Symbol.ExtraConfigBuilder]:
@@ -54,7 +60,8 @@ export type SQLiteTableWithColumns<T extends TableConfig> =
 	& SQLiteTable<T>
 	& {
 		[Key in keyof T['columns']]: T['columns'][Key];
-	};
+	}
+	& { strict: () => Omit<SQLiteTableWithColumns<T>, 'strict'> };
 
 export interface SQLiteTableFn<TSchema extends string | undefined = undefined> {
 	<
@@ -213,7 +220,17 @@ function sqliteTableBase<
 		) => SQLiteTableExtraConfig;
 	}
 
-	return table;
+	return Object.assign(table, {
+		strict: () => {
+			table[SQLiteTable.Symbol.Strict] = true;
+			return table as SQLiteTableWithColumns<{
+				name: TTableName;
+				schema: TSchema;
+				columns: BuildColumns<TTableName, TColumnsMap, 'sqlite'>;
+				dialect: 'sqlite';
+			}>;
+		},
+	});
 }
 
 export const sqliteTable: SQLiteTableFn = (name, columns, extraConfig) => {

--- a/drizzle-orm/src/sqlite-core/table.ts
+++ b/drizzle-orm/src/sqlite-core/table.ts
@@ -34,7 +34,7 @@ export class SQLiteTable<T extends TableConfig = TableConfig> extends Table<T> {
 	/** @internal */
 	static override readonly Symbol = Object.assign({}, Table.Symbol, {
 		InlineForeignKeys: InlineForeignKeys as typeof InlineForeignKeys,
-			Strict: Strict as typeof Strict,
+		Strict: Strict as typeof Strict,
 	});
 
 	/** @internal */

--- a/drizzle-orm/src/sqlite-core/utils.ts
+++ b/drizzle-orm/src/sqlite-core/utils.ts
@@ -24,6 +24,7 @@ export function getTableConfig<TTable extends SQLiteTable>(table: TTable) {
 	const uniqueConstraints: UniqueConstraint[] = [];
 	const foreignKeys: ForeignKey[] = Object.values(table[SQLiteTable.Symbol.InlineForeignKeys]);
 	const name = table[Table.Symbol.Name];
+	const isStrict: boolean = table[SQLiteTable.Symbol.Strict];
 
 	const extraConfigBuilder = table[SQLiteTable.Symbol.ExtraConfigBuilder];
 
@@ -53,6 +54,7 @@ export function getTableConfig<TTable extends SQLiteTable>(table: TTable) {
 		primaryKeys,
 		uniqueConstraints,
 		name,
+		isStrict,
 	};
 }
 


### PR DESCRIPTION
Adds `.strict()` method to `sqliteTable()` for creating SQLite STRICT tables.

```ts
const users = sqliteTable('users', {
  id: int('id').primaryKey(),
  name: text('name'),
}).strict();
```

Generates: `CREATE TABLE users (...) STRICT;`

**Changes**
- `.strict()` chained method on `sqliteTable` (like `enableRLS()` pattern)
- `isStrict` in schema serialization and DDL generation
- introspection support for existing STRICT tables
- runtime warnings for invalid STRICT column types (valid: INT, INTEGER, REAL, TEXT, BLOB, ANY)

**Docs:** drizzle-team/drizzle-orm-docs#653