### PR TITLE
fix(drizzle-seed): apply db casing to pg_get_serial_sequence column name

### DIFF
--- a/drizzle-seed/src/SeedService.ts
+++ b/drizzle-seed/src/SeedService.ts
@@ -932,15 +932,20 @@ export class SeedService {
 			&& schema[tableName] !== undefined
 		) {
 			const tableConfig = getTableConfigPg(schema[tableName] as PgTable);
+			const dbCasing =
+				(db as PgAsyncDatabase<any> & { dialect: { casing: { getColumnCasing: (col: unknown) => string } } }).dialect
+					.casing;
 			for (const column of tableConfig.columns) {
 				// TODO should I filter only primary key columns?
 				// should I filter column by dataType or by column drizzle type?
 				// column.dataType === 'number' || column.dataType === 'bigint'
 				if (isPostgresColumnIntLike(column)) {
+					// Use dialect casing to resolve the actual DB column name (e.g. camelCase -> snake_case)
+					const dbColumnName = dbCasing.getColumnCasing(column);
 					columnsToUpdateSeq.set(column.name, {
 						schemaName: tableConfig.schema,
 						tableName: tableConfig.name,
-						columnName: column.name,
+						columnName: dbColumnName,
 						valueToUpdate: undefined,
 					});
 				}


### PR DESCRIPTION
## What's changed

When a Drizzle database is configured with `casing: 'snake_case'`, columns defined without an explicit column name (i.e. `keyAsName: true`) have their `.name` set to the JS property key (camelCase). The dialect's `CasingCache` is responsible for converting these to the actual DB column names.

Previously, `updateColumnSequence` used `column.name` directly in the `pg_get_serial_sequence` call, causing it to pass the camelCase name (e.g. `'multiWordInt'`) instead of the snake_case DB name (`'multi_word_int'`), resulting in a runtime error for any multi-word integer-like column when seeding.

**Fix:** Retrieve the db dialect's `CasingCache` and use `getColumnCasing(column)` to obtain the actual DB column name before storing it in `columnsToUpdateSeq`.

Fixes #5470

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)