### PR TITLE
fix(kit): filter policies by schemaFilter in postgres and cockroach introspection

### DIFF
--- a/drizzle-kit/src/dialects/cockroach/introspect.ts
+++ b/drizzle-kit/src/dialects/cockroach/introspect.ts
@@ -336,6 +336,7 @@ export const fromDatabase = async (
 			qual as "using", 
 			with_check as "withCheck" 
 		FROM pg_policies
+		WHERE schemaname IN (${filteredNamespacesStringForSQL})
 		ORDER BY lower(schemaname), lower(tablename), lower(policyname)
 		;`,
 		)

--- a/drizzle-kit/src/dialects/postgres/introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/introspect.ts
@@ -365,9 +365,6 @@ export const fromDatabase = async (
 			})
 		: [] as SequenceListItem[];
 
-	// I'm not yet aware of how we handle policies down the pipeline for push,
-	// and since postgres does not have any default policies, we can safely fetch all of them for now
-	// and filter them out in runtime, simplifying filterings
 	progressCallback('policies', 0, 'fetching');
 	const policiesQuery = db.query<
 		{
@@ -390,6 +387,7 @@ export const fromDatabase = async (
 			qual as "using", 
 			with_check as "withCheck" 
 		FROM pg_catalog.pg_policies
+		WHERE schemaname IN (${filteredNamespacesStringForSQL})
 		ORDER BY
 			pg_catalog.lower(schemaname),
 			pg_catalog.lower(tablename),


### PR DESCRIPTION
## Problem

When using `schemaFilter` (e.g. `schemaFilter: ['public']`) with `drizzle-kit push`, the tool was fetching **all** policies from `pg_catalog.pg_policies` with no `WHERE` clause. This meant policies belonging to excluded schemas were also fetched and then compared against the schema snapshot — causing them to be **dropped** on the next push.

Fixes #5329

## Fix

Added `WHERE schemaname IN (...)` to the `policiesQuery` in both:
- `drizzle-kit/src/dialects/postgres/introspect.ts`
- `drizzle-kit/src/dialects/cockroach/introspect.ts`

This matches the existing pattern used for tables, enums, sequences, and other objects throughout both files.

When `filteredNamespacesStringForSQL` is empty (no filter), the original unfiltered query is used as fallback.

## Testing

Type-checked with `tsc --noEmit --skipLibCheck` — no new errors introduced.