### PR TITLE
[SQLite-kit] Fix column rename breaking INSERT INTO...SELECT during table recreate

### DIFF
--- a/drizzle-kit/src/jsonStatements.ts
+++ b/drizzle-kit/src/jsonStatements.ts
@@ -72,6 +72,7 @@ export interface JsonRecreateTableStatement {
 	compositePKs: string[][];
 	uniqueConstraints?: string[];
 	checkConstraints: string[];
+	columnRenames?: { oldName: string; newName: string }[];
 }
 
 export interface JsonRecreateSingleStoreTableStatement {

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -3769,10 +3769,22 @@ class SQLiteRecreateTableConvertor extends Convertor {
 	}
 
 	convert(statement: JsonRecreateTableStatement): string | string[] {
-		const { tableName, columns, compositePKs, referenceData, checkConstraints } = statement;
+		const { tableName, columns, compositePKs, referenceData, checkConstraints, columnRenames } = statement;
 
 		const columnNames = columns.map((it) => `"${it.name}"`).join(', ');
 		const newTableName = `__new_${tableName}`;
+
+		const renameMap = new Map<string, string>();
+		if (columnRenames) {
+			for (const { oldName, newName } of columnRenames) {
+				renameMap.set(newName, oldName);
+			}
+		}
+
+		const selectColumnNames = columns.map((it) => {
+			const oldName = renameMap.get(it.name);
+			return oldName ? `"${oldName}"` : `"${it.name}"`;
+		}).join(', ');
 
 		const sqlStatements: string[] = [];
 
@@ -3798,7 +3810,7 @@ class SQLiteRecreateTableConvertor extends Convertor {
 
 		// migrate data
 		sqlStatements.push(
-			`INSERT INTO \`${newTableName}\`(${columnNames}) SELECT ${columnNames} FROM \`${tableName}\`;`,
+			`INSERT INTO \`${newTableName}\`(${columnNames}) SELECT ${selectColumnNames} FROM \`${tableName}\`;`,
 		);
 
 		// drop table
@@ -3836,10 +3848,22 @@ class LibSQLRecreateTableConvertor extends Convertor {
 	}
 
 	convert(statement: JsonRecreateTableStatement): string[] {
-		const { tableName, columns, compositePKs, referenceData, checkConstraints } = statement;
+		const { tableName, columns, compositePKs, referenceData, checkConstraints, columnRenames } = statement;
 
 		const columnNames = columns.map((it) => `"${it.name}"`).join(', ');
 		const newTableName = `__new_${tableName}`;
+
+		const renameMap = new Map<string, string>();
+		if (columnRenames) {
+			for (const { oldName, newName } of columnRenames) {
+				renameMap.set(newName, oldName);
+			}
+		}
+
+		const selectColumnNames = columns.map((it) => {
+			const oldName = renameMap.get(it.name);
+			return oldName ? `"${oldName}"` : `"${it.name}"`;
+		}).join(', ');
 
 		const sqlStatements: string[] = [];
 
@@ -3864,7 +3888,7 @@ class LibSQLRecreateTableConvertor extends Convertor {
 
 		// migrate data
 		sqlStatements.push(
-			`INSERT INTO \`${newTableName}\`(${columnNames}) SELECT ${columnNames} FROM \`${tableName}\`;`,
+			`INSERT INTO \`${newTableName}\`(${columnNames}) SELECT ${selectColumnNames} FROM \`${tableName}\`;`,
 		);
 
 		// drop table

--- a/drizzle-kit/src/statementCombiner.ts
+++ b/drizzle-kit/src/statementCombiner.ts
@@ -1,6 +1,7 @@
 import {
 	JsonCreateIndexStatement,
 	JsonRecreateTableStatement,
+	JsonRenameColumnStatement,
 	JsonStatement,
 	prepareCreateIndexesJson,
 } from './jsonStatements';
@@ -80,7 +81,17 @@ export const libSQLCombineStatements = (
 ) => {
 	// const tablesContext: Record<string, string[]> = {};
 	const newStatements: Record<string, JsonStatement[]> = {};
+	const columnRenamesByTable: Record<string, { oldName: string; newName: string }[]> = {};
+
 	for (const statement of statements) {
+		if (statement.type === 'alter_table_rename_column') {
+			const s = statement as unknown as JsonRenameColumnStatement;
+			if (!columnRenamesByTable[s.tableName]) {
+				columnRenamesByTable[s.tableName] = [];
+			}
+			columnRenamesByTable[s.tableName].push({ oldName: s.oldColumnName, newName: s.newColumnName });
+		}
+
 		if (
 			statement.type === 'alter_table_alter_column_drop_autoincrement'
 			|| statement.type === 'alter_table_alter_column_set_autoincrement'
@@ -293,6 +304,18 @@ export const libSQLCombineStatements = (
 		}
 	}
 
+	for (const [tableName, renames] of Object.entries(columnRenamesByTable)) {
+		const stmts = newStatements[tableName];
+		if (stmts) {
+			const recreate = stmts.find((s) => s.type === 'recreate_table') as JsonRecreateTableStatement | undefined;
+			if (recreate) {
+				recreate.columnRenames = renames;
+				// drop retained rename_column stmts — recreate handles them via columnRenames
+				newStatements[tableName] = stmts.filter((s) => s.type !== 'alter_table_rename_column');
+			}
+		}
+	}
+
 	const combinedStatements = Object.values(newStatements).flat();
 	const renamedTables = combinedStatements.filter((it) => it.type === 'rename_table');
 	const renamedColumns = combinedStatements.filter((it) => it.type === 'alter_table_rename_column');
@@ -309,7 +332,17 @@ export const sqliteCombineStatements = (
 ) => {
 	// const tablesContext: Record<string, string[]> = {};
 	const newStatements: Record<string, JsonStatement[]> = {};
+	const columnRenamesByTable: Record<string, { oldName: string; newName: string }[]> = {};
+
 	for (const statement of statements) {
+		if (statement.type === 'alter_table_rename_column') {
+			const s = statement as unknown as JsonRenameColumnStatement;
+			if (!columnRenamesByTable[s.tableName]) {
+				columnRenamesByTable[s.tableName] = [];
+			}
+			columnRenamesByTable[s.tableName].push({ oldName: s.oldColumnName, newName: s.newColumnName });
+		}
+
 		if (
 			statement.type === 'alter_table_alter_column_set_type'
 			|| statement.type === 'alter_table_alter_column_set_default'
@@ -433,6 +466,18 @@ export const sqliteCombineStatements = (
 
 		if (!statementsForTable.some(({ type }) => type === 'recreate_table')) {
 			newStatements[tableName].push(statement);
+		}
+	}
+
+	for (const [tableName, renames] of Object.entries(columnRenamesByTable)) {
+		const stmts = newStatements[tableName];
+		if (stmts) {
+			const recreate = stmts.find((s) => s.type === 'recreate_table') as JsonRecreateTableStatement | undefined;
+			if (recreate) {
+				recreate.columnRenames = renames;
+				// drop retained rename_column stmts — recreate handles them via columnRenames
+				newStatements[tableName] = stmts.filter((s) => s.type !== 'alter_table_rename_column');
+			}
 		}
 	}
 

--- a/drizzle-kit/tests/statements-combiner/sqlite-statements-combiner.test.ts
+++ b/drizzle-kit/tests/statements-combiner/sqlite-statements-combiner.test.ts
@@ -137,6 +137,7 @@ test(`renamed column and altered this column type`, async (t) => {
 			referenceData: [],
 			uniqueConstraints: [],
 			checkConstraints: [],
+			columnRenames: [{ oldName: 'lastName', newName: 'lastName123' }],
 		},
 	];
 	expect(sqliteCombineStatements(statements, json2)).toStrictEqual(
@@ -1208,4 +1209,83 @@ test(`add column and fk`, async (t) => {
 	expect(sqliteCombineStatements(statements, json2)).toStrictEqual(
 		newJsonStatements,
 	);
+});
+
+test(`renamed table + renamed column + altered column type should absorb rename into recreate`, async (t) => {
+	const statements: JsonStatement[] = [
+		{
+			type: 'rename_table',
+			tableNameFrom: 'task',
+			tableNameTo: 'todo',
+			schema: '',
+		} as unknown as JsonStatement,
+		{
+			type: 'alter_table_rename_column',
+			tableName: 'todo',
+			oldColumnName: 'is_invisible',
+			newColumnName: 'is_visible',
+			schema: '',
+		},
+		{
+			type: 'alter_table_alter_column_set_type',
+			tableName: 'todo',
+			columnName: 'is_visible',
+			newDataType: 'integer',
+			oldDataType: 'text',
+			schema: '',
+			columnDefault: undefined,
+			columnOnUpdate: undefined,
+			columnNotNull: false,
+			columnAutoIncrement: false,
+			columnPk: false,
+			columnIsUnique: false,
+		} as unknown as JsonStatement,
+	];
+
+	const json2: SQLiteSchemaSquashed = {
+		version: '6',
+		dialect: 'sqlite',
+		tables: {
+			todo: {
+				name: 'todo',
+				columns: {
+					id: {
+						name: 'id',
+						type: 'integer',
+						primaryKey: true,
+						notNull: true,
+						autoincrement: false,
+					},
+					is_visible: {
+						name: 'is_visible',
+						type: 'integer',
+						primaryKey: false,
+						notNull: false,
+						autoincrement: false,
+					},
+				},
+				indexes: {},
+				foreignKeys: {},
+				compositePrimaryKeys: {},
+				uniqueConstraints: {},
+				checkConstraints: {},
+			},
+		},
+		enums: {},
+		views: {},
+	};
+
+	const result = sqliteCombineStatements(statements, json2);
+
+	const renameColStmts = result.filter((s) => s.type === 'alter_table_rename_column');
+	expect(renameColStmts).toHaveLength(0);
+
+	const renameTableStmts = result.filter((s) => s.type === 'rename_table');
+	expect(renameTableStmts).toHaveLength(1);
+
+	const recreateStmts = result.filter((s) => s.type === 'recreate_table');
+	expect(recreateStmts).toHaveLength(1);
+	expect((recreateStmts[0] as any).columnRenames).toStrictEqual([
+		{ oldName: 'is_invisible', newName: 'is_visible' },
+	]);
 });


### PR DESCRIPTION
## Summary

Fixes https://github.com/drizzle-team/drizzle-orm/issues/5587

When a SQLite column rename coincides with a table recreation (e.g., renaming a column while also changing its type or default value), the generated `INSERT INTO...SELECT` migration SQL uses the **new** column name in the `SELECT` clause. Since the old table still has the old column name, the migration fails.

**Before (broken):**
```sql
INSERT INTO `__new_task`("is_visible") SELECT "is_visible" FROM `task`;
-- ERROR: "is_visible" doesn't exist in old table (it's still "is_invisible")
```

**After (fixed):**
```sql
INSERT INTO `__new_task`("is_visible") SELECT "is_invisible" FROM `task`;
-- Correctly reads from old column name, writes to new column name
```

## Root Cause

When `sqliteCombineStatements` / `libSQLCombineStatements` combine an `alter_table_rename_column` with other statements that trigger table recreation, the column rename info is lost — the rename statement is dropped when `recreate_table` replaces existing statements, so the SQL generator uses new column names on both sides of the `INSERT INTO...SELECT`.

## Changes

- **`jsonStatements.ts`**: Added optional `columnRenames` field to `JsonRecreateTableStatement`
- **`statementCombiner.ts`**: Track column renames per table during statement combination, inject them into any `recreate_table` for that table. When `columnRenames` is injected, also strip retained `alter_table_rename_column` statements from the output — prevents double-rename when `rename_table` causes the combiner to preserve (push) rather than replace statements.
- **`sqlgenerator.ts`**: `SQLiteRecreateTableConvertor` and `LibSQLRecreateTableConvertor` build a rename map and use old column names in `SELECT` while keeping new names in `INSERT`
- **Tests**: Updated existing combiner test expectation; added test for `rename_table` + `rename_column` + type change on same table (verifies rename is absorbed into recreate, not retained as separate statement)

## Testing

- All 88 existing SQLite/LibSQL tests pass
- All 25 statement combiner tests pass (SQLite + LibSQL + SingleStore), including new test