### PR TITLE
fix: mark mssql and @types/mssql as optional peer dependencies

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -194,6 +194,12 @@
 		},
 		"zod": {
 			"optional": true
+		},
+		"mssql": {
+			"optional": true
+		},
+		"@types/mssql": {
+			"optional": true
 		}
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

- Add `mssql` and `@types/mssql` to `peerDependenciesMeta` with `"optional": true`
- All other 36+ database driver packages already have this flag — these two were missed when MSSQL support was added

## Problem

`mssql` and `@types/mssql` are listed in `peerDependencies` but not in `peerDependenciesMeta`, so npm 7+ treats them as **required** and auto-installs them. This pulls in `tedious` and the entire `@azure/*` SDK tree (~50MB) into every project using drizzle-orm, even if the project only uses PostgreSQL or another database.

Fixes #5623