### PR TITLE
[Kit] Remove stray backtick in CLI help text

### DIFF
--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -224,7 +224,7 @@ const optionsFilters = {
 	tablesFilter: string().desc('Table name filters'),
 	schemaFilters: string().desc('Schema name filters'),
 	extensionsFilters: string().desc(
-		'`Database extensions internal database filters',
+		'Database extensions internal database filters',
 	),
 } as const;
 


### PR DESCRIPTION
## Summary
- Removed an accidental backtick character (`` ` ``) at the beginning of the `extensionsFilters` description string in `drizzle-kit/src/cli/schema.ts`
- Before: `` '`Database extensions internal database filters' ``
- After: `'Database extensions internal database filters'`

## Test plan
- No functional change; typo-only fix in a CLI help description string