### PR TITLE
feat(drizzle-kit): support non-interactive generate conflicts

### DIFF
--- a/drizzle-kit/src/api.ts
+++ b/drizzle-kit/src/api.ts
@@ -16,6 +16,7 @@ import {
 import { AnySQLiteTable, SQLiteTable } from 'drizzle-orm/sqlite-core';
 import {
 	columnsResolver,
+	createMigrationResolver,
 	enumsResolver,
 	indPolicyResolver,
 	mySqlViewsResolver,
@@ -40,6 +41,12 @@ import type { SqliteCredentials } from './cli/validations/sqlite';
 import { getTablesFilterByExtensions } from './extensions/getTablesFilterByExtensions';
 import { originUUID } from './global';
 import type { Config } from './index';
+import {
+	type GenerateMigrationQuestion,
+	type GenerateMigrationQuestions,
+	GenerateMigrationQuestionsError,
+	parseGenerateMigrationQuestions,
+} from './migrationQuestions';
 import { MySqlSchema as MySQLSchemaKit, mysqlSchema, squashMysqlScheme } from './serializer/mysqlSchema';
 import { generateMySqlSnapshot } from './serializer/mysqlSerializer';
 import { prepareFromExports } from './serializer/pgImports';
@@ -60,6 +67,24 @@ export type DrizzleSnapshotJSON = PgSchemaKit;
 export type DrizzleSQLiteSnapshotJSON = SQLiteSchemaKit;
 export type DrizzleMySQLSnapshotJSON = MySQLSchemaKit;
 export type DrizzleSingleStoreSnapshotJSON = SingleStoreSchemaKit;
+export type {
+	GenerateMigrationChoice,
+	GenerateMigrationQuestion,
+	GenerateMigrationQuestionKind,
+	GenerateMigrationQuestions,
+	GenerateMigrationRef,
+} from './migrationQuestions';
+export { GenerateMigrationQuestionsError } from './migrationQuestions';
+
+export type GenerateMigrationOptions = {
+	answers?: GenerateMigrationQuestions | GenerateMigrationQuestion[];
+};
+
+const normalizeGenerateMigrationOptions = (options?: GenerateMigrationOptions) => {
+	return {
+		answers: options?.answers ? parseGenerateMigrationQuestions(options.answers) : undefined,
+	};
+};
 
 export const generateDrizzleJson = (
 	imports: Record<string, unknown>,
@@ -94,8 +119,13 @@ export const generateDrizzleJson = (
 export const generateMigration = async (
 	prev: DrizzleSnapshotJSON,
 	cur: DrizzleSnapshotJSON,
+	options?: GenerateMigrationOptions,
 ) => {
 	const { applyPgSnapshotsDiff } = await import('./snapshotsDiffer');
+	const normalizedOptions = normalizeGenerateMigrationOptions(options);
+	const resolver = normalizedOptions.answers
+		? createMigrationResolver({ answers: normalizedOptions.answers })
+		: undefined;
 
 	const validatedPrev = pgSchema.parse(prev);
 	const validatedCur = pgSchema.parse(cur);
@@ -106,20 +136,58 @@ export const generateMigration = async (
 	const { sqlStatements, _meta } = await applyPgSnapshotsDiff(
 		squashedPrev,
 		squashedCur,
-		schemasResolver,
-		enumsResolver,
-		sequencesResolver,
-		policyResolver,
-		indPolicyResolver,
-		roleResolver,
-		tablesResolver,
-		columnsResolver,
-		viewsResolver,
+		resolver?.schemasResolver ?? schemasResolver,
+		resolver?.enumsResolver ?? enumsResolver,
+		resolver?.sequencesResolver ?? sequencesResolver,
+		resolver?.policyResolver ?? policyResolver,
+		resolver?.indPolicyResolver ?? indPolicyResolver,
+		resolver?.roleResolver ?? roleResolver,
+		resolver?.tablesResolver ?? tablesResolver,
+		resolver?.columnsResolver ?? columnsResolver,
+		resolver?.viewsResolver ?? viewsResolver,
 		validatedPrev,
 		validatedCur,
 	);
 
+	if (resolver && resolver.hasUnresolvedQuestions()) {
+		throw new GenerateMigrationQuestionsError(resolver.questions());
+	}
+
 	return sqlStatements;
+};
+
+export const preflightMigration = async (
+	prev: DrizzleSnapshotJSON,
+	cur: DrizzleSnapshotJSON,
+	options?: GenerateMigrationOptions,
+) => {
+	const { applyPgSnapshotsDiff } = await import('./snapshotsDiffer');
+	const normalizedOptions = normalizeGenerateMigrationOptions(options);
+	const resolver = createMigrationResolver({ answers: normalizedOptions.answers });
+
+	const validatedPrev = pgSchema.parse(prev);
+	const validatedCur = pgSchema.parse(cur);
+
+	const squashedPrev = squashPgScheme(validatedPrev);
+	const squashedCur = squashPgScheme(validatedCur);
+
+	await applyPgSnapshotsDiff(
+		squashedPrev,
+		squashedCur,
+		resolver.schemasResolver,
+		resolver.enumsResolver,
+		resolver.sequencesResolver,
+		resolver.policyResolver,
+		resolver.indPolicyResolver,
+		resolver.roleResolver,
+		resolver.tablesResolver,
+		resolver.columnsResolver,
+		resolver.viewsResolver,
+		validatedPrev,
+		validatedCur,
+	);
+
+	return resolver.questions();
 };
 
 export const pushSchema = async (
@@ -245,8 +313,13 @@ export const generateSQLiteDrizzleJson = async (
 export const generateSQLiteMigration = async (
 	prev: DrizzleSQLiteSnapshotJSON,
 	cur: DrizzleSQLiteSnapshotJSON,
+	options?: GenerateMigrationOptions,
 ) => {
 	const { applySqliteSnapshotsDiff } = await import('./snapshotsDiffer');
+	const normalizedOptions = normalizeGenerateMigrationOptions(options);
+	const resolver = normalizedOptions.answers
+		? createMigrationResolver({ answers: normalizedOptions.answers })
+		: undefined;
 
 	const validatedPrev = sqliteSchema.parse(prev);
 	const validatedCur = sqliteSchema.parse(cur);
@@ -257,14 +330,46 @@ export const generateSQLiteMigration = async (
 	const { sqlStatements } = await applySqliteSnapshotsDiff(
 		squashedPrev,
 		squashedCur,
-		tablesResolver,
-		columnsResolver,
-		sqliteViewsResolver,
+		resolver?.tablesResolver ?? tablesResolver,
+		resolver?.columnsResolver ?? columnsResolver,
+		resolver?.sqliteViewsResolver ?? sqliteViewsResolver,
 		validatedPrev,
 		validatedCur,
 	);
 
+	if (resolver && resolver.hasUnresolvedQuestions()) {
+		throw new GenerateMigrationQuestionsError(resolver.questions());
+	}
+
 	return sqlStatements;
+};
+
+export const preflightSQLiteMigration = async (
+	prev: DrizzleSQLiteSnapshotJSON,
+	cur: DrizzleSQLiteSnapshotJSON,
+	options?: GenerateMigrationOptions,
+) => {
+	const { applySqliteSnapshotsDiff } = await import('./snapshotsDiffer');
+	const normalizedOptions = normalizeGenerateMigrationOptions(options);
+	const resolver = createMigrationResolver({ answers: normalizedOptions.answers });
+
+	const validatedPrev = sqliteSchema.parse(prev);
+	const validatedCur = sqliteSchema.parse(cur);
+
+	const squashedPrev = squashSqliteScheme(validatedPrev);
+	const squashedCur = squashSqliteScheme(validatedCur);
+
+	await applySqliteSnapshotsDiff(
+		squashedPrev,
+		squashedCur,
+		resolver.tablesResolver,
+		resolver.columnsResolver,
+		resolver.sqliteViewsResolver,
+		validatedPrev,
+		validatedCur,
+	);
+
+	return resolver.questions();
 };
 
 export const pushSQLiteSchema = async (
@@ -384,8 +489,13 @@ export const generateMySQLDrizzleJson = async (
 export const generateMySQLMigration = async (
 	prev: DrizzleMySQLSnapshotJSON,
 	cur: DrizzleMySQLSnapshotJSON,
+	options?: GenerateMigrationOptions,
 ) => {
 	const { applyMysqlSnapshotsDiff } = await import('./snapshotsDiffer');
+	const normalizedOptions = normalizeGenerateMigrationOptions(options);
+	const resolver = normalizedOptions.answers
+		? createMigrationResolver({ answers: normalizedOptions.answers })
+		: undefined;
 
 	const validatedPrev = mysqlSchema.parse(prev);
 	const validatedCur = mysqlSchema.parse(cur);
@@ -396,14 +506,46 @@ export const generateMySQLMigration = async (
 	const { sqlStatements } = await applyMysqlSnapshotsDiff(
 		squashedPrev,
 		squashedCur,
-		tablesResolver,
-		columnsResolver,
-		mySqlViewsResolver,
+		resolver?.tablesResolver ?? tablesResolver,
+		resolver?.columnsResolver ?? columnsResolver,
+		resolver?.mySqlViewsResolver ?? mySqlViewsResolver,
 		validatedPrev,
 		validatedCur,
 	);
 
+	if (resolver && resolver.hasUnresolvedQuestions()) {
+		throw new GenerateMigrationQuestionsError(resolver.questions());
+	}
+
 	return sqlStatements;
+};
+
+export const preflightMySQLMigration = async (
+	prev: DrizzleMySQLSnapshotJSON,
+	cur: DrizzleMySQLSnapshotJSON,
+	options?: GenerateMigrationOptions,
+) => {
+	const { applyMysqlSnapshotsDiff } = await import('./snapshotsDiffer');
+	const normalizedOptions = normalizeGenerateMigrationOptions(options);
+	const resolver = createMigrationResolver({ answers: normalizedOptions.answers });
+
+	const validatedPrev = mysqlSchema.parse(prev);
+	const validatedCur = mysqlSchema.parse(cur);
+
+	const squashedPrev = squashMysqlScheme(validatedPrev);
+	const squashedCur = squashMysqlScheme(validatedCur);
+
+	await applyMysqlSnapshotsDiff(
+		squashedPrev,
+		squashedCur,
+		resolver.tablesResolver,
+		resolver.columnsResolver,
+		resolver.mySqlViewsResolver,
+		validatedPrev,
+		validatedCur,
+	);
+
+	return resolver.questions();
 };
 
 export const pushMySQLSchema = async (
@@ -519,8 +661,13 @@ export const generateSingleStoreDrizzleJson = async (
 export const generateSingleStoreMigration = async (
 	prev: DrizzleSingleStoreSnapshotJSON,
 	cur: DrizzleSingleStoreSnapshotJSON,
+	options?: GenerateMigrationOptions,
 ) => {
 	const { applySingleStoreSnapshotsDiff } = await import('./snapshotsDiffer');
+	const normalizedOptions = normalizeGenerateMigrationOptions(options);
+	const resolver = normalizedOptions.answers
+		? createMigrationResolver({ answers: normalizedOptions.answers })
+		: undefined;
 
 	const validatedPrev = singlestoreSchema.parse(prev);
 	const validatedCur = singlestoreSchema.parse(cur);
@@ -531,15 +678,48 @@ export const generateSingleStoreMigration = async (
 	const { sqlStatements } = await applySingleStoreSnapshotsDiff(
 		squashedPrev,
 		squashedCur,
-		tablesResolver,
-		columnsResolver,
+		resolver?.tablesResolver ?? tablesResolver,
+		resolver?.columnsResolver ?? columnsResolver,
 		/* singleStoreViewsResolver, */
 		validatedPrev,
 		validatedCur,
 		'push',
 	);
 
+	if (resolver && resolver.hasUnresolvedQuestions()) {
+		throw new GenerateMigrationQuestionsError(resolver.questions());
+	}
+
 	return sqlStatements;
+};
+
+export const preflightSingleStoreMigration = async (
+	prev: DrizzleSingleStoreSnapshotJSON,
+	cur: DrizzleSingleStoreSnapshotJSON,
+	options?: GenerateMigrationOptions,
+) => {
+	const { applySingleStoreSnapshotsDiff } = await import('./snapshotsDiffer');
+	const normalizedOptions = normalizeGenerateMigrationOptions(options);
+	const resolver = createMigrationResolver({ answers: normalizedOptions.answers });
+
+	const validatedPrev = singlestoreSchema.parse(prev);
+	const validatedCur = singlestoreSchema.parse(cur);
+
+	const squashedPrev = squashSingleStoreScheme(validatedPrev);
+	const squashedCur = squashSingleStoreScheme(validatedCur);
+
+	await applySingleStoreSnapshotsDiff(
+		squashedPrev,
+		squashedCur,
+		resolver.tablesResolver,
+		resolver.columnsResolver,
+		/* singleStoreViewsResolver, */
+		validatedPrev,
+		validatedCur,
+		'push',
+	);
+
+	return resolver.questions();
 };
 
 export const pushSingleStoreSchema = async (

--- a/drizzle-kit/src/cli/commands/migrate.ts
+++ b/drizzle-kit/src/cli/commands/migrate.ts
@@ -41,6 +41,15 @@ import {
 	TablePolicyResolverInput,
 	TablePolicyResolverOutput,
 } from '../../snapshotsDiffer';
+import {
+	type GenerateMigrationChoice,
+	type GenerateMigrationQuestion,
+	type GenerateMigrationQuestionKind,
+	type GenerateMigrationQuestions,
+	GenerateMigrationQuestionsError,
+	createGenerateMigrationQuestionId,
+	normalizeGenerateMigrationRef,
+} from '../../migrationQuestions';
 import { assertV1OutFolder, Journal, prepareMigrationFolder } from '../../utils';
 import { prepareMigrationMetadata } from '../../utils/words';
 import { CasingType, Driver, Prefix } from '../validations/common';
@@ -65,87 +74,359 @@ export type NamedWithSchema = {
 	schema: string;
 };
 
-export const schemasResolver = async (
-	input: ResolverInput<Table>,
-): Promise<ResolverOutput<Table>> => {
-	try {
-		const { created, deleted, renamed } = await promptSchemasConflict(
-			input.created,
-			input.deleted,
-		);
-
-		return { created: created, deleted: deleted, renamed: renamed };
-	} catch (e) {
-		console.error(e);
-		throw e;
-	}
+type ConflictResolverState = {
+	answersById: Map<string, GenerateMigrationChoice>;
+	questions: Map<string, GenerateMigrationQuestion>;
 };
 
-export const tablesResolver = async (
-	input: ResolverInput<Table>,
-): Promise<ResolverOutputWithMoved<Table>> => {
-	try {
-		const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
+export type CreateMigrationResolverOptions = {
+	answers?: GenerateMigrationQuestions;
+};
+
+const createConflictResolverState = (
+	answers?: GenerateMigrationQuestions,
+): ConflictResolverState => {
+	return {
+		answersById: new Map(
+			(answers?.questions ?? [])
+				.filter((it) => it.answer)
+				.map((it) => [it.id, it.answer!] as const),
+		),
+		questions: new Map(),
+	};
+};
+
+const recordResolverQuestion = (
+	state: ConflictResolverState,
+	question: GenerateMigrationQuestion,
+) => {
+	const answer = state.answersById.get(question.id);
+	const existing = state.questions.get(question.id);
+	const nextQuestion = {
+		...existing,
+		...question,
+	};
+	const resolvedAnswer = answer ?? existing?.answer;
+	if (resolvedAnswer) {
+		nextQuestion.answer = resolvedAnswer;
+	}
+	state.questions.set(question.id, nextQuestion);
+	return answer;
+};
+
+const asMigrationRef = (
+	kind: GenerateMigrationQuestionKind,
+	item: { name: string; schema?: string },
+) => {
+	return normalizeGenerateMigrationRef(kind, item);
+};
+
+const sameMigrationRef = (
+	left: { name: string; schema?: string },
+	right: { name: string; schema?: string },
+) => {
+	return left.name === right.name && (left.schema ?? 'public') === (right.schema ?? 'public');
+};
+
+const resolvePromptChoice = async <T extends Named>(
+	state: ConflictResolverState | undefined,
+	question: GenerateMigrationQuestion,
+	created: T,
+	missing: T[],
+	interactive: () => Promise<RenamePropmtItem<T> | T>,
+): Promise<RenamePropmtItem<T> | T> => {
+	if (!state) {
+		return interactive();
+	}
+
+	const answer = recordResolverQuestion(state, question);
+	if (!answer || answer.type === 'create') {
+		return created;
+	}
+
+	const match = missing.find((item) => {
+		return sameMigrationRef(
+			asMigrationRef(question.kind, item),
+			answer.from,
+		);
+	});
+
+	if (!match) {
+		throw new Error(
+			`Invalid answer for "${question.id}". "${answer.from.schema ? `${answer.from.schema}.` : ''}${answer.from.name}" is not a valid rename source.`,
+		);
+	}
+
+	return { from: match, to: created };
+};
+
+const createPromptResolvers = (state?: ConflictResolverState) => {
+	const schemasResolver = async (
+		input: ResolverInput<Table>,
+	): Promise<ResolverOutput<Table>> => {
+		try {
+			const { created, deleted, renamed } = await promptSchemasConflict(
+				input.created,
+				input.deleted,
+				state,
+			);
+
+			return { created: created, deleted: deleted, renamed: renamed };
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
+	};
+
+	const tablesResolver = async (
+		input: ResolverInput<Table>,
+	): Promise<ResolverOutputWithMoved<Table>> => {
+		try {
+			const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
+				input.created,
+				input.deleted,
+				'table',
+				state,
+			);
+
+			return {
+				created: created,
+				deleted: deleted,
+				moved: moved,
+				renamed: renamed,
+			};
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
+	};
+
+	const viewsResolver = async (
+		input: ResolverInput<View>,
+	): Promise<ResolverOutputWithMoved<View>> => {
+		try {
+			const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
+				input.created,
+				input.deleted,
+				'view',
+				state,
+			);
+
+			return {
+				created: created,
+				deleted: deleted,
+				moved: moved,
+				renamed: renamed,
+			};
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
+	};
+
+	const mySqlViewsResolver = async (
+		input: ResolverInput<ViewSquashed & { schema: '' }>,
+	): Promise<ResolverOutputWithMoved<ViewSquashed>> => {
+		try {
+			const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
+				input.created,
+				input.deleted,
+				'view',
+				state,
+			);
+
+			return {
+				created: created,
+				deleted: deleted,
+				moved: moved,
+				renamed: renamed,
+			};
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
+	};
+
+	const sqliteViewsResolver = async (
+		input: ResolverInput<SQLiteView & { schema: '' }>,
+	): Promise<ResolverOutputWithMoved<SQLiteView>> => {
+		try {
+			const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
+				input.created,
+				input.deleted,
+				'view',
+				state,
+			);
+
+			return {
+				created: created,
+				deleted: deleted,
+				moved: moved,
+				renamed: renamed,
+			};
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
+	};
+
+	const sequencesResolver = async (
+		input: ResolverInput<Sequence>,
+	): Promise<ResolverOutputWithMoved<Sequence>> => {
+		try {
+			const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
+				input.created,
+				input.deleted,
+				'sequence',
+				state,
+			);
+
+			return {
+				created: created,
+				deleted: deleted,
+				moved: moved,
+				renamed: renamed,
+			};
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
+	};
+
+	const roleResolver = async (
+		input: RolesResolverInput<Role>,
+	): Promise<RolesResolverOutput<Role>> => {
+		const result = await promptNamedConflict(
 			input.created,
 			input.deleted,
-			'table',
+			'role',
+			state,
 		);
-
 		return {
-			created: created,
-			deleted: deleted,
-			moved: moved,
-			renamed: renamed,
+			created: result.created,
+			deleted: result.deleted,
+			renamed: result.renamed,
 		};
-	} catch (e) {
-		console.error(e);
-		throw e;
-	}
-};
+	};
 
-export const viewsResolver = async (
-	input: ResolverInput<View>,
-): Promise<ResolverOutputWithMoved<View>> => {
-	try {
-		const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
+	const policyResolver = async (
+		input: TablePolicyResolverInput<Policy>,
+	): Promise<TablePolicyResolverOutput<Policy>> => {
+		const result = await promptColumnsConflicts(
+			'policy',
+			input.tableName,
+			input.schema,
 			input.created,
 			input.deleted,
-			'view',
+			state,
 		);
-
 		return {
-			created: created,
-			deleted: deleted,
-			moved: moved,
-			renamed: renamed,
+			tableName: input.tableName,
+			schema: input.schema,
+			created: result.created,
+			deleted: result.deleted,
+			renamed: result.renamed,
 		};
-	} catch (e) {
-		console.error(e);
-		throw e;
-	}
-};
+	};
 
-export const mySqlViewsResolver = async (
-	input: ResolverInput<ViewSquashed & { schema: '' }>,
-): Promise<ResolverOutputWithMoved<ViewSquashed>> => {
-	try {
-		const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
+	const indPolicyResolver = async (
+		input: PolicyResolverInput<Policy>,
+	): Promise<PolicyResolverOutput<Policy>> => {
+		const result = await promptNamedConflict(
 			input.created,
 			input.deleted,
-			'view',
+			'policy',
+			state,
 		);
-
 		return {
-			created: created,
-			deleted: deleted,
-			moved: moved,
-			renamed: renamed,
+			created: result.created,
+			deleted: result.deleted,
+			renamed: result.renamed,
 		};
-	} catch (e) {
-		console.error(e);
-		throw e;
-	}
+	};
+
+	const enumsResolver = async (
+		input: ResolverInput<Enum>,
+	): Promise<ResolverOutputWithMoved<Enum>> => {
+		try {
+			const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
+				input.created,
+				input.deleted,
+				'enum',
+				state,
+			);
+
+			return {
+				created: created,
+				deleted: deleted,
+				moved: moved,
+				renamed: renamed,
+			};
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
+	};
+
+	const columnsResolver = async (
+		input: ColumnsResolverInput<Column>,
+	): Promise<ColumnsResolverOutput<Column>> => {
+		const result = await promptColumnsConflicts(
+			'column',
+			input.tableName,
+			input.schema,
+			input.created,
+			input.deleted,
+			state,
+		);
+		return {
+			tableName: input.tableName,
+			schema: input.schema,
+			created: result.created,
+			deleted: result.deleted,
+			renamed: result.renamed,
+		};
+	};
+
+	return {
+		schemasResolver,
+		tablesResolver,
+		viewsResolver,
+		mySqlViewsResolver,
+		sqliteViewsResolver,
+		sequencesResolver,
+		roleResolver,
+		policyResolver,
+		indPolicyResolver,
+		enumsResolver,
+		columnsResolver,
+	};
 };
+
+export const createMigrationResolver = (options: CreateMigrationResolverOptions = {}) => {
+	const state = createConflictResolverState(options.answers);
+	const resolvers = createPromptResolvers(state);
+
+	return {
+		...resolvers,
+		questions: (): GenerateMigrationQuestions => {
+			return {
+				version: 1,
+				questions: [...state.questions.values()],
+			};
+		},
+		hasUnresolvedQuestions: () => {
+			return [...state.questions.values()].some((it) => !it.answer);
+		},
+	};
+};
+
+const interactiveResolvers = createPromptResolvers();
+
+export const schemasResolver = interactiveResolvers.schemasResolver;
+export const tablesResolver = interactiveResolvers.tablesResolver;
+export const viewsResolver = interactiveResolvers.viewsResolver;
+export const mySqlViewsResolver = interactiveResolvers.mySqlViewsResolver;
 
 /* export const singleStoreViewsResolver = async (
 	input: ResolverInput<SingleStoreViewSquashed & { schema: '' }>,
@@ -169,134 +450,45 @@ export const mySqlViewsResolver = async (
 	}
 }; */
 
-export const sqliteViewsResolver = async (
-	input: ResolverInput<SQLiteView & { schema: '' }>,
-): Promise<ResolverOutputWithMoved<SQLiteView>> => {
-	try {
-		const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
-			input.created,
-			input.deleted,
-			'view',
-		);
+export const sqliteViewsResolver = interactiveResolvers.sqliteViewsResolver;
+export const sequencesResolver = interactiveResolvers.sequencesResolver;
+export const roleResolver = interactiveResolvers.roleResolver;
+export const policyResolver = interactiveResolvers.policyResolver;
+export const indPolicyResolver = interactiveResolvers.indPolicyResolver;
+export const enumsResolver = interactiveResolvers.enumsResolver;
+export const columnsResolver = interactiveResolvers.columnsResolver;
 
-		return {
-			created: created,
-			deleted: deleted,
-			moved: moved,
-			renamed: renamed,
-		};
-	} catch (e) {
-		console.error(e);
-		throw e;
+const createGenerateResolver = (
+	config: Pick<GenerateConfig, 'answers' | 'preflight'>,
+) => {
+	if (!config.preflight && !config.answers) {
+		return undefined;
 	}
+
+	return createMigrationResolver({
+		answers: config.answers,
+	});
 };
 
-export const sequencesResolver = async (
-	input: ResolverInput<Sequence>,
-): Promise<ResolverOutputWithMoved<Sequence>> => {
-	try {
-		const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
-			input.created,
-			input.deleted,
-			'sequence',
-		);
-
-		return {
-			created: created,
-			deleted: deleted,
-			moved: moved,
-			renamed: renamed,
-		};
-	} catch (e) {
-		console.error(e);
-		throw e;
+const finalizeGenerateResolver = (
+	config: Pick<GenerateConfig, 'preflight'>,
+	resolver: ReturnType<typeof createMigrationResolver> | undefined,
+) => {
+	if (!resolver) {
+		return undefined;
 	}
-};
 
-export const roleResolver = async (
-	input: RolesResolverInput<Role>,
-): Promise<RolesResolverOutput<Role>> => {
-	const result = await promptNamedConflict(
-		input.created,
-		input.deleted,
-		'role',
-	);
-	return {
-		created: result.created,
-		deleted: result.deleted,
-		renamed: result.renamed,
-	};
-};
+	const questions = resolver.questions();
 
-export const policyResolver = async (
-	input: TablePolicyResolverInput<Policy>,
-): Promise<TablePolicyResolverOutput<Policy>> => {
-	const result = await promptColumnsConflicts(
-		input.tableName,
-		input.created,
-		input.deleted,
-	);
-	return {
-		tableName: input.tableName,
-		schema: input.schema,
-		created: result.created,
-		deleted: result.deleted,
-		renamed: result.renamed,
-	};
-};
-
-export const indPolicyResolver = async (
-	input: PolicyResolverInput<Policy>,
-): Promise<PolicyResolverOutput<Policy>> => {
-	const result = await promptNamedConflict(
-		input.created,
-		input.deleted,
-		'policy',
-	);
-	return {
-		created: result.created,
-		deleted: result.deleted,
-		renamed: result.renamed,
-	};
-};
-
-export const enumsResolver = async (
-	input: ResolverInput<Enum>,
-): Promise<ResolverOutputWithMoved<Enum>> => {
-	try {
-		const { created, deleted, moved, renamed } = await promptNamedWithSchemasConflict(
-			input.created,
-			input.deleted,
-			'enum',
-		);
-
-		return {
-			created: created,
-			deleted: deleted,
-			moved: moved,
-			renamed: renamed,
-		};
-	} catch (e) {
-		console.error(e);
-		throw e;
+	if (config.preflight) {
+		return questions;
 	}
-};
 
-export const columnsResolver = async (
-	input: ColumnsResolverInput<Column>,
-): Promise<ColumnsResolverOutput<Column>> => {
-	const result = await promptColumnsConflicts(
-		input.tableName,
-		input.created,
-		input.deleted,
-	);
-	return {
-		tableName: input.tableName,
-		schema: input.schema,
-		created: result.created,
-		deleted: result.deleted,
-		renamed: result.renamed,
-	};
+	if (resolver.hasUnresolvedQuestions()) {
+		throw new GenerateMigrationQuestionsError(questions);
+	}
+
+	return undefined;
 };
 
 export const prepareAndMigratePg = async (config: GenerateConfig) => {
@@ -306,10 +498,12 @@ export const prepareAndMigratePg = async (config: GenerateConfig) => {
 
 	try {
 		assertV1OutFolder(outFolder);
+		const resolver = createGenerateResolver(config);
 
 		const { snapshots, journal } = prepareMigrationFolder(
 			outFolder,
 			'postgresql',
+			{ createIfMissing: !config.preflight },
 		);
 
 		const { prev, cur, custom } = await preparePgMigrationSnapshot(
@@ -341,18 +535,23 @@ export const prepareAndMigratePg = async (config: GenerateConfig) => {
 		const { sqlStatements, _meta } = await applyPgSnapshotsDiff(
 			squashedPrev,
 			squashedCur,
-			schemasResolver,
-			enumsResolver,
-			sequencesResolver,
-			policyResolver,
-			indPolicyResolver,
-			roleResolver,
-			tablesResolver,
-			columnsResolver,
-			viewsResolver,
+			resolver?.schemasResolver ?? schemasResolver,
+			resolver?.enumsResolver ?? enumsResolver,
+			resolver?.sequencesResolver ?? sequencesResolver,
+			resolver?.policyResolver ?? policyResolver,
+			resolver?.indPolicyResolver ?? indPolicyResolver,
+			resolver?.roleResolver ?? roleResolver,
+			resolver?.tablesResolver ?? tablesResolver,
+			resolver?.columnsResolver ?? columnsResolver,
+			resolver?.viewsResolver ?? viewsResolver,
 			validatedPrev,
 			validatedCur,
 		);
+
+		const questions = finalizeGenerateResolver(config, resolver);
+		if (questions) {
+			return questions;
+		}
 
 		writeResult({
 			cur,
@@ -364,7 +563,7 @@ export const prepareAndMigratePg = async (config: GenerateConfig) => {
 			prefixMode: config.prefix,
 		});
 	} catch (e) {
-		console.error(e);
+		throw e;
 	}
 };
 
@@ -402,7 +601,7 @@ export const prepareAndExportPg = async (config: ExportConfig) => {
 
 		console.log(sqlStatements.join('\n'));
 	} catch (e) {
-		console.error(e);
+		throw e;
 	}
 };
 
@@ -532,8 +731,11 @@ export const prepareAndMigrateMysql = async (config: GenerateConfig) => {
 	try {
 		// TODO: remove
 		assertV1OutFolder(outFolder);
+		const resolver = createGenerateResolver(config);
 
-		const { snapshots, journal } = prepareMigrationFolder(outFolder, 'mysql');
+		const { snapshots, journal } = prepareMigrationFolder(outFolder, 'mysql', {
+			createIfMissing: !config.preflight,
+		});
 		const { prev, cur, custom } = await prepareMySqlMigrationSnapshot(
 			snapshots,
 			schemaPath,
@@ -563,12 +765,17 @@ export const prepareAndMigrateMysql = async (config: GenerateConfig) => {
 		const { sqlStatements, statements, _meta } = await applyMysqlSnapshotsDiff(
 			squashedPrev,
 			squashedCur,
-			tablesResolver,
-			columnsResolver,
-			mySqlViewsResolver,
+			resolver?.tablesResolver ?? tablesResolver,
+			resolver?.columnsResolver ?? columnsResolver,
+			resolver?.mySqlViewsResolver ?? mySqlViewsResolver,
 			validatedPrev,
 			validatedCur,
 		);
+
+		const questions = finalizeGenerateResolver(config, resolver);
+		if (questions) {
+			return questions;
+		}
 
 		writeResult({
 			cur,
@@ -581,7 +788,7 @@ export const prepareAndMigrateMysql = async (config: GenerateConfig) => {
 			prefixMode: config.prefix,
 		});
 	} catch (e) {
-		console.error(e);
+		throw e;
 	}
 };
 
@@ -682,8 +889,11 @@ export const prepareAndMigrateSingleStore = async (config: GenerateConfig) => {
 	try {
 		// TODO: remove
 		assertV1OutFolder(outFolder);
+		const resolver = createGenerateResolver(config);
 
-		const { snapshots, journal } = prepareMigrationFolder(outFolder, 'singlestore');
+		const { snapshots, journal } = prepareMigrationFolder(outFolder, 'singlestore', {
+			createIfMissing: !config.preflight,
+		});
 		const { prev, cur, custom } = await prepareSingleStoreMigrationSnapshot(
 			snapshots,
 			schemaPath,
@@ -713,12 +923,17 @@ export const prepareAndMigrateSingleStore = async (config: GenerateConfig) => {
 		const { sqlStatements, _meta } = await applySingleStoreSnapshotsDiff(
 			squashedPrev,
 			squashedCur,
-			tablesResolver,
-			columnsResolver,
+			resolver?.tablesResolver ?? tablesResolver,
+			resolver?.columnsResolver ?? columnsResolver,
 			/* singleStoreViewsResolver, */
 			validatedPrev,
 			validatedCur,
 		);
+
+		const questions = finalizeGenerateResolver(config, resolver);
+		if (questions) {
+			return questions;
+		}
 
 		writeResult({
 			cur,
@@ -731,7 +946,7 @@ export const prepareAndMigrateSingleStore = async (config: GenerateConfig) => {
 			prefixMode: config.prefix,
 		});
 	} catch (e) {
-		console.error(e);
+		throw e;
 	}
 };
 
@@ -763,7 +978,7 @@ export const prepareAndExportSinglestore = async (config: ExportConfig) => {
 
 		console.log(sqlStatements.join('\n'));
 	} catch (e) {
-		console.error(e);
+		throw e;
 	}
 };
 
@@ -806,8 +1021,11 @@ export const prepareAndMigrateSqlite = async (config: GenerateConfig) => {
 
 	try {
 		assertV1OutFolder(outFolder);
+		const resolver = createGenerateResolver(config);
 
-		const { snapshots, journal } = prepareMigrationFolder(outFolder, 'sqlite');
+		const { snapshots, journal } = prepareMigrationFolder(outFolder, 'sqlite', {
+			createIfMissing: !config.preflight,
+		});
 		const { prev, cur, custom } = await prepareSqliteMigrationSnapshot(
 			snapshots,
 			schemaPath,
@@ -838,12 +1056,17 @@ export const prepareAndMigrateSqlite = async (config: GenerateConfig) => {
 		const { sqlStatements, _meta } = await applySqliteSnapshotsDiff(
 			squashedPrev,
 			squashedCur,
-			tablesResolver,
-			columnsResolver,
-			sqliteViewsResolver,
+			resolver?.tablesResolver ?? tablesResolver,
+			resolver?.columnsResolver ?? columnsResolver,
+			resolver?.sqliteViewsResolver ?? sqliteViewsResolver,
 			validatedPrev,
 			validatedCur,
 		);
+
+		const questions = finalizeGenerateResolver(config, resolver);
+		if (questions) {
+			return questions;
+		}
 
 		writeResult({
 			cur,
@@ -901,8 +1124,11 @@ export const prepareAndMigrateLibSQL = async (config: GenerateConfig) => {
 
 	try {
 		assertV1OutFolder(outFolder);
+		const resolver = createGenerateResolver(config);
 
-		const { snapshots, journal } = prepareMigrationFolder(outFolder, 'sqlite');
+		const { snapshots, journal } = prepareMigrationFolder(outFolder, 'sqlite', {
+			createIfMissing: !config.preflight,
+		});
 		const { prev, cur, custom } = await prepareSqliteMigrationSnapshot(
 			snapshots,
 			schemaPath,
@@ -933,12 +1159,17 @@ export const prepareAndMigrateLibSQL = async (config: GenerateConfig) => {
 		const { sqlStatements, _meta } = await applyLibSQLSnapshotsDiff(
 			squashedPrev,
 			squashedCur,
-			tablesResolver,
-			columnsResolver,
-			sqliteViewsResolver,
+			resolver?.tablesResolver ?? tablesResolver,
+			resolver?.columnsResolver ?? columnsResolver,
+			resolver?.sqliteViewsResolver ?? sqliteViewsResolver,
 			validatedPrev,
 			validatedCur,
 		);
+
+		const questions = finalizeGenerateResolver(config, resolver);
+		if (questions) {
+			return questions;
+		}
 
 		writeResult({
 			cur,
@@ -1064,9 +1295,12 @@ const freeeeeeze = (obj: any) => {
 };
 
 export const promptColumnsConflicts = async <T extends Named>(
+	entity: 'column' | 'policy',
 	tableName: string,
+	tableSchema: string,
 	newColumns: T[],
 	missingColumns: T[],
+	state?: ConflictResolverState,
 ) => {
 	if (newColumns.length === 0 || missingColumns.length === 0) {
 		return { created: newColumns, renamed: [], deleted: missingColumns };
@@ -1088,43 +1322,73 @@ export const promptColumnsConflicts = async <T extends Named>(
 		});
 
 		const promptData: (RenamePropmtItem<T> | T)[] = [created, ...renames];
-
-		const { status, data } = await render(
-			new ResolveColumnSelect<T>(tableName, created, promptData),
+		const data = await resolvePromptChoice(
+			state,
+			{
+				id: createGenerateMigrationQuestionId(
+					entity,
+					asMigrationRef(entity, created),
+					asMigrationRef('table', { name: tableName, schema: tableSchema }),
+				),
+				kind: entity,
+				to: asMigrationRef(entity, created),
+				table: asMigrationRef('table', { name: tableName, schema: tableSchema }),
+				choices: [
+					{ type: 'create' },
+					...leftMissing.map((it) => ({
+						type: 'rename' as const,
+						from: asMigrationRef(entity, it),
+					})),
+				],
+			},
+			created,
+			leftMissing,
+			async () => {
+				const { status, data } = await render(
+					new ResolveColumnSelect<T>(tableName, created, promptData, entity),
+				);
+				if (status === 'aborted') {
+					console.error('ERROR');
+					process.exit(1);
+				}
+				return data;
+			},
 		);
-		if (status === 'aborted') {
-			console.error('ERROR');
-			process.exit(1);
-		}
 
 		if (isRenamePromptItem(data)) {
-			console.log(
-				`${chalk.yellow('~')} ${data.from.name} › ${data.to.name} ${
-					chalk.gray(
-						'column will be renamed',
-					)
-				}`,
-			);
+			if (!state) {
+				console.log(
+					`${chalk.yellow('~')} ${data.from.name} › ${data.to.name} ${
+						chalk.gray(
+							`${entity} will be renamed`,
+						)
+					}`,
+				);
+			}
 			result.renamed.push(data);
 			// this will make [item1, undefined, item2]
 			delete leftMissing[leftMissing.indexOf(data.from)];
 			// this will make [item1, item2]
 			leftMissing = leftMissing.filter(Boolean);
 		} else {
-			console.log(
-				`${chalk.green('+')} ${data.name} ${
-					chalk.gray(
-						'column will be created',
-					)
-				}`,
-			);
+			if (!state) {
+				console.log(
+					`${chalk.green('+')} ${data.name} ${
+						chalk.gray(
+							`${entity} will be created`,
+						)
+					}`,
+				);
+			}
 			result.created.push(created);
 		}
 		index += 1;
 	} while (index < newColumns.length);
-	console.log(
-		chalk.gray(`--- all columns conflicts in ${tableName} table resolved ---\n`),
-	);
+	if (!state) {
+		console.log(
+			chalk.gray(`--- all ${entity} conflicts in ${tableName} table resolved ---\n`),
+		);
+	}
 
 	result.deleted.push(...leftMissing);
 	return result;
@@ -1134,6 +1398,7 @@ export const promptNamedConflict = async <T extends Named>(
 	newItems: T[],
 	missingItems: T[],
 	entity: 'role' | 'policy',
+	state?: ConflictResolverState,
 ): Promise<{
 	created: T[];
 	renamed: { from: T; to: T }[];
@@ -1161,23 +1426,47 @@ export const promptNamedConflict = async <T extends Named>(
 		});
 
 		const promptData: (RenamePropmtItem<T> | T)[] = [created, ...renames];
-
-		const { status, data } = await render(
-			new ResolveSelectNamed<T>(created, promptData, entity),
+		const data = await resolvePromptChoice(
+			state,
+			{
+				id: createGenerateMigrationQuestionId(
+					entity,
+					asMigrationRef(entity, created),
+				),
+				kind: entity,
+				to: asMigrationRef(entity, created),
+				choices: [
+					{ type: 'create' },
+					...leftMissing.map((it) => ({
+						type: 'rename' as const,
+						from: asMigrationRef(entity, it),
+					})),
+				],
+			},
+			created,
+			leftMissing,
+			async () => {
+				const { status, data } = await render(
+					new ResolveSelectNamed<T>(created, promptData, entity),
+				);
+				if (status === 'aborted') {
+					console.error('ERROR');
+					process.exit(1);
+				}
+				return data;
+			},
 		);
-		if (status === 'aborted') {
-			console.error('ERROR');
-			process.exit(1);
-		}
 
 		if (isRenamePromptItem(data)) {
-			console.log(
-				`${chalk.yellow('~')} ${data.from.name} › ${data.to.name} ${
-					chalk.gray(
-						`${entity} will be renamed/moved`,
-					)
-				}`,
-			);
+			if (!state) {
+				console.log(
+					`${chalk.yellow('~')} ${data.from.name} › ${data.to.name} ${
+						chalk.gray(
+							`${entity} will be renamed/moved`,
+						)
+					}`,
+				);
+			}
 
 			if (data.from.name !== data.to.name) {
 				result.renamed.push(data);
@@ -1186,18 +1475,22 @@ export const promptNamedConflict = async <T extends Named>(
 			delete leftMissing[leftMissing.indexOf(data.from)];
 			leftMissing = leftMissing.filter(Boolean);
 		} else {
-			console.log(
-				`${chalk.green('+')} ${data.name} ${
-					chalk.gray(
-						`${entity} will be created`,
-					)
-				}`,
-			);
+			if (!state) {
+				console.log(
+					`${chalk.green('+')} ${data.name} ${
+						chalk.gray(
+							`${entity} will be created`,
+						)
+					}`,
+				);
+			}
 			result.created.push(created);
 		}
 		index += 1;
 	} while (index < newItems.length);
-	console.log(chalk.gray(`--- all ${entity} conflicts resolved ---\n`));
+	if (!state) {
+		console.log(chalk.gray(`--- all ${entity} conflicts resolved ---\n`));
+	}
 	result.deleted.push(...leftMissing);
 	return result;
 };
@@ -1206,6 +1499,7 @@ export const promptNamedWithSchemasConflict = async <T extends NamedWithSchema>(
 	newItems: T[],
 	missingItems: T[],
 	entity: 'table' | 'enum' | 'sequence' | 'view',
+	state?: ConflictResolverState,
 ): Promise<{
 	created: T[];
 	renamed: { from: T; to: T }[];
@@ -1236,14 +1530,36 @@ export const promptNamedWithSchemasConflict = async <T extends NamedWithSchema>(
 		});
 
 		const promptData: (RenamePropmtItem<T> | T)[] = [created, ...renames];
-
-		const { status, data } = await render(
-			new ResolveSelect<T>(created, promptData, entity),
+		const data = await resolvePromptChoice(
+			state,
+			{
+				id: createGenerateMigrationQuestionId(
+					entity,
+					asMigrationRef(entity, created),
+				),
+				kind: entity,
+				to: asMigrationRef(entity, created),
+				choices: [
+					{ type: 'create' },
+					...leftMissing.map((it) => ({
+						type: 'rename' as const,
+						from: asMigrationRef(entity, it),
+					})),
+				],
+			},
+			created,
+			leftMissing,
+			async () => {
+				const { status, data } = await render(
+					new ResolveSelect<T>(created, promptData, entity),
+				);
+				if (status === 'aborted') {
+					console.error('ERROR');
+					process.exit(1);
+				}
+				return data;
+			},
 		);
-		if (status === 'aborted') {
-			console.error('ERROR');
-			process.exit(1);
-		}
 
 		if (isRenamePromptItem(data)) {
 			const schemaFromPrefix = !data.from.schema || data.from.schema === 'public'
@@ -1253,13 +1569,15 @@ export const promptNamedWithSchemasConflict = async <T extends NamedWithSchema>(
 				? ''
 				: `${data.to.schema}.`;
 
-			console.log(
-				`${chalk.yellow('~')} ${schemaFromPrefix}${data.from.name} › ${schemaToPrefix}${data.to.name} ${
-					chalk.gray(
-						`${entity} will be renamed/moved`,
-					)
-				}`,
-			);
+			if (!state) {
+				console.log(
+					`${chalk.yellow('~')} ${schemaFromPrefix}${data.from.name} › ${schemaToPrefix}${data.to.name} ${
+						chalk.gray(
+							`${entity} will be renamed/moved`,
+						)
+					}`,
+				);
+			}
 
 			if (data.from.name !== data.to.name) {
 				result.renamed.push(data);
@@ -1276,18 +1594,22 @@ export const promptNamedWithSchemasConflict = async <T extends NamedWithSchema>(
 			delete leftMissing[leftMissing.indexOf(data.from)];
 			leftMissing = leftMissing.filter(Boolean);
 		} else {
-			console.log(
-				`${chalk.green('+')} ${data.name} ${
-					chalk.gray(
-						`${entity} will be created`,
-					)
-				}`,
-			);
+			if (!state) {
+				console.log(
+					`${chalk.green('+')} ${data.name} ${
+						chalk.gray(
+							`${entity} will be created`,
+						)
+					}`,
+				);
+			}
 			result.created.push(created);
 		}
 		index += 1;
 	} while (index < newItems.length);
-	console.log(chalk.gray(`--- all ${entity} conflicts resolved ---\n`));
+	if (!state) {
+		console.log(chalk.gray(`--- all ${entity} conflicts resolved ---\n`));
+	}
 	result.deleted.push(...leftMissing);
 	return result;
 };
@@ -1295,6 +1617,7 @@ export const promptNamedWithSchemasConflict = async <T extends NamedWithSchema>(
 export const promptSchemasConflict = async <T extends Named>(
 	newSchemas: T[],
 	missingSchemas: T[],
+	state?: ConflictResolverState,
 ): Promise<{ created: T[]; renamed: { from: T; to: T }[]; deleted: T[] }> => {
 	if (missingSchemas.length === 0 || newSchemas.length === 0) {
 		return { created: newSchemas, renamed: [], deleted: missingSchemas };
@@ -1314,39 +1637,67 @@ export const promptSchemasConflict = async <T extends Named>(
 		});
 
 		const promptData: (RenamePropmtItem<T> | T)[] = [created, ...renames];
-
-		const { status, data } = await render(
-			new ResolveSchemasSelect<T>(created, promptData),
+		const data = await resolvePromptChoice(
+			state,
+			{
+				id: createGenerateMigrationQuestionId(
+					'schema',
+					asMigrationRef('schema', created),
+				),
+				kind: 'schema',
+				to: asMigrationRef('schema', created),
+				choices: [
+					{ type: 'create' },
+					...leftMissing.map((it) => ({
+						type: 'rename' as const,
+						from: asMigrationRef('schema', it),
+					})),
+				],
+			},
+			created,
+			leftMissing,
+			async () => {
+				const { status, data } = await render(
+					new ResolveSchemasSelect<T>(created, promptData),
+				);
+				if (status === 'aborted') {
+					console.error('ERROR');
+					process.exit(1);
+				}
+				return data;
+			},
 		);
-		if (status === 'aborted') {
-			console.error('ERROR');
-			process.exit(1);
-		}
 
 		if (isRenamePromptItem(data)) {
-			console.log(
-				`${chalk.yellow('~')} ${data.from.name} › ${data.to.name} ${
-					chalk.gray(
-						'schema will be renamed',
-					)
-				}`,
-			);
+			if (!state) {
+				console.log(
+					`${chalk.yellow('~')} ${data.from.name} › ${data.to.name} ${
+						chalk.gray(
+							'schema will be renamed',
+						)
+					}`,
+				);
+			}
 			result.renamed.push(data);
 			delete leftMissing[leftMissing.indexOf(data.from)];
 			leftMissing = leftMissing.filter(Boolean);
 		} else {
-			console.log(
-				`${chalk.green('+')} ${data.name} ${
-					chalk.gray(
-						'schema will be created',
-					)
-				}`,
-			);
+			if (!state) {
+				console.log(
+					`${chalk.green('+')} ${data.name} ${
+						chalk.gray(
+							'schema will be created',
+						)
+					}`,
+				);
+			}
 			result.created.push(created);
 		}
 		index += 1;
 	} while (index < newSchemas.length);
-	console.log(chalk.gray('--- all schemas conflicts resolved ---\n'));
+	if (!state) {
+		console.log(chalk.gray('--- all schemas conflicts resolved ---\n'));
+	}
 	result.deleted.push(...leftMissing);
 	return result;
 };

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -1,10 +1,14 @@
 import chalk from 'chalk';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { render } from 'hanji';
 import { join, resolve } from 'path';
 import { object, string } from 'zod';
 import { getTablesFilterByExtensions } from '../../extensions/getTablesFilterByExtensions';
 import { assertUnreachable } from '../../global';
+import {
+	type GenerateMigrationQuestions,
+	parseGenerateMigrationQuestions,
+} from '../../migrationQuestions';
 import { type Dialect, dialect } from '../../schemaValidator';
 import { prepareFilenames } from '../../serializer';
 import { Entities, pullParams, pushParams } from '../validations/cli';
@@ -147,6 +151,8 @@ export type GenerateConfig = {
 	bundle: boolean;
 	casing?: CasingType;
 	driver?: Driver;
+	preflight: boolean;
+	answers?: GenerateMigrationQuestions;
 };
 
 export type ExportConfig = {
@@ -167,6 +173,8 @@ export const prepareGenerateConfig = async (
 		driver?: Driver;
 		prefix?: Prefix;
 		casing?: CasingType;
+		preflight?: boolean;
+		answers?: string;
 	},
 	from: 'config' | 'cli',
 ): Promise<GenerateConfig> => {
@@ -188,8 +196,30 @@ export const prepareGenerateConfig = async (
 		process.exit(0);
 	}
 
+	if (options.custom && (options.preflight || options.answers)) {
+		console.log(error(`"--custom" can't be combined with "--preflight" or "--answers"`));
+		process.exit(1);
+	}
+
 	const prefix = ('migrations' in config ? config.migrations?.prefix : options.prefix)
 		|| 'index';
+
+	let answers: GenerateMigrationQuestions | undefined;
+	if (options.answers) {
+		const raw = existsSync(options.answers)
+			? readFileSync(resolve(options.answers), 'utf8')
+			: options.answers;
+
+		try {
+			answers = parseGenerateMigrationQuestions(JSON.parse(raw));
+		} catch (e) {
+			console.log(
+				error(`Unable to parse "--answers". Pass a JSON file path or an inline JSON string.`),
+			);
+			console.error(e);
+			process.exit(1);
+		}
+	}
 
 	return {
 		dialect: dialect,
@@ -202,6 +232,8 @@ export const prepareGenerateConfig = async (
 		bundle: driver === 'expo' || driver === 'durable-sqlite',
 		casing,
 		driver,
+		preflight: options.preflight ?? false,
+		answers,
 	};
 };
 

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -51,6 +51,7 @@ import {
 } from '../validations/sqlite';
 import { studioCliParams, studioConfig } from '../validations/studio';
 import { error } from '../views';
+import { writeInfoOutput } from '../output';
 
 // NextJs default config is target: es5, which esbuild-register can't consume
 const assertES5 = async (unregister: () => void) => {
@@ -178,7 +179,9 @@ export const prepareGenerateConfig = async (
 	},
 	from: 'config' | 'cli',
 ): Promise<GenerateConfig> => {
-	const config = from === 'config' ? await drizzleConfigFromFile(options.config) : options;
+	const config = from === 'config'
+		? await drizzleConfigFromFile(options.config, false, options.preflight ?? false)
+		: options;
 
 	const { schema, out, breakpoints, dialect, driver, casing } = config;
 
@@ -190,7 +193,7 @@ export const prepareGenerateConfig = async (
 		process.exit(1);
 	}
 
-	const fileNames = prepareFilenames(schema);
+	const fileNames = prepareFilenames(schema, options.preflight ?? false);
 	if (fileNames.length === 0) {
 		render(`[${chalk.blue('i')}] No schema file in ${schema} was found`);
 		process.exit(0);
@@ -908,6 +911,7 @@ export const prepareMigrateConfig = async (configPath: string | undefined) => {
 export const drizzleConfigFromFile = async (
 	configPath?: string,
 	isExport?: boolean,
+	machineReadableOutput = false,
 ): Promise<CliConfig> => {
 	const prefix = process.env.TEST_CONFIG_PATH_PREFIX || '';
 
@@ -924,21 +928,28 @@ export const drizzleConfigFromFile = async (
 		: 'drizzle.config.json';
 
 	if (!configPath && !isExport) {
-		console.log(
+		writeInfoOutput(
 			chalk.gray(
 				`No config path provided, using default '${defaultConfigPath}'`,
 			),
+			{ machineReadable: machineReadableOutput },
 		);
 	}
 
 	const path: string = resolve(join(prefix, configPath ?? defaultConfigPath));
 
 	if (!existsSync(path)) {
-		console.log(`${path} file does not exist`);
+		writeInfoOutput(`${path} file does not exist`, {
+			machineReadable: machineReadableOutput,
+		});
 		process.exit(1);
 	}
 
-	if (!isExport) console.log(chalk.grey(`Reading config file '${path}'`));
+	if (!isExport) {
+		writeInfoOutput(chalk.grey(`Reading config file '${path}'`), {
+			machineReadable: machineReadableOutput,
+		});
+	}
 
 	const { unregister } = await safeRegister();
 	const required = require(`${path}`);

--- a/drizzle-kit/src/cli/output.ts
+++ b/drizzle-kit/src/cli/output.ts
@@ -1,0 +1,37 @@
+export const MACHINE_OUTPUT_ENV = 'DRIZZLE_KIT_MACHINE_OUTPUT';
+
+export const isMachineOutputEnabled = () => process.env[MACHINE_OUTPUT_ENV] === '1';
+
+export const writeInfoOutput = (
+	message: string,
+	options?: { machineReadable?: boolean },
+) => {
+	const machineReadable = options?.machineReadable ?? isMachineOutputEnabled();
+	if (machineReadable) {
+		console.error(message);
+		return;
+	}
+	console.log(message);
+};
+
+export const withMachineOutput = async <T>(
+	enabled: boolean,
+	action: () => Promise<T>,
+): Promise<T> => {
+	const previous = process.env[MACHINE_OUTPUT_ENV];
+	if (enabled) {
+		process.env[MACHINE_OUTPUT_ENV] = '1';
+	} else {
+		delete process.env[MACHINE_OUTPUT_ENV];
+	}
+
+	try {
+		return await action();
+	} finally {
+		if (typeof previous === 'string') {
+			process.env[MACHINE_OUTPUT_ENV] = previous;
+		} else {
+			delete process.env[MACHINE_OUTPUT_ENV];
+		}
+	}
+};

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -30,6 +30,7 @@ import { assertOrmCoreVersion, assertPackages, assertStudioNodeVersion, ormVersi
 import { assertCollisions, drivers, prefixes } from './validations/common';
 import { withStyle } from './validations/outputs';
 import { error, grey, MigrateProgress } from './views';
+import { withMachineOutput } from './output';
 
 const optionDialect = string('dialect')
 	.enum(...dialects)
@@ -87,67 +88,67 @@ export const generate = command({
 		await assertOrmCoreVersion();
 		await assertPackages('drizzle-orm');
 
-		// const parsed = cliConfigGenerate.parse(opts);
+		await withMachineOutput(opts.preflight, async () => {
+			const {
+				prepareAndMigratePg,
+				prepareAndMigrateMysql,
+				prepareAndMigrateSqlite,
+				prepareAndMigrateLibSQL,
+				prepareAndMigrateSingleStore,
+			} = await import('./commands/migrate');
 
-		const {
-			prepareAndMigratePg,
-			prepareAndMigrateMysql,
-			prepareAndMigrateSqlite,
-			prepareAndMigrateLibSQL,
-			prepareAndMigrateSingleStore,
-		} = await import('./commands/migrate');
+			try {
+				const dialect = opts.dialect;
+				if (dialect === 'postgresql') {
+					const questions = await prepareAndMigratePg(opts);
+					if (opts.preflight) {
+						console.log(JSON.stringify(questions, null, 2));
+					}
+				} else if (dialect === 'mysql') {
+					const questions = await prepareAndMigrateMysql(opts);
+					if (opts.preflight) {
+						console.log(JSON.stringify(questions, null, 2));
+					}
+				} else if (dialect === 'sqlite') {
+					const questions = await prepareAndMigrateSqlite(opts);
+					if (opts.preflight) {
+						console.log(JSON.stringify(questions, null, 2));
+					}
+				} else if (dialect === 'turso') {
+					const questions = await prepareAndMigrateLibSQL(opts);
+					if (opts.preflight) {
+						console.log(JSON.stringify(questions, null, 2));
+					}
+				} else if (dialect === 'singlestore') {
+					const questions = await prepareAndMigrateSingleStore(opts);
+					if (opts.preflight) {
+						console.log(JSON.stringify(questions, null, 2));
+					}
+				} else if (dialect === 'gel') {
+					console.log(
+						error(
+							`You can't use 'generate' command with Gel dialect`,
+						),
+					);
+					process.exit(1);
+				} else {
+					assertUnreachable(dialect);
+				}
+			} catch (e) {
+				if (e instanceof GenerateMigrationQuestionsError) {
+					console.log(
+						error(
+							`Not all migration conflicts were answered. Re-run with "--preflight" to export the remaining questions.`,
+						),
+					);
+					console.log(JSON.stringify(e.questions, null, 2));
+					process.exit(1);
+				}
 
-		try {
-			const dialect = opts.dialect;
-			if (dialect === 'postgresql') {
-				const questions = await prepareAndMigratePg(opts);
-				if (opts.preflight) {
-					console.log(JSON.stringify(questions, null, 2));
-				}
-			} else if (dialect === 'mysql') {
-				const questions = await prepareAndMigrateMysql(opts);
-				if (opts.preflight) {
-					console.log(JSON.stringify(questions, null, 2));
-				}
-			} else if (dialect === 'sqlite') {
-				const questions = await prepareAndMigrateSqlite(opts);
-				if (opts.preflight) {
-					console.log(JSON.stringify(questions, null, 2));
-				}
-			} else if (dialect === 'turso') {
-				const questions = await prepareAndMigrateLibSQL(opts);
-				if (opts.preflight) {
-					console.log(JSON.stringify(questions, null, 2));
-				}
-			} else if (dialect === 'singlestore') {
-				const questions = await prepareAndMigrateSingleStore(opts);
-				if (opts.preflight) {
-					console.log(JSON.stringify(questions, null, 2));
-				}
-			} else if (dialect === 'gel') {
-				console.log(
-					error(
-						`You can't use 'generate' command with Gel dialect`,
-					),
-				);
+				console.error(e);
 				process.exit(1);
-			} else {
-				assertUnreachable(dialect);
 			}
-		} catch (e) {
-			if (e instanceof GenerateMigrationQuestionsError) {
-				console.log(
-					error(
-						`Not all migration conflicts were answered. Re-run with "--preflight" to export the remaining questions.`,
-					),
-				);
-				console.log(JSON.stringify(e.questions, null, 2));
-				process.exit(1);
-			}
-
-			console.error(e);
-			process.exit(1);
-		}
+		});
 	},
 });
 

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import 'dotenv/config';
 import { mkdirSync } from 'fs';
 import { renderWithTask } from 'hanji';
+import { GenerateMigrationQuestionsError } from '../migrationQuestions';
 import { dialects } from 'src/schemaValidator';
 import '../@types/utils';
 import { assertUnreachable } from '../global';
@@ -40,6 +41,12 @@ const optionConfig = string().desc('Path to drizzle config file');
 const optionBreakpoints = boolean().desc(
 	`Prepare SQL statements with breakpoints`,
 );
+const optionPreflight = boolean().desc(
+	'Export unresolved generate conflicts as JSON instead of writing a migration',
+);
+const optionAnswers = string().desc(
+	'Conflict answers as a JSON file path or inline JSON string',
+);
 
 const optionDriver = string()
 	.enum(...drivers)
@@ -58,6 +65,8 @@ export const generate = command({
 		out: optionOut,
 		name: string().desc('Migration file name'),
 		breakpoints: optionBreakpoints,
+		preflight: optionPreflight,
+		answers: optionAnswers,
 		custom: boolean()
 			.desc('Prepare empty migration file for custom SQL')
 			.default(false),
@@ -69,7 +78,7 @@ export const generate = command({
 		const from = assertCollisions(
 			'generate',
 			opts,
-			['prefix', 'name', 'custom'],
+			['prefix', 'name', 'custom', 'preflight', 'answers'],
 			['driver', 'breakpoints', 'schema', 'out', 'dialect', 'casing'],
 		);
 		return prepareGenerateConfig(opts, from);
@@ -88,26 +97,56 @@ export const generate = command({
 			prepareAndMigrateSingleStore,
 		} = await import('./commands/migrate');
 
-		const dialect = opts.dialect;
-		if (dialect === 'postgresql') {
-			await prepareAndMigratePg(opts);
-		} else if (dialect === 'mysql') {
-			await prepareAndMigrateMysql(opts);
-		} else if (dialect === 'sqlite') {
-			await prepareAndMigrateSqlite(opts);
-		} else if (dialect === 'turso') {
-			await prepareAndMigrateLibSQL(opts);
-		} else if (dialect === 'singlestore') {
-			await prepareAndMigrateSingleStore(opts);
-		} else if (dialect === 'gel') {
-			console.log(
-				error(
-					`You can't use 'generate' command with Gel dialect`,
-				),
-			);
+		try {
+			const dialect = opts.dialect;
+			if (dialect === 'postgresql') {
+				const questions = await prepareAndMigratePg(opts);
+				if (opts.preflight) {
+					console.log(JSON.stringify(questions, null, 2));
+				}
+			} else if (dialect === 'mysql') {
+				const questions = await prepareAndMigrateMysql(opts);
+				if (opts.preflight) {
+					console.log(JSON.stringify(questions, null, 2));
+				}
+			} else if (dialect === 'sqlite') {
+				const questions = await prepareAndMigrateSqlite(opts);
+				if (opts.preflight) {
+					console.log(JSON.stringify(questions, null, 2));
+				}
+			} else if (dialect === 'turso') {
+				const questions = await prepareAndMigrateLibSQL(opts);
+				if (opts.preflight) {
+					console.log(JSON.stringify(questions, null, 2));
+				}
+			} else if (dialect === 'singlestore') {
+				const questions = await prepareAndMigrateSingleStore(opts);
+				if (opts.preflight) {
+					console.log(JSON.stringify(questions, null, 2));
+				}
+			} else if (dialect === 'gel') {
+				console.log(
+					error(
+						`You can't use 'generate' command with Gel dialect`,
+					),
+				);
+				process.exit(1);
+			} else {
+				assertUnreachable(dialect);
+			}
+		} catch (e) {
+			if (e instanceof GenerateMigrationQuestionsError) {
+				console.log(
+					error(
+						`Not all migration conflicts were answered. Re-run with "--preflight" to export the remaining questions.`,
+					),
+				);
+				console.log(JSON.stringify(e.questions, null, 2));
+				process.exit(1);
+			}
+
+			console.error(e);
 			process.exit(1);
-		} else {
-			assertUnreachable(dialect);
 		}
 	},
 });

--- a/drizzle-kit/src/cli/views.ts
+++ b/drizzle-kit/src/cli/views.ts
@@ -95,6 +95,7 @@ export class ResolveColumnSelect<T extends Named> extends Prompt<
 		private readonly tableName: string,
 		private readonly base: Named,
 		data: (RenamePropmtItem<T> | T)[],
+		private readonly entityType: 'column' | 'policy' = 'column',
 	) {
 		super();
 		this.on('attach', (terminal) => terminal.toggleCursor('hide'));
@@ -111,11 +112,11 @@ export class ResolveColumnSelect<T extends Named> extends Prompt<
 			chalk.bold.blue(
 				this.base.name,
 			)
-		} column in ${
+		} ${this.entityType} in ${
 			chalk.bold.blue(
 				this.tableName,
 			)
-		} table created or renamed from another column?\n`;
+		} table created or renamed from another ${this.entityType}?\n`;
 
 		const isSelectedRenamed = isRenamePromptItem(
 			this.data.items[this.data.selectedIdx],
@@ -144,8 +145,8 @@ export class ResolveColumnSelect<T extends Named> extends Prompt<
 				? `${it.from.name} › ${it.to.name}`.padEnd(labelLength, ' ')
 				: it.name.padEnd(labelLength, ' ');
 			const label = isRenamed
-				? `${chalk.yellow('~')} ${title} ${chalk.gray('rename column')}`
-				: `${chalk.green('+')} ${title} ${chalk.gray('create column')}`;
+				? `${chalk.yellow('~')} ${title} ${chalk.gray(`rename ${this.entityType}`)}`
+				: `${chalk.green('+')} ${title} ${chalk.gray(`create ${this.entityType}`)}`;
 
 			text += isSelected ? `${selectedPrefix}${label}` : `  ${label}`;
 			text += idx != this.data.items.length - 1 ? '\n' : '';

--- a/drizzle-kit/src/migrationQuestions.ts
+++ b/drizzle-kit/src/migrationQuestions.ts
@@ -1,0 +1,147 @@
+import { array, literal, object, string, union } from 'zod';
+
+export type GenerateMigrationQuestionKind =
+	| 'column'
+	| 'enum'
+	| 'policy'
+	| 'role'
+	| 'schema'
+	| 'sequence'
+	| 'table'
+	| 'view';
+
+export type GenerateMigrationRef = {
+	name: string;
+	schema?: string;
+};
+
+export type GenerateMigrationChoice =
+	| { type: 'create' }
+	| { type: 'rename'; from: GenerateMigrationRef };
+
+export type GenerateMigrationQuestion = {
+	id: string;
+	kind: GenerateMigrationQuestionKind;
+	to: GenerateMigrationRef;
+	table?: GenerateMigrationRef;
+	choices: GenerateMigrationChoice[];
+	answer?: GenerateMigrationChoice;
+};
+
+export type GenerateMigrationQuestions = {
+	version: 1;
+	questions: GenerateMigrationQuestion[];
+};
+
+const generateMigrationRefSchema = object({
+	name: string(),
+	schema: string().optional(),
+}).strict();
+
+const generateMigrationChoiceSchema = union([
+	object({
+		type: literal('create'),
+	}).strict(),
+	object({
+		type: literal('rename'),
+		from: generateMigrationRefSchema,
+	}).strict(),
+]);
+
+const generateMigrationQuestionSchema = object({
+	id: string(),
+	kind: union([
+		literal('column'),
+		literal('enum'),
+		literal('policy'),
+		literal('role'),
+		literal('schema'),
+		literal('sequence'),
+		literal('table'),
+		literal('view'),
+	]),
+	to: generateMigrationRefSchema,
+	table: generateMigrationRefSchema.optional(),
+	choices: array(generateMigrationChoiceSchema),
+	answer: generateMigrationChoiceSchema.optional(),
+}).strict();
+
+const generateMigrationQuestionsSchema = object({
+	version: literal(1),
+	questions: array(generateMigrationQuestionSchema),
+}).strict();
+
+const generateMigrationQuestionsInputSchema = union([
+	generateMigrationQuestionsSchema,
+	array(generateMigrationQuestionSchema),
+]);
+
+const schemaAwareKinds = new Set<GenerateMigrationQuestionKind>([
+	'enum',
+	'sequence',
+	'table',
+	'view',
+]);
+
+const normalizeSchema = (schema?: string) => {
+	return schema || 'public';
+};
+
+const refKey = (ref: GenerateMigrationRef) => {
+	return ref.schema ? `${ref.schema}.${ref.name}` : ref.name;
+};
+
+export const parseGenerateMigrationQuestions = (
+	input: unknown,
+): GenerateMigrationQuestions => {
+	const parsed = generateMigrationQuestionsInputSchema.parse(input);
+
+	if (Array.isArray(parsed)) {
+		return {
+			version: 1,
+			questions: parsed,
+		};
+	}
+
+	return parsed;
+};
+
+export const normalizeGenerateMigrationRef = (
+	kind: GenerateMigrationQuestionKind,
+	ref: GenerateMigrationRef,
+): GenerateMigrationRef => {
+	if (!schemaAwareKinds.has(kind)) {
+		return { name: ref.name };
+	}
+
+	return {
+		name: ref.name,
+		schema: normalizeSchema(ref.schema),
+	};
+};
+
+export const createGenerateMigrationQuestionId = (
+	kind: GenerateMigrationQuestionKind,
+	to: GenerateMigrationRef,
+	table?: GenerateMigrationRef,
+) => {
+	if (kind === 'column' || kind === 'policy') {
+		if (!table) {
+			throw new Error(`"${kind}" questions require table context`);
+		}
+		return `${kind}:${refKey(table)}:${to.name}`;
+	}
+
+	return `${kind}:${refKey(to)}`;
+};
+
+export class GenerateMigrationQuestionsError extends Error {
+	readonly questions: GenerateMigrationQuestions;
+
+	constructor(questions: GenerateMigrationQuestions) {
+		const unresolved = questions.questions.filter((it) => !it.answer).length;
+		super(`Missing answers for ${unresolved} migration conflict${unresolved === 1 ? '' : 's'}`);
+		this.name = 'GenerateMigrationQuestionsError';
+		this.questions = questions;
+	}
+}

--- a/drizzle-kit/src/serializer/index.ts
+++ b/drizzle-kit/src/serializer/index.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import * as glob from 'glob';
 import Path from 'path';
 import { CasingType } from 'src/cli/validations/common';
+import { writeInfoOutput } from '../cli/output';
 import { error } from '../cli/views';
 import type { MySqlSchemaInternal } from './mysqlSchema';
 import type { PgSchemaInternal } from './pgSchema';
@@ -15,7 +16,7 @@ export const serializeMySql = async (
 ): Promise<MySqlSchemaInternal> => {
 	const filenames = prepareFilenames(path);
 
-	console.log(chalk.gray(`Reading schema files:\n${filenames.join('\n')}\n`));
+	writeInfoOutput(chalk.gray(`Reading schema files:\n${filenames.join('\n')}\n`));
 
 	const { prepareFromMySqlImports } = await import('./mysqlImports');
 	const { generateMySqlSnapshot } = await import('./mysqlSerializer');
@@ -60,7 +61,7 @@ export const serializeSingleStore = async (
 ): Promise<SingleStoreSchemaInternal> => {
 	const filenames = prepareFilenames(path);
 
-	console.log(chalk.gray(`Reading schema files:\n${filenames.join('\n')}\n`));
+	writeInfoOutput(chalk.gray(`Reading schema files:\n${filenames.join('\n')}\n`));
 
 	const { prepareFromSingleStoreImports } = await import('./singlestoreImports');
 	const { generateSingleStoreSnapshot } = await import('./singlestoreSerializer');
@@ -70,7 +71,10 @@ export const serializeSingleStore = async (
 	return generateSingleStoreSnapshot(tables, /* views, */ casing);
 };
 
-export const prepareFilenames = (path: string | string[]) => {
+export const prepareFilenames = (
+	path: string | string[],
+	machineReadableOutput?: boolean,
+) => {
 	if (typeof path === 'string') {
 		path = [path];
 	}
@@ -109,7 +113,7 @@ export const prepareFilenames = (path: string | string[]) => {
 
 	// when schema: "./schema" and not "./schema.ts"
 	if (res.length === 0) {
-		console.log(
+		writeInfoOutput(
 			error(
 				`No schema files found for path config [${
 					path
@@ -117,11 +121,13 @@ export const prepareFilenames = (path: string | string[]) => {
 						.join(', ')
 				}]`,
 			),
+			{ machineReadable: machineReadableOutput },
 		);
-		console.log(
+		writeInfoOutput(
 			error(
 				`If path represents a file - please make sure to use .ts or other extension in the path`,
 			),
+			{ machineReadable: machineReadableOutput },
 		);
 		process.exit(1);
 	}

--- a/drizzle-kit/src/utils.ts
+++ b/drizzle-kit/src/utils.ts
@@ -193,7 +193,19 @@ export const validateWithReport = (snapshots: string[], dialect: Dialect) => {
 export const prepareMigrationFolder = (
 	outFolder: string = 'drizzle',
 	dialect: Dialect,
+	options?: {
+		createIfMissing?: boolean;
+	},
 ) => {
+	if (!existsSync(join(outFolder, 'meta'))) {
+		if (options?.createIfMissing === false) {
+			return {
+				snapshots: [],
+				journal: dryJournal(dialect),
+			};
+		}
+	}
+
 	const { snapshots, journal } = prepareOutFolder(outFolder, dialect);
 	const report = validateWithReport(snapshots, dialect);
 	if (report.nonLatest.length > 0) {

--- a/drizzle-kit/tests/api-generate.test.ts
+++ b/drizzle-kit/tests/api-generate.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'vitest';
+import { integer, pgTable } from 'drizzle-orm/pg-core';
+import {
+	GenerateMigrationQuestionsError,
+	generateDrizzleJson,
+	generateMigration,
+	preflightMigration,
+} from '../src/api';
+
+test('api preflight exports questions and answers drive non-interactive generate', async () => {
+	const prev = generateDrizzleJson({
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+		}),
+	});
+
+	const cur = generateDrizzleJson(
+		{
+			accounts: pgTable('accounts', {
+				id: integer('id').primaryKey(),
+			}),
+		},
+		prev.id,
+	);
+
+	const questions = await preflightMigration(prev, cur);
+
+	expect(questions).toStrictEqual({
+		version: 1,
+		questions: [
+			{
+				id: 'table:public.accounts',
+				kind: 'table',
+				to: { name: 'accounts', schema: 'public' },
+				choices: [
+					{ type: 'create' },
+					{ type: 'rename', from: { name: 'users', schema: 'public' } },
+				],
+			},
+		],
+	});
+
+	await expect(
+		generateMigration(prev, cur, { answers: questions }),
+	).rejects.toBeInstanceOf(GenerateMigrationQuestionsError);
+
+	const sqlStatements = await generateMigration(prev, cur, {
+		answers: {
+			version: 1,
+			questions: [
+				{
+					...questions.questions[0]!,
+					answer: { type: 'rename', from: { name: 'users', schema: 'public' } },
+				},
+			],
+		},
+	});
+
+	expect(sqlStatements).toContain('ALTER TABLE "users" RENAME TO "accounts";');
+});

--- a/drizzle-kit/tests/cli-generate.test.ts
+++ b/drizzle-kit/tests/cli-generate.test.ts
@@ -33,6 +33,8 @@ test('generate #1', async (t) => {
 		dialect: 'postgresql',
 		name: undefined,
 		custom: false,
+		preflight: false,
+		answers: undefined,
 		prefix: 'index',
 		breakpoints: true,
 		schema: 'schema.ts',
@@ -54,6 +56,8 @@ test('generate #2', async (t) => {
 		dialect: 'postgresql',
 		name: undefined,
 		custom: false,
+		preflight: false,
+		answers: undefined,
 		prefix: 'index',
 		breakpoints: true,
 		schema: 'schema.ts',
@@ -72,6 +76,8 @@ test('generate #3', async (t) => {
 		dialect: 'postgresql',
 		name: undefined,
 		custom: false,
+		preflight: false,
+		answers: undefined,
 		prefix: 'index',
 		breakpoints: true,
 		schema: './schema.ts',
@@ -91,6 +97,8 @@ test('generate #4', async (t) => {
 		dialect: 'postgresql',
 		name: undefined,
 		custom: true,
+		preflight: false,
+		answers: undefined,
 		prefix: 'index',
 		breakpoints: true,
 		schema: './schema.ts',
@@ -109,6 +117,8 @@ test('generate #5', async (t) => {
 		dialect: 'postgresql',
 		name: 'custom',
 		custom: false,
+		preflight: false,
+		answers: undefined,
 		prefix: 'index',
 		breakpoints: true,
 		schema: './schema.ts',
@@ -127,6 +137,8 @@ test('generate #6', async (t) => {
 		dialect: 'postgresql',
 		name: undefined,
 		custom: false,
+		preflight: false,
+		answers: undefined,
 		prefix: 'timestamp',
 		breakpoints: true,
 		schema: './schema.ts',
@@ -148,6 +160,8 @@ test('generate #7', async (t) => {
 		dialect: 'postgresql',
 		name: 'custom',
 		custom: true,
+		preflight: false,
+		answers: undefined,
 		prefix: 'timestamp',
 		breakpoints: true,
 		schema: './schema.ts',
@@ -167,6 +181,8 @@ test('generate #8', async (t) => {
 		dialect: 'sqlite',
 		name: undefined,
 		custom: false,
+		preflight: false,
+		answers: undefined,
 		prefix: 'index',
 		breakpoints: true,
 		schema: './schema.ts',
@@ -185,6 +201,8 @@ test('generate #9', async (t) => {
 		dialect: 'sqlite',
 		name: undefined,
 		custom: false,
+		preflight: false,
+		answers: undefined,
 		prefix: 'index',
 		breakpoints: true,
 		schema: './schema.ts',
@@ -207,6 +225,8 @@ test('generate #9', async (t) => {
 		dialect: 'postgresql',
 		name: 'custom',
 		custom: true,
+		preflight: false,
+		answers: undefined,
 		prefix: 'timestamp',
 		breakpoints: true,
 		schema: 'schema.ts',
@@ -214,6 +234,55 @@ test('generate #9', async (t) => {
 		bundle: false,
 		casing: undefined,
 		driver: undefined,
+	});
+});
+
+test('generate preflight #1', async () => {
+	const res = await brotest(
+		generate,
+		'--dialect=postgresql --schema=schema.ts --preflight',
+	);
+
+	if (res.type !== 'handler') assert.fail(res.type, 'handler');
+	expect(res.options).toStrictEqual({
+		dialect: 'postgresql',
+		name: undefined,
+		custom: false,
+		preflight: true,
+		answers: undefined,
+		prefix: 'index',
+		breakpoints: true,
+		schema: 'schema.ts',
+		out: 'drizzle',
+		bundle: false,
+		casing: undefined,
+		driver: undefined,
+	});
+});
+
+test('generate preflight #2', async () => {
+	const res = await brotest(
+		generate,
+		'--config=expo.config.ts --preflight --answers=./tests/cli/generate.answers.json',
+	);
+
+	if (res.type !== 'handler') assert.fail(res.type, 'handler');
+	expect(res.options).toStrictEqual({
+		dialect: 'sqlite',
+		name: undefined,
+		custom: false,
+		preflight: true,
+		answers: {
+			version: 1,
+			questions: [],
+		},
+		prefix: 'index',
+		breakpoints: true,
+		schema: './schema.ts',
+		out: 'drizzle',
+		bundle: true,
+		casing: undefined,
+		driver: 'expo',
 	});
 });
 
@@ -255,5 +324,18 @@ test('err #7', async (t) => {
 
 test('err #8', async (t) => {
 	const res = await brotest(generate, '--config=drizzle.config.ts --dialect=postgresql');
+	assert.equal(res.type, 'error');
+});
+
+test('err #9', async () => {
+	const res = await brotest(generate, '--custom --preflight');
+	assert.equal(res.type, 'error');
+});
+
+test('err #10', async () => {
+	const res = await brotest(
+		generate,
+		'--config=expo.config.ts --custom --answers=./tests/cli/generate.answers.json',
+	);
 	assert.equal(res.type, 'error');
 });

--- a/drizzle-kit/tests/cli-preflight-output.test.ts
+++ b/drizzle-kit/tests/cli-preflight-output.test.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+vi.mock('../src/cli/utils', async () => {
+	const actual = await vi.importActual<typeof import('../src/cli/utils')>(
+		'../src/cli/utils',
+	);
+	return {
+		...actual,
+		assertOrmCoreVersion: vi.fn(async () => {}),
+		assertPackages: vi.fn(async () => {}),
+	};
+});
+
+vi.mock('../src/cli/commands/migrate', () => ({
+	prepareAndMigratePg: vi.fn(async () => ({
+		version: 1,
+		questions: [
+			{
+				id: 'table:public.accounts',
+				kind: 'table',
+				to: { name: 'accounts', schema: 'public' },
+				choices: [
+					{ type: 'create' },
+					{ type: 'rename', from: { name: 'users', schema: 'public' } },
+				],
+			},
+		],
+	})),
+	prepareAndMigrateMysql: vi.fn(async () => ({
+		version: 1,
+		questions: [],
+	})),
+	prepareAndMigrateSqlite: vi.fn(async () => ({
+		version: 1,
+		questions: [],
+	})),
+	prepareAndMigrateLibSQL: vi.fn(async () => ({
+		version: 1,
+		questions: [],
+	})),
+	prepareAndMigrateSingleStore: vi.fn(async () => ({
+		version: 1,
+		questions: [],
+	})),
+}));
+
+const tmpRoots: string[] = [];
+const packageRoot = join(__dirname, '..');
+
+const writeMysqlSchema = (dir: string) => {
+	writeFileSync(
+		join(dir, 'schema.ts'),
+		[
+			"import { int, mysqlTable } from 'drizzle-orm/mysql-core';",
+			'',
+			"export const users = mysqlTable('users', {",
+			"\tid: int('id').primaryKey(),",
+			'});',
+			'',
+		].join('\n'),
+	);
+};
+
+const writeConfig = (dir: string) => {
+	writeFileSync(
+		join(dir, 'drizzle.config.js'),
+		[
+			'module.exports = {',
+			"\tdialect: 'mysql',",
+			`\tschema: ${JSON.stringify(join(dir, 'schema.ts'))},`,
+			`\tout: ${JSON.stringify(join(dir, 'drizzle'))},`,
+			'};',
+			'',
+		].join('\n'),
+	);
+};
+
+afterEach(() => {
+	for (const dir of tmpRoots.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+test('preflight uses stderr for info logs and stdout for JSON payload', async () => {
+	const dir = mkdtempSync(join(packageRoot, 'tests/.tmp-preflight-'));
+	tmpRoots.push(dir);
+	writeMysqlSchema(dir);
+	writeConfig(dir);
+
+	const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+	const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+	const { prepareGenerateConfig } = await import('../src/cli/commands/utils');
+	const { serializeMySql } = await import('../src/serializer');
+	const schemaModule = await import('../src/cli/schema');
+	const { withMachineOutput } = await import('../src/cli/output');
+
+	await prepareGenerateConfig(
+		{ config: join(dir, 'drizzle.config.js'), preflight: true },
+		'config',
+	);
+	expect(logSpy).not.toHaveBeenCalledWith(
+		expect.stringContaining('Reading config file'),
+	);
+	expect(errorSpy).toHaveBeenCalledWith(
+		expect.stringContaining('Reading config file'),
+	);
+
+	logSpy.mockClear();
+	errorSpy.mockClear();
+
+	await withMachineOutput(true, async () => {
+		await serializeMySql(join(dir, 'schema.ts'), undefined);
+	});
+	expect(logSpy).not.toHaveBeenCalledWith(
+		expect.stringContaining('Reading schema files'),
+	);
+	expect(errorSpy).toHaveBeenCalledWith(
+		expect.stringContaining('Reading schema files'),
+	);
+
+	logSpy.mockClear();
+	errorSpy.mockClear();
+
+	const { generate } = schemaModule as any;
+	await generate.handler({
+		dialect: 'postgresql',
+		name: undefined,
+		custom: false,
+		prefix: 'index',
+		breakpoints: true,
+		schema: join(dir, 'schema.ts'),
+		out: join(dir, 'drizzle'),
+		bundle: false,
+		casing: undefined,
+		driver: undefined,
+		preflight: true,
+		answers: undefined,
+	});
+
+	expect(errorSpy).not.toHaveBeenCalled();
+	expect(logSpy).toHaveBeenCalledWith(
+		JSON.stringify(
+			{
+				version: 1,
+				questions: [
+					{
+						id: 'table:public.accounts',
+						kind: 'table',
+						to: { name: 'accounts', schema: 'public' },
+						choices: [
+							{ type: 'create' },
+							{ type: 'rename', from: { name: 'users', schema: 'public' } },
+						],
+					},
+				],
+			},
+			null,
+			2,
+		),
+	);
+});

--- a/drizzle-kit/tests/cli/generate.answers.json
+++ b/drizzle-kit/tests/cli/generate.answers.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "questions": []
+}

--- a/drizzle-kit/tests/generate-questions.test.ts
+++ b/drizzle-kit/tests/generate-questions.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from 'vitest';
+import { createMigrationResolver } from '../src/cli/commands/migrate';
+
+test('preflight collects unresolved table conflicts', async () => {
+	const resolver = createMigrationResolver();
+
+	const result = await resolver.tablesResolver({
+		created: [{ name: 'accounts', schema: 'public' }] as any,
+		deleted: [{ name: 'users', schema: 'public' }] as any,
+	});
+
+	expect(result).toStrictEqual({
+		created: [{ name: 'accounts', schema: 'public' }],
+		deleted: [{ name: 'users', schema: 'public' }],
+		moved: [],
+		renamed: [],
+	});
+
+	expect(resolver.hasUnresolvedQuestions()).toBe(true);
+	expect(resolver.questions()).toStrictEqual({
+		version: 1,
+		questions: [
+			{
+				id: 'table:public.accounts',
+				kind: 'table',
+				to: { name: 'accounts', schema: 'public' },
+				choices: [
+					{ type: 'create' },
+					{ type: 'rename', from: { name: 'users', schema: 'public' } },
+				],
+			},
+		],
+	});
+});
+
+test('answers apply renames without prompting', async () => {
+	const resolver = createMigrationResolver({
+		answers: {
+			version: 1,
+			questions: [
+				{
+					id: 'table:public.accounts',
+					kind: 'table',
+					to: { name: 'accounts', schema: 'public' },
+					choices: [
+						{ type: 'create' },
+						{ type: 'rename', from: { name: 'users', schema: 'public' } },
+					],
+					answer: { type: 'rename', from: { name: 'users', schema: 'public' } },
+				},
+			],
+		},
+	});
+
+	const result = await resolver.tablesResolver({
+		created: [{ name: 'accounts', schema: 'public' }] as any,
+		deleted: [{ name: 'users', schema: 'public' }] as any,
+	});
+
+	expect(result).toStrictEqual({
+		created: [],
+		deleted: [],
+		moved: [],
+		renamed: [
+			{
+				from: { name: 'users', schema: 'public' },
+				to: { name: 'accounts', schema: 'public' },
+			},
+		],
+	});
+
+	expect(resolver.hasUnresolvedQuestions()).toBe(false);
+	expect(resolver.questions().questions[0]?.answer).toStrictEqual({
+		type: 'rename',
+		from: { name: 'users', schema: 'public' },
+	});
+});
+
+test('column questions are keyed by table context', async () => {
+	const resolver = createMigrationResolver();
+
+	await resolver.columnsResolver({
+		tableName: 'users',
+		schema: 'public',
+		created: [{ name: 'full_name' }] as any,
+		deleted: [{ name: 'name' }] as any,
+	});
+
+	expect(resolver.questions()).toStrictEqual({
+		version: 1,
+		questions: [
+			{
+				id: 'column:public.users:full_name',
+				kind: 'column',
+				to: { name: 'full_name' },
+				table: { name: 'users', schema: 'public' },
+				choices: [
+					{ type: 'create' },
+					{ type: 'rename', from: { name: 'name' } },
+				],
+			},
+		],
+	});
+});


### PR DESCRIPTION
Refs #5307

## Summary
- add a shared migration-question model plus non-interactive conflict resolvers for `generate`
- support `drizzle-kit generate --preflight` and `--answers <json|path>` without creating the migration folder during preflight
- make `generate --preflight` machine-readable by keeping the JSON payload on stdout and routing incidental info logs to stderr
- expose matching API support via `generate*Migration(..., { answers })` and `preflight*Migration()` helpers

## Testing
- `pnpm -C drizzle-orm build`
- `pnpm -C drizzle-kit exec tsc -p tsconfig.build.json --noEmit`
- `pnpm -C drizzle-kit exec vitest run tests/api-generate.test.ts tests/generate-questions.test.ts`
- `pnpm -C drizzle-kit exec vitest run tests/cli-generate.test.ts tests/cli-preflight-output.test.ts`
- `pnpm -C drizzle-kit exec vitest run tests/pg-tables.test.ts tests/pg-columns.test.ts tests/rls/pg-policy.test.ts`
