### PR TITLE
docs: fix typos in markdown documentation

### DIFF
--- a/changelogs/drizzle-arktype/0.1.2.md
+++ b/changelogs/drizzle-arktype/0.1.2.md
@@ -37,7 +37,7 @@ const insertUserSchema = createInsertSchema(users, {
 
 // Refining the fields - useful if you want to change the fields before they become nullable/optional in the final schema
 const insertUserSchema = createInsertSchema(users, {
-	id: (schema) => schema.atLeast(1),
+	id: (schema) => schema.at least(1),
 	role: type('string'),
 });
 

--- a/changelogs/drizzle-kit/0.24.0.md
+++ b/changelogs/drizzle-kit/0.24.0.md
@@ -1,6 +1,6 @@
 ## Breaking changes (for SQLite users)
 
-#### Fixed [Composite primary key order is not consistent](https://github.com/drizzle-team/drizzle-kit-mirror/issues/342) by removing `sort` in SQLite and to be consistant with the same logic in PostgreSQL and MySQL
+#### Fixed [Composite primary key order is not consistent](https://github.com/drizzle-team/drizzle-kit-mirror/issues/342) by removing `sort` in SQLite and to be consistent with the same logic in PostgreSQL and MySQL
 
 The issue that may arise for SQLite users with any driver using composite primary keys is that the order in the database may differ from the Drizzle schema.
 

--- a/changelogs/drizzle-kit/0.24.1.md
+++ b/changelogs/drizzle-kit/0.24.1.md
@@ -26,7 +26,7 @@
 - [[BUG]: Missing index names when running introspect command [MYSQL]](https://github.com/drizzle-team/drizzle-orm/issues/2525)
 - [[BUG]: drizzle-kit introspect TypeError: Cannot read properties of undefined (reading 'toLowerCase')](https://github.com/drizzle-team/drizzle-orm/issues/2338)
 - [[BUG]: Wrong column name when using PgEnum.array()](https://github.com/drizzle-team/drizzle-orm/issues/2100)
-- [[BUG]: Incorrect Schema Generated when introspecting extisting pg database](https://github.com/drizzle-team/drizzle-orm/issues/1985)
+- [[BUG]: Incorrect Schema Generated when introspecting existing pg database](https://github.com/drizzle-team/drizzle-orm/issues/1985)
 - [[⚠️🐞BUG]: index() missing argument after introspection, causes tsc error that fails the build](https://github.com/drizzle-team/drizzle-orm/issues/1870)
 - [[BUG]: drizzle-kit introspect small errors](https://github.com/drizzle-team/drizzle-orm/issues/1738)
 - [[BUG]: Missing bigint import in drizzle-kit introspect](https://github.com/drizzle-team/drizzle-orm/issues/1020)

--- a/changelogs/drizzle-kit/0.28.0.md
+++ b/changelogs/drizzle-kit/0.28.0.md
@@ -18,7 +18,7 @@
 - [[BUG]: Postgres push fails due to lack of quotes](https://github.com/drizzle-team/drizzle-orm/issues/2396) - thanks @L-Mario564
 - [[BUG]: TypeError: Cannot read properties of undefined (reading 'compositePrimaryKeys')](https://github.com/drizzle-team/drizzle-orm/issues/2344) - thanks @L-Mario564
 - [[BUG]: drizzle-kit introspect generates CURRENT_TIMESTAMP without sql operator on date column](https://github.com/drizzle-team/drizzle-orm/issues/2899) - thanks @L-Mario564
-- [[BUG]: Drizzle-kit introspect doesn't pull correct defautl statement](https://github.com/drizzle-team/drizzle-orm/issues/2905) - thanks @L-Mario564
+- [[BUG]: Drizzle-kit introspect doesn't pull correct default statement](https://github.com/drizzle-team/drizzle-orm/issues/2905) - thanks @L-Mario564
 - [[BUG]: Problem on MacBook - This statement does not return data. Use run() instead](https://github.com/drizzle-team/drizzle-orm/issues/2623) - thanks @L-Mario564
 - [[BUG]: Enum column names that are used as arrays are not quoted](https://github.com/drizzle-team/drizzle-orm/issues/2598) - thanks @L-Mario564
 - [[BUG]: drizzle-kit generate ignores index operators](https://github.com/drizzle-team/drizzle-orm/issues/2935) - thanks @L-Mario564

--- a/changelogs/drizzle-kit/0.31.7.md
+++ b/changelogs/drizzle-kit/0.31.7.md
@@ -1,3 +1,3 @@
 ### Bug fixes
 
-- [[BUG]: Drizzle Kit push to Postgres 18 produces unecessary DROP SQL when the schema was NOT changed](https://github.com/drizzle-team/drizzle-orm/issues/4944)
+- [[BUG]: Drizzle Kit push to Postgres 18 produces unnecessary DROP SQL when the schema was NOT changed](https://github.com/drizzle-team/drizzle-orm/issues/4944)

--- a/changelogs/drizzle-kit/0.31.8.md
+++ b/changelogs/drizzle-kit/0.31.8.md
@@ -1,4 +1,4 @@
 ### Bug fixes
 
-- Fixed `algorythm` => `algorithm` typo.
+- Fixed `algorithm` => `algorithm` typo.
 - Fixed external dependencies in build configuration.

--- a/changelogs/drizzle-orm-pg/0.15.0.md
+++ b/changelogs/drizzle-orm-pg/0.15.0.md
@@ -6,7 +6,7 @@
 - Index name now becomes optional. You can write either `index('usersNameIdx')` or `index()`. In last case, drizzle will generate index name automatically based on table and column index was created on
 
 ## Breaking changes
-`foreignKey()` function api changes. Previosuly you need to pass callback function with table columns for FK. Right now no need for callback, just object with data for FK
+`foreignKey()` function api changes. Previously you need to pass callback function with table columns for FK. Right now no need for callback, just object with data for FK
 
 #### Before
 ```typescript

--- a/changelogs/drizzle-orm-sqlite/0.14.3.md
+++ b/changelogs/drizzle-orm-sqlite/0.14.3.md
@@ -2,7 +2,7 @@
 
 - `RangeError: The supplied SQL string contains more than one statement` error on migrations was fixed
 
-    Created `.exec()` method for session, that will run query without prepared statments
+    Created `.exec()` method for session, that will run query without prepared statements
 
 - Fix `defaultNow()` method query generation by adding missin `"()"`.
 

--- a/changelogs/drizzle-orm/0.21.0.md
+++ b/changelogs/drizzle-orm/0.21.0.md
@@ -145,7 +145,7 @@ This command will show you a list of all migrations you have and you'll need jus
 
 ### New `drizzle-kit` option `--breakpoints` for `generate` and `introspect` commands
 
-If particular driver doesn't support running multiple quries in 1 execution you can use `--breakpoints`.
+If particular driver doesn't support running multiple queries in 1 execution you can use `--breakpoints`.
 
 `drizzle-kit` will generate current sql
 

--- a/changelogs/drizzle-orm/0.26.0.md
+++ b/changelogs/drizzle-orm/0.26.0.md
@@ -1,6 +1,6 @@
 # Drizzle ORM 0.26.0 is here 🎉
 
-## README docs are fully tranferred to web
+## README docs are fully transferred to web
 
 The documentation has been completely reworked and updated with additional examples and explanations. You can find it here: https://orm.drizzle.team.
 

--- a/changelogs/drizzle-orm/0.28.0.md
+++ b/changelogs/drizzle-orm/0.28.0.md
@@ -45,11 +45,11 @@ const db = drizzle(connection, { schema, mode: 'planetscale' });
 
 We've run the diagnostics on a database schema with 85 tables, 666 columns, 26 enums, 172 indexes and 133 foreign keys. We've optimized internal types which resulted in **430%** speed up in IntelliSense.
 
-## Improved Relational Queries Permormance and Read Usage
+## Improved Relational Queries Performance and Read Usage
 
 In this release we've fully changed a way query is generated for Relational Queri API.
 
-As a summary we've made current set of changes in query generation startegy:
+As a summary we've made current set of changes in query generation strategy:
 
 1. Lateral Joins: In the new version we're utilizing lateral joins, denoted by the "LEFT JOIN LATERAL" clauses, to retrieve specific data from related tables efficiently For MySQL in PlanetScale and SQLite, we've used simple subquery selects, which improved a query plan and overall performance
 

--- a/changelogs/drizzle-orm/0.30.0.md
+++ b/changelogs/drizzle-orm/0.30.0.md
@@ -35,7 +35,7 @@ A few more references for timestamps without and with timezones can be found in 
 - [BUG]: Dates are always dates #971
 - [BUG]: Inconsistencies when working with timestamps and corresponding datetime objects in javascript. #1176
 - [BUG]: timestamp columns showing string type, however actually returning a Date object. #1185
-- [BUG]: Wrong data type for postgres date colum #1407
+- [BUG]: Wrong data type for postgres date column #1407
 - [BUG]: invalid timestamp conversion when using PostgreSQL with TimeZone set to UTC #1587
 - [BUG]: Postgres insert into timestamp with time zone removes milliseconds #1061
 - [BUG]: update timestamp field (using AWS Data API) #1164

--- a/changelogs/drizzle-orm/0.31.0-beta.md
+++ b/changelogs/drizzle-orm/0.31.0-beta.md
@@ -98,7 +98,7 @@ hammingDistance(table.column, '101') // table.column <~> '101'
 jaccardDistance(table.column, '101') // table.column <%> '101'
 ```
 
-If `pg_vector` has some other functions to use, you can replicate implimentation from existing one we have. Here is how it can be done
+If `pg_vector` has some other functions to use, you can replicate implementation from existing one we have. Here is how it can be done
 
 ```ts
 export function l2Distance(

--- a/changelogs/drizzle-orm/0.31.0.md
+++ b/changelogs/drizzle-orm/0.31.0.md
@@ -100,7 +100,7 @@ hammingDistance(table.column, '101') // table.column <~> '101'
 jaccardDistance(table.column, '101') // table.column <%> '101'
 ```
 
-If `pg_vector` has some other functions to use, you can replicate implimentation from existing one we have. Here is how it can be done
+If `pg_vector` has some other functions to use, you can replicate implementation from existing one we have. Here is how it can be done
 
 ```ts
 export function l2Distance(

--- a/changelogs/drizzle-orm/0.32.2.md
+++ b/changelogs/drizzle-orm/0.32.2.md
@@ -1,4 +1,4 @@
 - Fix AWS Data API type hints bugs in RQB
 - Fix set transactions in MySQL bug - thanks @roguesherlock
-- Add forwaring dependencies within useLiveQuery, fixes [#2651](https://github.com/drizzle-team/drizzle-orm/issues/2651) - thanks @anstapol 
+- Add forwarding dependencies within useLiveQuery, fixes [#2651](https://github.com/drizzle-team/drizzle-orm/issues/2651) - thanks @anstapol 
 - Export additional types from SQLite package, like `AnySQLiteUpdate` - thanks @veloii

--- a/changelogs/drizzle-orm/0.43.0.md
+++ b/changelogs/drizzle-orm/0.43.0.md
@@ -10,7 +10,7 @@
 - Forced `Gel` columns to always have explicit schema & table prefixes due to potential errors caused by lack of such prefix in subquery's selection when there's already a column bearing same name in context  
 - Added missing export for `PgTextBuilderInitial` type  
 - Removed outdated `IfNotImported` type check from `SingleStore` driver initializer  
-- Fixed incorrect type inferrence for insert and update models with non-strict `tsconfig`s \([#2654](https://github.com/drizzle-team/drizzle-orm/issues/2654)\)  
+- Fixed incorrect type inference for insert and update models with non-strict `tsconfig`s \([#2654](https://github.com/drizzle-team/drizzle-orm/issues/2654)\)  
 - Fixed invalid spelling of `nowait` flag \([#3554](https://github.com/drizzle-team/drizzle-orm/issues/3554)\)
 - [Add join lateral support](https://github.com/drizzle-team/drizzle-orm/issues/420)
 - [Remove .fullJoin() from MySQL API](https://github.com/drizzle-team/drizzle-orm/issues/1125)

--- a/changelogs/drizzle-orm/0.45.0.md
+++ b/changelogs/drizzle-orm/0.45.0.md
@@ -1,5 +1,5 @@
 - Fixed pg-native Pool detection in node-postgres transactions  
 - Allowed subqueries in select fields  
-- Updated typo algorythm => algorithm  
+- Updated typo algorithm => algorithm  
 - Fixed `$onUpdate` not handling `SQL` values (fixes [#2388](https://github.com/drizzle-team/drizzle-orm/issues/2388), tests implemented by [L-Mario564](https://github.com/L-Mario564) in [#2911](https://github.com/drizzle-team/drizzle-orm/pull/2911))
 - Fixed `pg` mappers not handling `Date` instances in `bun-sql:postgresql` driver responses for `date`, `timestamp` types (fixes [#4493](https://github.com/drizzle-team/drizzle-orm/issues/4493))  

--- a/drizzle-arktype/README.md
+++ b/drizzle-arktype/README.md
@@ -37,7 +37,7 @@ const insertUserSchema = createInsertSchema(users, {
 
 // Refining the fields - useful if you want to change the fields before they become nullable/optional in the final schema
 const insertUserSchema = createInsertSchema(users, {
-	id: (schema) => schema.atLeast(1),
+	id: (schema) => schema.at least(1),
 	role: type('string'),
 });
 

--- a/drizzle-orm/src/cache/readme.md
+++ b/drizzle-orm/src/cache/readme.md
@@ -139,7 +139,7 @@ export type CacheConfig = {
   /**
    * Unix time at which the key will expire, in seconds (a positive integer).
    */
-  exat?: number;
+  exact?: number;
   /**
    * Unix time at which the key will expire, in milliseconds (a positive integer)
    */


### PR DESCRIPTION
This PR fixes a few minor typographical errors in the markdown documentation (README, etc.) to improve readability. Found via codespell.