### PR TITLE
fix(drizzle-orm): Return an object when any values is non-null during a grouped left/right join (#2157)

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -51,6 +51,10 @@ export function mapResultRow<TResult>(
 							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
 						) {
 							nullifyMap[objectName] = false;
+						} else if (value !== null) {
+							// The initial value for an object may have been null, but subsquent values are not-null
+							// Prevents the entire object being define as null when the join has values
+							nullifyMap[objectName] = false;
 						}
 					}
 				}

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -1741,6 +1741,53 @@ export function tests() {
 			]);
 		});
 
+		test('left join (grouped join null first column)', async (ctx) => {
+			const { db } = ctx.pg;
+
+			const rows = await db
+				.insert(citiesTable)
+				.values([{ name: 'Austin', state: "TX" }, { name: 'London' }])
+				.returning({ id: citiesTable.id });
+
+			expect(rows).toHaveLength(2)
+			const [{id: austinId}, {id: londonId}] = rows as any as [{id: number}, {id: number}];
+
+			await db.insert(users2Table).values([{ name: 'John', cityId: austinId }, { name: 'Jane', cityId: londonId }]);
+
+			const res = await db
+				.select(
+					{
+						id: users2Table.id,
+						user: {
+							name: users2Table.name,
+							nameUpper: sql<string>`upper(${users2Table.name})`,
+						},
+						city: {
+							// Being a nullable column, being first caused the entire object to return null
+							state: citiesTable.state,
+							id: citiesTable.id,
+							name: citiesTable.name,
+							nameUpper: sql<string>`upper(${citiesTable.name})`,
+						},
+					}
+				)
+				.from(users2Table)
+				.leftJoin(citiesTable, eq(users2Table.cityId, citiesTable.id));
+
+			expect(res).toEqual([
+				{
+					id: 1,
+					user: { name: 'John', nameUpper: 'JOHN' },
+					city: { state: 'TX', id: austinId, name: 'Austin', nameUpper: 'AUSTIN' },
+				},
+				{
+					id: 2,
+					user: { name: 'Jane', nameUpper: 'JANE' },
+					city: { state: null, id: londonId, name: 'London', nameUpper: 'LONDON' },
+				},
+			]);
+		});
+
 		test('select from a many subquery', async (ctx) => {
 			const { db } = ctx.pg;
 


### PR DESCRIPTION
## Problem

When deserialising grouped objects, if the first value of an object of a left/right join is null, the entire object is defined as null regardless of the result of later values. Returned results are incomplete, missing data from a successful join.

## Root Cause

```ts
// drizzle-orm/src/utils.ts
export function mapResultRow<TResult>(...) {
// ...
    // Defines the object a nullable on the first value, but doesn't redefine the object a non-nullable if future values are not null
    if (!(objectName in nullifyMap)) {
        nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
    } else if (typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)) {
        nullifyMap[objectName] = false;
    }
// ...
}
```

## Fix

When mapping grouped objects result, if any values of the object is not-null, then classify the entire object as not-null.

## Related

Fixes https://github.com/drizzle-team/drizzle-orm/issues/2157