### PR TITLE
fix(expo-sqlite): make journal optional in useMigrations type

### DIFF
--- a/drizzle-orm/src/expo-sqlite/migrator.ts
+++ b/drizzle-orm/src/expo-sqlite/migrator.ts
@@ -62,7 +62,7 @@ type Action =
 	| { type: 'error'; payload: Error };
 
 export const useMigrations = (db: ExpoSQLiteDatabase<any, any>, migrations: {
-	journal: {
+	journal?: {
 		entries: { idx: number; when: number; tag: string; breakpoints: boolean }[];
 	};
 	migrations: Record<string, string>;


### PR DESCRIPTION
## Summary

In V2 migrations, the generated object no longer includes a `journal` field. However, `useMigrations()` required it in its type signature even though it was never actually used internally (the value is passed as `migrations as any` to `migrate()`).

## Problem

Users on V2 migrations get:
```
Argument of type '{ migrations: { ... } }' is not assignable to parameter
Property 'journal' is missing in type '{ migrations: ... }'
```

## Fix

Made `journal` optional (`journal?`) since it is never used at runtime.

Fixes #5214