### PR TITLE
fix: generate one() instead of many() for one-to-one relations with unique FK

### DIFF
--- a/drizzle-kit/src/cli/commands/introspect.ts
+++ b/drizzle-kit/src/cli/commands/introspect.ts
@@ -766,6 +766,7 @@ export const relationsToTypeScript = (
 						onDelete?: string | undefined;
 					}
 				>;
+				uniqueConstraints?: Record<string, string[]>;
 			}
 		>;
 	},
@@ -821,9 +822,15 @@ export const relationsToTypeScript = (
 				tableRelations[keyTo] = [];
 			}
 
+			// Check if the FK column has a unique constraint (one-to-one relationship)
+			const tableUniqueConstraints = table.uniqueConstraints || {};
+			const hasUniqueConstraint = Object.values(tableUniqueConstraints).some(
+				(uniqueCols) => uniqueCols.length === 1 && uniqueCols[0] === fk.columnsFrom[0],
+			);
+
 			tableRelations[keyTo].push({
-				name: plural(tableFrom),
-				type: 'many',
+				name: hasUniqueConstraint ? singular(tableFrom) : plural(tableFrom),
+				type: hasUniqueConstraint ? 'one' : 'many',
 				tableFrom: tableTo,
 				columnFrom: columnTo,
 				tableTo: tableFrom,


### PR DESCRIPTION
When a foreign key column has a UNIQUE constraint, the reverse relation should be one() instead of many(), representing a one-to-one relationship.

This fixes the issue where drizzle-kit pull generated many() for the reverse side of one-to-one relationships when the FK column has a UNIQUE constraint.

**Before:**
```typescript
export const usersRelations = relations(users, ({ many }) => ({
  profiles: many(profiles), // incorrect - should be one()
}));
```

**After:**
```typescript
export const usersRelations = relations(users, ({ one }) => ({
  profile: one(profiles), // correct for one-to-one
}));
```

Fixes #5478