### PR TITLE
fix: pass 'indexes' invokeSource for MSSQL filtered index WHERE clause

### DIFF
--- a/drizzle-kit/src/dialects/mssql/drizzle.ts
+++ b/drizzle-kit/src/dialects/mssql/drizzle.ts
@@ -267,7 +267,7 @@ export const fromDrizzleSchema = (
 				}
 			}
 
-			let where = index.config.where ? dialect.sqlToQuery(index.config.where).sql : '';
+			let where = index.config.where ? dialect.sqlToQuery(index.config.where, 'indexes').sql : '';
 			where = where === 'true' ? '' : where;
 
 			result.indexes.push({

--- a/drizzle-kit/tests/mssql/indexes.test.ts
+++ b/drizzle-kit/tests/mssql/indexes.test.ts
@@ -73,7 +73,7 @@ test('indexes #0', async (t) => {
 		'CREATE INDEX [removeColumn] ON [users] ([name]);',
 		'CREATE INDEX [addColumn] ON [users] ([name],[id]);',
 		'CREATE INDEX [removeWhere] ON [users] ([name]);',
-		"CREATE INDEX [addWhere] ON [users] ([name]) WHERE [users].[name] != 'name';",
+		"CREATE INDEX [addWhere] ON [users] ([name]) WHERE [name] != 'name';",
 	]);
 	expect(pst).toStrictEqual([
 		'DROP INDEX [changeName] ON [users];',
@@ -83,7 +83,7 @@ test('indexes #0', async (t) => {
 		'DROP INDEX [removeWhere] ON [users];',
 		'CREATE INDEX [newName] ON [users] ([name]);',
 		'CREATE INDEX [addColumn] ON [users] ([name],[id]);',
-		"CREATE INDEX [addWhere] ON [users] ([name]) WHERE [users].[name] != 'name';",
+		"CREATE INDEX [addWhere] ON [users] ([name]) WHERE [name] != 'name';",
 		'CREATE INDEX [removeColumn] ON [users] ([name]);',
 		'CREATE INDEX [removeWhere] ON [users] ([name]);',
 	]);

--- a/drizzle-kit/tests/mssql/tables.test.ts
+++ b/drizzle-kit/tests/mssql/tables.test.ts
@@ -870,7 +870,7 @@ test('optional db aliases (snake case)', async () => {
 
 	const st6 = `CREATE UNIQUE INDEX [t1_uni_idx] ON [t1] ([t1_uni_idx]);`;
 
-	const st7 = `CREATE INDEX [t1_idx] ON [t1] ([t1_idx]) WHERE [t1].[t1_idx] > 0;`;
+	const st7 = `CREATE INDEX [t1_idx] ON [t1] ([t1_idx]) WHERE [t1_idx] > 0;`;
 
 	expect(st).toStrictEqual([st1, st2, st3, st4, st5, st6, st7]);
 	expect(pst).toStrictEqual([st1, st2, st3, st4, st5, st6, st7]);
@@ -948,7 +948,7 @@ test('optional db aliases (camel case)', async () => {
 
 	const st6 = `CREATE UNIQUE INDEX [t1UniIdx] ON [t1] ([t1UniIdx]);`;
 
-	const st7 = `CREATE INDEX [t1Idx] ON [t1] ([t1Idx]) WHERE [t1].[t1Idx] > 0;`;
+	const st7 = `CREATE INDEX [t1Idx] ON [t1] ([t1Idx]) WHERE [t1Idx] > 0;`;
 
 	expect(st).toStrictEqual([st1, st2, st3, st4, st5, st6, st7]);
 	expect(pst).toStrictEqual([st1, st2, st3, st4, st5, st6, st7]);


### PR DESCRIPTION
## Summary

Fixes https://github.com/drizzle-team/drizzle-orm/issues/5593

When defining a filtered unique index with `where(isNotNull(...))` for SQL Server, drizzle-kit generates a fully qualified column name (e.g., `[schema].[table].[column]`) inside the `WHERE` clause, which SQL Server rejects for filtered indexes.

## Root Cause

In `drizzle-kit/src/dialects/mssql/drizzle.ts`, the `where` clause for indexes was serialized without passing the `'indexes'` invokeSource to `dialect.sqlToQuery()`:

```typescript
// Before (bug):
let where = index.config.where ? dialect.sqlToQuery(index.config.where).sql : '';

// After (fix):
let where = index.config.where ? dialect.sqlToQuery(index.config.where, 'indexes').sql : '';
```

Without `'indexes'`, column references in the WHERE clause get fully qualified as `[schema].[table].[column]`. The core SQL serializer in `drizzle-orm/src/sql/sql.ts` already has handling for `invokeSource === 'indexes'` — when set, it returns just the column name `[column]`, which is valid T-SQL for filtered indexes.

This matches how the Postgres dialect already handles index WHERE clauses (passing `'indexes'` to `sqlToQuery`).

## Changes

- **`drizzle-kit/src/dialects/mssql/drizzle.ts`**: Pass `'indexes'` as `invokeSource` when serializing the WHERE clause
- **`drizzle-kit/tests/mssql/indexes.test.ts`**: Update test expectations to match the unqualified column names
- **`drizzle-kit/tests/mssql/tables.test.ts`**: Update test expectations to match the unqualified column names

## Before / After

**Before** (invalid T-SQL):
```sql
CREATE UNIQUE INDEX [users_employee_id_idx]
ON [user_schema].[users] ([employee_id])
WHERE ([user_schema].[users].[employee_id] is not null);
```

**After** (valid T-SQL):
```sql
CREATE UNIQUE INDEX [users_employee_id_idx]
ON [user_schema].[users] ([employee_id])
WHERE ([employee_id] is not null);
```