### PR TITLE
fix(drizzle-kit): use DROP INDEX IF EXISTS for SQLite/Turso to prevent duplicate drop failures

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -2407,7 +2407,7 @@ export class LibSQLModifyColumn extends Convertor {
 		for (const table of Object.values(json2.tables)) {
 			for (const index of Object.values(table.indexes)) {
 				const unsquashed = SQLiteSquasher.unsquashIdx(index);
-				sqlStatements.push(`DROP INDEX "${unsquashed.name}";`);
+				sqlStatements.push(`DROP INDEX IF EXISTS "${unsquashed.name}";`);
 				indexes.push({ ...unsquashed, tableName: table.name });
 			}
 		}
@@ -3735,7 +3735,7 @@ export class SqliteDropIndexConvertor extends Convertor {
 
 	convert(statement: JsonDropIndexStatement): string {
 		const { name } = PgSquasher.unsquashIdx(statement.data);
-		return `DROP INDEX \`${name}\`;`;
+		return `DROP INDEX IF EXISTS \`${name}\`;`;
 	}
 }
 

--- a/drizzle-kit/tests/libsql-statements.test.ts
+++ b/drizzle-kit/tests/libsql-statements.test.ts
@@ -917,7 +917,7 @@ test('set not null with index', async (t) => {
 
 	expect(sqlStatements.length).toBe(3);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX "users_name_index";`,
+		`DROP INDEX IF EXISTS "users_name_index";`,
 	);
 	expect(sqlStatements[1]).toBe(
 		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text NOT NULL;`,
@@ -972,10 +972,10 @@ test('drop not null with two indexes', async (t) => {
 
 	expect(sqlStatements.length).toBe(5);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX "users_name_unique";`,
+		`DROP INDEX IF EXISTS "users_name_unique";`,
 	);
 	expect(sqlStatements[1]).toBe(
-		`DROP INDEX "users_age_index";`,
+		`DROP INDEX IF EXISTS "users_age_index";`,
 	);
 	expect(sqlStatements[2]).toBe(
 		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text;`,

--- a/drizzle-kit/tests/push/libsql.test.ts
+++ b/drizzle-kit/tests/push/libsql.test.ts
@@ -1398,3 +1398,123 @@ test('alter view ".as"', async () => {
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
 });
+
+test('modify two columns on same table with index', async (t) => {
+	const turso = createClient({
+		url: ':memory:',
+	});
+
+	const schema1 = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			name: text('name').notNull(),
+			age: int('age').notNull(),
+		}, (table) => ({
+			someIndex: index('users_name_index').on(table.name),
+		})),
+	};
+
+	const schema2 = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			name: text('name'),
+			age: int('age'),
+		}, (table) => ({
+			someIndex: index('users_name_index').on(table.name),
+		})),
+	};
+
+	const {
+		statements,
+		sqlStatements,
+	} = await diffTestSchemasPushLibSQL(
+		turso,
+		schema1,
+		schema2,
+		[],
+	);
+
+	// Each column mod triggers LibSQLModifyColumn which drops ALL indexes.
+	// Since both columns modify the same table with the same index,
+	// the second DROP/CREATE pair is deduplicated.
+	expect(sqlStatements.length).toBe(4);
+	expect(sqlStatements[0]).toBe(
+		`DROP INDEX IF EXISTS "users_name_index";`,
+	);
+	expect(sqlStatements[1]).toBe(
+		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text;`,
+	);
+	expect(sqlStatements[2]).toBe(
+		`CREATE INDEX \`users_name_index\` ON \`users\` (\`name\`);`,
+	);
+	expect(sqlStatements[3]).toBe(
+		`ALTER TABLE \`users\` ALTER COLUMN "age" TO "age" integer;`,
+	);
+});
+
+test('modify columns on two tables with indexes', async (t) => {
+	const turso = createClient({
+		url: ':memory:',
+	});
+
+	const schema1 = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			name: text('name').notNull(),
+		}, (table) => ({
+			someIndex: index('users_name_index').on(table.name),
+		})),
+		posts: sqliteTable('posts', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			title: text('title').notNull(),
+		}, (table) => ({
+			someIndex: index('posts_title_index').on(table.title),
+		})),
+	};
+
+	const schema2 = {
+		users: sqliteTable('users', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			name: text('name'),
+		}, (table) => ({
+			someIndex: index('users_name_index').on(table.name),
+		})),
+		posts: sqliteTable('posts', {
+			id: int('id').primaryKey({ autoIncrement: true }),
+			title: text('title'),
+		}, (table) => ({
+			someIndex: index('posts_title_index').on(table.title),
+		})),
+	};
+
+	const { sqlStatements } = await diffTestSchemasPushLibSQL(
+		turso,
+		schema1,
+		schema2,
+		[],
+	);
+
+	// Each table's column mod triggers a separate LibSQLModifyColumn call.
+	// LibSQLModifyColumn drops ALL indexes from ALL tables (the over-broad bug),
+	// then recreates them after the ALTER. The second call's DROP and CREATE
+	// statements are deduplicated because they match the first call's output.
+	expect(sqlStatements.length).toBe(6);
+	// First LibSQLModifyColumn (users.name): drops all indexes
+	expect(sqlStatements[0]).toBe(`DROP INDEX IF EXISTS "users_name_index";`);
+	expect(sqlStatements[1]).toBe(`DROP INDEX IF EXISTS "posts_title_index";`);
+	// First: alters users.name, recreates all indexes
+	expect(sqlStatements[2]).toBe(
+		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text;`,
+	);
+	expect(sqlStatements[3]).toBe(
+		`CREATE INDEX \`users_name_index\` ON \`users\` (\`name\`);`,
+	);
+	expect(sqlStatements[4]).toBe(
+		`CREATE INDEX \`posts_title_index\` ON \`posts\` (\`title\`);`,
+	);
+	// Second LibSQLModifyColumn (posts.title):
+	// DROP/CREATE pairs deduplicated, only the new ALTER remains
+	expect(sqlStatements[5]).toBe(
+		`ALTER TABLE \`posts\` ALTER COLUMN "title" TO "title" text;`,
+	);
+});

--- a/drizzle-kit/tests/push/libsql.test.ts
+++ b/drizzle-kit/tests/push/libsql.test.ts
@@ -185,7 +185,7 @@ test('added, dropped index', async (t) => {
 
 	expect(sqlStatements.length).toBe(2);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX \`customers_address_unique\`;`,
+		`DROP INDEX IF EXISTS \`customers_address_unique\`;`,
 	);
 	expect(sqlStatements[1]).toBe(
 		`CREATE UNIQUE INDEX \`customers_is_confirmed_unique\` ON \`customers\` (\`is_confirmed\`);`,
@@ -963,7 +963,7 @@ test('set not null with index', async (t) => {
 
 	expect(sqlStatements.length).toBe(3);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX "users_name_index";`,
+		`DROP INDEX IF EXISTS "users_name_index";`,
 	);
 	expect(sqlStatements[1]).toBe(
 		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text NOT NULL;`,
@@ -1035,10 +1035,10 @@ test('drop not null with two indexes', async (t) => {
 
 	expect(sqlStatements.length).toBe(5);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX "users_name_unique";`,
+		`DROP INDEX IF EXISTS "users_name_unique";`,
 	);
 	expect(sqlStatements[1]).toBe(
-		`DROP INDEX "users_age_index";`,
+		`DROP INDEX IF EXISTS "users_age_index";`,
 	);
 	expect(sqlStatements[2]).toBe(
 		`ALTER TABLE \`users\` ALTER COLUMN "name" TO "name" text;`,

--- a/drizzle-kit/tests/push/sqlite.test.ts
+++ b/drizzle-kit/tests/push/sqlite.test.ts
@@ -185,7 +185,7 @@ test('dropped, added unique index', async (t) => {
 
 	expect(sqlStatements.length).toBe(2);
 	expect(sqlStatements[0]).toBe(
-		`DROP INDEX \`customers_address_unique\`;`,
+		`DROP INDEX IF EXISTS \`customers_address_unique\`;`,
 	);
 	expect(sqlStatements[1]).toBe(
 		`CREATE UNIQUE INDEX \`customers_is_confirmed_unique\` ON \`customers\` (\`is_confirmed\`);`,


### PR DESCRIPTION
## Summary

Fixes #5564

When `LibSQLModifyColumn.convert()` is invoked for multiple columns in the same `db:push` operation, it emits `DROP INDEX` for every index in the schema on each invocation. The second call fails with `no such index` because the first call already dropped them.

`SqliteDropIndexConvertor.convert()` has the same issue with bare `DROP INDEX`.

**Fix:** Change both to `DROP INDEX IF EXISTS`, making them idempotent — consistent with `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` already used throughout the codebase.

## Changes

- `drizzle-kit/src/sqlgenerator.ts` — two one-line fixes
- Test snapshots updated in `libsql.test.ts`, `sqlite.test.ts`, `libsql-statements.test.ts`

## Test plan

- [ ] Existing snapshots updated to expect `IF EXISTS` form
- [ ] `db:push` with multiple column modifications across tables no longer fails with `no such index`