### PR TITLE
fix(kit): use path.basename/dirname in embeddedMigrations to fix Windows path separators

### DIFF
--- a/drizzle-kit/src/cli/commands/generate-common.ts
+++ b/drizzle-kit/src/cli/commands/generate-common.ts
@@ -97,7 +97,7 @@ export const embeddedMigrations = (snapshots: string[], driver?: Driver) => {
 	const migrations: Record<string, string> = {};
 
 	snapshots.forEach((entry, idx) => {
-		const prefix = entry.split(path.sep)[entry.split(path.sep).length - 2];
+		const prefix = path.basename(path.dirname(entry));
 		const importName = idx.toString().padStart(4, '0');
 		content += `import m${importName} from './${prefix}/migration.sql';\n`;
 		migrations[prefix] = importName;


### PR DESCRIPTION
## Problem

Fixes #5514.

On Windows, snapshot file paths use backslash separators (e.g. `C:\project\drizzle\20260320055809_initial\snapshot.json`). The previous implementation used `entry.split('/')[...length - 2]` to extract the migration folder name. Since Windows paths contain only backslashes, `split('/')` returns a single-element array and `[length - 2]` is `undefined`, causing `migrations.js` to import from `'./undefined/migration.sql'`.

## Fix

Replace the slash-split approach with `path.basename(path.dirname(entry))`, which correctly extracts the parent directory name on all platforms (POSIX and Windows).

```ts
// Before
const prefix = entry.split('/')[entry.split('/').length - 2];

// After
const prefix = path.basename(path.dirname(entry));
```

`path` is already imported in this file. The `path` module automatically handles both forward-slash and backslash separators on Windows via `path.dirname`/`path.basename`.