### PR TITLE
fix(drizzle-kit): include ON DELETE/ON UPDATE in SQLite ALTER TABLE ADD COLUMN

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -1880,7 +1880,7 @@ export class SQLiteAlterTableAddColumnConvertor extends Convertor {
 			: undefined;
 		const referenceStatement = `${
 			referenceAsObject
-				? ` REFERENCES ${referenceAsObject.tableTo}(${referenceAsObject.columnsTo})`
+				? ` REFERENCES ${referenceAsObject.tableTo}(${referenceAsObject.columnsTo})${referenceAsObject.onDelete ? ` ON DELETE ${referenceAsObject.onDelete}` : ''}${referenceAsObject.onUpdate ? ` ON UPDATE ${referenceAsObject.onUpdate}` : ''}`
 				: ''
 		}`;
 		// const autoincrementStatement = `${autoincrement ? 'AUTO_INCREMENT' : ''}`


### PR DESCRIPTION
## Summary

Fix `SQLiteAlterTableAddColumnConvertor` omitting `ON DELETE` and `ON UPDATE` clauses from `REFERENCES` in `ALTER TABLE ADD COLUMN` statements.

Fixes #5619

## Problem

When using `drizzle-kit generate` with SQLite, foreign key columns added via `ALTER TABLE ADD COLUMN` lost their referential actions:

```sql
-- Generated (missing ON DELETE SET NULL)
ALTER TABLE `tasks` ADD `assigned_to` text REFERENCES users(id);

-- Expected
ALTER TABLE `tasks` ADD `assigned_to` text REFERENCES users(id) ON DELETE SET NULL;
```

`SQLiteSquasher.unsquashFK()` correctly parsed `onDelete`/`onUpdate`, but the `referenceStatement` template in `SQLiteAlterTableAddColumnConvertor.convert()` only output `REFERENCES table(col)` without the action clauses.

## Fix

Append `ON DELETE` and `ON UPDATE` clauses to the `referenceStatement` when present, matching the pattern used by `SQLiteCreateTableConvertor`.

## Test plan

- [x] Existing SQLite tests pass (`tests/test/sqlite.test.ts`)
- [x] LibSQL statement combiner tests pass (`tests/statements-combiner/libsql-statements-combiner.test.ts`)