### PR TITLE
fix(drizzle-kit): use DROP INDEX IF EXISTS for SQLite/Turso index drops

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -2407,7 +2407,7 @@ export class LibSQLModifyColumn extends Convertor {
 		for (const table of Object.values(json2.tables)) {
 			for (const index of Object.values(table.indexes)) {
 				const unsquashed = SQLiteSquasher.unsquashIdx(index);
-				sqlStatements.push(`DROP INDEX "${unsquashed.name}";`);
+				sqlStatements.push(`DROP INDEX IF EXISTS "${unsquashed.name}";`);
 				indexes.push({ ...unsquashed, tableName: table.name });
 			}
 		}
@@ -3735,7 +3735,7 @@ export class SqliteDropIndexConvertor extends Convertor {
 
 	convert(statement: JsonDropIndexStatement): string {
 		const { name } = PgSquasher.unsquashIdx(statement.data);
-		return `DROP INDEX \`${name}\`;`;
+		return `DROP INDEX IF EXISTS \`${name}\`;`;
 	}
 }
 

--- a/drizzle-kit/tests/libsql-statements.test.ts
+++ b/drizzle-kit/tests/libsql-statements.test.ts
@@ -917,7 +917,7 @@ test('set not null with index', async (t) => {
 
 	expect(sqlStatements.length).toBe(3);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX "users_name_index";`,
+		`DROP INDEX IF EXISTS "users_name_index";`,
 	);
 	expect(sqlStatements[1]).toBe(
 		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text NOT NULL;`,
@@ -972,10 +972,10 @@ test('drop not null with two indexes', async (t) => {
 
 	expect(sqlStatements.length).toBe(5);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX "users_name_unique";`,
+		`DROP INDEX IF EXISTS "users_name_unique";`,
 	);
 	expect(sqlStatements[1]).toBe(
-		`DROP INDEX "users_age_index";`,
+		`DROP INDEX IF EXISTS "users_age_index";`,
 	);
 	expect(sqlStatements[2]).toBe(
 		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text;`,
@@ -986,4 +986,53 @@ test('drop not null with two indexes', async (t) => {
 	expect(sqlStatements[4]).toBe(
 		`CREATE INDEX \`users_age_index\` ON \`users\` (\`age\`);`,
 	);
+});
+
+test('set not null on two tables uses idempotent index drops', async (t) => {
+	const schema1 = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			name: text('name'),
+		}, (table) => ({
+			someIndex: index('users_name_index').on(table.name),
+		})),
+		projects: sqliteTable('projects', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			title: text('title'),
+		}, (table) => ({
+			someIndex: index('projects_title_index').on(table.title),
+		})),
+	};
+
+	const schema2 = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			name: text('name').notNull(),
+		}, (table) => ({
+			someIndex: index('users_name_index').on(table.name),
+		})),
+		projects: sqliteTable('projects', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			title: text('title').notNull(),
+		}, (table) => ({
+			someIndex: index('projects_title_index').on(table.title),
+		})),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasLibSQL(
+		schema1,
+		schema2,
+		[],
+	);
+
+	expect(statements.length).toBe(2);
+	expect(statements.every((statement) => statement.type === 'alter_table_alter_column_set_notnull')).toBe(true);
+
+	const usersDrops = sqlStatements.filter((statement) => statement === `DROP INDEX IF EXISTS "users_name_index";`);
+	const projectsDrops = sqlStatements.filter((statement) => statement === `DROP INDEX IF EXISTS "projects_title_index";`);
+
+	expect(usersDrops.length).toBeGreaterThanOrEqual(1);
+	expect(projectsDrops.length).toBeGreaterThanOrEqual(1);
+	expect(sqlStatements.some((statement) => statement.startsWith(`DROP INDEX "users_name_index"`))).toBe(false);
+	expect(sqlStatements.some((statement) => statement.startsWith(`DROP INDEX "projects_title_index"`))).toBe(false);
 });

--- a/drizzle-kit/tests/push/libsql.test.ts
+++ b/drizzle-kit/tests/push/libsql.test.ts
@@ -185,7 +185,7 @@ test('added, dropped index', async (t) => {
 
 	expect(sqlStatements.length).toBe(2);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX \`customers_address_unique\`;`,
+		`DROP INDEX IF EXISTS \`customers_address_unique\`;`,
 	);
 	expect(sqlStatements[1]).toBe(
 		`CREATE UNIQUE INDEX \`customers_is_confirmed_unique\` ON \`customers\` (\`is_confirmed\`);`,
@@ -963,7 +963,7 @@ test('set not null with index', async (t) => {
 
 	expect(sqlStatements.length).toBe(3);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX "users_name_index";`,
+		`DROP INDEX IF EXISTS "users_name_index";`,
 	);
 	expect(sqlStatements[1]).toBe(
 		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text NOT NULL;`,
@@ -1035,10 +1035,10 @@ test('drop not null with two indexes', async (t) => {
 
 	expect(sqlStatements.length).toBe(5);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX "users_name_unique";`,
+		`DROP INDEX IF EXISTS "users_name_unique";`,
 	);
 	expect(sqlStatements[1]).toBe(
-		`DROP INDEX "users_age_index";`,
+		`DROP INDEX IF EXISTS "users_age_index";`,
 	);
 	expect(sqlStatements[2]).toBe(
 		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text;`,

--- a/drizzle-kit/tests/push/sqlite.test.ts
+++ b/drizzle-kit/tests/push/sqlite.test.ts
@@ -185,7 +185,7 @@ test('dropped, added unique index', async (t) => {
 
 	expect(sqlStatements.length).toBe(2);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX \`customers_address_unique\`;`,
+		`DROP INDEX IF EXISTS \`customers_address_unique\`;`,
 	);
 	expect(sqlStatements[1]).toBe(
 		`CREATE UNIQUE INDEX \`customers_is_confirmed_unique\` ON \`customers\` (\`is_confirmed\`);`,


### PR DESCRIPTION
## Summary
- make `LibSQLModifyColumn` emit `DROP INDEX IF EXISTS` when dropping indexes during Turso/libSQL alter-column/check-constraint flows
- make `SqliteDropIndexConvertor` emit `DROP INDEX IF EXISTS` for explicit SQLite/Turso `drop_index` statements
- update affected SQLite/libSQL push + statement tests and add regression coverage for multi-table alter-column flows to assert idempotent index-drop SQL

## Root Cause
`LibSQLModifyColumn.convert()` can run multiple times in a single `drizzle-kit push` execution. It currently emits bare `DROP INDEX` statements; repeated drops on the same index then fail with `no such index` in SQLite/libSQL.

`SqliteDropIndexConvertor.convert()` also emits bare `DROP INDEX`, which is non-idempotent.

## Fix
Use `DROP INDEX IF EXISTS` in both paths so repeated drops become no-ops.

## Validation
- `pnpm --filter drizzle-kit exec vitest tests/libsql-statements.test.ts tests/push/libsql.test.ts tests/push/sqlite.test.ts --run`

Closes #5564
