### PR TITLE
fix(errors): include cause message in DrizzleQueryError output

### DIFF
--- a/drizzle-orm/src/effect-core/errors.ts
+++ b/drizzle-orm/src/effect-core/errors.ts
@@ -16,7 +16,12 @@ export class EffectDrizzleQueryError extends Schema.TaggedError<EffectDrizzleQue
 	static readonly [entityKind]: string = this._tag;
 
 	override get message() {
-		return `Failed query: ${this.query}\nparams: ${this.params}`;
+		const cause = this.cause;
+		const causeMsg = cause !== null && typeof cause === 'object' && 'message' in cause
+				&& typeof (cause as { message: unknown }).message === 'string'
+			? `\nerror: ${(cause as { message: string }).message}`
+			: '';
+		return `Failed query: ${this.query}\nparams: ${this.params}${causeMsg}`;
 	}
 
 	constructor(params: Omit<Schema.Struct.Constructor<typeof EffectDrizzleQueryError.fields>, '_tag'>) {

--- a/drizzle-orm/src/effect-core/errors.ts
+++ b/drizzle-orm/src/effect-core/errors.ts
@@ -18,7 +18,12 @@ export class EffectDrizzleQueryError
 	static readonly [entityKind]: string = 'EffectDrizzleQueryError';
 
 	override get message() {
-		return `Failed query: ${this.query}\nparams: ${this.params}`;
+		const cause = this.cause;
+		const causeMsg = cause !== null && typeof cause === 'object' && 'message' in cause
+				&& typeof (cause as { message: unknown }).message === 'string'
+			? `\nerror: ${(cause as { message: string }).message}`
+			: '';
+		return `Failed query: ${this.query}\nparams: ${this.params}${causeMsg}`;
 	}
 
 	constructor(params: Omit<Schema.Struct.MakeIn<typeof EffectDrizzleQueryError.fields>, '_tag'>) {

--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -18,7 +18,7 @@ export class DrizzleQueryError extends Error {
 		public params: any[],
 		public override cause?: Error,
 	) {
-		super(`Failed query: ${query}\nparams: ${params}`);
+		super(`Failed query: ${query}\nparams: ${params}${cause ? `\nerror: ${cause.message}` : ''}`);
 		Error.captureStackTrace(this, DrizzleQueryError);
 
 		// ES2022+: preserves original error on `.cause`

--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -18,7 +18,7 @@ export class DrizzleQueryError extends Error {
 		public params: any[],
 		public override cause?: Error,
 	) {
-		super(`Failed query: ${query}\nparams: ${params}`);
+		super(`Failed query: ${query}\nparams: ${params}${cause ? `\nerror: ${cause.message}` : ''}`);
 		this.name = 'DrizzleQueryError';
 		Error.captureStackTrace(this, DrizzleQueryError);
 


### PR DESCRIPTION
## Problem

Fixes #5238

When a query fails, `DrizzleQueryError` stores the underlying database error in `this.cause`, but never includes it in the `.message` string. This means error output like:

```
Error  Failed query: CREATE TABLE "users" ...
params: 
```

...completely hides the actual DB error (e.g. `relation "users" already exists`), making debugging very difficult unless you explicitly inspect `.cause`.

## Root Cause

Both `DrizzleQueryError` and `EffectDrizzleQueryError` build their `message` string from only `query` and `params`, ignoring `cause.message` entirely.

## Fix

Include the cause's message in the error output.

**Before:**
```
Failed query: CREATE TABLE "users" ("id" serial PRIMARY KEY)
params: 
```

**After:**
```
Failed query: CREATE TABLE "users" ("id" serial PRIMARY KEY)
params: 
error: relation "users" already exists
```

## Changes

- `drizzle-orm/src/errors.ts` — `DrizzleQueryError`: append `\nerror: <cause.message>` when cause is present
- `drizzle-orm/src/effect-core/errors.ts` — `EffectDrizzleQueryError`: same fix in the `get message()` getter, using a type-safe object property check (no `instanceof` per project rules)