### PR TITLE
fix: make not() accept undefined from and()/or()

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -174,7 +174,12 @@ export function or(
  *   .where(not(inArray(cars.make, ['GM', 'Ford'])))
  * ```
  */
-export function not(condition: SQLWrapper): SQL {
+export function not(condition: SQLWrapper): SQL;
+export function not(condition: SQLWrapper | undefined): SQL | undefined;
+export function not(condition: SQLWrapper | undefined): SQL | undefined {
+	if (condition === undefined) {
+		return undefined;
+	}
 	return sql`not ${condition}`;
 }
 


### PR DESCRIPTION
Fixes the type error when composing `not(and(...))` or `not(or(...))`.

`and()` and `or()` return `SQL | undefined`, but `not()` only accepted `SQLWrapper`. Added overloads so `not()` handles `undefined` input (passes it through), while `not(definiteSQL)` still returns plain `SQL` for backward compat.

Fixes #1818