### PR TITLE
[MySQL-kit] Fix create_index commutativity check false positives

### DIFF
--- a/drizzle-kit/src/dialects/mysql/commutativity.ts
+++ b/drizzle-kit/src/dialects/mysql/commutativity.ts
@@ -232,18 +232,21 @@ export function footprint(
 		formatFootprint(statement.type, info.objectName, info.columnName),
 	];
 
-	// For column-level operations, also produce a table-level statement footprint.
-	// This allows table-level operations (e.g. drop_table) whose conflict footprints
-	// use an empty column name to match against any column operation on that table,
-	// including newly-added columns not present in the parent snapshot.
-	const columnOps: JsonStatement['type'][] = [
+	// For column-level and index-level operations, also produce a table-level
+	// statement footprint. This allows table-level operations (e.g. drop_table)
+	// whose conflict footprints use an empty column name to match against any
+	// column/index operation on that table, including newly-added columns or
+	// indexes not present in the parent snapshot.
+	const subTableOps: JsonStatement['type'][] = [
 		'add_column',
 		'drop_column',
 		'alter_column',
 		'recreate_column',
 		'rename_column',
+		'create_index',
+		'drop_index',
 	];
-	if (columnOps.includes(statement.type) && info.columnName !== '') {
+	if (subTableOps.includes(statement.type) && info.columnName !== '') {
 		statementFootprint.push(
 			formatFootprint(statement.type, info.objectName, ''),
 		);

--- a/drizzle-kit/src/dialects/mysql/commutativity.ts
+++ b/drizzle-kit/src/dialects/mysql/commutativity.ts
@@ -144,7 +144,7 @@ function extractStatementInfo(statement: JsonStatement): {
 		case 'create_index':
 		case 'drop_index':
 			objectName = statement.index.table;
-			// columnName = statement.index.name;
+			columnName = statement.index.name;
 			break;
 
 		// Primary key operations

--- a/drizzle-kit/tests/mysql/commutativity.integration.test.ts
+++ b/drizzle-kit/tests/mysql/commutativity.integration.test.ts
@@ -114,7 +114,7 @@ describe('conflict rule coverage (statement pairs)', () => {
 		expect(conflicts).not.toBeUndefined();
 	});
 
-	test('unique: create vs drop', async () => {
+	test('unique: create on different column vs drop are commutative', async () => {
 		const parent = {
 			t: mysqlTable('t', (t) => ({
 				c: t.varchar({ length: 255 }).unique(),
@@ -140,7 +140,9 @@ describe('conflict rule coverage (statement pairs)', () => {
 			child2: { id: '3', prevId: '1', schema: child2 },
 		});
 
-		expect(conflicts).not.toBeUndefined();
+		// Creating a unique index on column d and dropping a unique index
+		// on column c are independent operations that commute.
+		expect(conflicts).toBeUndefined();
 	});
 
 	test('fk: recreate vs drop', async () => {

--- a/drizzle-kit/tests/mysql/commutativity.test.ts
+++ b/drizzle-kit/tests/mysql/commutativity.test.ts
@@ -914,4 +914,40 @@ describe('commutativity integration (mysql)', () => {
 		const report = await detectNonCommutative(files, 'mysql');
 		expect(report.conflicts.length).toBeGreaterThan(0);
 	});
+
+	test('conflict when one branch drops table and other adds index to it', async () => {
+		const { tmp } = mkTmp();
+		const files: string[] = [];
+
+		const parent = createDDL();
+		parent.tables.push({ name: 'orders' });
+		const p = makeSnapshot('p_idx4', [ORIGIN], parent.entities.list());
+
+		// Branch A: drop the table
+		const a = createDDL();
+		// no tables — orders is dropped
+
+		// Branch B: add a new index to the table
+		const b = createDDL();
+		b.tables.push({ name: 'orders' });
+		b.indexes.push({
+			table: 'orders',
+			name: 'idx_orders_new',
+			nameExplicit: true,
+			columns: [{ value: 'customer_id', isExpression: false }],
+			isUnique: false,
+			using: null,
+			algorithm: null,
+			lock: null,
+		} as any);
+
+		files.push(
+			writeTempSnapshot(tmp, '230_p_idx4', p),
+			writeTempSnapshot(tmp, '231_a_idx4', makeSnapshot('a_idx4', ['p_idx4'], a.entities.list())),
+			writeTempSnapshot(tmp, '232_b_idx4', makeSnapshot('b_idx4', ['p_idx4'], b.entities.list())),
+		);
+
+		const report = await detectNonCommutative(files, 'mysql');
+		expect(report.conflicts.length).toBeGreaterThan(0);
+	});
 });

--- a/drizzle-kit/tests/mysql/commutativity.test.ts
+++ b/drizzle-kit/tests/mysql/commutativity.test.ts
@@ -779,4 +779,139 @@ describe('commutativity integration (mysql)', () => {
 		const report = await detectNonCommutative(files, 'mysql');
 		expect(report.conflicts.length).toBeGreaterThan(0);
 	});
+
+	test('no conflict when branches create indexes on different tables', async () => {
+		const { tmp } = mkTmp();
+		const files: string[] = [];
+
+		const parent = createDDL();
+		parent.tables.push({ name: 'orders' });
+		parent.tables.push({ name: 'invoices' });
+		const p = makeSnapshot('p_idx', [ORIGIN], parent.entities.list());
+
+		const a = createDDL();
+		a.tables.push({ name: 'orders' });
+		a.tables.push({ name: 'invoices' });
+		a.indexes.push({
+			table: 'orders',
+			name: 'idx_orders_customer',
+			nameExplicit: true,
+			columns: [{ value: 'customer_id', isExpression: false }],
+			isUnique: false,
+			using: null,
+			algorithm: null,
+			lock: null,
+		} as any);
+
+		const b = createDDL();
+		b.tables.push({ name: 'orders' });
+		b.tables.push({ name: 'invoices' });
+		b.indexes.push({
+			table: 'invoices',
+			name: 'idx_invoices_date',
+			nameExplicit: true,
+			columns: [{ value: 'invoice_date', isExpression: false }],
+			isUnique: false,
+			using: null,
+			algorithm: null,
+			lock: null,
+		} as any);
+
+		files.push(
+			writeTempSnapshot(tmp, '200_p_idx', p),
+			writeTempSnapshot(tmp, '201_a_idx', makeSnapshot('a_idx', ['p_idx'], a.entities.list())),
+			writeTempSnapshot(tmp, '202_b_idx', makeSnapshot('b_idx', ['p_idx'], b.entities.list())),
+		);
+
+		const report = await detectNonCommutative(files, 'mysql');
+		expect(report.conflicts.length).toBe(0);
+	});
+
+	test('no conflict when branches create different indexes on same table', async () => {
+		const { tmp } = mkTmp();
+		const files: string[] = [];
+
+		const parent = createDDL();
+		parent.tables.push({ name: 'orders' });
+		const p = makeSnapshot('p_idx2', [ORIGIN], parent.entities.list());
+
+		const a = createDDL();
+		a.tables.push({ name: 'orders' });
+		a.indexes.push({
+			table: 'orders',
+			name: 'idx_orders_customer',
+			nameExplicit: true,
+			columns: [{ value: 'customer_id', isExpression: false }],
+			isUnique: false,
+			using: null,
+			algorithm: null,
+			lock: null,
+		} as any);
+
+		const b = createDDL();
+		b.tables.push({ name: 'orders' });
+		b.indexes.push({
+			table: 'orders',
+			name: 'idx_orders_date',
+			nameExplicit: true,
+			columns: [{ value: 'order_date', isExpression: false }],
+			isUnique: false,
+			using: null,
+			algorithm: null,
+			lock: null,
+		} as any);
+
+		files.push(
+			writeTempSnapshot(tmp, '210_p_idx2', p),
+			writeTempSnapshot(tmp, '211_a_idx2', makeSnapshot('a_idx2', ['p_idx2'], a.entities.list())),
+			writeTempSnapshot(tmp, '212_b_idx2', makeSnapshot('b_idx2', ['p_idx2'], b.entities.list())),
+		);
+
+		const report = await detectNonCommutative(files, 'mysql');
+		expect(report.conflicts.length).toBe(0);
+	});
+
+	test('conflict when branches create same-named index', async () => {
+		const { tmp } = mkTmp();
+		const files: string[] = [];
+
+		const parent = createDDL();
+		parent.tables.push({ name: 'orders' });
+		const p = makeSnapshot('p_idx3', [ORIGIN], parent.entities.list());
+
+		const a = createDDL();
+		a.tables.push({ name: 'orders' });
+		a.indexes.push({
+			table: 'orders',
+			name: 'idx_orders_status',
+			nameExplicit: true,
+			columns: [{ value: 'status', isExpression: false }],
+			isUnique: false,
+			using: null,
+			algorithm: null,
+			lock: null,
+		} as any);
+
+		const b = createDDL();
+		b.tables.push({ name: 'orders' });
+		b.indexes.push({
+			table: 'orders',
+			name: 'idx_orders_status',
+			nameExplicit: true,
+			columns: [{ value: 'status', isExpression: false }],
+			isUnique: false,
+			using: null,
+			algorithm: null,
+			lock: null,
+		} as any);
+
+		files.push(
+			writeTempSnapshot(tmp, '220_p_idx3', p),
+			writeTempSnapshot(tmp, '221_a_idx3', makeSnapshot('a_idx3', ['p_idx3'], a.entities.list())),
+			writeTempSnapshot(tmp, '222_b_idx3', makeSnapshot('b_idx3', ['p_idx3'], b.entities.list())),
+		);
+
+		const report = await detectNonCommutative(files, 'mysql');
+		expect(report.conflicts.length).toBeGreaterThan(0);
+	});
 });


### PR DESCRIPTION
## Summary
- Fix false positive non-commutative migration conflicts for MySQL `create_index`/`drop_index` statements
- The `create_index` and `drop_index` cases in `extractStatementInfo` used only `statement.index.table` as `objectName` with an empty `columnName`, so all index operations on the same table produced identical fingerprints — even for completely different indexes
- Uncommented the existing `columnName = statement.index.name` line (the author had left it commented out with `// columnName = statement.index.name;`)
- Added `create_index`/`drop_index` to the dual-footprint pattern (alongside column operations) so that `drop_table`'s catch-all conflict footprint still matches new indexes on the dropped table — this was why the line was originally commented out
- Same class of bug as #5639 (postgres `create_index` empty fingerprint), but MySQL-specific: false positives at the table level rather than globally

Related: #5640 (postgres fix for #5639)

## Test plan
- [x] Added test: "no conflict when branches create indexes on different tables" — was failing before fix
- [x] Added test: "no conflict when branches create different indexes on same table" — was failing before fix (the MySQL-specific case)
- [x] Added test: "conflict when branches create same-named index" — correctly detects real conflicts
- [x] Added test: "conflict when one branch drops table and other adds index to it" — regression guard for the dual-footprint fix
- [x] All 16 MySQL commutativity tests pass