### PR TITLE
[Pg-kit] Fix create_index commutativity check false positives (fixes #5639)

### DIFF
--- a/drizzle-kit/src/dialects/postgres/commutativity.ts
+++ b/drizzle-kit/src/dialects/postgres/commutativity.ts
@@ -382,6 +382,8 @@ function extractStatementInfo(statement: JsonStatement): {
 
 		// Index operations
 		case 'create_index':
+			schema = statement.index.schema;
+			objectName = statement.index.name;
 			break;
 		case 'drop_index':
 			schema = statement.index.schema;

--- a/drizzle-kit/src/dialects/postgres/commutativity.ts
+++ b/drizzle-kit/src/dialects/postgres/commutativity.ts
@@ -632,6 +632,24 @@ export function footprint(
 		),
 	];
 
+	// For index operations, also produce a table-level statement footprint.
+	// Index fingerprints use the index name as objectName, but drop_table's
+	// conflict footprints use the table name. The table-level footprint lets
+	// drop_table detect conflicts with new indexes not in the parent snapshot.
+	if (
+		(statement.type === 'create_index' || statement.type === 'drop_index')
+		&& statement.index.table
+	) {
+		statementFootprint.push(
+			formatFootprint(
+				statement.type,
+				statement.index.schema,
+				statement.index.table,
+				'',
+			),
+		);
+	}
+
 	let conflictFootprints = conflictingTypes.map((conflictType) =>
 		formatFootprint(
 			conflictType,
@@ -733,10 +751,12 @@ function expandFootprintsFromSnapshot(
 				);
 			}
 		}
-		// all indexes in changed tables should make a conflict in this case
-		// maybe we need to make other fields optional
-		// TODO: revise formatFootprint
-		expandedFootprints.push(formatFootprint('create_index', '', '', ''));
+		// Catch-all for new indexes not in the parent snapshot: use the
+		// table's schema+name so it matches the table-level secondary
+		// footprint emitted by create_index statements.
+		expandedFootprints.push(
+			formatFootprint('create_index', info.schema, info.objectName, ''),
+		);
 	}
 
 	return expandedFootprints;

--- a/drizzle-kit/tests/postgres/commutativity.test.ts
+++ b/drizzle-kit/tests/postgres/commutativity.test.ts
@@ -1098,6 +1098,52 @@ describe('commutativity integration (postgres)', () => {
 		expect(report.conflicts.length).toBeGreaterThan(0);
 	});
 
+	test('conflict when one branch drops table and other adds index to it', async () => {
+		const { tmp } = mkTmp();
+		const files: string[] = [];
+
+		const parent = createDDL();
+		parent.tables.push({ schema: 'public', isRlsEnabled: false, name: 'orders' });
+		const p = makeSnapshot('p_idx3', [ORIGIN], parent.entities.list());
+
+		// Branch A: drop the table
+		const a = createDDL();
+		// no tables — orders is dropped
+
+		// Branch B: add a new index to the table
+		const b = createDDL();
+		b.tables.push({ schema: 'public', isRlsEnabled: false, name: 'orders' });
+		b.indexes.push(
+			{
+				schema: 'public',
+				table: 'orders',
+				name: 'idx_orders_new',
+				nameExplicit: true,
+				columns: [{
+					value: 'customer_id',
+					isExpression: false,
+					asc: true,
+					nullsFirst: false,
+					opclass: { name: '', default: true },
+				}],
+				isUnique: false,
+				where: null,
+				with: '',
+				method: 'btree',
+				concurrently: false,
+			} as any,
+		);
+
+		files.push(
+			writeTempSnapshot(tmp, '220_p_idx3', p),
+			writeTempSnapshot(tmp, '221_a_idx3', makeSnapshot('a_idx3', ['p_idx3'], a.entities.list())),
+			writeTempSnapshot(tmp, '222_b_idx3', makeSnapshot('b_idx3', ['p_idx3'], b.entities.list())),
+		);
+
+		const report = await detectNonCommutative(files, 'postgresql');
+		expect(report.conflicts.length).toBeGreaterThan(0);
+	});
+
 	test('complex schema and moves: rename, move, drop schema/table conflicts', async () => {
 		const { tmp } = mkTmp();
 		const files: string[] = [];

--- a/drizzle-kit/tests/postgres/commutativity.test.ts
+++ b/drizzle-kit/tests/postgres/commutativity.test.ts
@@ -967,6 +967,137 @@ describe('commutativity integration (postgres)', () => {
 		expect(report.conflicts.length).toBeGreaterThan(0);
 	});
 
+	test('no conflict when branches create indexes on different tables', async () => {
+		const { tmp } = mkTmp();
+		const files: string[] = [];
+
+		const parent = createDDL();
+		parent.tables.push({ schema: 'public', isRlsEnabled: false, name: 'orders' });
+		parent.tables.push({ schema: 'public', isRlsEnabled: false, name: 'invoices' });
+		const p = makeSnapshot('p_idx', [ORIGIN], parent.entities.list());
+
+		const a = createDDL();
+		a.tables.push({ schema: 'public', isRlsEnabled: false, name: 'orders' });
+		a.tables.push({ schema: 'public', isRlsEnabled: false, name: 'invoices' });
+		a.indexes.push(
+			{
+				schema: 'public',
+				table: 'orders',
+				name: 'idx_orders_customer',
+				nameExplicit: true,
+				columns: [{
+					value: 'customer_id',
+					isExpression: false,
+					asc: true,
+					nullsFirst: false,
+					opclass: { name: '', default: true },
+				}],
+				isUnique: false,
+				where: null,
+				with: '',
+				method: 'btree',
+				concurrently: false,
+			} as any,
+		);
+
+		const b = createDDL();
+		b.tables.push({ schema: 'public', isRlsEnabled: false, name: 'orders' });
+		b.tables.push({ schema: 'public', isRlsEnabled: false, name: 'invoices' });
+		b.indexes.push(
+			{
+				schema: 'public',
+				table: 'invoices',
+				name: 'idx_invoices_date',
+				nameExplicit: true,
+				columns: [{
+					value: 'invoice_date',
+					isExpression: false,
+					asc: true,
+					nullsFirst: false,
+					opclass: { name: '', default: true },
+				}],
+				isUnique: false,
+				where: null,
+				with: '',
+				method: 'btree',
+				concurrently: false,
+			} as any,
+		);
+
+		files.push(
+			writeTempSnapshot(tmp, '200_p_idx', p),
+			writeTempSnapshot(tmp, '201_a_idx', makeSnapshot('a_idx', ['p_idx'], a.entities.list())),
+			writeTempSnapshot(tmp, '202_b_idx', makeSnapshot('b_idx', ['p_idx'], b.entities.list())),
+		);
+
+		const report = await detectNonCommutative(files, 'postgresql');
+		expect(report.conflicts.length).toBe(0);
+	});
+
+	test('conflict when branches create same-named index', async () => {
+		const { tmp } = mkTmp();
+		const files: string[] = [];
+
+		const parent = createDDL();
+		parent.tables.push({ schema: 'public', isRlsEnabled: false, name: 'orders' });
+		const p = makeSnapshot('p_idx2', [ORIGIN], parent.entities.list());
+
+		const a = createDDL();
+		a.tables.push({ schema: 'public', isRlsEnabled: false, name: 'orders' });
+		a.indexes.push(
+			{
+				schema: 'public',
+				table: 'orders',
+				name: 'idx_orders_status',
+				nameExplicit: true,
+				columns: [{
+					value: 'status',
+					isExpression: false,
+					asc: true,
+					nullsFirst: false,
+					opclass: { name: '', default: true },
+				}],
+				isUnique: false,
+				where: null,
+				with: '',
+				method: 'btree',
+				concurrently: false,
+			} as any,
+		);
+
+		const b = createDDL();
+		b.tables.push({ schema: 'public', isRlsEnabled: false, name: 'orders' });
+		b.indexes.push(
+			{
+				schema: 'public',
+				table: 'orders',
+				name: 'idx_orders_status',
+				nameExplicit: true,
+				columns: [{
+					value: 'status',
+					isExpression: false,
+					asc: true,
+					nullsFirst: false,
+					opclass: { name: '', default: true },
+				}],
+				isUnique: false,
+				where: null,
+				with: '',
+				method: 'btree',
+				concurrently: false,
+			} as any,
+		);
+
+		files.push(
+			writeTempSnapshot(tmp, '210_p_idx2', p),
+			writeTempSnapshot(tmp, '211_a_idx2', makeSnapshot('a_idx2', ['p_idx2'], a.entities.list())),
+			writeTempSnapshot(tmp, '212_b_idx2', makeSnapshot('b_idx2', ['p_idx2'], b.entities.list())),
+		);
+
+		const report = await detectNonCommutative(files, 'postgresql');
+		expect(report.conflicts.length).toBeGreaterThan(0);
+	});
+
 	test('complex schema and moves: rename, move, drop schema/table conflicts', async () => {
 		const { tmp } = mkTmp();
 		const files: string[] = [];


### PR DESCRIPTION
## Summary
- Fix false positive non-commutative migration conflicts for `create_index` statements
- The `create_index` case in `extractStatementInfo` was missing metadata extraction — it just had `break;` with no `schema`/`objectName` assignment, producing identical empty fingerprints (`"create_index;;;"`) for all index creations
- Added `schema = statement.index.schema` and `objectName = statement.index.name` to match the pattern used by `drop_index`, `rename_index`, and `recreate_index`

Fixes #5639

## Test plan
- [x] Added test: "no conflict when branches create indexes on different tables" — was failing before fix, passes after
- [x] Added test: "conflict when branches create same-named index" — correctly detects real conflicts
- [x] All 19 commutativity tests pass