### PR TITLE
[Pg]: Fix json/jsonb double-parsing with node-postgres driver

### DIFF
--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -59,6 +59,12 @@ export class NodePgPreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 					if (typeId === types.builtins.INTERVAL) {
 						return (val) => val;
 					}
+					if (typeId === types.builtins.JSON) {
+						return (val) => val;
+					}
+					if (typeId === types.builtins.JSONB) {
+						return (val) => val;
+					}
 					// numeric[]
 					if (typeId === 1231) {
 						return (val) => val;
@@ -101,6 +107,12 @@ export class NodePgPreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 						return (val) => val;
 					}
 					if (typeId === types.builtins.INTERVAL) {
+						return (val) => val;
+					}
+					if (typeId === types.builtins.JSON) {
+						return (val) => val;
+					}
+					if (typeId === types.builtins.JSONB) {
 						return (val) => val;
 					}
 					// numeric[]


### PR DESCRIPTION
Fixes #5485

## Problem

`node-postgres` (pg) already parses `json`/`jsonb` columns via its built-in type parser (OIDs 114 and 3802), returning JS objects/values. Drizzle's `mapFromDriverValue` then calls `JSON.parse` again on the result.

For most values this is harmless — objects and arrays pass the `typeof value === 'string'` guard without being re-parsed. But **JSON string scalars** get double-parsed:

```
stored: "\"0.1\""  →  pg returns: "0.1"  →  drizzle parses: 0.1 (number)
```

This silently converts string values to numbers/booleans, which can cause data corruption.

## Fix

Override the JSON and JSONB type parsers in the node-postgres session to return raw strings, matching the existing pattern already used for timestamps, dates, and intervals. This lets `mapFromDriverValue` handle the single parse correctly.

## Notes

- Same pattern as the existing `TIMESTAMPTZ`/`TIMESTAMP`/`DATE`/`INTERVAL` overrides in the same file
- Only affects `node-postgres` — other drivers that return raw strings are unaffected
- `mapToDriverValue` (JSON.stringify on write) remains unchanged