### PR TITLE
fix(pg): prevent TypeError when constraint_definition is null during introspection

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1367,8 +1367,14 @@ WHERE
 					for (const checks of tableChecks) {
 						// CHECK (((email)::text <> 'test@gmail.com'::text))
 						// Where (email) is column in table
-						let checkValue: string = checks.constraint_definition;
-						const constraintName: string = checks.constraint_name;
+						let checkValue: string | null | undefined = checks.constraint_definition;
+					    const constraintName: string = checks.constraint_name;
+					
+					    // Fix: Prevent TypeError crashing if Postgres returns null/undefined for constraints 
+					    // due to permissions or internal schemas like in Supabase.
+					    if (!checkValue) {
+					        continue;
+					    }
 
 						checkValue = checkValue.replace(/^CHECK\s*\(\(/, '').replace(/\)\)\s*$/, '');
 


### PR DESCRIPTION
When introspecting managed PostgreSQL databases like Supabase, `checks.constraint_definition` can return `null` due to access restrictions on internal schemas. Attempting to `call .replace()` on it throws a `TypeError` and crashes the entire `pull` or `push` process. 
Added a strict truthy check to gracefully `continue` mapping if the definition is missing. 

_Note for maintainers_: During testing, bypassing this error revealed that using `Promise.all` (`.map` returning Promises) for introspecting all tables concurrently fires hundreds of `db.query` calls at once, which can starve the connection pool and hang the process indefinitely on Supabase. Consider using `p-limit` or chunking in `fromDatabase`.