### PR TITLE
fix(relations): add optional property to ManyConfig interface

### DIFF
--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -1031,6 +1031,7 @@ export type AnyOneConfig = OneConfig<
 >;
 
 export interface ManyConfig<TTargetTable extends SchemaEntry> {
+	optional?: boolean;
 	from?: RelationsBuilderColumnBase | [RelationsBuilderColumnBase, ...RelationsBuilderColumnBase[]];
 	to?: RelationsBuilderColumnBase | [RelationsBuilderColumnBase, ...RelationsBuilderColumnBase[]];
 	where?: TableFilter<TTargetTable>;


### PR DESCRIPTION
Fixes #5335

## Problem
The docs mention an `optional` property for `many()` relations, but `ManyConfig` interface doesn't define it. Users get a TypeScript error when trying to use it:

```ts
r.many.posts({
  from: r.users.id,
  to: r.posts.ownerId,
  optional: false, // TS error: 'optional' does not exist in type 'ManyConfig'
})
```

## Fix
Add `optional?: boolean` to `ManyConfig` interface, matching the `OneConfig` pattern.

Note: for `many()` relations the result is always a `TResult[]`, so this property currently doesn't affect the query result type (an empty array is returned when no records match). The property is accepted to match the documented API and for future use.