### PR TITLE
[Pg, Gel] Fix PgRole and GelRole .d.ts type errors (TS2559)

### DIFF
--- a/drizzle-orm/src/gel-core/roles.ts
+++ b/drizzle-orm/src/gel-core/roles.ts
@@ -12,11 +12,8 @@ export class GelRole implements GelRoleConfig {
 	/** @internal */
 	_existing?: boolean;
 
-	/** @internal */
 	readonly createDb: GelRoleConfig['createDb'];
-	/** @internal */
 	readonly createRole: GelRoleConfig['createRole'];
-	/** @internal */
 	readonly inherit: GelRoleConfig['inherit'];
 
 	constructor(

--- a/drizzle-orm/src/pg-core/roles.ts
+++ b/drizzle-orm/src/pg-core/roles.ts
@@ -12,11 +12,8 @@ export class PgRole implements PgRoleConfig {
 	/** @internal */
 	_existing?: boolean;
 
-	/** @internal */
 	readonly createDb: PgRoleConfig['createDb'];
-	/** @internal */
 	readonly createRole: PgRoleConfig['createRole'];
-	/** @internal */
 	readonly inherit: PgRoleConfig['inherit'];
 
 	constructor(


### PR DESCRIPTION
## Summary

`PgRole` and `GelRole` declare `implements PgRoleConfig` / `GelRoleConfig`, but all three config properties (`createDb`, `createRole`, `inherit`) are marked `/** @internal */`. The `stripInternal: true` tsconfig setting strips them from the emitted `.d.ts` files, leaving the class with no properties in common with the interface it claims to implement.

This produces **TS2559** when consumers use `skipLibCheck: false`:

```
error TS2559: Type 'PgRole' has no properties in common with type 'PgRoleConfig'.
error TS2559: Type 'GelRole' has no properties in common with type 'GelRoleConfig'.
```

## Root cause

The root `tsconfig.json` combines `stripInternal: true` with `skipLibCheck: true`. The build pipeline (`tsc -p tsconfig.dts.json`) emits `.d.ts` files that strip `@internal` members, but never validates the output with `skipLibCheck: false`. This means the emitted declarations can (and do) violate TypeScript's type rules without being caught.

## Fix

Remove `/** @internal */` from `createDb`, `createRole`, and `inherit` in both `pg-core/roles.ts` and `gel-core/roles.ts`.

These properties:
- Are part of the public `PgRoleConfig`/`GelRoleConfig` interfaces
- Are accessed by `drizzle-kit` (currently via `as any` cast in `pgSerializer.ts:700` and `gelSerializer.ts:686`)
- Are used in tests (`tests/rls/pg-role.test.ts`)

The `_existing` property remains `@internal` as it is not part of the config interface.

## Changes

| File | Change |
|---|---|
| `drizzle-orm/src/pg-core/roles.ts` | Remove `/** @internal */` from 3 properties |
| `drizzle-orm/src/gel-core/roles.ts` | Remove `/** @internal */` from 3 properties |

## Emitted `.d.ts` before vs after

**Before** (broken):
```typescript
export declare class PgRole implements PgRoleConfig {
    readonly name: string;
    static readonly [entityKind]: string;
    // createDb, createRole, inherit are MISSING — stripped by @internal
    constructor(name: string, config?: PgRoleConfig);
    existing(): this;
}
```

**After** (fixed):
```typescript
export declare class PgRole implements PgRoleConfig {
    readonly name: string;
    static readonly [entityKind]: string;
    readonly createDb: PgRoleConfig['createDb'];
    readonly createRole: PgRoleConfig['createRole'];
    readonly inherit: PgRoleConfig['inherit'];
    constructor(name: string, config?: PgRoleConfig);
    existing(): this;
}
```

## Validation

- `tsc --noEmit` — zero errors
- `eslint` — zero warnings
- `dprint check` — no formatting issues
- `tsc -p tsconfig.dts.json` — `.d.ts` generation succeeds
- `vitest run` — 562/562 tests pass
- Type tests (`cd type-tests && tsc`) — zero errors
- `.d.ts` validation with `skipLibCheck: false` — zero role-related errors

Fixes part of #5187. Related: #4299, #4818, #3617.
