### PR TITLE
fix(eslint-plugin): enforce-update-with-where false positive when .from() precedes .where()

### DIFF
--- a/eslint-plugin-drizzle/src/enforce-update-with-where.ts
+++ b/eslint-plugin-drizzle/src/enforce-update-with-where.ts
@@ -1,11 +1,48 @@
-import { ESLintUtils } from '@typescript-eslint/utils';
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
 import { resolveMemberExpressionPath } from './utils/ast';
 import { isDrizzleObj, type Options } from './utils/options';
 
 const createRule = ESLintUtils.RuleCreator(() => 'https://github.com/drizzle-team/eslint-plugin-drizzle');
 type MessageIds = 'enforceUpdateWithWhere';
 
-let lastNodeName: string = '';
+/**
+ * Walk upward from a MemberExpression through the chained call pattern
+ * (CallExpression → MemberExpression → CallExpression → …) and return
+ * true if any property in the chain is named `where`.
+ */
+function chainContainsWhere(node: TSESTree.MemberExpression): boolean {
+	let current: TSESTree.Node = node;
+
+	// Walk up through the chain: MemberExpression → CallExpression → MemberExpression → …
+	while (current.parent) {
+		const parent = current.parent;
+
+		// A CallExpression wrapping the current node (e.g. `.set(...)`)
+		if (parent.type === 'CallExpression' && parent.callee === current) {
+			current = parent;
+			continue;
+		}
+
+		// A MemberExpression whose object is the current CallExpression (e.g. `.from(...)` after `.set(...)`)
+		if (parent.type === 'MemberExpression' && parent.object === current) {
+			if (parent.property.type === 'Identifier' && parent.property.name === 'where') {
+				return true;
+			}
+			current = parent;
+			continue;
+		}
+
+		// AwaitExpression wraps the whole chain — keep going
+		if (parent.type === 'AwaitExpression') {
+			current = parent;
+			continue;
+		}
+
+		break;
+	}
+
+	return false;
+}
 
 const updateRule = createRule<Options, MessageIds>({
 	defaultOptions: [{ drizzleObjectName: [] }],
@@ -35,13 +72,13 @@ const updateRule = createRule<Options, MessageIds>({
 			MemberExpression: (node) => {
 				if (node.property.type === 'Identifier') {
 					if (
-						lastNodeName !== 'where'
-						&& node.property.name === 'set'
+						node.property.name === 'set'
 						&& node.object.type === 'CallExpression'
 						&& node.object.callee.type === 'MemberExpression'
 						&& node.object.callee.property.type === 'Identifier'
 						&& node.object.callee.property.name === 'update'
 						&& isDrizzleObj(node.object.callee, options)
+						&& !chainContainsWhere(node)
 					) {
 						context.report({
 							node,
@@ -51,7 +88,6 @@ const updateRule = createRule<Options, MessageIds>({
 							},
 						});
 					}
-					lastNodeName = node.property.name;
 				}
 				return;
 			},

--- a/eslint-plugin-drizzle/tests/update.test.ts
+++ b/eslint-plugin-drizzle/tests/update.test.ts
@@ -18,6 +18,13 @@ ruleTester.run('enforce update with where (default options)', myRule, {
       .update()
       .set()
       .where()`,
+		// .from() before .where() should not be a false positive
+		`db
+      .update()
+      .set()
+      .from()
+      .where()`,
+		'const a = db.update({}).set({}).from(sql).where(eq(a, b));',
 		`dataSource
       .update()
       .set()


### PR DESCRIPTION
## Summary

Fixes #5612

The `enforce-update-with-where` rule incorrectly flags update chains where `.from()` appears before `.where()`:

```typescript
// ❌ Incorrectly flagged as missing .where()
await tx
  .update(table)
  .set({ ... })
  .from(sql\`(VALUES ...) AS v(...)\`)
  .where(eq(table.id, v.id));
```

## Root Cause

The rule used a module-level `lastNodeName` variable to track whether `.where()` appeared before `.set()` in AST traversal order. Since ESLint visits nodes depth-first, the `.set()` MemberExpression is visited **before** the outer `.from().where()` chain — so `lastNodeName` is never `'where'` when the rule checks.

This approach also has a secondary issue: the global variable leaks state across unrelated expressions in the same file.

## Fix

Replace the `lastNodeName` approach with a `chainContainsWhere()` function that walks **upward** through the AST from the `.set()` node, following the `CallExpression → MemberExpression` chain pattern, to check if `.where()` exists anywhere in the method chain.

## Tests

Added valid cases for `.from().where()` chains.