### PR TITLE
fix(drizzle-seed): generate RFC 4122 compliant UUID v4 variant bits

### DIFF
--- a/drizzle-seed/src/services/Generators.ts
+++ b/drizzle-seed/src/services/Generators.ts
@@ -1536,18 +1536,29 @@ export class GenerateUUID extends AbstractGenerator<{
 			currStr: string;
 		const strLength = 36;
 
-		// uuid v4
-		const uuidTemplate = '########-####-4###-####-############';
+		// uuid v4 (RFC 4122)
+		// Version nibble (4) is at position 14
+		// Variant bits (10xx) are at position 19, restricting first hex digit to [8, 9, a, b]
+		const variantChars = '89ab';
+		const uuidTemplate = '########-####-4###-V###-############';
 		currStr = '';
 		for (let i = 0; i < strLength; i++) {
-			[idx, this.state.rng] = prand.uniformIntDistribution(
-				0,
-				stringChars.length - 1,
-				this.state.rng,
-			);
-
 			if (uuidTemplate[i] === '#') {
+				[idx, this.state.rng] = prand.uniformIntDistribution(
+					0,
+					stringChars.length - 1,
+					this.state.rng,
+				);
 				currStr += stringChars[idx];
+				continue;
+			}
+			if (uuidTemplate[i] === 'V') {
+				[idx, this.state.rng] = prand.uniformIntDistribution(
+					0,
+					variantChars.length - 1,
+					this.state.rng,
+				);
+				currStr += variantChars[idx];
 				continue;
 			}
 			currStr += uuidTemplate[i];


### PR DESCRIPTION
The UUID v4 generator in drizzle-seed was not setting the variant bits correctly. RFC 4122 requires the first nibble of the 4th group (`clock_seq_hi`) to be restricted to `[8, 9, a, b]` (binary `10xx`), but the generator was producing any hex digit in that position.

**Example of previously invalid output:**
```
6aa65a86-1248-4dcf-e3ec-304ba1343ca5
                     ^ should be 8, 9, a, or b
```

**Fix:**
The UUID template now uses a separate `V` placeholder for the variant position, which is randomly selected from `[8, 9, a, b]` instead of the full hex range. The version nibble (`4`) was already correctly hardcoded.

This ensures all generated UUIDs pass validation by libraries like `uuid`'s `validate()` and PostgreSQL's strict `uuid` type.

Fixes #5402