### PR TITLE
fix(relations): handle null filter in relationsFieldFilterToSQL

### DIFF
--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -1258,7 +1258,7 @@ export function fieldSelectionToSQL(table: SchemaEntry, target: string) {
 }
 
 function relationsFieldFilterToSQL(column: SQLWrapper, filter: RelationsFieldFilter<unknown>): SQL | undefined {
-	if (typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
+	if (filter === null || typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
 
 	const entries = Object.entries(filter as RelationFieldsFilterInternals<unknown>);
 	if (!entries.length) return undefined;


### PR DESCRIPTION
Fixes #5418

## Problem
In `relationsFieldFilterToSQL()`, the guard `typeof filter !== 'object'` correctly rejects primitives, but `typeof null === 'object'` in JavaScript, so a `null` filter passes through and reaches `Object.entries(null)`, throwing a `TypeError` at runtime.

## Fix
Add an explicit `filter === null` check before the `typeof` check:

```ts
// before
if (typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);

// after
if (filter === null || typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
```

This makes `{ field: null }` work correctly with rqb-v2 relational queries, treating `null` as a scalar value passed directly to `eq(column, null)`.