### PR TITLE
fix: handle null filter in relationsFieldFilterToSQL (rqb-v2)

### DIFF
--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -1259,6 +1259,7 @@ export function fieldSelectionToSQL(table: SchemaEntry, target: string) {
 
 function relationsFieldFilterToSQL(column: SQLWrapper, filter: RelationsFieldFilter<unknown>): SQL | undefined {
 	if (typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
+	if (filter === null) return isNull(column);
 
 	const entries = Object.entries(filter as RelationFieldsFilterInternals<unknown>);
 	if (!entries.length) return undefined;


### PR DESCRIPTION
## Summary

- Fix crash when filtering with `{ field: null }` in rqb-v2 relational queries
- Add null check in `relationsFieldFilterToSQL` to generate `IS NULL` instead of calling `Object.entries(null)`

## Problem

Using rqb-v2 with a null filter value:

```ts
db.query.table.findMany({
  where: { field: null },
});
```

throws `TypeError: Cannot convert undefined or null to object` because `relationsFieldFilterToSQL` in `src/relations.ts` calls `Object.entries()` on `null`.

This happens because the early return guard:
```ts
if (typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
```
does not catch `null`, since `typeof null === 'object'` in JavaScript. The function falls through to `Object.entries(null)`, which throws.

## Fix

Add a single-line null check after the existing type guard:

```ts
if (filter === null) return isNull(column);
```

When the filter value is `null`, this generates an `IS NULL` SQL condition, which is the semantically correct behavior — consistent with the existing `{ isNull: true }` workaround mentioned in the issue.

Fixes #5418

🤖 Generated with [Claude Code](https://claude.com/claude-code)