### PR TITLE
feat: add deferrable constraint support for PostgreSQL

### DIFF
--- a/drizzle-kit/src/serializer/pgSchema.ts
+++ b/drizzle-kit/src/serializer/pgSchema.ts
@@ -134,6 +134,8 @@ const fk = object({
 	columnsTo: string().array(),
 	onUpdate: string().optional(),
 	onDelete: string().optional(),
+	deferrable: string().optional(),
+	initially: string().optional(),
 }).strict();
 
 export const sequenceSchema = object({
@@ -223,12 +225,16 @@ const tableV3 = object({
 const compositePK = object({
 	name: string(),
 	columns: string().array(),
+	deferrable: string().optional(),
+	initially: string().optional(),
 }).strict();
 
 const uniqueConstraint = object({
 	name: string(),
 	columns: string().array(),
 	nullsNotDistinct: boolean(),
+	deferrable: string().optional(),
+	initially: string().optional(),
 }).strict();
 
 export const policy = object({
@@ -632,7 +638,7 @@ export const PgSquasher = {
 	squashFK: (fk: ForeignKey) => {
 		return `${fk.name};${fk.tableFrom};${fk.columnsFrom.join(',')};${fk.tableTo};${fk.columnsTo.join(',')};${
 			fk.onUpdate ?? ''
-		};${fk.onDelete ?? ''};${fk.schemaTo || 'public'}`;
+		};${fk.onDelete ?? ''};${fk.schemaTo || 'public'};${fk.deferrable ?? ''};${fk.initially ?? ''}`;
 	},
 	squashPolicy: (policy: Policy) => {
 		return `${policy.name}--${policy.as}--${policy.for}--${
@@ -665,21 +671,28 @@ export const PgSquasher = {
 		};
 	},
 	squashPK: (pk: PrimaryKey) => {
-		return `${pk.columns.join(',')};${pk.name}`;
+		return `${pk.columns.join(',')};${pk.name};${pk.deferrable ?? ''};${pk.initially ?? ''}`;
 	},
 	unsquashPK: (pk: string): PrimaryKey => {
 		const splitted = pk.split(';');
-		return { name: splitted[1], columns: splitted[0].split(',') };
+		return {
+			name: splitted[1],
+			columns: splitted[0].split(','),
+			deferrable: splitted[2] || undefined,
+			initially: splitted[3] || undefined,
+		};
 	},
 	squashUnique: (unq: UniqueConstraint) => {
-		return `${unq.name};${unq.columns.join(',')};${unq.nullsNotDistinct}`;
+		return `${unq.name};${unq.columns.join(',')};${unq.nullsNotDistinct};${unq.deferrable ?? ''};${unq.initially ?? ''}`;
 	},
 	unsquashUnique: (unq: string): UniqueConstraint => {
-		const [name, columns, nullsNotDistinct] = unq.split(';');
+		const [name, columns, nullsNotDistinct, deferrable, initially] = unq.split(';');
 		return {
 			name,
 			columns: columns.split(','),
 			nullsNotDistinct: nullsNotDistinct === 'true',
+			deferrable: deferrable || undefined,
+			initially: initially || undefined,
 		};
 	},
 	unsquashFK: (input: string): ForeignKey => {
@@ -692,6 +705,8 @@ export const PgSquasher = {
 			onUpdate,
 			onDelete,
 			schemaTo,
+			deferrable,
+			initially,
 		] = input.split(';');
 
 		const result: ForeignKey = fk.parse({
@@ -703,6 +718,8 @@ export const PgSquasher = {
 			columnsTo: columnsToStr.split(','),
 			onUpdate,
 			onDelete,
+			deferrable: deferrable || undefined,
+			initially: initially || undefined,
 		});
 		return result;
 	},

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -288,6 +288,8 @@ export const generatePgSnapshot = (
 			primaryKeysObject[name] = {
 				name,
 				columns: columnNames,
+				deferrable: pk.deferrable,
+				initially: pk.initially,
 			};
 		});
 
@@ -319,6 +321,8 @@ export const generatePgSnapshot = (
 				name: unq.name!,
 				nullsNotDistinct: unq.nullsNotDistinct,
 				columns: columnNames,
+				deferrable: unq.deferrable,
+				initially: unq.initially,
 			};
 		});
 
@@ -326,6 +330,8 @@ export const generatePgSnapshot = (
 			const tableFrom = tableName;
 			const onDelete = fk.onDelete;
 			const onUpdate = fk.onUpdate;
+			const deferrable = fk.deferrable;
+			const initially = fk.initially;
 			const reference = fk.reference();
 
 			const tableTo = getTableName(reference.foreignTable);
@@ -357,6 +363,8 @@ export const generatePgSnapshot = (
 				columnsTo,
 				onDelete,
 				onUpdate,
+				deferrable,
+				initially,
 			} as ForeignKey;
 		});
 
@@ -1288,7 +1296,9 @@ WHERE
               WHEN 'n' THEN 'SET NULL'
               WHEN 'c' THEN 'CASCADE'
               WHEN 'd' THEN 'SET DEFAULT'
-            END AS delete_rule
+            END AS delete_rule,
+            CASE WHEN con.condeferrable THEN 'deferrable' ELSE NULL END AS deferrable,
+            CASE WHEN con.condeferred THEN 'deferred' ELSE NULL END AS initially
           FROM
             pg_catalog.pg_constraint con
             JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
@@ -1318,6 +1328,8 @@ WHERE
 						const foreignKeyName = fk.constraint_name;
 						const onUpdate = fk.update_rule?.toLowerCase();
 						const onDelete = fk.delete_rule?.toLowerCase();
+						const deferrable: string | undefined = fk.deferrable ?? undefined;
+						const initially: string | undefined = fk.initially ?? undefined;
 
 						if (typeof foreignKeysToReturn[foreignKeyName] !== 'undefined') {
 							foreignKeysToReturn[foreignKeyName].columnsFrom.push(columnFrom);
@@ -1332,6 +1344,8 @@ WHERE
 								columnsTo: [columnTo],
 								onDelete,
 								onUpdate,
+								deferrable,
+								initially,
 							};
 						}
 
@@ -1344,6 +1358,25 @@ WHERE
 
 					const uniqueConstrainsRows = tableConstraints.filter((mapRow) => mapRow.constraint_type === 'UNIQUE');
 
+					const deferrableInfo = await db.query(
+						`SELECT con.conname AS constraint_name,
+            CASE WHEN con.condeferrable THEN 'deferrable' ELSE NULL END AS deferrable,
+            CASE WHEN con.condeferred THEN 'deferred' ELSE NULL END AS initially
+          FROM pg_catalog.pg_constraint con
+            JOIN pg_catalog.pg_class rel ON rel.oid = con.conrelid
+            JOIN pg_catalog.pg_namespace nsp ON nsp.oid = con.connamespace
+          WHERE nsp.nspname = '${tableSchema}'
+            AND rel.relname = '${tableName}'
+            AND con.contype IN ('u', 'p');`,
+					);
+					const deferrableMap: Record<string, { deferrable?: string; initially?: string }> = {};
+					for (const row of deferrableInfo) {
+						deferrableMap[row.constraint_name] = {
+							deferrable: row.deferrable ?? undefined,
+							initially: row.initially ?? undefined,
+						};
+					}
+
 					for (const unqs of uniqueConstrainsRows) {
 						// const tableFrom = fk.table_name;
 						const columnName: string = unqs.column_name;
@@ -1352,10 +1385,13 @@ WHERE
 						if (typeof uniqueConstrains[constraintName] !== 'undefined') {
 							uniqueConstrains[constraintName].columns.push(columnName);
 						} else {
+							const defInfo = deferrableMap[constraintName];
 							uniqueConstrains[constraintName] = {
 								columns: [columnName],
 								nullsNotDistinct: false,
 								name: constraintName,
+								deferrable: defInfo?.deferrable,
+								initially: defInfo?.initially,
 							};
 						}
 					}
@@ -1413,9 +1449,13 @@ WHERE
             AND    pg_class.relname = $2;`,
 								[tableSchema, tableName],
 							);
-							primaryKeys[tableCompositePkName[0].primary_key] = {
-								name: tableCompositePkName[0].primary_key,
+							const pkName = tableCompositePkName[0].primary_key;
+							const pkDefInfo = deferrableMap[pkName];
+							primaryKeys[pkName] = {
+								name: pkName,
 								columns: cprimaryKey.map((c: any) => c.column_name),
+								deferrable: pkDefInfo?.deferrable,
+								initially: pkDefInfo?.initially,
 							};
 						}
 

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -455,8 +455,9 @@ class PgCreateTableConvertor extends Convertor {
 		if (typeof compositePKs !== 'undefined' && compositePKs.length > 0) {
 			statement += ',\n';
 			const compositePK = PgSquasher.unsquashPK(compositePKs[0]);
-			statement += `\tCONSTRAINT "${st.compositePkName}" PRIMARY KEY(\"${compositePK.columns.join(`","`)}\")`;
-			// statement += `\n`;
+			const deferrablePK = compositePK.deferrable ? ` ${compositePK.deferrable.toUpperCase()}` : '';
+			const initiallyPK = compositePK.initially ? ` INITIALLY ${compositePK.initially.toUpperCase()}` : '';
+			statement += `\tCONSTRAINT "${st.compositePkName}" PRIMARY KEY(\"${compositePK.columns.join(`","`)}\")${deferrablePK}${initiallyPK}`;
 		}
 
 		if (
@@ -466,10 +467,11 @@ class PgCreateTableConvertor extends Convertor {
 			for (const uniqueConstraint of uniqueConstraints) {
 				statement += ',\n';
 				const unsquashedUnique = PgSquasher.unsquashUnique(uniqueConstraint);
+				const deferrableUnq = unsquashedUnique.deferrable ? ` ${unsquashedUnique.deferrable.toUpperCase()}` : '';
+				const initiallyUnq = unsquashedUnique.initially ? ` INITIALLY ${unsquashedUnique.initially.toUpperCase()}` : '';
 				statement += `\tCONSTRAINT "${unsquashedUnique.name}" UNIQUE${
 					unsquashedUnique.nullsNotDistinct ? ' NULLS NOT DISTINCT' : ''
-				}(\"${unsquashedUnique.columns.join(`","`)}\")`;
-				// statement += `\n`;
+				}(\"${unsquashedUnique.columns.join(`","`)}\")${deferrableUnq}${initiallyUnq}`;
 			}
 		}
 
@@ -1154,9 +1156,11 @@ class PgAlterTableAddUniqueConstraintConvertor extends Convertor {
 			? `"${statement.schema}"."${statement.tableName}"`
 			: `"${statement.tableName}"`;
 
+		const deferrableStr = unsquashed.deferrable ? ` ${unsquashed.deferrable.toUpperCase()}` : '';
+		const initiallyStr = unsquashed.initially ? ` INITIALLY ${unsquashed.initially.toUpperCase()}` : '';
 		return `ALTER TABLE ${tableNameWithSchema} ADD CONSTRAINT "${unsquashed.name}" UNIQUE${
 			unsquashed.nullsNotDistinct ? ' NULLS NOT DISTINCT' : ''
-		}("${unsquashed.columns.join('","')}");`;
+		}("${unsquashed.columns.join('","')}")${deferrableStr}${initiallyStr};`;
 	}
 }
 
@@ -3076,15 +3080,17 @@ class PgAlterTableCreateCompositePrimaryKeyConvertor extends Convertor {
 	}
 
 	convert(statement: JsonCreateCompositePK) {
-		const { name, columns } = PgSquasher.unsquashPK(statement.data);
+		const { name, columns, deferrable, initially } = PgSquasher.unsquashPK(statement.data);
 
 		const tableNameWithSchema = statement.schema
 			? `"${statement.schema}"."${statement.tableName}"`
 			: `"${statement.tableName}"`;
 
+		const deferrableStr = deferrable ? ` ${deferrable.toUpperCase()}` : '';
+		const initiallyStr = initially ? ` INITIALLY ${initially.toUpperCase()}` : '';
 		return `ALTER TABLE ${tableNameWithSchema} ADD CONSTRAINT "${statement.constraintName}" PRIMARY KEY("${
 			columns.join('","')
-		}");`;
+		}")${deferrableStr}${initiallyStr};`;
 	}
 }
 class PgAlterTableDeleteCompositePrimaryKeyConvertor extends Convertor {
@@ -3110,7 +3116,7 @@ class PgAlterTableAlterCompositePrimaryKeyConvertor extends Convertor {
 
 	convert(statement: JsonAlterCompositePK) {
 		const { name, columns } = PgSquasher.unsquashPK(statement.old);
-		const { name: newName, columns: newColumns } = PgSquasher.unsquashPK(
+		const { name: newName, columns: newColumns, deferrable, initially } = PgSquasher.unsquashPK(
 			statement.new,
 		);
 
@@ -3118,9 +3124,11 @@ class PgAlterTableAlterCompositePrimaryKeyConvertor extends Convertor {
 			? `"${statement.schema}"."${statement.tableName}"`
 			: `"${statement.tableName}"`;
 
+		const deferrableStr = deferrable ? ` ${deferrable.toUpperCase()}` : '';
+		const initiallyStr = initially ? ` INITIALLY ${initially.toUpperCase()}` : '';
 		return `ALTER TABLE ${tableNameWithSchema} DROP CONSTRAINT "${statement.oldConstraintName}";\n${BREAKPOINT}ALTER TABLE ${tableNameWithSchema} ADD CONSTRAINT "${statement.newConstraintName}" PRIMARY KEY("${
 			newColumns.join('","')
-		}");`;
+		}")${deferrableStr}${initiallyStr};`;
 	}
 }
 
@@ -3345,9 +3353,13 @@ class PgCreateForeignKeyConvertor extends Convertor {
 			onDelete,
 			onUpdate,
 			schemaTo,
+			deferrable,
+			initially,
 		} = PgSquasher.unsquashFK(statement.data);
 		const onDeleteStatement = onDelete ? ` ON DELETE ${onDelete}` : '';
 		const onUpdateStatement = onUpdate ? ` ON UPDATE ${onUpdate}` : '';
+		const deferrableStatement = deferrable ? ` ${deferrable.toUpperCase()}` : '';
+		const initiallyStatement = initially ? ` INITIALLY ${initially.toUpperCase()}` : '';
 		const fromColumnsString = columnsFrom.map((it) => `"${it}"`).join(',');
 		const toColumnsString = columnsTo.map((it) => `"${it}"`).join(',');
 
@@ -3360,7 +3372,7 @@ class PgCreateForeignKeyConvertor extends Convertor {
 			: `"${tableTo}"`;
 
 		const alterStatement =
-			`ALTER TABLE ${tableNameWithSchema} ADD CONSTRAINT "${name}" FOREIGN KEY (${fromColumnsString}) REFERENCES ${tableToNameWithSchema}(${toColumnsString})${onDeleteStatement}${onUpdateStatement};`;
+			`ALTER TABLE ${tableNameWithSchema} ADD CONSTRAINT "${name}" FOREIGN KEY (${fromColumnsString}) REFERENCES ${tableToNameWithSchema}(${toColumnsString})${onDeleteStatement}${onUpdateStatement}${deferrableStatement}${initiallyStatement};`;
 
 		return alterStatement;
 	}
@@ -3444,6 +3456,12 @@ class PgAlterForeignKeyConvertor extends Convertor {
 		const onUpdateStatement = newFk.onUpdate
 			? ` ON UPDATE ${newFk.onUpdate}`
 			: '';
+		const deferrableStatement = newFk.deferrable
+			? ` ${newFk.deferrable.toUpperCase()}`
+			: '';
+		const initiallyStatement = newFk.initially
+			? ` INITIALLY ${newFk.initially.toUpperCase()}`
+			: '';
 
 		const fromColumnsString = newFk.columnsFrom
 			.map((it) => `"${it}"`)
@@ -3459,7 +3477,7 @@ class PgAlterForeignKeyConvertor extends Convertor {
 			: `"${newFk.tableFrom}"`;
 
 		const alterStatement =
-			`ALTER TABLE ${tableFromNameWithSchema} ADD CONSTRAINT "${newFk.name}" FOREIGN KEY (${fromColumnsString}) REFERENCES ${tableToNameWithSchema}(${toColumnsString})${onDeleteStatement}${onUpdateStatement};`;
+			`ALTER TABLE ${tableFromNameWithSchema} ADD CONSTRAINT "${newFk.name}" FOREIGN KEY (${fromColumnsString}) REFERENCES ${tableToNameWithSchema}(${toColumnsString})${onDeleteStatement}${onUpdateStatement}${deferrableStatement}${initiallyStatement};`;
 
 		sql += alterStatement;
 		return sql;

--- a/drizzle-kit/tests/pg-tables.test.ts
+++ b/drizzle-kit/tests/pg-tables.test.ts
@@ -106,7 +106,7 @@ test('add table #3', async () => {
 				type: 'serial',
 			},
 		],
-		compositePKs: ['id;users_pk'],
+		compositePKs: ['id;users_pk;;'],
 		policies: [],
 		uniqueConstraints: [],
 		isRLSEnabled: false,
@@ -954,4 +954,191 @@ test('optional db aliases (camel case)', async () => {
 	const st7 = `CREATE INDEX "t1Idx" ON "t1" USING btree ("t1Idx") WHERE "t1"."t1Idx" > 0;`;
 
 	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6, st7]);
+});
+
+test('deferrable unique constraint', async () => {
+	const from = {};
+	const to = {
+		table: pgTable('users', {
+			id: serial('id').primaryKey(),
+			name: text('name').notNull(),
+		}, (t) => ({
+			unq: unique('name_unique').on(t.name).deferrable().initiallyDeferred(),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements).toStrictEqual([
+		'CREATE TABLE "users" (\n\t"id" serial PRIMARY KEY NOT NULL,\n\t"name" text NOT NULL,\n\tCONSTRAINT "name_unique" UNIQUE("name") DEFERRABLE INITIALLY DEFERRED\n);\n',
+	]);
+});
+
+test('deferrable unique constraint: initially immediate', async () => {
+	const from = {};
+	const to = {
+		table: pgTable('users', {
+			id: serial('id').primaryKey(),
+			email: text('email').notNull(),
+		}, (t) => ({
+			unq: unique('email_unique').on(t.email).deferrable().initiallyImmediate(),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements).toStrictEqual([
+		'CREATE TABLE "users" (\n\t"id" serial PRIMARY KEY NOT NULL,\n\t"email" text NOT NULL,\n\tCONSTRAINT "email_unique" UNIQUE("email") DEFERRABLE INITIALLY IMMEDIATE\n);\n',
+	]);
+});
+
+test('add deferrable unique constraint to existing table', async () => {
+	const from = {
+		table: pgTable('users', {
+			id: serial('id').primaryKey(),
+			name: text('name').notNull(),
+		}),
+	};
+	const to = {
+		table: pgTable('users', {
+			id: serial('id').primaryKey(),
+			name: text('name').notNull(),
+		}, (t) => ({
+			unq: unique('name_unique').on(t.name).deferrable().initiallyDeferred(),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements).toStrictEqual([
+		'ALTER TABLE "users" ADD CONSTRAINT "name_unique" UNIQUE("name") DEFERRABLE INITIALLY DEFERRED;',
+	]);
+});
+
+test('deferrable composite primary key', async () => {
+	const from = {};
+	const to = {
+		table: pgTable('items', {
+			col1: integer('col1').notNull(),
+			col2: integer('col2').notNull(),
+		}, (t) => ({
+			pk: primaryKey({
+				name: 'items_pk',
+				columns: [t.col1, t.col2],
+				deferrable: 'deferrable',
+				initially: 'deferred',
+			}),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements).toStrictEqual([
+		'CREATE TABLE "items" (\n\t"col1" integer NOT NULL,\n\t"col2" integer NOT NULL,\n\tCONSTRAINT "items_pk" PRIMARY KEY("col1","col2") DEFERRABLE INITIALLY DEFERRED\n);\n',
+	]);
+});
+
+test('alter deferrable composite primary key', async () => {
+	const from = {
+		table: pgTable('items', {
+			col1: integer('col1').notNull(),
+			col2: integer('col2').notNull(),
+			col3: integer('col3').notNull(),
+		}, (t) => ({
+			pk: primaryKey({
+				name: 'items_pk',
+				columns: [t.col1, t.col2],
+			}),
+		})),
+	};
+	const to = {
+		table: pgTable('items', {
+			col1: integer('col1').notNull(),
+			col2: integer('col2').notNull(),
+			col3: integer('col3').notNull(),
+		}, (t) => ({
+			pk: primaryKey({
+				name: 'items_pk',
+				columns: [t.col1, t.col2],
+				deferrable: 'deferrable',
+				initially: 'deferred',
+			}),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements).toStrictEqual([
+		'ALTER TABLE "items" DROP CONSTRAINT "items_pk";\n--> statement-breakpoint\nALTER TABLE "items" ADD CONSTRAINT "items_pk" PRIMARY KEY("col1","col2") DEFERRABLE INITIALLY DEFERRED;',
+	]);
+});
+
+test('deferrable foreign key', async () => {
+	const from = {};
+	const to = {
+		users: pgTable('users', {
+			id: serial('id').primaryKey(),
+		}),
+		posts: pgTable('posts', {
+			id: serial('id').primaryKey(),
+			userId: integer('user_id'),
+		}, (t) => ({
+			fk: foreignKey({
+				columns: [t.userId],
+				foreignColumns: [to.users.id],
+				name: 'posts_user_fk',
+			}).deferrable().initiallyDeferred(),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements[0]).toContain('CREATE TABLE "users"');
+	expect(sqlStatements[1]).toContain('CREATE TABLE "posts"');
+	expect(sqlStatements[2]).toBe(
+		'ALTER TABLE "posts" ADD CONSTRAINT "posts_user_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action DEFERRABLE INITIALLY DEFERRED;',
+	);
+});
+
+test('deferrable foreign key: initially immediate', async () => {
+	const from = {};
+	const to = {
+		users: pgTable('users', {
+			id: serial('id').primaryKey(),
+		}),
+		posts: pgTable('posts', {
+			id: serial('id').primaryKey(),
+			userId: integer('user_id'),
+		}, (t) => ({
+			fk: foreignKey({
+				columns: [t.userId],
+				foreignColumns: [to.users.id],
+				name: 'posts_user_fk',
+			}).onDelete('cascade').deferrable().initiallyImmediate(),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements[2]).toBe(
+		'ALTER TABLE "posts" ADD CONSTRAINT "posts_user_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action DEFERRABLE INITIALLY IMMEDIATE;',
+	);
+});
+
+test('not deferrable unique constraint', async () => {
+	const from = {};
+	const to = {
+		table: pgTable('users', {
+			id: serial('id').primaryKey(),
+			name: text('name').notNull(),
+		}, (t) => ({
+			unq: unique('name_unique').on(t.name).notDeferrable(),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(from, to, []);
+
+	expect(sqlStatements).toStrictEqual([
+		'CREATE TABLE "users" (\n\t"id" serial PRIMARY KEY NOT NULL,\n\t"name" text NOT NULL,\n\tCONSTRAINT "name_unique" UNIQUE("name") NOT DEFERRABLE\n);\n',
+	]);
 });

--- a/drizzle-orm/src/pg-core/foreign-keys.ts
+++ b/drizzle-orm/src/pg-core/foreign-keys.ts
@@ -24,6 +24,12 @@ export class ForeignKeyBuilder {
 	/** @internal */
 	_onDelete: UpdateDeleteAction | undefined = 'no action';
 
+	/** @internal */
+	_deferrable: 'deferrable' | 'not deferrable' | undefined;
+
+	/** @internal */
+	_initially: 'deferred' | 'immediate' | undefined;
+
 	constructor(
 		config: () => {
 			name?: string;
@@ -55,6 +61,26 @@ export class ForeignKeyBuilder {
 		return this;
 	}
 
+	deferrable(): this {
+		this._deferrable = 'deferrable';
+		return this;
+	}
+
+	notDeferrable(): this {
+		this._deferrable = 'not deferrable';
+		return this;
+	}
+
+	initiallyDeferred(): this {
+		this._initially = 'deferred';
+		return this;
+	}
+
+	initiallyImmediate(): this {
+		this._initially = 'immediate';
+		return this;
+	}
+
 	/** @internal */
 	build(table: PgTable): ForeignKey {
 		return new ForeignKey(table, this);
@@ -69,11 +95,15 @@ export class ForeignKey {
 	readonly reference: Reference;
 	readonly onUpdate: UpdateDeleteAction | undefined;
 	readonly onDelete: UpdateDeleteAction | undefined;
+	readonly deferrable: 'deferrable' | 'not deferrable' | undefined;
+	readonly initially: 'deferred' | 'immediate' | undefined;
 
 	constructor(readonly table: PgTable, builder: ForeignKeyBuilder) {
 		this.reference = builder.reference;
 		this.onUpdate = builder._onUpdate;
 		this.onDelete = builder._onDelete;
+		this.deferrable = builder._deferrable;
+		this.initially = builder._initially;
 	}
 
 	getName(): string {

--- a/drizzle-orm/src/pg-core/primary-keys.ts
+++ b/drizzle-orm/src/pg-core/primary-keys.ts
@@ -6,7 +6,7 @@ export function primaryKey<
 	TTableName extends string,
 	TColumn extends AnyPgColumn<{ tableName: TTableName }>,
 	TColumns extends AnyPgColumn<{ tableName: TTableName }>[],
->(config: { name?: string; columns: [TColumn, ...TColumns] }): PrimaryKeyBuilder;
+>(config: { name?: string; columns: [TColumn, ...TColumns]; deferrable?: 'deferrable' | 'not deferrable'; initially?: 'deferred' | 'immediate' }): PrimaryKeyBuilder;
 /**
  * @deprecated: Please use primaryKey({ columns: [] }) instead of this function
  * @param columns
@@ -17,7 +17,7 @@ export function primaryKey<
 >(...columns: TColumns): PrimaryKeyBuilder;
 export function primaryKey(...config: any) {
 	if (config[0].columns) {
-		return new PrimaryKeyBuilder(config[0].columns, config[0].name);
+		return new PrimaryKeyBuilder(config[0].columns, config[0].name, config[0].deferrable, config[0].initially);
 	}
 	return new PrimaryKeyBuilder(config);
 }
@@ -31,17 +31,27 @@ export class PrimaryKeyBuilder {
 	/** @internal */
 	name?: string;
 
+	/** @internal */
+	_deferrable: 'deferrable' | 'not deferrable' | undefined;
+
+	/** @internal */
+	_initially: 'deferred' | 'immediate' | undefined;
+
 	constructor(
 		columns: PgColumn[],
 		name?: string,
+		deferrable?: 'deferrable' | 'not deferrable',
+		initially?: 'deferred' | 'immediate',
 	) {
 		this.columns = columns;
 		this.name = name;
+		this._deferrable = deferrable;
+		this._initially = initially;
 	}
 
 	/** @internal */
 	build(table: PgTable): PrimaryKey {
-		return new PrimaryKey(table, this.columns, this.name);
+		return new PrimaryKey(table, this.columns, this.name, this._deferrable, this._initially);
 	}
 }
 
@@ -50,10 +60,20 @@ export class PrimaryKey {
 
 	readonly columns: AnyPgColumn<{}>[];
 	readonly name?: string;
+	readonly deferrable: 'deferrable' | 'not deferrable' | undefined;
+	readonly initially: 'deferred' | 'immediate' | undefined;
 
-	constructor(readonly table: PgTable, columns: AnyPgColumn<{}>[], name?: string) {
+	constructor(
+		readonly table: PgTable,
+		columns: AnyPgColumn<{}>[],
+		name?: string,
+		deferrable?: 'deferrable' | 'not deferrable',
+		initially?: 'deferred' | 'immediate',
+	) {
 		this.columns = columns;
 		this.name = name;
+		this.deferrable = deferrable;
+		this.initially = initially;
 	}
 
 	getName(): string {

--- a/drizzle-orm/src/pg-core/unique-constraint.ts
+++ b/drizzle-orm/src/pg-core/unique-constraint.ts
@@ -18,6 +18,10 @@ export class UniqueConstraintBuilder {
 	columns: PgColumn[];
 	/** @internal */
 	nullsNotDistinctConfig = false;
+	/** @internal */
+	_deferrable: 'deferrable' | 'not deferrable' | undefined;
+	/** @internal */
+	_initially: 'deferred' | 'immediate' | undefined;
 
 	constructor(
 		columns: PgColumn[],
@@ -31,9 +35,29 @@ export class UniqueConstraintBuilder {
 		return this;
 	}
 
+	deferrable() {
+		this._deferrable = 'deferrable';
+		return this;
+	}
+
+	notDeferrable() {
+		this._deferrable = 'not deferrable';
+		return this;
+	}
+
+	initiallyDeferred() {
+		this._initially = 'deferred';
+		return this;
+	}
+
+	initiallyImmediate() {
+		this._initially = 'immediate';
+		return this;
+	}
+
 	/** @internal */
 	build(table: PgTable): UniqueConstraint {
-		return new UniqueConstraint(table, this.columns, this.nullsNotDistinctConfig, this.name);
+		return new UniqueConstraint(table, this.columns, this.nullsNotDistinctConfig, this.name, this._deferrable, this._initially);
 	}
 }
 
@@ -60,11 +84,22 @@ export class UniqueConstraint {
 	readonly columns: PgColumn[];
 	readonly name?: string;
 	readonly nullsNotDistinct: boolean = false;
+	readonly deferrable: 'deferrable' | 'not deferrable' | undefined;
+	readonly initially: 'deferred' | 'immediate' | undefined;
 
-	constructor(readonly table: PgTable, columns: PgColumn[], nullsNotDistinct: boolean, name?: string) {
+	constructor(
+		readonly table: PgTable,
+		columns: PgColumn[],
+		nullsNotDistinct: boolean,
+		name?: string,
+		deferrable?: 'deferrable' | 'not deferrable',
+		initially?: 'deferred' | 'immediate',
+	) {
 		this.columns = columns;
 		this.name = name ?? uniqueKeyName(this.table, this.columns.map((column) => column.name));
 		this.nullsNotDistinct = nullsNotDistinct;
+		this.deferrable = deferrable;
+		this.initially = initially;
 	}
 
 	getName() {


### PR DESCRIPTION
## Summary

Add `DEFERRABLE` / `NOT DEFERRABLE` and `INITIALLY DEFERRED` / `INITIALLY IMMEDIATE` support for unique constraints, foreign keys, and composite primary keys in PostgreSQL.

PostgreSQL allows constraints to be deferred to the end of a transaction, which is essential for certain data manipulation patterns such as swapping unique values, circular foreign key references, and bulk data loading.

### API

**Unique constraints:**
```typescript
pgTable('users', {
  name: text('name').notNull(),
}, (t) => ({
  unq: unique('name_unique').on(t.name).deferrable().initiallyDeferred(),
}));
```

**Foreign keys:**
```typescript
foreignKey({
  columns: [posts.userId],
  foreignColumns: [users.id],
}).onDelete('cascade').deferrable().initiallyDeferred();
```

**Composite primary keys:**
```typescript
primaryKey({
  columns: [t.col1, t.col2],
  deferrable: 'deferrable',
  initially: 'deferred',
});
```

### Changes

**drizzle-orm (3 files):**
- `pg-core/unique-constraint.ts`: Add `deferrable()`, `notDeferrable()`, `initiallyDeferred()`, `initiallyImmediate()` methods to `UniqueConstraintBuilder`
- `pg-core/foreign-keys.ts`: Add same methods to `ForeignKeyBuilder`
- `pg-core/primary-keys.ts`: Add `deferrable` and `initially` options to `primaryKey()` config

**drizzle-kit (3 files):**
- `serializer/pgSchema.ts`: Add `deferrable` and `initially` fields to FK, PK, and unique constraint schemas; update squash/unsquash functions
- `serializer/pgSerializer.ts`: Serialize deferrable properties during snapshot generation; query `pg_constraint.condeferrable`/`condeferred` during introspection
- `sqlgenerator.ts`: Emit `DEFERRABLE`/`NOT DEFERRABLE` and `INITIALLY DEFERRED`/`INITIALLY IMMEDIATE` clauses in CREATE TABLE and ALTER TABLE statements

**Tests (1 file):**
- `tests/pg-tables.test.ts`: 9 new tests covering deferrable unique constraints, foreign keys, and composite primary keys

Closes #1429