### PR TITLE
fix(pg-core): prevent double JSON.parse in jsonb mapFromDriverValue (#5485)

### DIFF
--- a/drizzle-orm/src/pg-core/columns/jsonb.ts
+++ b/drizzle-orm/src/pg-core/columns/jsonb.ts
@@ -44,12 +44,30 @@ export class PgJsonb<T extends ColumnBaseConfig<'json', 'PgJsonb'>> extends PgCo
 	}
 
 	override mapFromDriverValue(value: T['data'] | string): T['data'] {
-		if (typeof value === 'string') {
-			try {
-				return JSON.parse(value);
-			} catch {
-				return value as T['data'];
+		// The pg driver automatically parses JSON/JSONB columns via JSON.parse.
+		// When the JSON value is a string (e.g., `"hello"` or `"0.1"`), the driver
+		// returns it as a JavaScript string. We must NOT call JSON.parse again here,
+		// as that would incorrectly convert JSON strings like `"0.1"` to numbers.
+		//
+		// For objects, arrays, numbers, booleans, and null - the driver already
+		// returns the correct JavaScript type.
+		//
+		// If the driver returns a raw JSON string (e.g., when type parsing is disabled),
+		// it will start with `{`, `[`, or `"`, which we can detect and parse.
+		if (typeof value === 'string' && value.length > 0) {
+			const firstChar = value[0];
+			if (firstChar === '{' || firstChar === '[') {
+				// Raw JSON object or array - parse it
+				try {
+					return JSON.parse(value);
+				} catch {
+					return value as T['data'];
+				}
 			}
+			// For strings starting with `"`, the pg driver already parsed the outer
+			// quotes and returned the inner string value. For strings starting with
+			// other chars (numbers as strings like "0.1", "true", "null"), these are
+			// the actual JSON string values after driver parsing, so return as-is.
 		}
 		return value;
 	}


### PR DESCRIPTION
## Problem

The pg driver automatically parses JSON/JSONB columns using `JSON.parse`. When a JSONB column contains a JSON string value like `"0.1"`, the driver returns it as the JavaScript string `"0.1"`.

The current `mapFromDriverValue` in `PgJsonb` calls `JSON.parse` on all string values, which incorrectly converts JSON strings:

```typescript
// Store: JSON.stringify("0.1") → DB has: "\"0.1\""
// pg driver returns: "0.1" (JavaScript string)
// Current code: JSON.parse("0.1") → 0.1 (WRONG - number instead of string)
```

This causes silent data corruption for any JSONB column storing numeric-looking strings.

## Root Cause

```typescript
override mapFromDriverValue(value: T["data"] | string): T["data"] {
  if (typeof value === "string") {
    try {
      return JSON.parse(value);  // ← Double-parses already-parsed values
    } catch {
      return value as T["data"];
    }
  }
  return value;
}
```

## Fix

Only parse strings that look like raw JSON objects/arrays (starting with `{` or `[`), which indicates the driver returned unparsed JSON. String values from already-parsed JSON are returned as-is.

## Related

Fixes #5485