### PR TITLE
Added Tests for PostgreSQL and documentation

### DIFF
--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -1,5 +1,20 @@
 import { entityKind } from '~/entity.ts';
 
+/**
+ * Base error class for all Drizzle ORM errors.
+ * Extend this class when creating custom Drizzle errors.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await db.select().from(users);
+ * } catch (error) {
+ *   if (error instanceof DrizzleError) {
+ *     console.error('Drizzle error:', error.message);
+ *   }
+ * }
+ * ```
+ */
 export class DrizzleError extends Error {
 	static readonly [entityKind]: string = 'DrizzleError';
 
@@ -10,10 +25,29 @@ export class DrizzleError extends Error {
 	}
 }
 
+/**
+ * Error thrown when a database query fails to execute.
+ * Contains the original query and parameters for debugging.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await db.execute(sql`SELECT * FROM users`);
+ * } catch (error) {
+ *   if (error instanceof DrizzleQueryError) {
+ *     console.error('Query failed:', error.query);
+ *     console.error('With params:', error.params);
+ *   }
+ * }
+ * ```
+ */
 export class DrizzleQueryError extends Error {
 	constructor(
+		/** The SQL query string that failed */
 		public query: string,
+		/** The parameters that were passed to the query */
 		public params: any[],
+		/** The underlying error that caused the query to fail */
 		public override cause?: Error,
 	) {
 		super(`Failed query: ${query}\nparams: ${params}`);
@@ -24,6 +58,19 @@ export class DrizzleQueryError extends Error {
 	}
 }
 
+/**
+ * Error thrown when a transaction is explicitly rolled back.
+ * This is used for intentional rollbacks via `tx.rollback()`.
+ *
+ * @example
+ * ```ts
+ * await db.transaction(async (tx) => {
+ *   await tx.insert(users).values({ name: 'John' });
+ *   // Rollback the transaction
+ *   tx.rollback();
+ * });
+ * ```
+ */
 export class TransactionRollbackError extends DrizzleError {
 	static override readonly [entityKind]: string = 'TransactionRollbackError';
 

--- a/drizzle-orm/src/pg-core/query-builders/insert.ts
+++ b/drizzle-orm/src/pg-core/query-builders/insert.ts
@@ -174,7 +174,6 @@ export interface PgInsertOnConflictDoUpdateConfig<T extends AnyPgInsert> {
 	target: IndexColumn | IndexColumn[];
 	/** @deprecated use either `targetWhere` or `setWhere` */
 	where?: SQL;
-	// TODO: add tests for targetWhere and setWhere
 	targetWhere?: SQL;
 	setWhere?: SQL;
 	set: PgUpdateSetSource<T['_']['table']>;

--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -157,7 +157,6 @@ export type SQLiteInsertOnConflictDoUpdateConfig<T extends AnySQLiteInsert> = {
 	target: IndexColumn | IndexColumn[];
 	/** @deprecated - use either `targetWhere` or `setWhere` */
 	where?: SQL;
-	// TODO: add tests for targetWhere and setWhere
 	targetWhere?: SQL;
 	setWhere?: SQL;
 	set: SQLiteUpdateSetSource<T['_']['table']>;

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -1550,6 +1550,84 @@ export function tests() {
 			});
 		});
 
+		test('build query insert with onConflict do update with targetWhere', async (ctx) => {
+			const { db } = ctx.pg;
+
+			const query = db
+				.insert(usersTable)
+				.values({ name: 'John', jsonb: ['foo', 'bar'] })
+				.onConflictDoUpdate({
+					target: usersTable.id,
+					targetWhere: sql`${usersTable.verified} = true`,
+					set: { name: 'John1' },
+				})
+				.toSQL();
+
+			expect(query).toEqual({
+				sql:
+					'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id") where "users"."verified" = true do update set "name" = $3',
+				params: ['John', '["foo","bar"]', 'John1'],
+			});
+		});
+
+		test('build query insert with onConflict do update with setWhere', async (ctx) => {
+			const { db } = ctx.pg;
+
+			const query = db
+				.insert(usersTable)
+				.values({ name: 'John', jsonb: ['foo', 'bar'] })
+				.onConflictDoUpdate({
+					target: usersTable.id,
+					set: { name: 'John1' },
+					setWhere: sql`${usersTable.name} != 'Admin'`,
+				})
+				.toSQL();
+
+			expect(query).toEqual({
+				sql:
+					'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id") do update set "name" = $3 where "users"."name" != \'Admin\'',
+				params: ['John', '["foo","bar"]', 'John1'],
+			});
+		});
+
+		test('build query insert with onConflict do update with targetWhere and setWhere', async (ctx) => {
+			const { db } = ctx.pg;
+
+			const query = db
+				.insert(usersTable)
+				.values({ name: 'John', jsonb: ['foo', 'bar'] })
+				.onConflictDoUpdate({
+					target: usersTable.id,
+					targetWhere: sql`${usersTable.verified} = true`,
+					set: { name: 'John1' },
+					setWhere: sql`${usersTable.name} != 'Admin'`,
+				})
+				.toSQL();
+
+			expect(query).toEqual({
+				sql:
+					'insert into "users" ("id", "name", "verified", "jsonb", "created_at") values (default, $1, default, $2, default) on conflict ("id") where "users"."verified" = true do update set "name" = $3 where "users"."name" != \'Admin\'',
+				params: ['John', '["foo","bar"]', 'John1'],
+			});
+		});
+
+		test('insert with onConflict do update with targetWhere and setWhere throws error when used with deprecated where', async (ctx) => {
+			const { db } = ctx.pg;
+
+			expect(() => {
+				db
+					.insert(usersTable)
+					.values({ name: 'John' })
+					.onConflictDoUpdate({
+						target: usersTable.id,
+						where: sql`${usersTable.verified} = true`,
+						targetWhere: sql`${usersTable.verified} = true`,
+						set: { name: 'John1' },
+					})
+					.toSQL();
+			}).toThrow('You cannot use both "where" and "targetWhere"/"setWhere" at the same time');
+		});
+
 		test('build query insert with onConflict do nothing', async (ctx) => {
 			const { db } = ctx.pg;
 

--- a/integration-tests/tests/sqlite/sqlite-common.ts
+++ b/integration-tests/tests/sqlite/sqlite-common.ts
@@ -2146,6 +2146,88 @@ export function tests() {
 			expect(res).toEqual([{ id: 1, name: 'John1', verified: true }]);
 		});
 
+		test('insert with onConflict do update with targetWhere', async (ctx) => {
+			const { db } = ctx.sqlite;
+
+			await db
+				.insert(usersTable)
+				.values([{ id: 1, name: 'John', verified: true }])
+				.run();
+
+			await db
+				.insert(usersTable)
+				.values({ id: 1, name: 'John1' })
+				.onConflictDoUpdate({
+					target: usersTable.id,
+					targetWhere: eq(usersTable.verified, true),
+					set: { name: 'John Updated' },
+				})
+				.run();
+
+			const res = await db
+				.select({ id: usersTable.id, name: usersTable.name })
+				.from(usersTable)
+				.where(eq(usersTable.id, 1))
+				.all();
+
+			expect(res).toEqual([{ id: 1, name: 'John Updated' }]);
+		});
+
+		test('insert with onConflict do update with setWhere', async (ctx) => {
+			const { db } = ctx.sqlite;
+
+			await db
+				.insert(usersTable)
+				.values([{ id: 1, name: 'John', verified: false }])
+				.run();
+
+			await db
+				.insert(usersTable)
+				.values({ id: 1, name: 'John1' })
+				.onConflictDoUpdate({
+					target: usersTable.id,
+					set: { name: 'John Updated' },
+					setWhere: eq(usersTable.verified, false),
+				})
+				.run();
+
+			const res = await db
+				.select({ id: usersTable.id, name: usersTable.name })
+				.from(usersTable)
+				.where(eq(usersTable.id, 1))
+				.all();
+
+			expect(res).toEqual([{ id: 1, name: 'John Updated' }]);
+		});
+
+		test('insert with onConflict do update with targetWhere and setWhere', async (ctx) => {
+			const { db } = ctx.sqlite;
+
+			await db
+				.insert(usersTable)
+				.values([{ id: 1, name: 'John', verified: true }])
+				.run();
+
+			await db
+				.insert(usersTable)
+				.values({ id: 1, name: 'John1' })
+				.onConflictDoUpdate({
+					target: usersTable.id,
+					targetWhere: eq(usersTable.verified, true),
+					set: { name: 'John Updated' },
+					setWhere: sql`${usersTable.name} != 'Admin'`,
+				})
+				.run();
+
+			const res = await db
+				.select({ id: usersTable.id, name: usersTable.name })
+				.from(usersTable)
+				.where(eq(usersTable.id, 1))
+				.all();
+
+			expect(res).toEqual([{ id: 1, name: 'John Updated' }]);
+		});
+
 		test('insert with onConflict do update using composite pk', async (ctx) => {
 			const { db } = ctx.sqlite;
 


### PR DESCRIPTION
### Tests Added
- **PostgreSQL** (`integration-tests/tests/pg/pg-common.ts`):
  - `build query insert with onConflict do update with targetWhere` - SQL generation test
  - `build query insert with onConflict do update with setWhere` - SQL generation test
  - `build query insert with onConflict do update with targetWhere and setWhere` - Combined test
  - `throws error when used with deprecated where` - Error handling test

- **SQLite** (`integration-tests/tests/sqlite/sqlite-common.ts`):
  - `insert with onConflict do update with targetWhere` - Integration test
  - `insert with onConflict do update with setWhere` - Integration test
  - `insert with onConflict do update with targetWhere and setWhere` - Combined integration test

### Documentation Added
- Added JSDoc comments with usage examples to:
  - `DrizzleError`
  - `DrizzleQueryError` (including parameter documentation)
  - `TransactionRollbackError`

### Cleanup
- Removed TODO comments from:
  - `drizzle-orm/src/pg-core/query-builders/insert.ts`
  - `drizzle-orm/src/sqlite-core/query-builders/insert.ts`