### PR TITLE
fix(drizzle-orm): make not() accept SQL | undefined from and()/or()

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -174,7 +174,10 @@ export function or(
  *   .where(not(inArray(cars.make, ['GM', 'Ford'])))
  * ```
  */
-export function not(condition: SQLWrapper): SQL {
+export function not(condition: SQLWrapper | undefined): SQL | undefined {
+	if (condition === undefined) {
+		return undefined;
+	}
 	return sql`not ${condition}`;
 }
 


### PR DESCRIPTION
## Problem

`not()` only accepts `SQLWrapper`, but `and()` and `or()` return `SQL | undefined`. This causes a type error when composing them:

```ts
await db.query.users.findMany({
  where: not(and(ilike(users.name, '%asdf%')))
})
```

## Solution

Updated `not()` to accept `SQLWrapper | undefined` and return `SQL | undefined`, consistent with `and()` and `or()`. When `undefined` is passed, it returns `undefined` (no-op), matching the existing pattern.

## Changes

- `drizzle-orm/src/sql/expressions/conditions.ts`: Changed `not(condition: SQLWrapper): SQL` to `not(condition: SQLWrapper | undefined): SQL | undefined`

Fixes #1818
