### PR TITLE
[Pg-kit] fix: use opcname instead of amname for index operator class introspection

### DIFF
--- a/drizzle-kit/src/dialects/postgres/aws-introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/aws-introspect.ts
@@ -965,13 +965,12 @@ export const fromDatabase = async (
 			SELECT
 			  pg_catalog.json_build_object(
 				'oid', opclass.oid,
-				'name', pg_am.amname,
+				'name', pg_opclass.opcname,
 				'default', pg_opclass.opcdefault
 			  )
 			FROM
 			  pg_catalog.unnest(indclass) WITH ORDINALITY AS opclass(oid, ordinality)
 			JOIN pg_catalog.pg_opclass ON opclass.oid OPERATOR(pg_catalog.=) pg_opclass.oid
-			JOIN pg_catalog.pg_am ON pg_opclass.opcmethod OPERATOR(pg_catalog.=) pg_am.oid
 			ORDER BY opclass.ordinality
 		  ) as "opclasses"
         FROM

--- a/drizzle-kit/src/dialects/postgres/introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/introspect.ts
@@ -977,13 +977,12 @@ export const fromDatabase = async (
 			SELECT
 			  pg_catalog.json_build_object(
 				'oid', opclass.oid,
-				'name', pg_am.amname,
+				'name', pg_opclass.opcname,
 				'default', pg_opclass.opcdefault
 			  )
 			FROM
 			  pg_catalog.unnest(indclass) WITH ORDINALITY AS opclass(oid, ordinality)
 			JOIN pg_catalog.pg_opclass ON opclass.oid OPERATOR(pg_catalog.=) pg_opclass.oid
-			JOIN pg_catalog.pg_am ON pg_opclass.opcmethod OPERATOR(pg_catalog.=) pg_am.oid
 			ORDER BY opclass.ordinality
 		  ) as "opclasses"
         FROM

--- a/drizzle-kit/tests/postgres/pull.test.ts
+++ b/drizzle-kit/tests/postgres/pull.test.ts
@@ -1977,3 +1977,28 @@ test('issue No4655. Problem with backslash in check constraint + custom type', a
 	expect(sqlStatements).toStrictEqual([]);
 	expect(statements).toStrictEqual([]);
 });
+
+// https://github.com/drizzle-team/drizzle-orm/issues/5495
+test('ivfflat index opclass introspection returns operator class name not access method name', async () => {
+	await db.query(`CREATE EXTENSION IF NOT EXISTS vector;`);
+
+	await db.query(`
+		CREATE TABLE public.items (
+			id integer NOT NULL,
+			embedding vector(3) NOT NULL
+		);
+	`);
+	await db.query(`
+		CREATE INDEX items_embedding_idx ON public.items USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+	`);
+
+	const { indexes } = await fromDatabase(db, () => true);
+
+	const vectorIdx = indexes.find((idx) => idx.name === 'items_embedding_idx');
+	expect(vectorIdx).toBeDefined();
+	expect(vectorIdx!.method).toBe('ivfflat');
+	expect(vectorIdx!.columns[0]!.opclass).toStrictEqual({
+		name: 'vector_cosine_ops',
+		default: false,
+	});
+});


### PR DESCRIPTION
## Problem

Fixes #5495

When running `drizzle-kit pull` against PostgreSQL databases with pgvector `ivfflat` indexes (or other non-default access methods), the generated schema uses the **access method name** (`ivfflat`) in the operator class position instead of the actual **operator class** (e.g. `vector_cosine_ops`).

**Incorrect output:**
```ts
index("idx").using("ivfflat", table.embedding.asc().nullsLast().op("ivfflat"))
```
which generates invalid SQL:
```sql
CREATE INDEX ... USING ivfflat (embedding ivfflat);
```

## Root Cause

In `drizzle-kit/src/dialects/postgres/introspect.ts` (and `aws-introspect.ts`), the opclasses subquery built an array of `{oid, name, default}` objects for each index column, but used `pg_am.amname` (the access method name) instead of `pg_opclass.opcname` (the operator class name).

## Fix

Replace `pg_am.amname` with `pg_opclass.opcname` in the opclasses subquery, and remove the now-unnecessary `JOIN pg_catalog.pg_am` from that subquery (the outer query already joins `pg_am` for the index access method).

**Correct output:**
```ts
index("idx").using("ivfflat", table.embedding.asc().nullsLast().op("vector_cosine_ops"))
```
which generates valid SQL:
```sql
CREATE INDEX ... USING ivfflat (embedding vector_cosine_ops);
```

## Changes

- `drizzle-kit/src/dialects/postgres/introspect.ts`: use `pg_opclass.opcname` instead of `pg_am.amname`, remove unused `pg_am` JOIN from opclasses subquery
- `drizzle-kit/src/dialects/postgres/aws-introspect.ts`: same fix
- `drizzle-kit/tests/postgres/pull.test.ts`: add test for ivfflat index opclass introspection using PGlite's vector extension