### PR TITLE
[Drizzle Kit][Pg]: Altering a UNIQUE constraint: generated SQL ignores the new changes

### DIFF
--- a/drizzle-kit/src/dialects/postgres/convertor.ts
+++ b/drizzle-kit/src/dialects/postgres/convertor.ts
@@ -698,7 +698,7 @@ const alterUniqueConvertor = convertor('alter_unique', (st) => {
 	const statements: string[] = [];
 
 	statements.push(dropUniqueConvertor.convert({ unique: st.diff.$left }) as string);
-	statements.push(addUniqueConvertor.convert({ unique: st.diff.$left }) as string);
+	statements.push(addUniqueConvertor.convert({ unique: st.diff.$right }) as string);
 
 	return statements;
 });

--- a/drizzle-kit/tests/postgres/pg-tables.test.ts
+++ b/drizzle-kit/tests/postgres/pg-tables.test.ts
@@ -1549,3 +1549,57 @@ test('rename table with identity column', async () => {
 	expect(st).toStrictEqual(expectedSt);
 	expect(pst).toStrictEqual(expectedSt);
 });
+
+// https://github.com/drizzle-team/drizzle-orm/issues/5585
+test('alter unique constraint: add nullsNotDistinct', async () => {
+	const from = {
+		table: pgTable('table', {
+			name: text('name').notNull(),
+		}, (t) => [unique('table_unique').on(t.name)]),
+	};
+	const to = {
+		table: pgTable('table', {
+			name: text('name').notNull(),
+		}, (t) => [unique('table_unique').on(t.name).nullsNotDistinct()]),
+	};
+
+	const { sqlStatements: st } = await diff(from, to, []);
+
+	await push({ db, to: from });
+	const { sqlStatements: pst } = await push({ db, to });
+
+	const st0 = [
+		'ALTER TABLE "table" DROP CONSTRAINT "table_unique";',
+		'ALTER TABLE "table" ADD CONSTRAINT "table_unique" UNIQUE NULLS NOT DISTINCT("name");',
+	];
+	expect(st).toStrictEqual(st0);
+	expect(pst).toStrictEqual(st0);
+});
+
+// https://github.com/drizzle-team/drizzle-orm/issues/5585
+test('alter unique constraint: add column', async () => {
+	const from = {
+		table: pgTable('table', {
+			foo: text('foo').notNull(),
+			bar: text('bar').notNull(),
+		}, (t) => [unique('table_unique').on(t.foo)]),
+	};
+	const to = {
+		table: pgTable('table', {
+			foo: text('foo').notNull(),
+			bar: text('bar').notNull(),
+		}, (t) => [unique('table_unique').on(t.foo, t.bar)]),
+	};
+
+	const { sqlStatements: st } = await diff(from, to, []);
+
+	await push({ db, to: from });
+	const { sqlStatements: pst } = await push({ db, to });
+
+	const st0 = [
+		'ALTER TABLE "table" DROP CONSTRAINT "table_unique";',
+		'ALTER TABLE "table" ADD CONSTRAINT "table_unique" UNIQUE("foo","bar");',
+	];
+	expect(st).toStrictEqual(st0);
+	expect(pst).toStrictEqual(st0);
+});


### PR DESCRIPTION
Fixes https://github.com/drizzle-team/drizzle-orm/issues/5585

The cause of the bug seems to be at https://github.com/drizzle-team/drizzle-orm/blob/1a010829653a463fa498c2d0eaad3003e7cd46a3/drizzle-kit/src/dialects/postgres/convertor.ts#L701

```ts
const alterUniqueConvertor = convertor('alter_unique', (st) => {
	const statements: string[] = [];

	statements.push(dropUniqueConvertor.convert({ unique: st.diff.$left }) as string);
	statements.push(addUniqueConvertor.convert({ unique: st.diff.$left }) as string); // --> st.diff.$left should be change to st.diff.$right

	return statements;
});
```