### PR TITLE
fix(postgres-js): widen PostgresJsSession constraint for TransactionSql

### DIFF
--- a/drizzle-orm/src/postgres-js/session.ts
+++ b/drizzle-orm/src/postgres-js/session.ts
@@ -105,7 +105,7 @@ export interface PostgresJsSessionOptions {
 }
 
 export class PostgresJsSession<
-	TSQL extends Sql,
+	TSQL extends Sql | TransactionSql,
 	TFullSchema extends Record<string, unknown>,
 	TSchema extends TablesRelationalConfig,
 > extends PgSession<PostgresJsQueryResultHKT, TFullSchema, TSchema> {


### PR DESCRIPTION
## Summary

Widen `PostgresJsSession`'s generic constraint from `TSQL extends Sql` to `TSQL extends Sql | TransactionSql`.

### Problem

Since `postgres@3.4.8`, `TransactionSql` extends `Omit<Sql, 'reserve'>` instead of `Sql`. The `transaction()` method creates `new PostgresJsSession<TransactionSql, ...>`, but `TransactionSql` no longer satisfies `TSQL extends Sql`, producing TS2344.

This affects users regardless of `skipLibCheck` — any direct use of `PostgresJsSession` with the `postgres` package at v3.4.8+ triggers the error.

### Fix

```diff
 export class PostgresJsSession<
-  TSQL extends Sql,
+  TSQL extends Sql | TransactionSql,
```

The union is backward-compatible: on older `postgres` versions where `TransactionSql extends Sql`, the `| TransactionSql` is redundant but harmless.

Related: #5187
