### PR TITLE
fix(pg-core): restore PgArray columnType and dataType for array columns

### DIFF
--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -442,6 +442,12 @@ export abstract class PgColumn<
 		this.table = table;
 		this.dimensions = config.dimensions ?? 0;
 
+		// Override columnType and dataType to reflect array nature when dimensions > 0
+		if (this.dimensions) {
+			(this as any).columnType = 'PgArray';
+			(this as any).dataType = 'array';
+		}
+
 		// Wrap mapFromDriverValue/mapToDriverValue with array handling if this is an array column
 		if (this.dimensions) {
 			const originalFromDriver = this.mapFromDriverValue.bind(this);


### PR DESCRIPTION
## What's changed

When `.array()` is called on a `PgColumnBuilder`, the resulting column's `columnType` and `dataType` runtime properties were not updated to reflect the array nature of the column.

**Bug**: In V1 Beta 17, `text().array()` reports `columnType: 'PgText'` and `dataType: 'string'` instead of `'PgArray'` and `'array'`. This breaks `drizzle-zod` and any tool that relies on these runtime metadata properties to detect array columns.

**Fix**: Override `columnType` to `'PgArray'` and `dataType` to `'array'` in the `PgColumn` constructor when `dimensions > 0` (i.e., when the column is an array column).

This restores the behavior from v0.45.1 where array columns correctly reported their type metadata at runtime.

Fixes #5479