### PR TITLE
Make effect-schema bufferSchema browser-safe

### DIFF
--- a/drizzle-orm/src/effect-schema/column.ts
+++ b/drizzle-orm/src/effect-schema/column.ts
@@ -28,7 +28,9 @@ export const jsonSchema = S.Union(
 	S.Array(S.Any),
 ) satisfies Schema<Json>;
 
-export const bufferSchema = S.instanceOf(Buffer) satisfies Schema<Buffer>;
+export const bufferSchema: Schema<Buffer> = S.declare( // oxlint-disable-line no-instanceof-builtins drizzle-internal/no-instanceof
+	(input: unknown): input is Buffer => input instanceof Buffer,
+);
 
 export function columnToSchema(
 	column: Column,


### PR DESCRIPTION
The new `drizzle-orm/effect-schema` package (added in beta.15) has the same browser compatibility issue that was previously fixed for `drizzle-arktype` in #4424.

In `effect-schema/column.ts`:

```ts
export const bufferSchema = S.instanceOf(Buffer) satisfies Schema<Buffer>;
```

`S.instanceOf(Buffer)` evaluates `Buffer` eagerly at module load time. In browser environments `Buffer` doesn't exist, so importing `drizzle-orm/effect-schema` crashes immediately — even if none of your tables use buffer columns.

Same class of issue as #4383. The other validator packages (zod, valibot) already avoid this because `zod.custom()` / `v.custom()` wrap the `instanceof` check in a callback. The arktype fix in #4424 did the same thing.

## Fix

```ts
// before — eagerly evaluates Buffer at import time
export const bufferSchema = S.instanceOf(Buffer) satisfies Schema<Buffer>;

// after — Buffer is only referenced at validation time
export const bufferSchema: Schema<Buffer> = S.declare(
	(input: unknown): input is Buffer => input instanceof Buffer,
);
```

Uses `S.declare` with a type guard so `Buffer` is only referenced when the schema is actually used for validation, not at module load. Same runtime behavior, just deferred.
