### PR TITLE
fix(pg): prevent enum names with native type prefixes from losing schema prefix

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -143,7 +143,12 @@ const parseType = (schemaPrefix: string, type: string) => {
 	const arrayDefinitionRegex = /\[\d*(?:\[\d*\])*\]/g;
 	const arrayDefinition = (type.match(arrayDefinitionRegex) ?? []).join('');
 	const withoutArrayDefinition = type.replace(arrayDefinitionRegex, '');
-	return pgNativeTypes.some((it) => type.startsWith(it))
+	return pgNativeTypes.some(
+		(it) =>
+			withoutArrayDefinition === it ||
+			withoutArrayDefinition.startsWith(it + '(') ||
+			withoutArrayDefinition.startsWith(it + ' '),
+	)
 		? `${withoutArrayDefinition}${arrayDefinition}`
 		: `${schemaPrefix}"${withoutArrayDefinition}"${arrayDefinition}`;
 };


### PR DESCRIPTION
Fixes #5609

## Problem

`parseType()` in `drizzle-kit/src/sqlgenerator.ts` used `type.startsWith(nativeType)` to decide whether a PostgreSQL type is a native type or a user-defined type (enum/domain). This caused a false positive when an enum name begins with a native type name.

**Example:**
```sql
-- Schema: myschema
-- Enum name: char_type
-- Column type: char_type

-- Before fix (incorrect): native type check matched because "char_type".startsWith("char")
ALTER TABLE "mytable" ADD COLUMN "status" char_type;
--                                        ^ missing "myschema". prefix

-- After fix (correct):
ALTER TABLE "mytable" ADD COLUMN "status" "myschema"."char_type";
```

Other affected enum names: anything starting with `text`, `bit`, `time`, `date`, `real`, `json`, `uuid`, `integer`, `interval`, `numeric`, `decimal`, `vector`, `boolean`, `varchar`, `geometry`, etc.

## Fix

The original check used `type.startsWith(it)` against the raw type string. The fix switches to `withoutArrayDefinition` (array brackets already stripped two lines above) and tightens the match with three precise conditions:

```typescript
// Before
return pgNativeTypes.some((it) => type.startsWith(it))

// After
return pgNativeTypes.some(
    (it) =>
        withoutArrayDefinition === it ||
        withoutArrayDefinition.startsWith(it + '(') ||
        withoutArrayDefinition.startsWith(it + ' '),
)
```

Each condition covers a distinct case:

| Condition | Matches | Example |
|-----------|---------|---------|
| `=== it` | Exact native type | `text`, `integer`, `boolean` |
| `startsWith(it + '(')` | Parameterized type | `varchar(255)`, `char(10)`, `numeric(10,2)` |
| `startsWith(it + ' ')` | Multi-word type | `timestamp with time zone`, `double precision`, `time without time zone` |

`char_type` does not satisfy any of these for the native type `char`, so it correctly gets the schema prefix. `char(10)` still matches via the `(` condition.

## Impact

- Only `parseType()` is changed — one expression, no logic restructuring.
- Fixes the schema prefix being silently dropped for enums/domains whose names start with a native type keyword.