### PR TITLE
fix: handle empty result for sqlite-proxy get method

### DIFF
--- a/drizzle-orm/src/sqlite-proxy/session.ts
+++ b/drizzle-orm/src/sqlite-proxy/session.ts
@@ -240,7 +240,7 @@ export class RemotePreparedQuery<T extends PreparedQueryConfig = PreparedQueryCo
 			return row;
 		}
 
-		if (!row) {
+		if (!row || (Array.isArray(row) && row.length === 0)) {
 			return undefined;
 		}
 


### PR DESCRIPTION
## Summary
Fixes #5461.
**Root cause:** When `method === 'get'` and no rows are returned, the sqlite-proxy returned `{ rows: [] }` but the runtime expected `undefined` to indicate no matching row. This caused `findFirst` to return `{ id: undefined }` instead of `undefined`.
**Fix:** Updated the `get` method result handling to return `undefined` when no rows are found.
## Changes
- Updated sqlite-proxy result handling for empty `get` queries
## Testing
- Verified fix addresses reported behavior (findFirst returns undefined when no row matches)
- Change is minimal and follows existing code patterns