### PR TITLE
fix(types): remove @internal from public API methods (getSQL, generatedAlwaysAs)

### DIFF
--- a/drizzle-orm/src/gel-core/query-builders/query.ts
+++ b/drizzle-orm/src/gel-core/query-builders/query.ts
@@ -125,7 +125,6 @@ export class GelRelationalQuery<TResult> extends QueryPromise<TResult>
 		});
 	}
 
-	/** @internal */
 	getSQL(): SQL {
 		return this._getQuery().sql as SQL;
 	}

--- a/drizzle-orm/src/mysql-core/query-builders/delete.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/delete.ts
@@ -172,7 +172,6 @@ export class MySqlDeleteBase<
 		return this as any;
 	}
 
-	/** @internal */
 	getSQL(): SQL {
 		return this.dialect.buildDeleteQuery(this.config);
 	}

--- a/drizzle-orm/src/mysql-core/query-builders/select.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.ts
@@ -1028,7 +1028,6 @@ export abstract class MySqlSelectQueryBuilderBase<
 		return this as any;
 	}
 
-	/** @internal */
 	getSQL(): SQL {
 		return this.dialect.buildSelectQuery(this.config);
 	}

--- a/drizzle-orm/src/pg-core/query-builders/query.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query.ts
@@ -125,7 +125,6 @@ export class PgRelationalQuery<TResult> extends QueryPromise<TResult>
 		});
 	}
 
-	/** @internal */
 	getSQL(): SQL {
 		return this._getQuery().sql as SQL;
 	}

--- a/drizzle-orm/src/singlestore-core/columns/common.ts
+++ b/drizzle-orm/src/singlestore-core/columns/common.ts
@@ -45,7 +45,6 @@ export abstract class SingleStoreColumnBuilder<
 	}
 
 	// TODO: Implement generated columns for SingleStore (https://docs.singlestore.com/cloud/create-a-database/using-persistent-computed-columns/)
-	/** @internal */
 	generatedAlwaysAs(as: SQL | T['data'] | (() => SQL), config?: SingleStoreGeneratedColumnConfig) {
 		this.config.generated = {
 			as,

--- a/drizzle-orm/src/singlestore-core/columns/enum.ts
+++ b/drizzle-orm/src/singlestore-core/columns/enum.ts
@@ -30,7 +30,7 @@ export class SingleStoreEnumColumnBuilder<T extends ColumnBuilderBaseConfig<'str
 	override generatedAlwaysAs(
 		as: SQL<unknown> | (() => SQL) | T['data'],
 		config?: Partial<GeneratedColumnConfig<unknown>>,
-	): HasGenerated<this, {}> {
+	): HasGenerated<this, { type: 'always' }> {
 		throw new Error('Method not implemented.');
 	}
 	static override readonly [entityKind]: string = 'SingleStoreEnumColumnBuilder';

--- a/drizzle-orm/src/singlestore-core/query-builders/delete.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/delete.ts
@@ -172,7 +172,6 @@ export class SingleStoreDeleteBase<
 		return this as any;
 	}
 
-	/** @internal */
 	getSQL(): SQL {
 		return this.dialect.buildDeleteQuery(this.config);
 	}

--- a/drizzle-orm/src/singlestore-core/query-builders/select.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/select.ts
@@ -899,7 +899,6 @@ export abstract class SingleStoreSelectQueryBuilderBase<
 		return this as any;
 	}
 
-	/** @internal */
 	getSQL(): SQL {
 		return this.dialect.buildSelectQuery(this.config);
 	}

--- a/drizzle-orm/src/sqlite-core/query-builders/query.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/query.ts
@@ -125,7 +125,6 @@ export class SQLiteRelationalQuery<TType extends 'sync' | 'async', TResult> exte
 		this.mode = mode;
 	}
 
-	/** @internal */
 	getSQL(): SQL {
 		return this.dialect.buildRelationalQuery({
 			fullSchema: this.fullSchema,

--- a/drizzle-orm/src/sqlite-core/query-builders/select.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/select.ts
@@ -814,7 +814,6 @@ export abstract class SQLiteSelectQueryBuilderBase<
 		return this as any;
 	}
 
-	/** @internal */
 	getSQL(): SQL {
 		return this.dialect.buildSelectQuery(this.config);
 	}


### PR DESCRIPTION
## Summary

Remove `/** @internal */` from `getSQL()` in 8 query builder classes and `generatedAlwaysAs()` in SingleStoreColumnBuilder. These methods implement the public `SQLWrapper` interface or override abstract base class members, so stripping them from `.d.ts` via `stripInternal: true` produces TS2420/TS2515 errors for consumers with `skipLibCheck: false`.

### getSQL() — 8 files

| File | Class | Error |
|------|-------|-------|
| `src/pg-core/query-builders/query.ts` | `PgRelationalQuery` | TS2420: missing `getSQL` from `SQLWrapper` |
| `src/gel-core/query-builders/query.ts` | `GelRelationalQuery` | TS2420 |
| `src/mysql-core/query-builders/delete.ts` | `MySqlDeleteBase` | TS2420 |
| `src/mysql-core/query-builders/select.ts` | `MySqlSelectBase` | TS2515: missing abstract `getSQL` |
| `src/singlestore-core/query-builders/delete.ts` | `SingleStoreDeleteBase` | TS2420 |
| `src/singlestore-core/query-builders/select.ts` | `SingleStoreSelectBase` | TS2515 |
| `src/sqlite-core/query-builders/query.ts` | `SQLiteRelationalQuery` | TS2420 |
| `src/sqlite-core/query-builders/select.ts` | `SQLiteSelectBase` | TS2515 |

### generatedAlwaysAs() — 2 files

- `src/singlestore-core/columns/common.ts`: Remove `@internal` from `generatedAlwaysAs()` (matching the MySQL dialect which is NOT marked `@internal`)
- `src/singlestore-core/columns/enum.ts`: Fix return type from `HasGenerated<this, {}>` to `HasGenerated<this, { type: 'always' }>` (matching the MySQL enum equivalent)

### Root cause

`tsconfig.json` uses `stripInternal: true` + `skipLibCheck: true`. The build strips `@internal` members from `.d.ts` without validating the output. These methods are part of the public `SQLWrapper` interface contract and should never have been `@internal`.

Related: #5187, #4299, #4818, #3617, #1662
