### PR TITLE
fix(types): relax type constraints broken by stripInternal

### DIFF
--- a/drizzle-orm/src/gel-core/policies.ts
+++ b/drizzle-orm/src/gel-core/policies.ts
@@ -20,7 +20,7 @@ export interface GelPolicyConfig {
 	withCheck?: SQL;
 }
 
-export class GelPolicy implements GelPolicyConfig {
+export class GelPolicy {
 	static readonly [entityKind]: string = 'GelPolicy';
 
 	readonly as: GelPolicyConfig['as'];

--- a/drizzle-orm/src/mysql-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/select.types.ts
@@ -243,7 +243,7 @@ export type MySqlSetOperatorExcludedMethods =
 export type MySqlSelectWithout<
 	T extends AnyMySqlSelectQueryBuilder,
 	TDynamic extends boolean,
-	K extends keyof T & string,
+	K extends string,
 	TResetExcluded extends boolean = false,
 > = TDynamic extends true ? T : Omit<
 	MySqlSelectKind<

--- a/drizzle-orm/src/pg-core/policies.ts
+++ b/drizzle-orm/src/pg-core/policies.ts
@@ -20,7 +20,7 @@ export interface PgPolicyConfig {
 	withCheck?: SQL;
 }
 
-export class PgPolicy implements PgPolicyConfig {
+export class PgPolicy {
 	static readonly [entityKind]: string = 'PgPolicy';
 
 	readonly as: PgPolicyConfig['as'];

--- a/drizzle-orm/src/singlestore-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/select.types.ts
@@ -228,7 +228,7 @@ export type SingleStoreSetOperatorExcludedMethods =
 export type SingleStoreSelectWithout<
 	T extends AnySingleStoreSelectQueryBuilder,
 	TDynamic extends boolean,
-	K extends keyof T & string,
+	K extends string,
 	TResetExcluded extends boolean = false,
 > = TDynamic extends true ? T : Omit<
 	SingleStoreSelectKind<

--- a/drizzle-orm/src/sqlite-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/select.types.ts
@@ -235,7 +235,7 @@ export type CreateSQLiteSelectFromBuilderMode<
 export type SQLiteSelectWithout<
 	T extends AnySQLiteSelectQueryBuilder,
 	TDynamic extends boolean,
-	K extends keyof T & string,
+	K extends string,
 	TResetExcluded extends boolean = false,
 > = TDynamic extends true ? T : Omit<
 	SQLiteSelectKind<


### PR DESCRIPTION
## Summary

Two fixes for type declarations that become invalid after `@internal` properties are stripped from `.d.ts` output by `stripInternal: true`:

### 1. Relax `SelectWithout` generic constraint (3 files)

`K extends keyof T & string` → `K extends string` in:
- `src/mysql-core/query-builders/select.types.ts`
- `src/singlestore-core/query-builders/select.types.ts`
- `src/sqlite-core/query-builders/select.types.ts`

The constraint fails because set operator excluded method lists include `'session'` — a property marked `@internal` and stripped from `.d.ts`. When `'session'` is absent from the emitted type, `'session'` no longer satisfies `keyof T & string`. `Omit<>` already handles missing keys safely (they're simply ignored), so `K extends string` is sufficient.

### 2. Remove `implements` clause from Policy classes (2 files)

`PgPolicy implements PgPolicyConfig` → `PgPolicy` in:
- `src/pg-core/policies.ts`
- `src/gel-core/policies.ts`

The config interfaces have optional properties (`as?`, `for?`), but the class declares them as non-optional readonly. After `@internal` stripping, the `implements` clause produces TS2420 because the structural match fails. The class remains structurally compatible without the clause — removing it eliminates the false type error without changing behavior.

Related: #5187, #4299
