### PR TITLE
fix(mssql-core): add mapFromDriverValue to MsSqlReal to fix float32 precision

### DIFF
--- a/drizzle-orm/src/mssql-core/columns/real.ts
+++ b/drizzle-orm/src/mssql-core/columns/real.ts
@@ -28,6 +28,10 @@ export class MsSqlReal<T extends ColumnBaseConfig<'number float'>> extends MsSql
 	getSQLType(): string {
 		return 'real';
 	}
+
+	override mapFromDriverValue(value: number): number {
+		return parseFloat(value.toPrecision(7));
+	}
 }
 
 export function real(name?: string) {


### PR DESCRIPTION
## Description

The MSSQL real() column type returns imprecise float64 representations of float32 values. A value stored as 0.01 in a SQL Server real column was returned as 0.009999999776482582 due to float32-to-float64 widening by the mssql driver.

## Changes

Added mapFromDriverValue to MsSqlReal class that rounds to 7 significant digits (the actual precision of float32), so 0.01 in the database comes back as 0.01 in JavaScript instead of 0.009999999776482582.

## Fix

override mapFromDriverValue(value: number): number {
  return parseFloat(value.toPrecision(7));
}

## Issue

Fixes #5527