### PR TITLE
fix(drizzle-kit): handle MySQL functional/expression indexes in introspection

### DIFF
--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -264,6 +264,7 @@ export const schemaToTypeScript = (
 				table.name,
 				Object.values(table.indexes),
 				withCasing,
+				schema,
 			);
 			statement += createTableFKs(Object.values(filteredFKs), withCasing);
 			statement += createTablePKs(
@@ -273,6 +274,7 @@ export const schemaToTypeScript = (
 			statement += createTableUniques(
 				Object.values(table.uniqueConstraints),
 				withCasing,
+				schema,
 			);
 			statement += createTableChecks(
 				Object.values(table.checkConstraint),
@@ -902,6 +904,7 @@ const createTableIndexes = (
 	tableName: string,
 	idxs: Index[],
 	casing: (value: string) => string,
+	schema?: MySqlSchemaInternal,
 ): string => {
 	let statement = '';
 
@@ -920,7 +923,15 @@ const createTableIndexes = (
 		statement += `"${it.name}")`;
 		statement += `.on(${
 			it.columns
-				.map((it) => `table.${casing(it)}`)
+				.map((col) => {
+					// Check if this column is an expression in the index
+					const isExpression = schema?.internal?.indexes?.[it.name]?.columns?.[col]?.isExpression;
+					if (isExpression) {
+						// For expression columns, wrap in sql\`...\`
+						return `sql\`${col.replace(/`/g, '\\`')}\``;
+					}
+					return `table.${casing(col)}`;
+				})
 				.join(', ')
 		}),`;
 	});
@@ -931,6 +942,7 @@ const createTableIndexes = (
 const createTableUniques = (
 	unqs: UniqueConstraint[],
 	casing: (value: string) => string,
+	schema?: MySqlSchemaInternal,
 ): string => {
 	let statement = '';
 
@@ -942,7 +954,15 @@ const createTableUniques = (
 		statement += `"${it.name}")`;
 		statement += `.on(${
 			it.columns
-				.map((it) => `table.${casing(it)}`)
+				.map((col) => {
+					// Check if this column is an expression in the unique constraint
+					const isExpression = schema?.internal?.indexes?.[it.name]?.columns?.[col]?.isExpression;
+					if (isExpression) {
+						// For expression columns, wrap in sql\`...\`
+						return `sql\`${col.replace(/`/g, '\\`')}\``;
+					}
+					return `table.${casing(col)}`;
+				})
 				.join(', ')
 		}),`;
 	});

--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -862,13 +862,43 @@ export const fromDatabase = async (
 		const tableSchema = idxRow['TABLE_SCHEMA'];
 		const tableName = idxRow['TABLE_NAME'];
 		const constraintName = idxRow['INDEX_NAME'];
-		const columnName: string = idxRow['COLUMN_NAME'];
+		const columnName: string | null = idxRow['COLUMN_NAME'];
+		const expression: string | null = idxRow['EXPRESSION'];
 		const isUnique = idxRow['NON_UNIQUE'] === 0;
 
 		const tableInResult = result[tableName];
 		if (typeof tableInResult === 'undefined') continue;
 
-		// if (tableInResult.columns[columnName].type === "serial") continue;
+		// Handle functional/expression indexes where COLUMN_NAME is null
+		// In MySQL 8+, functional indexes have COLUMN_NAME = null and EXPRESSION contains the actual expression
+		let indexColumnName: string;
+		let isExpression = false;
+		if (columnName === null && expression !== null) {
+			indexColumnName = expression;
+			isExpression = true;
+		} else if (columnName !== null) {
+			indexColumnName = columnName;
+		} else {
+			// Skip if both COLUMN_NAME and EXPRESSION are null (shouldn't happen)
+			continue;
+		}
+
+		// Track expression columns in internals for proper TypeScript generation
+		if (isExpression) {
+			if (typeof internals!.indexes![constraintName] === 'undefined') {
+				internals!.indexes![constraintName] = {
+					columns: {
+						[indexColumnName]: {
+							isExpression: true,
+						},
+					},
+				};
+			} else {
+				internals!.indexes![constraintName]!.columns[indexColumnName] = {
+					isExpression: true,
+				};
+			}
+		}
 
 		indexesCount += 1;
 		if (progressCallback) {
@@ -880,12 +910,12 @@ export const fromDatabase = async (
 				typeof tableInResult.uniqueConstraints[constraintName] !== 'undefined'
 			) {
 				tableInResult.uniqueConstraints[constraintName]!.columns.push(
-					columnName,
+					indexColumnName,
 				);
 			} else {
 				tableInResult.uniqueConstraints[constraintName] = {
 					name: constraintName,
-					columns: [columnName],
+					columns: [indexColumnName],
 				};
 			}
 		} else {
@@ -893,11 +923,11 @@ export const fromDatabase = async (
 			// so for introspect we will just skip it
 			if (typeof tableInResult.foreignKeys[constraintName] === 'undefined') {
 				if (typeof tableInResult.indexes[constraintName] !== 'undefined') {
-					tableInResult.indexes[constraintName]!.columns.push(columnName);
+					tableInResult.indexes[constraintName]!.columns.push(indexColumnName);
 				} else {
 					tableInResult.indexes[constraintName] = {
 						name: constraintName,
-						columns: [columnName],
+						columns: [indexColumnName],
 						isUnique: isUnique,
 					};
 				}


### PR DESCRIPTION
## Bug Description

MySQL 8+ functional indexes have `COLUMN_NAME = null` in `INFORMATION_SCHEMA.STATISTICS` with the actual expression stored in the `EXPRESSION` column. This caused `drizzle-kit pull` to crash with:

```
TypeError: Cannot read properties of null (reading 'camelCase')
```

when introspecting databases with functional/expression indexes.

## Changes

### mysqlSerializer.ts
- Check for null `COLUMN_NAME` and use `EXPRESSION` column instead for functional indexes
- Track expression columns in `internals.indexes` for proper TypeScript generation
- Skip entries where both `COLUMN_NAME` and `EXPRESSION` are null

### introspect-mysql.ts  
- Updated `createTableIndexes` and `createTableUniques` to accept schema parameter
- Expression columns are now wrapped in `sql\`...\`` instead of `table.column`

## Example

Before (crash):
```sql
CREATE UNIQUE INDEX idx ON table ((CASE WHEN col = 1 THEN 1 ELSE NULL END));
```

After (works):
```typescript
unique("idx").on(sql`CASE WHEN col = 1 THEN 1 ELSE NULL END`)
```

## Testing

This fix was tested against the reproduction case provided in #5546.

Fixes #5546