### PR TITLE
fix: made mssql optional

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -194,6 +194,12 @@
 		},
 		"zod": {
 			"optional": true
+		},
+		"mssql": {
+			"optional": true
+		},
+		"@types/mssql": {
+			"optional": true
 		}
 	},
 	"devDependencies": {


### PR DESCRIPTION
this should reduce install size from 60mb down to 15mb (which is still a lot tbh, but welp)

<img width="873" height="435" alt="image" src="https://github.com/user-attachments/assets/64391580-e65a-4dde-acc3-0fa93e3b47d8" />
