### PR TITLE
fix(drizzle-valibot): handle compound dataType strings for UUID and other columns

### DIFF
--- a/drizzle-valibot/src/column.ts
+++ b/drizzle-valibot/src/column.ts
@@ -97,24 +97,44 @@ export function columnToSchema(column: Column): v.GenericSchema {
 		else if (isColumnType<PgArray<any, any>>(column, ['PgArray'])) {
 			schema = v.array(columnToSchema(column.baseColumn));
 			schema = column.size ? v.pipe(schema as v.ArraySchema<any, any>, v.length(column.size)) : schema;
-		} else if (column.dataType === 'array') {
-			schema = v.array(v.any());
-		} else if (column.dataType === 'number') {
-			schema = numberColumnToSchema(column);
-		} else if (column.dataType === 'bigint') {
-			schema = bigintColumnToSchema(column);
-		} else if (column.dataType === 'boolean') {
-			schema = v.boolean();
-		} else if (column.dataType === 'date') {
-			schema = v.date();
-		} else if (column.dataType === 'string') {
-			schema = stringColumnToSchema(column);
-		} else if (column.dataType === 'json') {
-			schema = jsonSchema;
-		} else if (column.dataType === 'custom') {
-			schema = v.any();
-		} else if (column.dataType === 'buffer') {
-			schema = bufferSchema;
+		} else {
+			// Extract the base data type from potentially compound types
+			// (e.g. "string uuid" -> "string", "number int32" -> "number").
+			// drizzle-orm beta uses compound dataType strings while stable uses
+			// simple ones, so we match on the first word to support both.
+			const baseDataType = column.dataType.split(' ')[0];
+
+			if (baseDataType === 'array') {
+				schema = v.array(v.any());
+			} else if (baseDataType === 'number') {
+				schema = numberColumnToSchema(column);
+			} else if (baseDataType === 'bigint') {
+				schema = bigintColumnToSchema(column);
+			} else if (baseDataType === 'boolean') {
+				schema = v.boolean();
+			} else if (baseDataType === 'date') {
+				schema = v.date();
+			} else if (baseDataType === 'string') {
+				schema = stringColumnToSchema(column);
+			} else if (baseDataType === 'json') {
+				schema = jsonSchema;
+			} else if (baseDataType === 'custom') {
+				schema = v.any();
+			} else if (baseDataType === 'buffer') {
+				schema = bufferSchema;
+			} else if (baseDataType === 'object') {
+				// Handle compound "object <constraint>" types from drizzle-orm beta
+				const constraint = column.dataType.split(' ')[1];
+				if (constraint === 'buffer') {
+					schema = bufferSchema;
+				} else if (constraint === 'date') {
+					schema = v.date();
+				} else if (constraint === 'json') {
+					schema = jsonSchema;
+				} else {
+					schema = v.any();
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #5338

When using `drizzle-orm@1.0.0-beta.*` with `drizzle-valibot@0.4.2`, `createSelectSchema()` produces `v.any()` (which becomes `{}` in OpenAPI) for UUID columns instead of the expected `v.pipe(v.string(), v.uuid())`.

### Root cause

`drizzle-orm` beta changed column `dataType` from simple strings to compound strings:

| Column | Stable `dataType` | Beta `dataType` |
|--------|-------------------|-----------------|
| `uuid()` | `"string"` | `"string uuid"` |
| `integer()` | `"number"` | `"number int32"` |
| `json()` | `"json"` | `"object json"` |
| `bytea()` | `"buffer"` | `"object buffer"` |

`columnToSchema()` in `drizzle-valibot` uses exact equality checks like `column.dataType === 'string'`, which fails for `"string uuid"`. The UUID column falls through all checks and lands on the `v.any()` fallback.

### Fix

Extract the base type from the first word of `column.dataType` (e.g. `"string uuid".split(' ')[0]` = `"string"`) before matching. This way both `"string"` (stable) and `"string uuid"` (beta) route to `stringColumnToSchema()`, which already handles `PgUUID` correctly via `isColumnType()`.

Also added handling for the new `"object <constraint>"` compound types (`buffer`, `date`, `json`) that the beta uses.

### Note

The same bug exists in `drizzle-zod`, `drizzle-typebox`, and `drizzle-arktype` — they all use the same `column.dataType === '...'` pattern. This PR only fixes `drizzle-valibot` as reported in the issue, but the same fix should be applied to the other packages.

## Test plan

- Existing tests continue to pass (they use stable `dataType` strings)
- Verified that `"string uuid".split(' ')[0]` correctly extracts `"string"`, routing UUID columns to `stringColumnToSchema()` which returns `v.pipe(v.string(), v.uuid())`
- The fix is backward-compatible: for stable `dataType` values like `"string"`, `"string".split(' ')[0]` = `"string"` — same result as before