### PR TITLE
[Pg-kit]: Fix invalid nextval default rendering in pg introspection

### DIFF
--- a/drizzle-kit/src/introspect-pg.ts
+++ b/drizzle-kit/src/introspect-pg.ts
@@ -148,6 +148,30 @@ const mapColumnDefault = (defaultValue: any, isExpression?: boolean) => {
 	return defaultValue;
 };
 
+const isSequenceDefaultExpression = (defaultValue: unknown): boolean => {
+	return typeof defaultValue === 'string' && /^\s*(?:\(+\s*)?(?:pg_catalog\.)?nextval\s*\(/i.test(defaultValue);
+};
+
+const mapNumericLikeDefault = (defaultValue: unknown, isExpression: boolean): string => {
+	if (typeof defaultValue === 'undefined') return '';
+	const forceExpression = isExpression || isSequenceDefaultExpression(defaultValue);
+	return `.default(${mapColumnDefault(defaultValue, forceExpression)})`;
+};
+
+const getInternalTableKey = (tableName: string, tableSchema: string): string => {
+	return `${tableSchema === '' ? 'public' : tableSchema}.${tableName}`;
+};
+
+const getColumnInternals = (
+	internals: PgKitInternals | undefined,
+	tableName: string,
+	tableSchema: string,
+	columnName: string,
+) => {
+	const tableKey = getInternalTableKey(tableName, tableSchema);
+	return internals?.tables[tableKey]?.columns[columnName] ?? internals?.tables[tableName]?.columns[columnName];
+};
+
 const importsPatch = {
 	'double precision': 'doublePrecision',
 	'timestamp without time zone': 'timestamp',
@@ -513,6 +537,7 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 		let statement = `export const ${withCasing(paramName, casing)} = ${func}("${table.name}", {\n`;
 		statement += createTableColumns(
 			table.name,
+			table.schema || 'public',
 			Object.values(table.columns),
 			Object.values(table.foreignKeys),
 			enumTypes,
@@ -583,7 +608,8 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 			const tablespace = it.tablespace ?? '';
 
 			const columns = createTableColumns(
-				'',
+				it.name,
+				it.schema || 'public',
 				Object.values(it.columns),
 				[],
 				enumTypes,
@@ -672,6 +698,7 @@ const buildArrayDefault = (defaultValue: string, typeName: string): string => {
 
 const mapDefault = (
 	tableName: string,
+	tableSchema: string,
 	type: string,
 	name: string,
 	enumTypes: Set<string>,
@@ -679,8 +706,9 @@ const mapDefault = (
 	defaultValue?: any,
 	internals?: PgKitInternals,
 ) => {
-	const isExpression = internals?.tables[tableName]?.columns[name]?.isDefaultAnExpression ?? false;
-	const isArray = internals?.tables[tableName]?.columns[name]?.isArray ?? false;
+	const columnInternals = getColumnInternals(internals, tableName, tableSchema, name);
+	const isExpression = columnInternals?.isDefaultAnExpression ?? false;
+	const isArray = columnInternals?.isArray ?? false;
 	const lowered = type.toLowerCase().replace('[]', '');
 
 	if (isArray) {
@@ -694,15 +722,15 @@ const mapDefault = (
 	}
 
 	if (lowered.startsWith('integer')) {
-		return typeof defaultValue !== 'undefined' ? `.default(${mapColumnDefault(defaultValue, isExpression)})` : '';
+		return mapNumericLikeDefault(defaultValue, isExpression);
 	}
 
 	if (lowered.startsWith('smallint')) {
-		return typeof defaultValue !== 'undefined' ? `.default(${mapColumnDefault(defaultValue, isExpression)})` : '';
+		return mapNumericLikeDefault(defaultValue, isExpression);
 	}
 
 	if (lowered.startsWith('bigint')) {
-		return typeof defaultValue !== 'undefined' ? `.default(${mapColumnDefault(defaultValue, isExpression)})` : '';
+		return mapNumericLikeDefault(defaultValue, isExpression);
 	}
 
 	if (lowered.startsWith('boolean')) {
@@ -710,11 +738,11 @@ const mapDefault = (
 	}
 
 	if (lowered.startsWith('double precision')) {
-		return typeof defaultValue !== 'undefined' ? `.default(${mapColumnDefault(defaultValue, isExpression)})` : '';
+		return mapNumericLikeDefault(defaultValue, isExpression);
 	}
 
 	if (lowered.startsWith('real')) {
-		return typeof defaultValue !== 'undefined' ? `.default(${mapColumnDefault(defaultValue, isExpression)})` : '';
+		return mapNumericLikeDefault(defaultValue, isExpression);
 	}
 
 	if (lowered.startsWith('uuid')) {
@@ -837,6 +865,7 @@ const mapDefault = (
 
 const column = (
 	tableName: string,
+	tableSchema: string,
 	type: string,
 	name: string,
 	enumTypes: Set<string>,
@@ -845,7 +874,7 @@ const column = (
 	defaultValue?: any,
 	internals?: PgKitInternals,
 ) => {
-	const isExpression = internals?.tables[tableName]?.columns[name]?.isDefaultAnExpression ?? false;
+	const isExpression = getColumnInternals(internals, tableName, tableSchema, name)?.isDefaultAnExpression ?? false;
 	const lowered = type.toLowerCase().replace('[]', '');
 
 	if (enumTypes.has(`${typeSchema}.${type.replace('[]', '')}`)) {
@@ -1111,6 +1140,7 @@ const dimensionsInArray = (size?: number): string => {
 
 const createTableColumns = (
 	tableName: string,
+	tableSchema: string,
 	columns: Column[],
 	fks: ForeignKey[],
 	enumTypes: Set<string>,
@@ -1135,8 +1165,10 @@ const createTableColumns = (
 	}, {} as Record<string, ForeignKey[]>);
 
 	columns.forEach((it) => {
+		const columnInternals = getColumnInternals(internals, tableName, tableSchema, it.name);
 		const columnStatement = column(
 			tableName,
+			tableSchema,
 			it.type,
 			it.name,
 			enumTypes,
@@ -1148,10 +1180,19 @@ const createTableColumns = (
 		statement += '\t';
 		statement += columnStatement;
 		// Provide just this in column function
-		if (internals?.tables[tableName]?.columns[it.name]?.isArray) {
-			statement += dimensionsInArray(internals?.tables[tableName]?.columns[it.name]?.dimensions);
+		if (columnInternals?.isArray) {
+			statement += dimensionsInArray(columnInternals.dimensions);
 		}
-		statement += mapDefault(tableName, it.type, it.name, enumTypes, it.typeSchema ?? 'public', it.default, internals);
+		statement += mapDefault(
+			tableName,
+			tableSchema,
+			it.type,
+			it.name,
+			enumTypes,
+			it.typeSchema ?? 'public',
+			it.default,
+			internals,
+		);
 		statement += it.primaryKey ? '.primaryKey()' : '';
 		statement += it.notNull && !it.identity ? '.notNull()' : '';
 

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1216,6 +1216,7 @@ WHERE
 				if (!tablesFilter(tableName)) return res('');
 				tableCount += 1;
 				const tableSchema = row.table_schema;
+				const tableKey = schemaQualifiedTableName(tableSchema, tableName);
 
 				try {
 					const columnToReturn: Record<string, Column> = {};
@@ -1423,49 +1424,18 @@ WHERE
 
 						// Set default to internal object
 						if (columnAdditionalDT === 'ARRAY') {
-							if (typeof internals.tables[tableName] === 'undefined') {
-								internals.tables[tableName] = {
-									columns: {
-										[columnName]: {
-											isArray: true,
-											dimensions: columnDimensions,
-											rawType: columnTypeMapped.substring(0, columnTypeMapped.length - 2),
-										},
-									},
-								};
-							} else {
-								if (typeof internals.tables[tableName]!.columns[columnName] === 'undefined') {
-									internals.tables[tableName]!.columns[columnName] = {
-										isArray: true,
-										dimensions: columnDimensions,
-										rawType: columnTypeMapped.substring(0, columnTypeMapped.length - 2),
-									};
-								}
-							}
+							const columnInternals = ensureInternalsColumn(internals, tableKey, columnName);
+							columnInternals.isArray = true;
+							columnInternals.dimensions = columnDimensions;
+							columnInternals.rawType = columnTypeMapped.substring(0, columnTypeMapped.length - 2);
 						}
 
-						const defaultValue = defaultForColumn(columnResponse, internals, tableName);
+						const defaultValue = defaultForColumn(columnResponse, internals, tableKey);
 						if (
 							defaultValue === 'NULL'
 							|| (defaultValueRes && defaultValueRes.startsWith('(') && defaultValueRes.endsWith(')'))
 						) {
-							if (typeof internals!.tables![tableName] === 'undefined') {
-								internals!.tables![tableName] = {
-									columns: {
-										[columnName]: {
-											isDefaultAnExpression: true,
-										},
-									},
-								};
-							} else {
-								if (typeof internals!.tables![tableName]!.columns[columnName] === 'undefined') {
-									internals!.tables![tableName]!.columns[columnName] = {
-										isDefaultAnExpression: true,
-									};
-								} else {
-									internals!.tables![tableName]!.columns[columnName]!.isDefaultAnExpression = true;
-								}
-							}
+							ensureInternalsColumn(internals, tableKey, columnName).isDefaultAnExpression = true;
 						}
 
 						const isSerial = columnType === 'serial';
@@ -1685,6 +1655,7 @@ WHERE
 				if (!tablesFilter(viewName)) return res('');
 				tableCount += 1;
 				const viewSchema = row.table_schema;
+				const viewKey = schemaQualifiedTableName(viewSchema, viewName);
 
 				try {
 					const columnToReturn: Record<string, Column> = {};
@@ -1718,49 +1689,18 @@ WHERE
 
 						// Set default to internal object
 						if (columnAdditionalDT === 'ARRAY') {
-							if (typeof internals.tables[viewName] === 'undefined') {
-								internals.tables[viewName] = {
-									columns: {
-										[columnName]: {
-											isArray: true,
-											dimensions: columnDimensions,
-											rawType: columnTypeMapped.substring(0, columnTypeMapped.length - 2),
-										},
-									},
-								};
-							} else {
-								if (typeof internals.tables[viewName]!.columns[columnName] === 'undefined') {
-									internals.tables[viewName]!.columns[columnName] = {
-										isArray: true,
-										dimensions: columnDimensions,
-										rawType: columnTypeMapped.substring(0, columnTypeMapped.length - 2),
-									};
-								}
-							}
+							const columnInternals = ensureInternalsColumn(internals, viewKey, columnName);
+							columnInternals.isArray = true;
+							columnInternals.dimensions = columnDimensions;
+							columnInternals.rawType = columnTypeMapped.substring(0, columnTypeMapped.length - 2);
 						}
 
-						const defaultValue = defaultForColumn(viewResponse, internals, viewName);
+						const defaultValue = defaultForColumn(viewResponse, internals, viewKey);
 						if (
 							defaultValue === 'NULL'
 							|| (defaultValueRes && defaultValueRes.startsWith('(') && defaultValueRes.endsWith(')'))
 						) {
-							if (typeof internals!.tables![viewName] === 'undefined') {
-								internals!.tables![viewName] = {
-									columns: {
-										[columnName]: {
-											isDefaultAnExpression: true,
-										},
-									},
-								};
-							} else {
-								if (typeof internals!.tables![viewName]!.columns[columnName] === 'undefined') {
-									internals!.tables![viewName]!.columns[columnName] = {
-										isDefaultAnExpression: true,
-									};
-								} else {
-									internals!.tables![viewName]!.columns[columnName]!.isDefaultAnExpression = true;
-								}
-							}
+							ensureInternalsColumn(internals, viewKey, columnName).isDefaultAnExpression = true;
 						}
 
 						const isSerial = columnType === 'serial';
@@ -1936,9 +1876,23 @@ WHERE
 	};
 };
 
-const defaultForColumn = (column: any, internals: PgKitInternals, tableName: string) => {
+const schemaQualifiedTableName = (tableSchema: string, tableName: string) => `${tableSchema}.${tableName}`;
+
+const ensureInternalsColumn = (internals: PgKitInternals, tableKey: string, columnName: string) => {
+	if (typeof internals.tables[tableKey] === 'undefined') {
+		internals.tables[tableKey] = { columns: {} };
+	}
+
+	if (typeof internals.tables[tableKey]!.columns[columnName] === 'undefined') {
+		internals.tables[tableKey]!.columns[columnName] = {};
+	}
+
+	return internals.tables[tableKey]!.columns[columnName]!;
+};
+
+const defaultForColumn = (column: any, internals: PgKitInternals, tableKey: string) => {
 	const columnName = column.column_name;
-	const isArray = internals?.tables[tableName]?.columns[columnName]?.isArray ?? false;
+	const isArray = internals?.tables[tableKey]?.columns[columnName]?.isArray ?? false;
 
 	if (
 		column.column_default === null
@@ -1990,23 +1944,7 @@ const defaultForColumn = (column: any, internals: PgKitInternals, tableName: str
 		if (/^-?[\d.]+(?:e-?\d+)?$/.test(columnDefaultAsString)) {
 			return Number(columnDefaultAsString);
 		} else {
-			if (typeof internals!.tables![tableName] === 'undefined') {
-				internals!.tables![tableName] = {
-					columns: {
-						[columnName]: {
-							isDefaultAnExpression: true,
-						},
-					},
-				};
-			} else {
-				if (typeof internals!.tables![tableName]!.columns[columnName] === 'undefined') {
-					internals!.tables![tableName]!.columns[columnName] = {
-						isDefaultAnExpression: true,
-					};
-				} else {
-					internals!.tables![tableName]!.columns[columnName]!.isDefaultAnExpression = true;
-				}
-			}
+			ensureInternalsColumn(internals, tableKey, columnName).isDefaultAnExpression = true;
 			return columnDefaultAsString;
 		}
 	} else if (column.data_type.includes('numeric')) {

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -23,6 +23,7 @@ import {
 	pgPolicy,
 	pgRole,
 	pgSchema,
+	pgSequence,
 	pgTable,
 	pgView,
 	real,
@@ -921,6 +922,97 @@ test('multiple policies with roles from schema', async () => {
 		'multiple-policies-with-roles-from-schema',
 		['public'],
 		{ roles: { include: ['user_role'] } },
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
+test('introspect nextval defaults on integer columns', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		usersIdSeq: pgSequence('users_id_seq'),
+		users: pgTable('users', {
+			id: integer('id').notNull().default(sql`nextval('users_id_seq'::regclass)`),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'introspect-nextval-default-integer',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
+test('introspect nextval defaults on integer columns in non-public schema', async () => {
+	const client = new PGlite();
+	const musicbrainz = pgSchema('musicbrainz');
+
+	const schema = {
+		musicbrainz,
+		usersIdSeq: musicbrainz.sequence('users_id_seq'),
+		users: musicbrainz.table('users', {
+			id: integer('id').notNull().default(sql`nextval('musicbrainz.users_id_seq'::regclass)`),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'introspect-nextval-default-integer-non-public-schema',
+		['musicbrainz'],
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
+test('introspect pg_catalog.nextval defaults on integer columns', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		usersIdSeq: pgSequence('users_id_seq'),
+		users: pgTable('users', {
+			id: integer('id').notNull().default(sql`pg_catalog.nextval('users_id_seq'::regclass)`),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'introspect-pg-catalog-nextval-default-integer',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
+test('introspect defaults with duplicate table names across schemas', async () => {
+	const client = new PGlite();
+	const schemaA = pgSchema('schema_a');
+	const schemaB = pgSchema('schema_b');
+
+	const schema = {
+		schemaA,
+		schemaB,
+		schemaAUsersIdSeq: schemaA.sequence('users_id_seq'),
+		schemaAUsers: schemaA.table('users', {
+			id: integer('id').notNull().default(sql`nextval('schema_a.users_id_seq'::regclass)`),
+		}),
+		schemaBUsers: schemaB.table('users', {
+			id: integer('id').notNull().default(0),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'introspect-defaults-duplicate-table-names-across-schemas',
+		['schema_a', 'schema_b'],
 	);
 
 	expect(statements.length).toBe(0);


### PR DESCRIPTION
## Summary
Fixes invalid TypeScript generation for Postgres sequence-based numeric defaults during introspection.

Closes #5413

## Root Cause
Default-expression metadata could be missed in schema-sensitive cases due to internals key mismatch and non-schema-aware lookup paths. When missed, `nextval(...)` could be emitted without `sql\`\`` wrapping.

## Changes
- Normalize internal metadata keys to `schema.table` in pg serializer.
- Make default/array internals lookup schema-aware in `introspect-pg`.
- Force numeric `nextval(...)` and `pg_catalog.nextval(...)` defaults to expression rendering.
- Use proper view identity (`name + schema`) in view column mapping path.
- Add regressions:
  - sequence default on integer (public)
  - sequence default on integer (non-public schema)
  - `pg_catalog.nextval(...)`
  - duplicate table names across schemas

## Validation
- `pnpm --filter drizzle-kit exec vitest tests/introspect/pg.test.ts`
  - pass: `38 passed | 1 skipped`
- `pnpm --filter drizzle-kit exec vitest tests/introspect`
  - environment failures only:
    - sqlite native binding missing (`better-sqlite3`)
    - docker socket unavailable for docker-dependent suites
