### PR TITLE
fix(sqlite-proxy): handle undefined/empty rows in get() method

### DIFF
--- a/drizzle-orm/src/sqlite-proxy/driver.ts
+++ b/drizzle-orm/src/sqlite-proxy/driver.ts
@@ -27,17 +27,26 @@ export class SqliteRemoteDatabase<
 	}
 }
 
+/**
+ * Callback for executing individual SQL queries against the remote SQLite database.
+ *
+ * The `rows` field in the return value depends on the method:
+ * - `'run'`: `rows` is ignored (can be `[]` or `undefined`)
+ * - `'all'` / `'values'`: `rows` must be an array of result rows
+ * - `'get'`: `rows` should be `undefined` when no matching row is found;
+ *   returning an empty array `[]` is also handled gracefully
+ */
 export type AsyncRemoteCallback = (
 	sql: string,
 	params: any[],
 	method: 'run' | 'all' | 'values' | 'get',
-) => Promise<{ rows: any[] }>;
+) => Promise<{ rows: any[] | undefined }>;
 
 export type AsyncBatchRemoteCallback = (batch: {
 	sql: string;
 	params: any[];
 	method: 'run' | 'all' | 'values' | 'get';
-}[]) => Promise<{ rows: any[] }[]>;
+}[]) => Promise<{ rows: any[] | undefined }[]>;
 
 export type RemoteCallback = AsyncRemoteCallback;
 

--- a/drizzle-orm/src/sqlite-proxy/driver.ts
+++ b/drizzle-orm/src/sqlite-proxy/driver.ts
@@ -27,17 +27,29 @@ export class SqliteRemoteDatabase<
 	}
 }
 
+/**
+ * Callback for executing individual SQL queries against the remote SQLite database.
+ *
+ * The `rows` field must always be present; its meaning depends on the method:
+ * - `'run'`: `rows` is ignored (can be `[]` or `undefined`)
+ * - `'all'` / `'values'`: `rows` is the array of result rows
+ * - `'get'`: `rows` should be `undefined` when no matching row is found;
+ *   returning an empty array `[]` is also handled gracefully
+ *
+ * `rows` is `any[] | undefined` (not optional) so a no-row `get` can return
+ * `undefined`, while still forcing `all`/`values` callbacks to return the field.
+ */
 export type AsyncRemoteCallback = (
 	sql: string,
 	params: any[],
 	method: 'run' | 'all' | 'values' | 'get',
-) => Promise<{ rows: any[] }>;
+) => Promise<{ rows: any[] | undefined }>;
 
 export type AsyncBatchRemoteCallback = (batch: {
 	sql: string;
 	params: any[];
 	method: 'run' | 'all' | 'values' | 'get';
-}[]) => Promise<{ rows: any[] }[]>;
+}[]) => Promise<{ rows: any[] | undefined }[]>;
 
 export type RemoteCallback = AsyncRemoteCallback;
 

--- a/drizzle-orm/src/sqlite-proxy/session.ts
+++ b/drizzle-orm/src/sqlite-proxy/session.ts
@@ -109,7 +109,8 @@ export class SQLiteRemoteSession<
 	}
 
 	override extractRawGetValueFromBatchResult(result: unknown): unknown {
-		return (result as SqliteRemoteResult).rows![0];
+		const rows = (result as SqliteRemoteResult).rows;
+		return rows?.[0];
 	}
 
 	override extractRawValuesValueFromBatchResult(result: unknown): unknown {
@@ -226,7 +227,12 @@ export class RemotePreparedQuery<T extends PreparedQueryConfig = PreparedQueryCo
 			return await (client as AsyncRemoteCallback)(query.sql, params, 'get');
 		});
 
-		return this.mapGetResult(clientResult.rows);
+		// Normalize empty array to undefined for 'get' with no matching row.
+		// Native SQLite drivers (better-sqlite3, bun:sqlite) return undefined when
+		// get() finds no row, but proxy implementers often return [] following the
+		// typed callback signature. Treat both as "no result".
+		const rows = clientResult.rows;
+		return this.mapGetResult(Array.isArray(rows) && rows.length === 0 ? undefined : rows);
 	}
 
 	override mapGetResult(rows: unknown, isFromBatch?: boolean): unknown {

--- a/drizzle-orm/src/sqlite-proxy/session.ts
+++ b/drizzle-orm/src/sqlite-proxy/session.ts
@@ -109,7 +109,10 @@ export class SQLiteRemoteSession<
 	}
 
 	override extractRawGetValueFromBatchResult(result: unknown): unknown {
-		return (result as SqliteRemoteResult).rows![0];
+		// `rows` may be `undefined` for a no-row `get` (see the no-row handling in
+		// `mapGetResult` below); use optional chaining instead of `rows![0]`.
+		const rows = (result as SqliteRemoteResult).rows;
+		return rows?.[0];
 	}
 
 	override extractRawValuesValueFromBatchResult(result: unknown): unknown {
@@ -234,7 +237,14 @@ export class RemotePreparedQuery<T extends PreparedQueryConfig = PreparedQueryCo
 			rows = (rows as SqliteRemoteResult).rows;
 		}
 
-		const row = rows as unknown[];
+		// A `get` that matches no row should resolve to `undefined`, matching native
+		// SQLite drivers (better-sqlite3, bun:sqlite). Proxy implementers naturally
+		// return `{ rows: [] }` for "no row" (the callback may return `rows: undefined`
+		// too), so normalize an empty array to `undefined` here, at the single mapping
+		// boundary shared by the direct `.get()`, `findFirst`, and batch paths.
+		// (Unlike `all`, a `get` row is the flat column-value array, so `[]` is
+		// unambiguously "no row" and never a real zero-column result.)
+		const row = Array.isArray(rows) && rows.length === 0 ? undefined : rows as unknown[];
 
 		if (!this.fields && !this.customResultMapper) {
 			return row;
@@ -245,7 +255,7 @@ export class RemotePreparedQuery<T extends PreparedQueryConfig = PreparedQueryCo
 		}
 
 		if (this.customResultMapper) {
-			return this.customResultMapper([rows] as unknown[][]) as T['get'];
+			return this.customResultMapper([row] as unknown[][]) as T['get'];
 		}
 
 		return mapResultRow(

--- a/drizzle-orm/tests/sqlite-proxy-get.test.ts
+++ b/drizzle-orm/tests/sqlite-proxy-get.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { int, sqliteTable, text } from '~/sqlite-core/index.ts';
+import { drizzle } from '~/sqlite-proxy/index.ts';
+import type { AsyncRemoteCallback } from '~/sqlite-proxy/driver.ts';
+
+const users = sqliteTable('users', {
+	id: int('id').primaryKey(),
+	name: text('name').notNull(),
+});
+
+describe('sqlite-proxy get() with no matching row', () => {
+	test('returns undefined when callback returns { rows: undefined }', async () => {
+		const callback: AsyncRemoteCallback = async (_sql, _params, _method) => {
+			return { rows: undefined };
+		};
+
+		const db = drizzle(callback);
+		const result = await db.select().from(users).get();
+
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when callback returns { rows: [] } for get', async () => {
+		const callback: AsyncRemoteCallback = async (_sql, _params, _method) => {
+			// Before the fix, returning an empty array for 'get' would cause
+			// drizzle to return { id: undefined, name: undefined } instead of undefined
+			return { rows: [] };
+		};
+
+		const db = drizzle(callback);
+		const result = await db.select().from(users).get();
+
+		expect(result).toBeUndefined();
+	});
+
+	test('returns the row when callback returns a valid result for get', async () => {
+		const callback: AsyncRemoteCallback = async (_sql, _params, _method) => {
+			return { rows: [1, 'Alice'] };
+		};
+
+		const db = drizzle(callback);
+		const result = await db.select().from(users).get();
+
+		expect(result).toEqual({ id: 1, name: 'Alice' });
+	});
+});

--- a/drizzle-orm/tests/sqlite-proxy-get.test.ts
+++ b/drizzle-orm/tests/sqlite-proxy-get.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest';
+import { relations } from '~/relations.ts';
+import { int, sqliteTable, text } from '~/sqlite-core/index.ts';
+import type { AsyncBatchRemoteCallback, AsyncRemoteCallback } from '~/sqlite-proxy/driver.ts';
+import { drizzle } from '~/sqlite-proxy/index.ts';
+
+const users = sqliteTable('users', {
+	id: int('id').primaryKey(),
+	name: text('name').notNull(),
+});
+
+const usersRelations = relations(users, () => ({}));
+const schema = { users, usersRelations };
+
+// Proxy implementers naturally return `{ rows: [] }` for a no-row `get` because the
+// callback is typed `rows?: any[]`. Native SQLite drivers return `undefined` here, so
+// the proxy must treat an empty array the same as `undefined` (regression for #5461).
+const emptyRowsGet: AsyncRemoteCallback = async () => ({ rows: [] });
+const undefinedRowsGet: AsyncRemoteCallback = async () => ({ rows: undefined });
+
+describe('sqlite-proxy get() with no matching row (#5461)', () => {
+	test('select().get() returns undefined when callback returns { rows: undefined }', async () => {
+		const db = drizzle(undefinedRowsGet);
+		const result = await db.select().from(users).get();
+
+		expect(result).toBeUndefined();
+	});
+
+	test('select().get() returns undefined when callback returns { rows: [] }', async () => {
+		// Before the fix the empty array was truthy and got mapped field-by-field to
+		// { id: undefined, name: undefined } instead of undefined.
+		const db = drizzle(emptyRowsGet);
+		const result = await db.select().from(users).get();
+
+		expect(result).toBeUndefined();
+	});
+
+	test('query.findFirst() returns undefined when callback returns { rows: [] }', async () => {
+		// The exact scenario from the issue: findFirst goes through the customResultMapper
+		// path, which previously produced { id: undefined }.
+		const db = drizzle(emptyRowsGet, { schema });
+		const result = await db.query.users.findFirst({ columns: { id: true } });
+
+		expect(result).toBeUndefined();
+	});
+
+	test('batch findFirst() returns undefined when callback returns { rows: [] }', async () => {
+		// Batch get flows through mapResult(result, true) -> mapGetResult(result, true),
+		// a path the get()-level guard did not cover. Centralizing the normalization in
+		// mapGetResult fixes it.
+		const batchEmpty: AsyncBatchRemoteCallback = async (batch) => batch.map(() => ({ rows: [] }));
+		const db = drizzle(emptyRowsGet, batchEmpty, { schema });
+		const [result] = await db.batch([db.query.users.findFirst({ columns: { id: true } })]);
+
+		expect(result).toBeUndefined();
+	});
+
+	test('select().get() still maps a valid row', async () => {
+		const validGet: AsyncRemoteCallback = async () => ({ rows: [1, 'Alice'] });
+		const db = drizzle(validGet);
+		const result = await db.select().from(users).get();
+
+		expect(result).toEqual({ id: 1, name: 'Alice' });
+	});
+
+	test('batch findFirst() still maps a valid row', async () => {
+		const validGet: AsyncRemoteCallback = async () => ({ rows: [1, 'Alice'] });
+		const batchValid: AsyncBatchRemoteCallback = async (batch) => batch.map(() => ({ rows: [1, 'Alice'] }));
+		const db = drizzle(validGet, batchValid, { schema });
+		const [result] = await db.batch([db.query.users.findFirst()]);
+
+		expect(result).toEqual({ id: 1, name: 'Alice' });
+	});
+});


### PR DESCRIPTION
## Bug

Fixes #5461

With `drizzle-orm/sqlite-proxy`, a `get` that matches no row returns an all-`undefined` object (e.g. `{ id: undefined }`) instead of `undefined` when the proxy callback returns `{ rows: [] }`.

Root cause: for `get`, the proxy treats `rows` as the **flat column-value array of the single row** (unlike `all`, where it is an array of rows). An empty array `[]` is truthy, so `mapGetResult` maps it field-by-field to an all-`undefined` object. Native SQLite drivers (`better-sqlite3` `stmt.get()`, `bun:sqlite`) and the sibling `libsql` driver return `undefined` for a no-row `get`; the proxy should match that.

## Fix

- **Centralize the normalization in `mapGetResult`.** Treat an empty array as `undefined` right after the `isFromBatch` extraction, so the fix covers every `get` path through the single mapping boundary: direct `.get()`, RQB `findFirst()`, raw `get`, **and the batch `get` path** (`mapResult(result, true)` → `mapGetResult(result, true)`), which a `get()`-only guard would miss.
- **Type:** relax the callback return type to `{ rows: any[] | undefined }`. The `rows` field stays required (so `all`/`values` callbacks can't silently omit it), but its value may be `undefined` so a no-row `get` is expressible without a cast.
- **Batch guard:** `extractRawGetValueFromBatchResult` uses optional chaining (`rows?.[0]`) instead of the non-null assertion (`rows![0]`).
- **Tests:** unit coverage for direct `.get()`, `findFirst()`, and batch `findFirst()` with `{ rows: [] }` and `{ rows: undefined }`, plus valid-row mapping (direct and batch). Unit-level because the integration server-simulator runs a real `better-sqlite3` whose `stmt.get()` already returns `undefined`, masking the `{ rows: [] }` case.

A real matched row always has at least one column, so an empty `[]` for `get` is unambiguously "no row" and never a real zero-column result; valid rows are unaffected.

## Verification

- New regression tests pass (6/6).
- Full `drizzle-orm` unit suite green (572 tests).
- `tsc` and `dprint` clean.
- Rebased onto the latest `main`.
