### PR TITLE
fix(rqb): handle null filter value in relationsFieldFilterToSQL

### DIFF
--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -1258,7 +1258,7 @@ export function fieldSelectionToSQL(table: SchemaEntry, target: string) {
 }
 
 function relationsFieldFilterToSQL(column: SQLWrapper, filter: RelationsFieldFilter<unknown>): SQL | undefined {
-	if (typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
+	if (filter === null || typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
 
 	const entries = Object.entries(filter as RelationFieldsFilterInternals<unknown>);
 	if (!entries.length) return undefined;


### PR DESCRIPTION
## Summary

Fixes a crash when using `{ field: null }` in RQB-v2 `where` clause.

## Problem

```ts
db.query.table.findMany({ where: { field: null } });
// TypeError: Cannot convert undefined or null to object
//   at Function.entries (<anonymous>)
//   at relationsFieldFilterToSQL (relations.ts:1263)
```

In JavaScript, `typeof null === 'object'`, so `null` bypassed the primitive check and was passed to `Object.entries()`, causing the crash.

## Fix

Added an explicit `filter === null` guard before the `typeof` check so `null` is correctly treated as a plain value and uses the `eq()` operator.

**Before:**
```ts
if (typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
```

**After:**
```ts
if (filter === null || typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
```

The workaround `{ field: { isNull: true } }` still works as before.

Fixes #5418