### PR TITLE
fix(drizzle-kit): add drizzle-orm as peerDependency

### DIFF
--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -124,6 +124,9 @@
 		"zod": "^3.20.2",
 		"zx": "^8.8.5"
 	},
+	"peerDependencies": {
+		"drizzle-orm": ">=1.0.0-beta.2"
+	},
 	"exports": {
 		".": {
 			"import": {


### PR DESCRIPTION
## Summary

- `drizzle-kit`'s `build.ts` marks `drizzle-orm` as `external` in esbuild, so `bin.cjs` emits `require('drizzle-orm/...')` calls at runtime (including the new `_relations` subpath)
- However, `drizzle-orm` is not declared as a `dependency` or `peerDependency` — it only appears as a `devDependency` with a `workspace:./path` reference that is published as-is to npm
- This causes `Cannot find module 'drizzle-orm/_relations'` errors in npm workspace monorepos when `drizzle-orm` cannot be hoisted to the root `node_modules/` (e.g., due to conflicting peer dependencies from other packages)
- Added `drizzle-orm` as a `peerDependency` (consistent with `drizzle-seed`'s approach) to ensure npm resolves it correctly in all workspace layouts

Fixes #5573