### PR TITLE
fix(kit): fix many-through relation alias mismatch in pull-common

### DIFF
--- a/drizzle-kit/src/cli/commands/pull-common.ts
+++ b/drizzle-kit/src/cli/commands/pull-common.ts
@@ -112,9 +112,9 @@ export const relationsToTypeScript = (
 					// this type is used for .many() side of relation, when another side has .through() with from and to fields
 					type: 'many-through',
 					tableFrom: toTable2,
-					columnsFrom: fk2.columnsTo,
+					columnsFrom: columnsTo2,
 					tableTo: toTable1,
-					columnsTo: columnsTo2,
+					columnsTo: columnsTo1,
 					tableThrough,
 					columnsThroughFrom,
 					columnsThroughTo,


### PR DESCRIPTION
## Problem

Fixes #5493

When running `drizzle-kit pull` on a PostgreSQL database with a many-many relation via a join table, the generated `relations.ts` contains mismatched aliases between the `through` and `many-through` sides, causing a runtime error:

```
Error: relations -> customer: { billingAccountsViaContract: r.many.billingAccount(...) }: not enough data provided to build the relation - "from"/"to" are not defined, and there is no reverse relation of table "billingAccount" with alias "billingAccount_customerId_customer_customer_id_via_contract"
```

## Root Cause

In `drizzle-kit/src/cli/commands/pull-common.ts`, the `many-through` relation push used:
- `columnsFrom: fk2.columnsTo` — raw uncased strings (e.g. `customer_id`) instead of the casing-applied `columnsTo2`
- `columnsTo: columnsTo2` — fk2's target columns instead of `columnsTo1` (fk1's target columns)

This caused the alias for the `many-through` side to differ from the `through` side:
- **through** alias: `billingAccount_billingAccountId_customer_customerId_via_contract`
- **many-through** alias (buggy): `billingAccount_customerId_customer_customer_id_via_contract`

## Fix

Use `columnsTo2` (with casing applied) for `columnsFrom` and `columnsTo1` for `columnsTo` in the `many-through` push, so both aliases match.

## Changes

- `drizzle-kit/src/cli/commands/pull-common.ts`: use `columnsTo2` and `columnsTo1` for the `many-through` relation push