### PR TITLE
docs(valibot): add V1 migration guide from drizzle-valibot to drizzle-orm/valibot

### DIFF
--- a/changelogs/drizzle-valibot/1.0.0-beta.md
+++ b/changelogs/drizzle-valibot/1.0.0-beta.md
@@ -1,0 +1,25 @@
+# `drizzle-valibot` → `drizzle-orm/valibot`
+
+As of `drizzle-orm@1.0.0-beta`, the `drizzle-valibot` package has been merged into `drizzle-orm` directly.
+
+## Breaking change
+
+The separate `drizzle-valibot` package is no longer published for V1 beta versions. All functionality is now available as a subpath of `drizzle-orm`.
+
+## Migration
+
+1. Uninstall the old package:
+   ```sh
+   npm uninstall drizzle-valibot
+   ```
+
+2. Update imports:
+   ```ts
+   // Before
+   import { createSelectSchema, createInsertSchema, createUpdateSchema } from 'drizzle-valibot';
+
+   // After
+   import { createSelectSchema, createInsertSchema, createUpdateSchema } from 'drizzle-orm/valibot';
+   ```
+
+The API remains the same. No other changes required.

--- a/drizzle-orm/src/valibot/README.md
+++ b/drizzle-orm/src/valibot/README.md
@@ -6,6 +6,24 @@ Allows you to generate [valibot](https://valibot.dev/) schemas from Drizzle ORM 
 - Create insert and update schemas for tables.
 - Supported dialects: CockroachDB, MSSQL, MySQL, PostgreSQL, SingleStore, SQLite.
 
+## Migrating from `drizzle-valibot`
+
+If you were using the separate `drizzle-valibot` package (v0.x), it has been merged into `drizzle-orm` as of V1 beta. You no longer need the separate package.
+
+**Steps to migrate:**
+1. Uninstall `drizzle-valibot`: `npm uninstall drizzle-valibot`
+2. Update your imports:
+
+```ts
+// Before
+import { createSelectSchema, createInsertSchema } from 'drizzle-valibot';
+
+// After
+import { createSelectSchema, createInsertSchema } from 'drizzle-orm/valibot';
+```
+
+The API is otherwise identical.
+
 # Usage
 
 ```ts


### PR DESCRIPTION
Closes #5361

Users on drizzle-orm@1.0.0-beta.x are confused because the separate drizzle-valibot package is incompatible with V1 beta. This PR:
1. Comments on the issue explaining the root cause
2. Updates the valibot README with a migration section
3. Adds a changelog entry for the drizzle-valibot → drizzle-orm/valibot move