### PR TITLE
[MySQL-kit] Fix CHECK constraint column case mismatch causing MariaDB push failure

### DIFF
--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -949,9 +949,9 @@ export const fromDatabase = async (
 
 	const checkConstraints = await db.query(
 		`SELECT 
-    tc.table_name, 
-    tc.constraint_name, 
-    cc.check_clause
+    tc.table_name AS TABLE_NAME, 
+    tc.constraint_name AS CONSTRAINT_NAME, 
+    cc.check_clause AS CHECK_CLAUSE
 FROM 
     information_schema.table_constraints tc
 JOIN 
@@ -973,7 +973,7 @@ AND
 		const tableName = checkConstraintRow['TABLE_NAME'];
 
 		const tableInResult = result[tableName];
-		// if (typeof tableInResult === 'undefined') continue;
+		if (typeof tableInResult === 'undefined') continue;
 
 		tableInResult.checkConstraint[constraintName] = {
 			name: constraintName,


### PR DESCRIPTION
## Problem

`drizzle-kit push` exits with code 1 on MariaDB databases containing CHECK constraints. The issue occurs during schema introspection ("Pulling schema from database...").

### Root Cause

The CHECK constraints introspection query selects columns with lowercase names:
```sql
SELECT tc.table_name, tc.constraint_name, cc.check_clause FROM ...
```

But the result mapping reads uppercase keys:
```ts
const constraintName = checkConstraintRow['CONSTRAINT_NAME'];
const constraintValue = checkConstraintRow['CHECK_CLAUSE'];
const tableName = checkConstraintRow['TABLE_NAME'];
```

On MySQL, `information_schema` returns uppercase column names regardless of the query, so this works. On **MariaDB** (with `mysql2` driver), result keys match the case used in the SQL query - returning lowercase keys. This mismatch produces `undefined` values, which crash when accessing `tableInResult.checkConstraint`.

## Fix

1. **Add explicit `AS` aliases** to the SELECT columns so they always return uppercase keys regardless of the database engine:
```sql
SELECT
    tc.table_name AS TABLE_NAME,
    tc.constraint_name AS CONSTRAINT_NAME,
    cc.check_clause AS CHECK_CLAUSE
FROM ...
```

2. **Uncomment the `tableInResult` guard** (was commented out) to safely skip CHECK constraints for tables not in the result set (e.g., filtered tables), preventing potential runtime crashes.

## Reproduction

1. Use MariaDB (e.g., 10.4.x)
2. Create a table with a CHECK constraint:
```sql
CREATE TABLE inventories (
    id INT AUTO_INCREMENT PRIMARY KEY,
    items LONGTEXT,
    CONSTRAINT items CHECK (json_valid(items))
);
```
3. Run `npx drizzle-kit push`
4. Observe: exits with code 1 during schema pull

Fixes #5550
