### PR TITLE
fix(drizzle-orm): is() crash on objects with null prototype

### DIFF
--- a/drizzle-orm/src/entity.ts
+++ b/drizzle-orm/src/entity.ts
@@ -26,7 +26,7 @@ export function is<T extends DrizzleEntityClass<any>>(value: any, type: T): valu
 		);
 	}
 
-	let cls = Object.getPrototypeOf(value).constructor;
+	let cls = Object.getPrototypeOf(value)?.constructor;
 	if (cls) {
 		// Traverse the prototype chain to find the entityKind
 		while (cls) {

--- a/drizzle-orm/tests/is.test.ts
+++ b/drizzle-orm/tests/is.test.ts
@@ -1,10 +1,21 @@
+import postgres from 'postgres';
 import { describe, test } from 'vitest';
-import { Column, is } from '~/index.ts';
-import { PgArray, PgColumn, PgSerial, pgTable, serial } from '~/pg-core/index.ts';
+import { Column, is, SQL } from '~/index.ts';
+import { jsonb, PgArray, PgColumn, PgSerial, pgTable, serial, text } from '~/pg-core/index.ts';
+import { drizzle } from '~/postgres-js/index.ts';
+import { eq } from '~/sql/index.ts';
 
 const pgExampleTable = pgTable('test', {
 	a: serial('a').array(),
 });
+
+const nullProtoTable = pgTable('null_proto_test', {
+	id: serial('id').primaryKey(),
+	name: text('name').notNull(),
+	data: jsonb('data'),
+});
+
+const db = drizzle(postgres(''));
 
 describe.concurrent('is', () => {
 	test('Column', ({ expect }) => {
@@ -12,5 +23,34 @@ describe.concurrent('is', () => {
 		expect(is(pgExampleTable.a, PgColumn)).toBe(true);
 		expect(is(pgExampleTable.a, PgArray)).toBe(true);
 		expect(is(pgExampleTable.a, PgSerial)).toBe(false);
+	});
+
+	test('Object.create(null) value does not throw', ({ expect }) => {
+		const nullProtoValue = Object.create(null);
+		expect(is(nullProtoValue, SQL)).toBe(false);
+		expect(is(nullProtoValue, Column)).toBe(false);
+	});
+
+	test('insert with Object.create(null) value', ({ expect }) => {
+		const jsonValue = Object.create(null);
+		jsonValue.key = 'value';
+
+		const query = db
+			.insert(nullProtoTable)
+			.values({ name: 'test', data: jsonValue });
+
+		expect(query.toSQL()).toBeTruthy();
+	});
+
+	test('update with Object.create(null) value', ({ expect }) => {
+		const jsonValue = Object.create(null);
+		jsonValue.key = 'value';
+
+		const query = db
+			.update(nullProtoTable)
+			.set({ data: jsonValue })
+			.where(eq(nullProtoTable.id, 1));
+
+		expect(query.toSQL()).toBeTruthy();
 	});
 });


### PR DESCRIPTION
## What

Adds optional chaining (`?.`) to the `Object.getPrototypeOf(value)` call in the `is()` function in entity.ts.

## Why

`Object.getPrototypeOf()` returns `null` for objects created with `Object.create(null)`. Without optional chaining, accessing `.constructor` on `null` throws:

```
TypeError: Cannot read properties of null (reading 'constructor')
```

This affects insert and update operations when a user passes an `Object.create(null)`-based value (e.g. a JSON column value), because the query builder calls `is(colValue, SQL)` on each column value:

```typescript
// This crashes without the fix
const jsonValue = Object.create(null);
jsonValue.key = 'value';

db.insert(myTable).values({ name: 'test', data: jsonValue });
db.update(myTable).set({ data: jsonValue }).where(eq(myTable.id, 1));
```

## Changes

- **entity.ts** — Changed `Object.getPrototypeOf(value).constructor` to `Object.getPrototypeOf(value)?.constructor` on line 29.
- **is.test.ts** — Added 3 test cases:
  - `is()` returns `false` (instead of throwing) for `Object.create(null)` values
  - Insert query building succeeds when a column value is an `Object.create(null)` object
  - Update query building succeeds when a column value is an `Object.create(null)` object

All 3 tests produce `TypeError: Cannot read properties of null (reading 'constructor')` without the fix.