### PR TITLE
[Validators] Create upsert schema

### DIFF
--- a/drizzle-orm/src/table.ts
+++ b/drizzle-orm/src/table.ts
@@ -152,7 +152,7 @@ export type MapColumnName<TName extends string, TColumn extends Column, TDBColum
 
 export type InferModelFromColumns<
 	TColumns extends Columns,
-	TInferMode extends 'select' | 'insert' = 'select',
+	TInferMode extends 'select' | 'insert' | 'upsert' = 'select',
 	TConfig extends { override?: boolean } = { dbColumnNames: false; override: false },
 > = Simplify<
 	TInferMode extends 'insert' ?
@@ -195,6 +195,11 @@ export type InferInsertModel<
 	TTable extends Table,
 	TOverride extends { override?: boolean } = { override: false },
 > = InferModelFromColumns<TTable['_']['columns'], 'insert', TOverride>;
+
+export type InferUpsertModel<
+	TTable extends Table,
+	TOverride extends { override?: boolean } = { override: false },
+> = InferModelFromColumns<TTable['_']['columns'], 'upsert', TOverride>;
 
 export type InferEnum<T> = T extends { enumValues: readonly (infer U)[] } ? U
 	: never;

--- a/drizzle-orm/src/zod/column.types.ts
+++ b/drizzle-orm/src/zod/column.types.ts
@@ -101,7 +101,7 @@ type HandleUpdateColumn<
 	: z.ZodOptional<z.ZodNullable<TSchema>>;
 
 export type HandleColumn<
-	TType extends 'select' | 'insert' | 'update',
+	TType extends 'select' | 'insert' | 'update' | 'upsert',
 	TColumn extends Column,
 	TCoerce extends CoerceOptions,
 > = TType extends 'select' ? HandleSelectColumn<GetZodType<TColumn, TCoerce>, TColumn>

--- a/drizzle-orm/src/zod/schema.ts
+++ b/drizzle-orm/src/zod/schema.ts
@@ -14,6 +14,7 @@ import type {
 	CreateSchemaFactoryOptions,
 	CreateSelectSchema,
 	CreateUpdateSchema,
+	CreateUpsertSchema,
 	FactoryOptions,
 } from './schema.types.ts';
 
@@ -92,6 +93,15 @@ const updateConditions: Conditions = {
 	nullable: (column) => !column.notNull,
 };
 
+const upsertConditions: Conditions = {
+	never: () => false,
+	optional: (column) =>
+		!column.notNull || (column.notNull && column.hasDefault) || column?.generated?.type === 'always'
+		|| column?.generatedIdentity?.type === 'always'
+		|| ('identity' in (column ?? {}) && typeof (column as any)?.identity !== 'undefined'),
+	nullable: (column) => !column.notNull,
+};
+
 export const createSelectSchema: CreateSelectSchema<undefined> = (
 	entity: Table | View | PgEnum<[string, ...string[]]>,
 	refine?: Record<string, any>,
@@ -117,6 +127,14 @@ export const createUpdateSchema: CreateUpdateSchema<undefined> = (
 ) => {
 	const columns = getColumns(entity);
 	return handleColumns(columns, refine ?? {}, updateConditions) as any;
+};
+
+export const createUpsertSchema: CreateUpsertSchema<undefined> = (
+	entity: Table,
+	refine?: Record<string, any>,
+) => {
+	const columns = getColumns(entity);
+	return handleColumns(columns, refine ?? {}, upsertConditions) as any;
 };
 
 export function createSchemaFactory<
@@ -149,5 +167,13 @@ export function createSchemaFactory<
 		return handleColumns(columns, refine ?? {}, updateConditions, options) as any;
 	};
 
-	return { createSelectSchema, createInsertSchema, createUpdateSchema };
+	const createUpsertSchema: CreateUpsertSchema<TCoerce> = (
+		entity: Table,
+		refine?: Record<string, any>,
+	) => {
+		const columns = getColumns(entity);
+		return handleColumns(columns, refine ?? {}, upsertConditions, options) as any;
+	};
+
+	return { createSelectSchema, createInsertSchema, createUpdateSchema, createUpsertSchema };
 }

--- a/drizzle-orm/src/zod/schema.types.internal.ts
+++ b/drizzle-orm/src/zod/schema.types.internal.ts
@@ -26,7 +26,7 @@ export type BuildRefine<
 };
 
 type HandleRefinement<
-	TType extends 'select' | 'insert' | 'update',
+	TType extends 'select' | 'insert' | 'update' | 'upsert',
 	TRefinement,
 	TColumn extends Column,
 > = TRefinement extends (schema: any) => z.ZodType ? (TColumn['_']['notNull'] extends true ? ReturnType<TRefinement>
@@ -43,7 +43,7 @@ type IsRefinementDefined<
 	: false;
 
 export type BuildSchema<
-	TType extends 'select' | 'insert' | 'update',
+	TType extends 'select' | 'insert' | 'update' | 'upsert',
 	TColumns extends Record<string, any>,
 	TRefinements extends Record<string, any> | undefined,
 	TCoerce extends CoerceOptions,

--- a/drizzle-orm/src/zod/schema.types.ts
+++ b/drizzle-orm/src/zod/schema.types.ts
@@ -2,7 +2,7 @@ import type { z } from 'zod/v4';
 import type { CockroachEnum } from '~/cockroach-core/columns/enum.ts';
 import type { PgEnum } from '~/pg-core/columns/enum.ts';
 import type { View } from '~/sql/sql.ts';
-import type { InferInsertModel, InferSelectModel, Table } from '~/table.ts';
+import type { InferInsertModel, InferSelectModel, InferUpsertModel, Table } from '~/table.ts';
 import type { BuildRefine, BuildSchema, NoUnknownKeys } from './schema.types.internal.ts';
 
 export interface CreateSelectSchema<
@@ -53,6 +53,19 @@ export interface CreateUpdateSchema<
 		table: TTable,
 		refine?: TRefine,
 	): BuildSchema<'update', TTable['_']['columns'], TRefine, TCoerce>;
+}
+
+export interface CreateUpsertSchema<
+	TCoerce extends CoerceOptions,
+> {
+	<TTable extends Table>(table: TTable): BuildSchema<'upsert', TTable['_']['columns'], undefined, TCoerce>;
+	<
+		TTable extends Table,
+		TRefine extends BuildRefine<Pick<TTable['_']['columns'], keyof InferUpsertModel<TTable>>, TCoerce>,
+	>(
+		table: TTable,
+		refine?: NoUnknownKeys<TRefine, InferUpsertModel<TTable>>,
+	): BuildSchema<'upsert', TTable['_']['columns'], TRefine, TCoerce>;
 }
 
 export interface CreateSchemaFactoryOptions<

--- a/integration-tests/tests/validators/zod/cockroach.test.ts
+++ b/integration-tests/tests/validators/zod/cockroach.test.ts
@@ -10,7 +10,13 @@ import {
 	text,
 } from 'drizzle-orm/cockroach-core';
 import { CONSTANTS } from 'drizzle-orm/utils';
-import { createInsertSchema, createSchemaFactory, createSelectSchema, createUpdateSchema } from 'drizzle-orm/zod';
+import {
+	createInsertSchema,
+	createSchemaFactory,
+	createSelectSchema,
+	createUpdateSchema,
+	createUpsertSchema,
+} from 'drizzle-orm/zod';
 import { jsonSchema } from 'drizzle-orm/zod/column';
 import type { TopLevelCondition } from 'json-rules-engine';
 import { test } from 'vitest';
@@ -84,6 +90,19 @@ test('table - update', (t) => {
 		name: textOptionalSchema,
 		age: int4NullableOptionalSchema,
 	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('table - upsert', (t) => {
+	const table = cockroachTable('test', {
+		id: int4().generatedAlwaysAsIdentity().primaryKey(),
+		name: text().notNull(),
+		age: int4(),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({ id: int4OptionalSchema, name: textSchema, age: int4NullableOptionalSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });
@@ -239,6 +258,31 @@ test('nullability - update', (t) => {
 	Expect<Equal<typeof result, typeof expected>>();
 });
 
+test('nullability - upsert', (t) => {
+	const table = cockroachTable('test', {
+		c1: int4(),
+		c2: int4().notNull(),
+		c3: int4().default(1),
+		c4: int4().notNull().default(1),
+		c5: int4().generatedAlwaysAs(sql`1`),
+		c6: int4().generatedAlwaysAsIdentity(),
+		c7: int4().generatedByDefaultAsIdentity(),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({
+		c1: int4NullableOptionalSchema,
+		c2: int4Schema,
+		c3: int4NullableOptionalSchema,
+		c4: int4OptionalSchema,
+		c5: int4NullableOptionalSchema,
+		c6: int4OptionalSchema,
+		c7: int4OptionalSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
 test('refine table - select', (t) => {
 	const table = cockroachTable('test', {
 		c1: int4(),
@@ -322,6 +366,28 @@ test('refine table - update', (t) => {
 		c1: int4NullableOptionalSchema,
 		c2: extendedOptionalSchema,
 		c3: customSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('refine table - upsert', (t) => {
+	const table = cockroachTable('test', {
+		c1: int4(),
+		c2: int4().notNull(),
+		c3: int4().notNull(),
+		c4: int4().generatedAlwaysAs(sql`1`),
+	});
+
+	const result = createUpsertSchema(table, {
+		c2: (schema) => schema.lte(1000),
+		c3: z.string().transform(Number),
+	});
+	const expected = z.object({
+		c1: int4NullableOptionalSchema,
+		c2: extendedSchema,
+		c3: customSchema,
+		c4: int4NullableOptionalSchema,
 	});
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
@@ -591,6 +657,12 @@ test('type coercion - mixed', (t) => {
 	const table = cockroachTable('test', { id: int4() });
 	// @ts-expect-error
 	createUpdateSchema(table, { unknown: z.string() });
+}
+
+/* Disallow unknown keys in table refinement - upsert */ {
+	const table = cockroachTable('test', { id: int4() });
+	// @ts-expect-error
+	createUpsertSchema(table, { unknown: z.string() });
 }
 
 /* Disallow unknown keys in view qb - select */ {

--- a/integration-tests/tests/validators/zod/mssql.test.ts
+++ b/integration-tests/tests/validators/zod/mssql.test.ts
@@ -1,7 +1,13 @@
 import { type Equal, sql } from 'drizzle-orm';
 import { customType, int, mssqlSchema, mssqlTable, mssqlView, text } from 'drizzle-orm/mssql-core';
 import { CONSTANTS } from 'drizzle-orm/utils';
-import { createInsertSchema, createSchemaFactory, createSelectSchema, createUpdateSchema } from 'drizzle-orm/zod';
+import {
+	createInsertSchema,
+	createSchemaFactory,
+	createSelectSchema,
+	createUpdateSchema,
+	createUpsertSchema,
+} from 'drizzle-orm/zod';
 import { bigintStringModeSchema, bufferSchema } from 'drizzle-orm/zod/column';
 import type { TopLevelCondition } from 'json-rules-engine';
 import { test } from 'vitest';
@@ -75,6 +81,19 @@ test('table - update', (t) => {
 		name: textOptionalSchema,
 		age: integerNullableOptionalSchema,
 	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('table - upsert', (t) => {
+	const table = mssqlTable('test', {
+		id: int().identity().primaryKey(),
+		name: text().notNull(),
+		age: int(),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({ id: integerOptionalSchema, name: textSchema, age: integerNullableOptionalSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });
@@ -190,6 +209,29 @@ test('nullability - update', (t) => {
 	Expect<Equal<typeof result, typeof expected>>();
 });
 
+test('nullability - upsert', (t) => {
+	const table = mssqlTable('test', {
+		c1: int(),
+		c2: int().notNull(),
+		c3: int().default(1),
+		c4: int().notNull().default(1),
+		c5: int().generatedAlwaysAs(sql`1`),
+		c6: int().identity(),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({
+		c1: integerNullableOptionalSchema,
+		c2: integerSchema,
+		c3: integerNullableOptionalSchema,
+		c4: integerOptionalSchema,
+		c5: integerNullableOptionalSchema,
+		c6: integerNullableOptionalSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
 test('refine table - select', (t) => {
 	const table = mssqlTable('test', {
 		c1: int(),
@@ -273,6 +315,28 @@ test('refine table - update', (t) => {
 		c1: integerNullableOptionalSchema,
 		c2: extendedOptionalSchema,
 		c3: customSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('refine table - upsert', (t) => {
+	const table = mssqlTable('test', {
+		c1: int(),
+		c2: int().notNull(),
+		c3: int().notNull(),
+		c4: int().generatedAlwaysAs(sql`1`),
+	});
+
+	const result = createUpsertSchema(table, {
+		c2: (schema) => schema.lte(1000),
+		c3: z.string().transform(Number),
+	});
+	const expected = z.object({
+		c1: integerNullableOptionalSchema,
+		c2: extendedSchema,
+		c3: customSchema,
+		c4: integerNullableOptionalSchema,
 	});
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
@@ -534,6 +598,12 @@ test('type coercion - mixed', (t) => {
 	const table = mssqlTable('test', { id: int() });
 	// @ts-expect-error
 	createUpdateSchema(table, { unknown: z.string() });
+}
+
+/* Disallow unknown keys in table refinement - upsert */ {
+	const table = mssqlTable('test', { id: int() });
+	// @ts-expect-error
+	createUpsertSchema(table, { unknown: z.string() });
 }
 
 /* Disallow unknown keys in view qb - select */ {

--- a/integration-tests/tests/validators/zod/mysql.test.ts
+++ b/integration-tests/tests/validators/zod/mysql.test.ts
@@ -1,7 +1,13 @@
 import { type Equal, sql } from 'drizzle-orm';
 import { customType, int, json, mysqlSchema, mysqlTable, mysqlView, serial, text } from 'drizzle-orm/mysql-core';
 import { CONSTANTS } from 'drizzle-orm/utils';
-import { createInsertSchema, createSchemaFactory, createSelectSchema, createUpdateSchema } from 'drizzle-orm/zod';
+import {
+	createInsertSchema,
+	createSchemaFactory,
+	createSelectSchema,
+	createUpdateSchema,
+	createUpsertSchema,
+} from 'drizzle-orm/zod';
 import { bigintStringModeSchema, jsonSchema, unsignedBigintStringModeSchema } from 'drizzle-orm/zod/column';
 import type { TopLevelCondition } from 'json-rules-engine';
 import { test } from 'vitest';
@@ -81,6 +87,23 @@ test('table - update', (t) => {
 	const expected = z.object({
 		id: serialOptionalSchema,
 		name: textOptionalSchema,
+		age: intNullableOptionalSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('table - upsert', (t) => {
+	const table = mysqlTable('test', {
+		id: serial().primaryKey(),
+		name: text().notNull(),
+		age: int(),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({
+		id: serialOptionalSchema,
+		name: textSchema,
 		age: intNullableOptionalSchema,
 	});
 	expectSchemaShape(t, expected).from(result);
@@ -197,6 +220,27 @@ test('nullability - update', (t) => {
 	Expect<Equal<typeof result, typeof expected>>();
 });
 
+test('nullability - upsert', (t) => {
+	const table = mysqlTable('test', {
+		c1: int(),
+		c2: int().notNull(),
+		c3: int().default(1),
+		c4: int().notNull().default(1),
+		c5: int().generatedAlwaysAs(sql`1`),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({
+		c1: intNullableOptionalSchema,
+		c2: intSchema,
+		c3: intNullableOptionalSchema,
+		c4: intOptionalSchema,
+		c5: intNullableOptionalSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
 test('refine table - select', (t) => {
 	const table = mysqlTable('test', {
 		c1: int(),
@@ -281,6 +325,28 @@ test('refine table - update', (t) => {
 		c1: intNullableOptionalSchema,
 		c2: extendedOptionalSchema,
 		c3: customSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('refine table - upsert', (t) => {
+	const table = mysqlTable('test', {
+		c1: int(),
+		c2: int().notNull(),
+		c3: int().notNull(),
+		c4: int().generatedAlwaysAs(sql`1`),
+	});
+
+	const result = createUpsertSchema(table, {
+		c2: (schema) => schema.lte(1000),
+		c3: z.string().transform(Number),
+	});
+	const expected = z.object({
+		c1: intNullableOptionalSchema,
+		c2: extendedSchema,
+		c3: customSchema,
+		c4: intNullableOptionalSchema,
 	});
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
@@ -574,6 +640,12 @@ test('type coercion - mixed', (t) => {
 	const table = mysqlTable('test', { id: int() });
 	// @ts-expect-error
 	createUpdateSchema(table, { unknown: z.string() });
+}
+
+/* Disallow unknown keys in table refinement - upsert */ {
+	const table = mysqlTable('test', { id: int() });
+	// @ts-expect-error
+	createUpsertSchema(table, { unknown: z.string() });
 }
 
 /* Disallow unknown keys in view qb - select */ {

--- a/integration-tests/tests/validators/zod/pg.test.ts
+++ b/integration-tests/tests/validators/zod/pg.test.ts
@@ -13,7 +13,13 @@ import {
 	text,
 } from 'drizzle-orm/pg-core';
 import { CONSTANTS } from 'drizzle-orm/utils';
-import { createInsertSchema, createSchemaFactory, createSelectSchema, createUpdateSchema } from 'drizzle-orm/zod';
+import {
+	createInsertSchema,
+	createSchemaFactory,
+	createSelectSchema,
+	createUpdateSchema,
+	createUpsertSchema,
+} from 'drizzle-orm/zod';
 import { bigintStringModeSchema, jsonSchema } from 'drizzle-orm/zod/column';
 import type { TopLevelCondition } from 'json-rules-engine';
 import { test } from 'vitest';
@@ -85,6 +91,23 @@ test('table - update', (t) => {
 	const result = createUpdateSchema(table);
 	const expected = z.object({
 		name: textOptionalSchema,
+		age: integerNullableOptionalSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('table - upsert', (t) => {
+	const table = pgTable('test', {
+		id: integer().generatedAlwaysAsIdentity().primaryKey(),
+		name: text().notNull(),
+		age: integer(),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({
+		id: integerOptionalSchema,
+		name: textSchema,
 		age: integerNullableOptionalSchema,
 	});
 	expectSchemaShape(t, expected).from(result);
@@ -240,6 +263,31 @@ test('nullability - update', (t) => {
 	Expect<Equal<typeof result, typeof expected>>();
 });
 
+test('nullability - upsert', (t) => {
+	const table = pgTable('test', {
+		c1: integer(),
+		c2: integer().notNull(),
+		c3: integer().default(1),
+		c4: integer().notNull().default(1),
+		c5: integer().generatedAlwaysAs(sql`1`),
+		c6: integer().generatedAlwaysAsIdentity(),
+		c7: integer().generatedByDefaultAsIdentity(),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({
+		c1: integerNullableOptionalSchema,
+		c2: integerSchema,
+		c3: integerNullableOptionalSchema,
+		c4: integerOptionalSchema,
+		c5: integerNullableOptionalSchema,
+		c6: integerOptionalSchema,
+		c7: integerOptionalSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
 test('refine table - select', (t) => {
 	const table = pgTable('test', {
 		c1: integer(),
@@ -323,6 +371,28 @@ test('refine table - update', (t) => {
 		c1: integerNullableOptionalSchema,
 		c2: extendedOptionalSchema,
 		c3: customSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('refine table - upsert', (t) => {
+	const table = pgTable('test', {
+		c1: integer(),
+		c2: integer().notNull(),
+		c3: integer().notNull(),
+		c4: integer().generatedAlwaysAs(sql`1`),
+	});
+
+	const result = createUpsertSchema(table, {
+		c2: (schema) => schema.lte(1000),
+		c3: z.string().transform(Number),
+	});
+	const expected = z.object({
+		c1: integerNullableOptionalSchema,
+		c2: extendedSchema,
+		c3: customSchema,
+		c4: integerNullableOptionalSchema,
 	});
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
@@ -614,6 +684,12 @@ test('type coercion - mixed', (t) => {
 	const table = pgTable('test', { id: integer() });
 	// @ts-expect-error
 	createUpdateSchema(table, { unknown: z.string() });
+}
+
+/* Disallow unknown keys in table refinement - upsert */ {
+	const table = pgTable('test', { id: integer() });
+	// @ts-expect-error
+	createUpsertSchema(table, { unknown: z.string() });
 }
 
 /* Disallow unknown keys in view qb - select */ {

--- a/integration-tests/tests/validators/zod/singlestore.test.ts
+++ b/integration-tests/tests/validators/zod/singlestore.test.ts
@@ -1,7 +1,13 @@
 import { type Equal, sql } from 'drizzle-orm';
 import { customType, int, json, serial, singlestoreSchema, singlestoreTable, text } from 'drizzle-orm/singlestore-core';
 import { CONSTANTS } from 'drizzle-orm/utils';
-import { createInsertSchema, createSchemaFactory, createSelectSchema, createUpdateSchema } from 'drizzle-orm/zod';
+import {
+	createInsertSchema,
+	createSchemaFactory,
+	createSelectSchema,
+	createUpdateSchema,
+	createUpsertSchema,
+} from 'drizzle-orm/zod';
 import { bigintStringModeSchema, jsonSchema, unsignedBigintStringModeSchema } from 'drizzle-orm/zod/column';
 import type { TopLevelCondition } from 'json-rules-engine';
 import { test } from 'vitest';
@@ -81,6 +87,23 @@ test('table - update', (t) => {
 	const expected = z.object({
 		id: serialOptionalSchema,
 		name: textOptionalSchema,
+		age: intNullableOptionalSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('table - upsert', (t) => {
+	const table = singlestoreTable('test', {
+		id: serial().primaryKey(),
+		name: text().notNull(),
+		age: int(),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({
+		id: serialOptionalSchema,
+		name: textSchema,
 		age: intNullableOptionalSchema,
 	});
 	expectSchemaShape(t, expected).from(result);
@@ -199,6 +222,27 @@ test('nullability - update', (t) => {
 	Expect<Equal<typeof result, typeof expected>>();
 });
 
+test('nullability - upsert', (t) => {
+	const table = singlestoreTable('test', {
+		c1: int(),
+		c2: int().notNull(),
+		c3: int().default(1),
+		c4: int().notNull().default(1),
+		c5: int().generatedAlwaysAs(sql`1`),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({
+		c1: intNullableOptionalSchema,
+		c2: intSchema,
+		c3: intNullableOptionalSchema,
+		c4: intOptionalSchema,
+		c5: intNullableOptionalSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
 test('refine table - select', (t) => {
 	const table = singlestoreTable('test', {
 		c1: int(),
@@ -283,6 +327,28 @@ test('refine table - update', (t) => {
 		c1: intNullableOptionalSchema,
 		c2: extendedOptionalSchema,
 		c3: customSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('refine table - upsert', (t) => {
+	const table = singlestoreTable('test', {
+		c1: int(),
+		c2: int().notNull(),
+		c3: int().notNull(),
+		c4: int().generatedAlwaysAs(sql`1`),
+	});
+
+	const result = createUpsertSchema(table, {
+		c2: (schema) => schema.lte(1000),
+		c3: z.string().transform(Number),
+	});
+	const expected = z.object({
+		c1: intNullableOptionalSchema,
+		c2: extendedSchema,
+		c3: customSchema,
+		c4: intNullableOptionalSchema,
 	});
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
@@ -587,6 +653,12 @@ test('type coercion - mixed', (t) => {
 	const table = singlestoreTable('test', { id: int() });
 	// @ts-expect-error
 	createUpdateSchema(table, { unknown: z.string() });
+}
+
+/* Disallow unknown keys in table refinement - upsert */ {
+	const table = singlestoreTable('test', { id: int() });
+	// @ts-expect-error
+	createUpsertSchema(table, { unknown: z.string() });
 }
 
 // /* Disallow unknown keys in view qb - select */ {

--- a/integration-tests/tests/validators/zod/sqlite.test.ts
+++ b/integration-tests/tests/validators/zod/sqlite.test.ts
@@ -1,7 +1,13 @@
 import { type Equal, sql } from 'drizzle-orm';
 import { customType, int, sqliteTable, sqliteView, text } from 'drizzle-orm/sqlite-core';
 import { CONSTANTS } from 'drizzle-orm/utils';
-import { createInsertSchema, createSchemaFactory, createSelectSchema, createUpdateSchema } from 'drizzle-orm/zod';
+import {
+	createInsertSchema,
+	createSchemaFactory,
+	createSelectSchema,
+	createUpdateSchema,
+	createUpsertSchema,
+} from 'drizzle-orm/zod';
 import { bufferSchema, jsonSchema } from 'drizzle-orm/zod/column';
 import type { TopLevelCondition } from 'json-rules-engine';
 import { test } from 'vitest';
@@ -63,6 +69,19 @@ test('table - update', (t) => {
 		name: textOptionalSchema,
 		age: intNullableOptionalSchema,
 	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('table - upsert', (t) => {
+	const table = sqliteTable('test', {
+		id: int().primaryKey({ autoIncrement: true }),
+		name: text().notNull(),
+		age: int(),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({ id: intOptionalSchema, name: textSchema, age: intNullableOptionalSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });
@@ -177,6 +196,27 @@ test('nullability - update', (t) => {
 	Expect<Equal<typeof result, typeof expected>>();
 });
 
+test('nullability - upsert', (t) => {
+	const table = sqliteTable('test', {
+		c1: int(),
+		c2: int().notNull(),
+		c3: int().default(1),
+		c4: int().notNull().default(1),
+		c5: int().generatedAlwaysAs(sql`1`),
+	});
+
+	const result = createUpsertSchema(table);
+	const expected = z.object({
+		c1: intNullableOptionalSchema,
+		c2: intSchema,
+		c3: intNullableOptionalSchema,
+		c4: intOptionalSchema,
+		c5: intNullableOptionalSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
 test('refine table - select', (t) => {
 	const table = sqliteTable('test', {
 		c1: int(),
@@ -260,6 +300,28 @@ test('refine table - update', (t) => {
 		c1: intNullableOptionalSchema,
 		c2: extendedOptionalSchema,
 		c3: customSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('refine table - upsert', (t) => {
+	const table = sqliteTable('test', {
+		c1: int(),
+		c2: int().notNull(),
+		c3: int().notNull(),
+		c4: int().generatedAlwaysAs(sql`1`),
+	});
+
+	const result = createUpsertSchema(table, {
+		c2: (schema) => schema.lte(1000),
+		c3: z.string().transform(Number),
+	});
+	const expected = z.object({
+		c1: intNullableOptionalSchema,
+		c2: extendedSchema,
+		c3: customSchema,
+		c4: intNullableOptionalSchema,
 	});
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
@@ -457,6 +519,12 @@ test('type coercion - mixed', (t) => {
 	const table = sqliteTable('test', { id: int() });
 	// @ts-expect-error
 	createUpdateSchema(table, { unknown: z.string() });
+}
+
+/* Disallow unknown keys in table refinement - upsert */ {
+	const table = sqliteTable('test', { id: int() });
+	// @ts-expect-error
+	createUpsertSchema(table, { unknown: z.string() });
 }
 
 /* Disallow unknown keys in view qb - select */ {


### PR DESCRIPTION
Introducing the `createUpsertSchema` utility to provide a type-safe method for handling upsert operations.
Currently, the codebase lacks a built-in approach to generate schemas specifically for update-or-insert logic, often requiring manual schema merging or repetitive boilerplate.
This new method automates the schema generation process, ensuring that input data is correctly validated against the database model while maintaining full type safety for both the required insertion fields and the unique identifiers necessary for updates.

```ts
import { integer, pgTable, varchar } from 'drizzle-orm/pg-core'
import { createInsertSchema, createSelectSchema, createUpdateSchema } from 'drizzle-orm/zod'
import * as z from 'zod'

export const usersTable = pgTable('users', {
  id: integer().primaryKey().generatedAlwaysAsIdentity(),
  name: varchar({ length: 255 }).notNull(),
  age: integer().notNull(),
  email: varchar({ length: 255 }).notNull().unique(),
})

/*
{
  id: number | undefined;
  name: string;
  age: number;
  email: string;
}
*/
type Upsert = z.infer<typeof upsertSchema>
const upsertSchema = createUpsertSchema(usersTable)
```