### PR TITLE
fix(mysql, singlestore): scope migration table lookup to current database

### DIFF
--- a/drizzle-orm/src/up-migrations/mysql.ts
+++ b/drizzle-orm/src/up-migrations/mysql.ts
@@ -151,7 +151,8 @@ export async function upgradeIfNeeded(
 	const result = await all<{ '1': 1 }>(
 		session,
 		sql`SELECT 1 FROM information_schema.tables 
-			WHERE table_name = ${migrationsTable}`,
+			WHERE table_schema = DATABASE()
+			AND table_name = ${migrationsTable}`,
 		(row) => ({ '1': row[0] }),
 	);
 
@@ -164,7 +165,8 @@ export async function upgradeIfNeeded(
 		session,
 		sql`SELECT column_name as \`column_name\`
 		FROM information_schema.columns
-		WHERE table_name = ${migrationsTable}
+		WHERE table_schema = DATABASE()
+		AND table_name = ${migrationsTable}
 		ORDER BY ordinal_position`,
 		(row) => ({ column_name: row[0] }),
 	);

--- a/drizzle-orm/src/up-migrations/singlestore.ts
+++ b/drizzle-orm/src/up-migrations/singlestore.ts
@@ -151,7 +151,8 @@ export async function upgradeIfNeeded(
 	const result = await all<{ '1': 1 }>(
 		session,
 		sql`SELECT 1 FROM information_schema.tables 
-			WHERE table_name = ${migrationsTable}`,
+			WHERE table_schema = DATABASE()
+			AND table_name = ${migrationsTable}`,
 		(row) => ({ '1': row[0] }),
 	);
 
@@ -164,7 +165,8 @@ export async function upgradeIfNeeded(
 		session,
 		sql`SELECT column_name as \`column_name\`
 		FROM information_schema.columns
-		WHERE table_name = ${migrationsTable}
+		WHERE table_schema = DATABASE()
+		AND table_name = ${migrationsTable}
 		ORDER BY ordinal_position`,
 		(row) => ({ column_name: row[0] }),
 	);


### PR DESCRIPTION
## Problem

When running Drizzle migrations against multiple databases on the same MySQL
server, `migrate()` fails on any database that doesn't already have the
`__drizzle_migrations` table — even though Drizzle is supposed to create it
automatically.

The `upgradeIfNeeded` function checks `information_schema.tables` for the
migrations table, but doesn't filter by `table_schema`. This means it finds
the table in a *different* database, concludes the current database isn't new,
skips `CREATE TABLE`, and then fails when it tries to read from a table that
doesn't exist in the current database.

Postgres, CockroachDB, and MSSQL don't have this problem because they already
filter by `migrationsSchema`. MySQL and SingleStore were missing the equivalent
filter.

## Fix

Add `WHERE table_schema = DATABASE()` to both `information_schema` queries in
the MySQL and SingleStore `upgradeIfNeeded` functions. `DATABASE()` returns the
currently selected database name — the MySQL equivalent of Postgres's schema
scoping.

**2 files changed, 4 lines added:**
- `drizzle-orm/src/up-migrations/mysql.ts`
- `drizzle-orm/src/up-migrations/singlestore.ts`