### PR TITLE
feat: deduplicate parameters in postgres

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -598,6 +598,7 @@ export class PgDialect {
 			escapeString: this.escapeString,
 			prepareTyping: this.prepareTyping,
 			invokeSource,
+			paramDedupMap: new Map(),
 		});
 	}
 

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -38,6 +38,11 @@ export interface BuildQueryConfig {
 	paramStartIndex?: { value: number };
 	inlineParams?: boolean;
 	invokeSource?: 'indexes' | 'mssql-check' | 'mssql-view-with-schemabinding' | undefined;
+	/**
+	 * When set, duplicate parameter values will reuse existing placeholders instead of creating new ones.
+	 * Only useful for dialects with numbered placeholders (e.g. PostgreSQL's $1, $2, ...).
+	 */
+	paramDedupMap?: Map<unknown, { paramIndex: number; typing: QueryTypingsValue }>;
 }
 
 export type QueryTypingsValue = 'json' | 'decimal' | 'time' | 'timestamp' | 'uuid' | 'date' | 'none';
@@ -160,6 +165,7 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 			inlineParams,
 			paramStartIndex,
 			invokeSource,
+			paramDedupMap,
 		} = config;
 
 		return mergeQueries(chunks.map((chunk): QueryWithTypings => {
@@ -261,6 +267,18 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 					typings = [prepareTyping(chunk.encoder)];
 				}
 
+				if (paramDedupMap) {
+					const existing = paramDedupMap.get(mappedValue);
+					if (existing !== undefined && existing.typing === typings[0]) {
+						return { sql: escapeParam(existing.paramIndex, mappedValue), params: [], typings: [] };
+					}
+					const idx = paramStartIndex.value++;
+					if (existing === undefined) {
+						paramDedupMap.set(mappedValue, { paramIndex: idx, typing: typings[0]! });
+					}
+					return { sql: escapeParam(idx, mappedValue), params: [mappedValue], typings };
+				}
+
 				return { sql: escapeParam(paramStartIndex.value++, mappedValue), params: [mappedValue], typings };
 			}
 
@@ -307,6 +325,16 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 
 			if (inlineParams) {
 				return { sql: this.mapInlineParam(chunk, config), params: [] };
+			}
+
+			if (paramDedupMap) {
+				const existing = paramDedupMap.get(chunk);
+				if (existing !== undefined) {
+					return { sql: escapeParam(existing.paramIndex, chunk), params: [], typings: [] };
+				}
+				const idx = paramStartIndex.value++;
+				paramDedupMap.set(chunk, { paramIndex: idx, typing: 'none' });
+				return { sql: escapeParam(idx, chunk), params: [chunk], typings: ['none'] };
 			}
 
 			return { sql: escapeParam(paramStartIndex.value++, chunk), params: [chunk], typings: ['none'] };

--- a/drizzle-orm/tests/casing/pg-to-camel.test.ts
+++ b/drizzle-orm/tests/casing/pg-to-camel.test.ts
@@ -151,9 +151,9 @@ describe('postgres to camel case', () => {
 
 		expect(query.toSQL()).toEqual({
 			sql:
-				'select "users"."id", "users"."AGE", "users"."firstName" || \' \' || "users"."lastName" as "name", "users_developers"."data" as "developers" from "users" "users" left join lateral (select json_build_array("users_developers"."usesDrizzleOrm") as "data" from (select * from "test"."developers" "users_developers" where "users_developers"."userId" = "users"."id" limit $1) "users_developers") "users_developers" on true where "users"."id" = $2 limit $3',
-			params: [1, 1, 1],
-			typings: ['none', 'none', 'none'],
+				'select "users"."id", "users"."AGE", "users"."firstName" || \' \' || "users"."lastName" as "name", "users_developers"."data" as "developers" from "users" "users" left join lateral (select json_build_array("users_developers"."usesDrizzleOrm") as "data" from (select * from "test"."developers" "users_developers" where "users_developers"."userId" = "users"."id" limit $1) "users_developers") "users_developers" on true where "users"."id" = $1 limit $1',
+			params: [1],
+			typings: ['none'],
 		});
 		expect(db.dialect.casing.cache).toEqual(cache);
 	});
@@ -179,9 +179,9 @@ describe('postgres to camel case', () => {
 
 		expect(query.toSQL()).toEqual({
 			sql:
-				'select "users"."id", "users"."AGE", "users"."firstName" || \' \' || "users"."lastName" as "name", "users_developers"."data" as "developers" from "users" "users" left join lateral (select json_build_array("users_developers"."usesDrizzleOrm") as "data" from (select * from "test"."developers" "users_developers" where "users_developers"."userId" = "users"."id" limit $1) "users_developers") "users_developers" on true where "users"."id" = $2',
-			params: [1, 1],
-			typings: ['none', 'none'],
+				'select "users"."id", "users"."AGE", "users"."firstName" || \' \' || "users"."lastName" as "name", "users_developers"."data" as "developers" from "users" "users" left join lateral (select json_build_array("users_developers"."usesDrizzleOrm") as "data" from (select * from "test"."developers" "users_developers" where "users_developers"."userId" = "users"."id" limit $1) "users_developers") "users_developers" on true where "users"."id" = $1',
+			params: [1],
+			typings: ['none'],
 		});
 		expect(db.dialect.casing.cache).toEqual(cache);
 	});

--- a/drizzle-orm/tests/casing/pg-to-snake.test.ts
+++ b/drizzle-orm/tests/casing/pg-to-snake.test.ts
@@ -153,9 +153,9 @@ describe('postgres to snake case', () => {
 
 		expect(query.toSQL()).toEqual({
 			sql:
-				'select "users"."id", "users"."AGE", "users"."first_name" || \' \' || "users"."last_name" as "name", "users_developers"."data" as "developers" from "users" "users" left join lateral (select json_build_array("users_developers"."uses_drizzle_orm") as "data" from (select * from "test"."developers" "users_developers" where "users_developers"."user_id" = "users"."id" limit $1) "users_developers") "users_developers" on true where "users"."id" = $2 limit $3',
-			params: [1, 1, 1],
-			typings: ['none', 'none', 'none'],
+				'select "users"."id", "users"."AGE", "users"."first_name" || \' \' || "users"."last_name" as "name", "users_developers"."data" as "developers" from "users" "users" left join lateral (select json_build_array("users_developers"."uses_drizzle_orm") as "data" from (select * from "test"."developers" "users_developers" where "users_developers"."user_id" = "users"."id" limit $1) "users_developers") "users_developers" on true where "users"."id" = $1 limit $1',
+			params: [1],
+			typings: ['none'],
 		});
 		expect(db.dialect.casing.cache).toEqual(cache);
 	});
@@ -181,9 +181,9 @@ describe('postgres to snake case', () => {
 
 		expect(query.toSQL()).toEqual({
 			sql:
-				'select "users"."id", "users"."AGE", "users"."first_name" || \' \' || "users"."last_name" as "name", "users_developers"."data" as "developers" from "users" "users" left join lateral (select json_build_array("users_developers"."uses_drizzle_orm") as "data" from (select * from "test"."developers" "users_developers" where "users_developers"."user_id" = "users"."id" limit $1) "users_developers") "users_developers" on true where "users"."id" = $2',
-			params: [1, 1],
-			typings: ['none', 'none'],
+				'select "users"."id", "users"."AGE", "users"."first_name" || \' \' || "users"."last_name" as "name", "users_developers"."data" as "developers" from "users" "users" left join lateral (select json_build_array("users_developers"."uses_drizzle_orm") as "data" from (select * from "test"."developers" "users_developers" where "users_developers"."user_id" = "users"."id" limit $1) "users_developers") "users_developers" on true where "users"."id" = $1',
+			params: [1],
+			typings: ['none'],
 		});
 		expect(db.dialect.casing.cache).toEqual(cache);
 	});


### PR DESCRIPTION
Postgres has max params of `65534`, which can be quite annoying on batch inserts, but postgres also allows reusing parameters. So an insert inserting 10 rows, with 5 equal columns could use 5 params instead of 50 params.

As I think most other dialects enforce ordered params, i added a map for deduplication exclusively on the postgres dialect.

targeted beta as we're using beta, let me know if that was wrong