### PR TITLE
fix(drizzle-kit): handle hyphenated enum names in default value comparison

### DIFF
--- a/drizzle-kit/src/dialects/postgres/grammar.ts
+++ b/drizzle-kit/src/dialects/postgres/grammar.ts
@@ -1975,7 +1975,7 @@ export const defaultNameForIndex = (table: string, columns: string[]) => {
 
 export const trimDefaultValueSuffix = (value: string) => {
 	let res = value.endsWith('[]') ? value.slice(0, -2) : value;
-	res = res.replace(/(::["\w.\s]+(?:\([^)]*\))?(?:\swith(?:out)?\stime\szone)?(?:\[\])?)+$/gi, '');
+	res = res.replace(/(::["\w.\s-]+(?:\([^)]*\))?(?:\swith(?:out)?\stime\szone)?(?:\[\])?)+$/gi, '');
 	return res;
 };
 

--- a/drizzle-kit/tests/postgres/grammar.test.ts
+++ b/drizzle-kit/tests/postgres/grammar.test.ts
@@ -3,6 +3,9 @@ import { expect, test } from 'vitest';
 
 test.each([
 	["'a'::my_enum", "'a'"],
+	[`'customer'::"user-role"`, `'customer'`],
+	[`'admin'::"my-custom-enum"`, `'admin'`],
+	[`'{a,b}'::"my-enum"[]`, `'{a,b}'`],
 	["'abc'::text", "'abc'"],
 	["'abc'::character varying", "'abc'"],
 	["'abc'::bpchar", "'abc'"],


### PR DESCRIPTION
## Summary

Fixes #5569

`drizzle-kit push` falsely detects schema changes for columns with enum defaults when the enum name contains hyphens (e.g. `"user-role"`). This causes an infinite loop of `ALTER TABLE ... SET DEFAULT` statements on every push.

## Root Cause

The regex in `trimDefaultValueSuffix` strips type-casting suffixes from PostgreSQL default values (e.g. `'customer'::"user-role"` → `'customer'`). However, the character class `["\w.\s]` does not include hyphens (`-`), so quoted enum names like `"user-role"` are not matched and the cast is not removed.

This means the DB snapshot stores `'customer'::"user-role"` while the schema serializer produces `'customer'`, causing a diff on every push.

## Fix

Added `-` to the character class in the regex: `["\w.\s-]`

**Before:**
```
'customer'::"user-role"  →  'customer'::"user-role"  (not stripped)
```

**After:**
```
'customer'::"user-role"  →  'customer'  (correctly stripped)
```

## Tests

Added 3 test cases to `drizzle-kit/tests/postgres/grammar.test.ts`:
- `'customer'::"user-role"` → `'customer'`
- `'admin'::"my-custom-enum"` → `'admin'`
- `'{a,b}'::"my-enum"[]` → `'{a,b}'`

All 42 existing tests continue to pass.

## Changed Files

- `drizzle-kit/src/dialects/postgres/grammar.ts` — 1 character fix in regex
- `drizzle-kit/tests/postgres/grammar.test.ts` — 3 new test cases