### PR TITLE
fix(kit): use batchWithPragma for libSQL push to avoid HTTP transaction errors

### DIFF
--- a/drizzle-kit/src/cli/commands/push-sqlite.ts
+++ b/drizzle-kit/src/cli/commands/push-sqlite.ts
@@ -7,7 +7,7 @@ import { interimToDDL } from 'src/dialects/sqlite/ddl';
 import { ddlDiff } from 'src/dialects/sqlite/diff';
 import { fromDrizzleSchema, prepareFromSchemaFiles } from 'src/dialects/sqlite/drizzle';
 import type { JsonStatement } from 'src/dialects/sqlite/statements';
-import type { SQLiteDB } from '../../utils';
+import type { LibSQLDB, SQLiteDB } from '../../utils';
 import { prepareFilenames } from '../../utils/utils-node';
 import { highlightSQL } from '../highlighter';
 import { resolver } from '../prompts';
@@ -29,12 +29,12 @@ export const handle = async (
 		table: string;
 		schema: string;
 	},
-	sqliteDB?: SQLiteDB,
+	sqliteDB?: SQLiteDB | LibSQLDB,
 ) => {
 	const { connectToSQLite } = await import('../connections');
 	const { introspect: sqliteIntrospect } = await import('./pull-sqlite');
 
-	const db = sqliteDB ?? await connectToSQLite(credentials);
+	const db: SQLiteDB | LibSQLDB = sqliteDB ?? await connectToSQLite(credentials);
 	const files = prepareFilenames(schemaPath);
 	const res = await prepareFromSchemaFiles(files);
 
@@ -89,23 +89,39 @@ export const handle = async (
 	if (sqlStatements.length === 0) {
 		render(`\n[${chalk.blue('i')}] No changes detected`);
 	} else {
-		if (!('driver' in credentials)) {
-			// D1-HTTP does not support transactions
-			// there might a be a better way to fix this
-			// in the db connection itself
-			const isD1 = 'driver' in credentials && credentials.driver === 'd1-http';
-			if (!isD1) await db.run('begin');
-			try {
-				for (const statement of [...lossStatements, ...sqlStatements]) {
-					if (verbose) console.log(highlightSQL(statement));
+		const allStatements = [...lossStatements, ...sqlStatements];
+		if (verbose) allStatements.forEach((s) => console.log(highlightSQL(s)));
 
-					await db.run(statement);
-				}
-				if (!isD1) await db.run('commit');
+		if ('batchWithPragma' in db && db.batchWithPragma) {
+			// libSQL/Turso HTTP connections use client.migrate() for DDL batches;
+			// manual begin/commit via execute() doesn't work over HTTP
+			try {
+				await db.batchWithPragma(allStatements);
 			} catch (e) {
 				console.error(e);
-
-				if (!isD1) await db.run('rollback');
+				process.exit(1);
+			}
+		} else if (!('driver' in credentials) || credentials.driver !== 'd1-http') {
+			// D1-HTTP does not support transactions; all other SQLite drivers do
+			await db.run('begin');
+			try {
+				for (const statement of allStatements) {
+					await db.run(statement);
+				}
+				await db.run('commit');
+			} catch (e) {
+				console.error(e);
+				await db.run('rollback');
+				process.exit(1);
+			}
+		} else {
+			// D1-HTTP: run statements individually without transaction
+			try {
+				for (const statement of allStatements) {
+					await db.run(statement);
+				}
+			} catch (e) {
+				console.error(e);
 				process.exit(1);
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #5489

libSQL/Turso HTTP clients do not support manual `begin`/`commit` via `execute()` because each call is an independent HTTP request with no shared transaction context. This causes `drizzle-kit push` to fail with:

```
QueryError: cannot commit - no transaction is active
```

when a schema change requires table recreation (e.g. changing a foreign key's `onDelete` action).

## Root Cause

In `push-sqlite.ts`, the push handler wraps DDL statements in manual `begin`/`commit` transactions:

```ts
if (!isD1) await db.run('begin');
// ...
if (!isD1) await db.run('commit');
```

The outer `if (!('driver' in credentials))` check was meant to skip this for D1-HTTP, but `LibSQLCredentials` also has no `driver` field, so the libSQL path falls into the transaction block too — and fails on HTTP.

## Fix

`connectToLibSQL` already exposes `batchWithPragma()` which wraps `client.migrate()` — the correct API for running DDL batches over the libSQL HTTP protocol.

The fix detects `batchWithPragma` on the db object and uses it for libSQL connections. Regular SQLite drivers continue to use the `begin`/`commit` transaction path. D1-HTTP continues to run statements individually without transactions.

## Changes

- `drizzle-kit/src/cli/commands/push-sqlite.ts`: detect `db.batchWithPragma` and use it for libSQL; fix D1 transaction skip (was broken — always ran transaction due to outer if-check); consolidate verbose logging across all execution paths