### PR TITLE
fix(sql): allow not() to accept SQL | undefined (and/or return type)

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -174,7 +174,10 @@ export function or(
  *   .where(not(inArray(cars.make, ['GM', 'Ford'])))
  * ```
  */
-export function not(condition: SQLWrapper): SQL {
+export function not(condition: SQL | undefined): SQL | undefined;
+export function not(condition: SQLWrapper): SQL;
+export function not(condition: SQLWrapper | undefined): SQL | undefined {
+	if (condition === undefined) return undefined;
 	return sql`not ${condition}`;
 }
 


### PR DESCRIPTION
## What
Fixes #1818

The [not()](cci:1://file:///Users/vaibhavsingh/Desktop/SESD_Workshop_2/yarn/drizzle-orm/drizzle-orm/src/sql/expressions/conditions.ts:165:0-176:65) function previously only accepted `SQLWrapper`, causing a TypeScript
error when composing it with [and()](cci:1://file:///Users/vaibhavsingh/Desktop/SESD_Workshop_2/yarn/drizzle-orm/drizzle-orm/src/sql/expressions/conditions.ts:104:0-124:1) or [or()](cci:1://file:///Users/vaibhavsingh/Desktop/SESD_Workshop_2/yarn/drizzle-orm/drizzle-orm/src/sql/expressions/conditions.ts:126:0-142:79), which both return `SQL | undefined`:

```ts
// ❌ Before — TypeScript error
not(and(ilike(users.name, '%asdf%')))

// ✅ After — works perfectly
not(and(ilike(users.name, '%asdf%')))
