### PR TITLE
fix: skip MySQL expression indexes with null COLUMN_NAME during introspection

### DIFF
--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -862,11 +862,15 @@ export const fromDatabase = async (
 		const tableSchema = idxRow['TABLE_SCHEMA'];
 		const tableName = idxRow['TABLE_NAME'];
 		const constraintName = idxRow['INDEX_NAME'];
-		const columnName: string = idxRow['COLUMN_NAME'];
+		const columnName: string | null = idxRow['COLUMN_NAME'];
 		const isUnique = idxRow['NON_UNIQUE'] === 0;
 
 		const tableInResult = result[tableName];
 		if (typeof tableInResult === 'undefined') continue;
+
+		// MySQL 8+ functional/expression indexes have COLUMN_NAME = NULL.
+		// Skip these since Drizzle doesn't support expression indexes yet.
+		if (columnName === null) continue;
 
 		// if (tableInResult.columns[columnName].type === "serial") continue;
 


### PR DESCRIPTION
Fixes drizzle-kit pull crash on MySQL 8+ databases with functional/expression indexes.

MySQL 8+ expression indexes return NULL for COLUMN_NAME in INFORMATION_SCHEMA.STATISTICS. The serializer pushed this null into the columns array, and later casing(null) crashed with TypeError.

Skip index rows where COLUMN_NAME is null since Drizzle doesn't support expression indexes yet.

Fixes #5546