### PR TITLE
fix: show table name in 'to' column validation error message

### DIFF
--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -129,7 +129,7 @@ export function processRelations(tablesConfig: TablesRelationalConfig, tables: S
 				for (const tName of targetColumnTableNames) {
 					if (tName !== targetTableName) {
 						throw new Error(
-							`${relationPrintName}: all "to" columns must belong to table "${targetTable}", found column of table "${tName}"`,
+							`${relationPrintName}: all "to" columns must belong to table "${targetTableName}", found column of table "${tName}"`,
 						);
 					}
 				}


### PR DESCRIPTION
When a relation's `to` column doesn't belong to the expected table, the error message was printing the table object itself instead of the table name string, so it showed `[object Object]` in the output.

**Before:**
```
relations -> blogs: { posts: r.many.post(...) }: all "to" columns must belong to table "[object Object]", found column of table "blog"
```

**After:**
```
relations -> blogs: { posts: r.many.post(...) }: all "to" columns must belong to table "post", found column of table "blog"
```

**Change:** In `processRelations`, the error string was interpolating `targetTable` (the table object) instead of `targetTableName` (the string). One-character difference in variable name.

Fixes #5350