### PR TITLE
fix(eslint-plugin): enforce-update-with-where false positive when .from() precedes .where()

### DIFF
--- a/eslint-plugin-drizzle/src/enforce-delete-with-where.ts
+++ b/eslint-plugin-drizzle/src/enforce-delete-with-where.ts
@@ -1,3 +1,4 @@
+import type { TSESTree } from '@typescript-eslint/utils';
 import { ESLintUtils } from '@typescript-eslint/utils';
 import { resolveMemberExpressionPath } from './utils/ast';
 import { isDrizzleObj, type Options } from './utils/options';
@@ -6,7 +7,26 @@ const createRule = ESLintUtils.RuleCreator(() => 'https://github.com/drizzle-tea
 
 type MessageIds = 'enforceDeleteWithWhere';
 
-let lastNodeName: string = '';
+function chainHasMethod(node: TSESTree.MemberExpression, name: string): boolean {
+	let current: TSESTree.Node | undefined = node.parent;
+	while (current) {
+		if (
+			current.type === 'MemberExpression'
+			&& current.property.type === 'Identifier'
+			&& current.property.name === name
+		) {
+			return true;
+		}
+		if (current.type === 'CallExpression') {
+			current = current.parent;
+		} else if (current.type === 'MemberExpression') {
+			current = current.parent;
+		} else {
+			break;
+		}
+	}
+	return false;
+}
 
 const deleteRule = createRule<Options, MessageIds>({
 	defaultOptions: [{ drizzleObjectName: [] }],
@@ -35,7 +55,7 @@ const deleteRule = createRule<Options, MessageIds>({
 		return {
 			MemberExpression: (node) => {
 				if (node.property.type === 'Identifier') {
-					if (node.property.name === 'delete' && lastNodeName !== 'where' && isDrizzleObj(node, options)) {
+					if (node.property.name === 'delete' && isDrizzleObj(node, options) && !chainHasMethod(node, 'where')) {
 						context.report({
 							node,
 							messageId: 'enforceDeleteWithWhere',
@@ -44,7 +64,6 @@ const deleteRule = createRule<Options, MessageIds>({
 							},
 						});
 					}
-					lastNodeName = node.property.name;
 				}
 				return;
 			},

--- a/eslint-plugin-drizzle/src/enforce-update-with-where.ts
+++ b/eslint-plugin-drizzle/src/enforce-update-with-where.ts
@@ -1,3 +1,4 @@
+import type { TSESTree } from '@typescript-eslint/utils';
 import { ESLintUtils } from '@typescript-eslint/utils';
 import { resolveMemberExpressionPath } from './utils/ast';
 import { isDrizzleObj, type Options } from './utils/options';
@@ -5,7 +6,26 @@ import { isDrizzleObj, type Options } from './utils/options';
 const createRule = ESLintUtils.RuleCreator(() => 'https://github.com/drizzle-team/eslint-plugin-drizzle');
 type MessageIds = 'enforceUpdateWithWhere';
 
-let lastNodeName: string = '';
+function chainHasMethod(node: TSESTree.MemberExpression, name: string): boolean {
+	let current: TSESTree.Node | undefined = node.parent;
+	while (current) {
+		if (
+			current.type === 'MemberExpression'
+			&& current.property.type === 'Identifier'
+			&& current.property.name === name
+		) {
+			return true;
+		}
+		if (current.type === 'CallExpression') {
+			current = current.parent;
+		} else if (current.type === 'MemberExpression') {
+			current = current.parent;
+		} else {
+			break;
+		}
+	}
+	return false;
+}
 
 const updateRule = createRule<Options, MessageIds>({
 	defaultOptions: [{ drizzleObjectName: [] }],
@@ -35,13 +55,13 @@ const updateRule = createRule<Options, MessageIds>({
 			MemberExpression: (node) => {
 				if (node.property.type === 'Identifier') {
 					if (
-						lastNodeName !== 'where'
-						&& node.property.name === 'set'
+						node.property.name === 'set'
 						&& node.object.type === 'CallExpression'
 						&& node.object.callee.type === 'MemberExpression'
 						&& node.object.callee.property.type === 'Identifier'
 						&& node.object.callee.property.name === 'update'
 						&& isDrizzleObj(node.object.callee, options)
+						&& !chainHasMethod(node, 'where')
 					) {
 						context.report({
 							node,
@@ -51,7 +71,6 @@ const updateRule = createRule<Options, MessageIds>({
 							},
 						});
 					}
-					lastNodeName = node.property.name;
 				}
 				return;
 			},

--- a/eslint-plugin-drizzle/tests/update.test.ts
+++ b/eslint-plugin-drizzle/tests/update.test.ts
@@ -27,6 +27,12 @@ ruleTester.run('enforce update with where (default options)', myRule, {
       .update()
       .set()
       .where()`,
+		'db.update({}).set({}).from(sql).where(eq())',
+		`db
+      .update()
+      .set()
+      .from(sql)
+      .where()`,
 	],
 	invalid: [
 		{


### PR DESCRIPTION
## Problem

The `enforce-update-with-where` rule uses a global `lastNodeName` variable to track whether `.where()` was called. ESLint visits `MemberExpression` nodes outer-to-inner, so when `.from()` appears between `.set()` and `.where()` in the chain, `.from` overwrites `lastNodeName` before `.set` is visited, causing a false positive.

`	s
// Incorrectly flagged as missing .where()
await tx
  .update(table)
  .set({ ... })
  .from(sql``(VALUES ...) AS v(...)``)
  .where(eq(table.id, v.id));
``n
## Fix

Replace `lastNodeName` with a `chainHasMethod()` helper that walks up the AST parent chain from the `.set` node to check if `.where()` exists anywhere above. This correctly handles any intermediate methods like `.from()`, `.returning()`, etc.

Also applied the same fix to `enforce-delete-with-where` which had the identical fragile pattern.

All 123 existing + 2 new regression tests pass.

Fixes #5612