### PR TITLE
[Pg]: Fix unawaited promise chains in queryWithCache and bun-sql execute

### DIFF
--- a/drizzle-orm/src/bun-sql/postgres/session.ts
+++ b/drizzle-orm/src/bun-sql/postgres/session.ts
@@ -71,7 +71,7 @@ export class BunSQLPreparedQuery<T extends PreparedQueryConfig, TIsRqbV2 extends
 				});
 
 				return await this.queryWithCache(query, params, async () => {
-					return client.unsafe(query, params as any[]).values();
+					return await client.unsafe(query, params as any[]).values();
 				});
 			});
 

--- a/drizzle-orm/src/pg-core/async/session.ts
+++ b/drizzle-orm/src/pg-core/async/session.ts
@@ -67,21 +67,26 @@ export abstract class PgAsyncPreparedQuery<T extends PreparedQueryConfig> extend
 			: { type: 'skip' as const };
 
 		if (cacheStrat.type === 'skip') {
-			return query().catch((e) => {
+			try {
+				return await query();
+			} catch (e) {
 				throw new DrizzleQueryError(queryString, params, e as Error);
-			});
+			}
 		}
 
 		const cache = this.cache!;
 
 		// For mutate queries, we should query the database, wait for a response, and then perform invalidation
 		if (cacheStrat.type === 'invalidate') {
-			return Promise.all([
-				query(),
-				cache.onMutate({ tables: cacheStrat.tables }),
-			]).then((res) => res[0]).catch((e) => {
+			try {
+				const [result] = await Promise.all([
+					query(),
+					cache.onMutate({ tables: cacheStrat.tables }),
+				]);
+				return result;
+			} catch (e) {
 				throw new DrizzleQueryError(queryString, params, e as Error);
-			});
+			}
 		}
 
 		if (cacheStrat.type === 'try') {


### PR DESCRIPTION
## Summary

Fixes unawaited promise chains in `PgAsyncPreparedQuery.queryWithCache()` and `BunSQLPreparedQuery.execute()` that cause race conditions with Bun's event loop, leading to silent process exits (code 0) in standalone scripts.

Fixes #5451

## Changes

### 1. `queryWithCache` skip path (`pg-core/async/session.ts`)

**Before:** `return query().catch(...)` - returns an unawaited promise chain from an `async` method.

**After:** `try { return await query(); } catch (e) { ... }` - properly awaits the query callback.

This matches the main branch's implementation in `pg-core/session.ts` which already uses `try { return await query(); }`.

### 2. `queryWithCache` invalidate path (`pg-core/async/session.ts`)

**Before:** `return Promise.all([query(), cache.onMutate(...)]).then((res) => res[0]).catch(...)` - returns an unawaited `.then().catch()` chain.

**After:** `const [result] = await Promise.all([...]); return result;` with `try/catch` - properly awaits the Promise.all result.

### 3. `BunSQLPreparedQuery.execute()` Path B (`bun-sql/postgres/session.ts`)

**Before:** The async callback passed to `queryWithCache` returns `client.unsafe(query, params).values()` without `await`.

**After:** `return await client.unsafe(query, params).values()` - explicit await on the lazy Bun SQL query.

This matches Path A in the same method, which already uses `return await client.unsafe(query, params)`. Bun SQL queries are lazy - they extend `Promise` but defer execution until `.then()` is called. Without `await`, the I/O registration is deferred to a microtask, creating a window where Bun's event loop can exit before the query starts.

## Root cause analysis

The reporter's script runs `INSERT` followed by `SELECT` using the Core Query Builder (`db.select().from()`). The `SELECT` goes through `queryWithCache`'s skip path, which returned `query().catch(...)` without `await`. Inside the callback, `client.unsafe().values()` also lacked `await`. The combination of unawaited promise chains creates microtask boundaries where Bun's event loop sees no pending I/O and exits cleanly with code 0.

Other APIs (`db.execute(sql)`, `db.query.*.findMany()`, `db.$count()`) work because they either bypass `queryWithCache` entirely (`executeRqbV2`) or use Path A which already has explicit `await`.

## Testing

Reproduced and verified in Docker (Bun 1.3.10, PostgreSQL 18) using the reporter's MRE:
- Baseline: ~62% failure rate (5/8 runs fail with silent exit)
- With queryWithCache bypass (`return await query()`): 8/8 pass
- Raw `bun:sql` without Drizzle: 8/8 pass (confirms bug is in Drizzle, not Bun)