### PR TITLE
[SQLite-kit]: Support custom base API URL for d1-http

### DIFF
--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -1029,13 +1029,15 @@ export const connectToSQLite = async (
 					errors: { code: number; message: string }[];
 				};
 
+			const baseApiUrl = credentials.baseApiUrl ?? 'https://api.cloudflare.com/client/v4';
+
 			const remoteCallback: Parameters<typeof drizzle>[0] = async (
 				sql,
 				params,
 				method,
 			) => {
 				const res = await fetch(
-					`https://api.cloudflare.com/client/v4/accounts/${credentials.accountId}/d1/database/${credentials.databaseId}/${
+					`${baseApiUrl}/accounts/${credentials.accountId}/d1/database/${credentials.databaseId}/${
 						method === 'values' ? 'raw' : 'query'
 					}`,
 					{
@@ -1071,7 +1073,7 @@ export const connectToSQLite = async (
 			) => {
 				const sql = queries.map((q) => q.sql).join('; ');
 				const res = await fetch(
-					`https://api.cloudflare.com/client/v4/accounts/${credentials.accountId}/d1/database/${credentials.databaseId}/query`,
+					`${baseApiUrl}/accounts/${credentials.accountId}/d1/database/${credentials.databaseId}/query`,
 					{
 						method: 'POST',
 						body: JSON.stringify({ sql }),

--- a/drizzle-kit/src/cli/validations/sqlite.ts
+++ b/drizzle-kit/src/cli/validations/sqlite.ts
@@ -14,6 +14,7 @@ export const sqliteCredentials = union([
 		accountId: string().min(1),
 		databaseId: string().min(1),
 		token: string().min(1),
+		baseApiUrl: string().min(1).optional(),
 	}),
 	object({
 		driver: undefined(),
@@ -30,6 +31,7 @@ export type SqliteCredentials =
 		accountId: string;
 		databaseId: string;
 		token: string;
+		baseApiUrl?: string;
 	}
 	| {
 		url: string;

--- a/drizzle-kit/tests/validations.test.ts
+++ b/drizzle-kit/tests/validations.test.ts
@@ -136,6 +136,40 @@ test('d1-http #7', () => {
 	).toThrowError();
 });
 
+test('d1-http #8 - with baseApiUrl', () => {
+	sqliteCredentials.parse({
+		dialect: 'sqlite',
+		driver: 'd1-http',
+		accountId: 'accountId',
+		databaseId: 'databaseId',
+		token: 'token',
+		baseApiUrl: 'https://custom.api.example.com/v4',
+	});
+});
+
+test('d1-http #9 - without baseApiUrl (optional)', () => {
+	sqliteCredentials.parse({
+		dialect: 'sqlite',
+		driver: 'd1-http',
+		accountId: 'accountId',
+		databaseId: 'databaseId',
+		token: 'token',
+	});
+});
+
+test('d1-http #10 - empty baseApiUrl should fail', () => {
+	expect(() =>
+		sqliteCredentials.parse({
+			dialect: 'sqlite',
+			driver: 'd1-http',
+			accountId: 'accountId',
+			databaseId: 'databaseId',
+			token: 'token',
+			baseApiUrl: '',
+		})
+	).toThrowError();
+});
+
 // omit undefined driver
 test('sqlite #1', () => {
 	expect(


### PR DESCRIPTION
The d1-http driver has the Cloudflare API base URL hardcoded. Wrangler supports overriding this via `CLOUDFLARE_BASE_API_URL` but drizzle-kit has no equivalent, so custom endpoints like proxies or testing environments can't be used.

Added an optional `baseApiUrl` field to d1-http credentials. Falls back to `https://api.cloudflare.com/client/v4` when not specified.

```ts
// drizzle.config.ts
export default defineConfig({
  dialect: 'sqlite',
  driver: 'd1-http',
  dbCredentials: {
    accountId: '...',
    databaseId: '...',
    token: '...',
    baseApiUrl: 'https://custom.endpoint.com/client/v4', // optional
  },
});
```