### PR TITLE
Use a different formulation of `KnownKeysOnly`

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -247,7 +247,7 @@ export type ValidateShape<T, ValidShape, TResult = T> = T extends ValidShape
 	: never;
 
 export type KnownKeysOnly<T, U> = {
-	[K in keyof T]: K extends keyof U ? T[K] : never;
+	[K in keyof T]: K extends keyof U ? T[K] & KnownKeysOnly<T[K], U[K]> : never;
 };
 
 export type IsAny<T> = 0 extends (1 & T) ? true : false;


### PR DESCRIPTION
Why? https://github.com/microsoft/typescript-go/issues/2889#issuecomment-3968116300

⚠️ This is just a quick drive-by change committed directly from GitHub's web UI. I'm just interested to see if this will break your CI or not for now 😉 
