### PR TITLE
fix(expo-sqlite): make journal optional in useMigrations migration config

### DIFF
--- a/drizzle-orm/src/expo-sqlite/migrator.ts
+++ b/drizzle-orm/src/expo-sqlite/migrator.ts
@@ -62,7 +62,7 @@ type Action =
 	| { type: 'error'; payload: Error };
 
 export const useMigrations = (db: ExpoSQLiteDatabase<any, any>, migrations: {
-	journal: {
+	journal?: {
 		entries: { idx: number; when: number; tag: string; breakpoints: boolean }[];
 	};
 	migrations: Record<string, string>;

--- a/drizzle-orm/src/expo-sqlite/migrator.ts
+++ b/drizzle-orm/src/expo-sqlite/migrator.ts
@@ -60,8 +60,8 @@ type Action =
 	| { type: 'migrated'; payload: true }
 	| { type: 'error'; payload: Error };
 
-export const useMigrations = (db: ExpoSQLiteDatabase<any>, migrations: {
-	journal: {
+export const useMigrations = (db: ExpoSQLiteDatabase<any, any>, migrations: {
+	journal?: {
 		entries: { idx: number; when: number; tag: string; breakpoints: boolean }[];
 	};
 	migrations: Record<string, string>;


### PR DESCRIPTION
Fixes #5214

## Problem
`useMigrations()` requires a `journal` property in the second argument, but the `journal` field is never read — the function just passes the object as `migrations as any` to `migrate()`. Users generating migrations with the new V1 format don't have a `journal` file and hit a TypeScript compile error:

```
Property 'journal' is missing in type '{ migrations: {...} }' but required in type '{ journal: ...; migrations: ... }'
```

## Fix
Mark `journal` as optional (`journal?`) in the `useMigrations` parameter type. No runtime behaviour changes — the field was already unused.