### PR TITLE
[Pg/Gel] Break circular dependency in pg-core and gel-core

### DIFF
--- a/drizzle-orm/src/gel-core/utils.ts
+++ b/drizzle-orm/src/gel-core/utils.ts
@@ -13,8 +13,8 @@ import { type PrimaryKey, PrimaryKeyBuilder } from './primary-keys.ts';
 import { GelTable } from './table.ts';
 import { type UniqueConstraint, UniqueConstraintBuilder } from './unique-constraint.ts';
 import type { GelViewBase } from './view-base.ts';
-import { GelViewConfig } from './view-common.ts';
-import { type GelMaterializedView, GelMaterializedViewConfig, type GelView } from './view.ts';
+import { GelMaterializedViewConfig, GelViewConfig } from './view-common.ts';
+import type { GelMaterializedView, GelView } from './view.ts';
 
 export function getTableConfig<TTable extends GelTable>(table: TTable) {
 	const columns = Object.values(table[Table.Symbol.Columns]);

--- a/drizzle-orm/src/gel-core/view-common.ts
+++ b/drizzle-orm/src/gel-core/view-common.ts
@@ -1,1 +1,2 @@
 export const GelViewConfig = Symbol.for('drizzle:GelViewConfig');
+export const GelMaterializedViewConfig = Symbol.for('drizzle:GelMaterializedViewConfig');

--- a/drizzle-orm/src/gel-core/view.ts
+++ b/drizzle-orm/src/gel-core/view.ts
@@ -10,7 +10,9 @@ import type { GelColumn, GelColumnBuilderBase } from './columns/common.ts';
 import { QueryBuilder } from './query-builders/query-builder.ts';
 import { gelTable } from './table.ts';
 import { GelViewBase } from './view-base.ts';
-import { GelViewConfig } from './view-common.ts';
+import { GelMaterializedViewConfig, GelViewConfig } from './view-common.ts';
+
+export { GelMaterializedViewConfig } from './view-common.ts';
 
 export type ViewWithConfig = RequireAtLeastOne<{
 	checkOption: 'local' | 'cascaded';
@@ -334,8 +336,6 @@ export type GelViewWithSelection<
 	TExisting extends boolean = boolean,
 	TSelectedFields extends ColumnsSelection = ColumnsSelection,
 > = GelView<TName, TExisting, TSelectedFields> & TSelectedFields;
-
-export const GelMaterializedViewConfig = Symbol.for('drizzle:GelMaterializedViewConfig');
 
 export class GelMaterializedView<
 	TName extends string = string,

--- a/drizzle-orm/src/pg-core/utils.ts
+++ b/drizzle-orm/src/pg-core/utils.ts
@@ -13,8 +13,8 @@ import { PgPolicy } from './policies.ts';
 import { type PrimaryKey, PrimaryKeyBuilder } from './primary-keys.ts';
 import { type UniqueConstraint, UniqueConstraintBuilder } from './unique-constraint.ts';
 import type { PgViewBase } from './view-base.ts';
-import { PgViewConfig } from './view-common.ts';
-import { type PgMaterializedView, PgMaterializedViewConfig, type PgView } from './view.ts';
+import { PgMaterializedViewConfig, PgViewConfig } from './view-common.ts';
+import type { PgMaterializedView, PgView } from './view.ts';
 
 export function getTableConfig<TTable extends PgTable>(table: TTable) {
 	const columns = Object.values(table[Table.Symbol.Columns]);

--- a/drizzle-orm/src/pg-core/view-common.ts
+++ b/drizzle-orm/src/pg-core/view-common.ts
@@ -1,1 +1,2 @@
 export const PgViewConfig = Symbol.for('drizzle:PgViewConfig');
+export const PgMaterializedViewConfig = Symbol.for('drizzle:PgMaterializedViewConfig');

--- a/drizzle-orm/src/pg-core/view.ts
+++ b/drizzle-orm/src/pg-core/view.ts
@@ -10,7 +10,9 @@ import type { PgColumn, PgColumnBuilderBase } from './columns/common.ts';
 import { QueryBuilder } from './query-builders/query-builder.ts';
 import { pgTable } from './table.ts';
 import { PgViewBase } from './view-base.ts';
-import { PgViewConfig } from './view-common.ts';
+import { PgMaterializedViewConfig, PgViewConfig } from './view-common.ts';
+
+export { PgMaterializedViewConfig } from './view-common.ts';
 
 export type ViewWithConfig = RequireAtLeastOne<{
 	checkOption: 'local' | 'cascaded';
@@ -334,8 +336,6 @@ export type PgViewWithSelection<
 	TExisting extends boolean = boolean,
 	TSelectedFields extends ColumnsSelection = ColumnsSelection,
 > = PgView<TName, TExisting, TSelectedFields> & TSelectedFields;
-
-export const PgMaterializedViewConfig = Symbol.for('drizzle:PgMaterializedViewConfig');
 
 export class PgMaterializedView<
 	TName extends string = string,


### PR DESCRIPTION
## Summary

Bundlers (Rollup, Vite, Nuxt/Nitro) currently emit a circular dependency warning in every consumer's build:

```
Circular dependency:
  drizzle-orm/pg-core/utils.js
  -> drizzle-orm/pg-core/view.js
  -> drizzle-orm/pg-core/query-builders/query-builder.js
  -> drizzle-orm/pg-core/query-builders/select.js
  -> drizzle-orm/pg-core/utils.js
```

The cycle exists because `pg-core/utils.ts` imports `PgMaterializedViewConfig` from `view.ts` (used in `getMaterializedViewConfig`), while `view.ts` transitively depends on `select.ts`, and `select.ts` imports `extractUsedTable` from `utils.ts`.

`view-common.ts` is already a leaf module that exports `PgViewConfig`. Moving the `PgMaterializedViewConfig` symbol declaration there as well — and importing it from `view-common.ts` in both `view.ts` and `utils.ts` — breaks the cycle with no behavior change. `view.ts` re-exports the symbol so the public API (`import { PgMaterializedViewConfig } from 'drizzle-orm/pg-core'`) is unchanged.

`gel-core` had the exact same pattern (`GelMaterializedViewConfig`), so the identical fix is applied there too.

## Verification

Reproduced with a minimal Rollup setup against `drizzle-orm@0.45.2`:

```js
// test.mjs
import { pgTable, text, integer } from 'drizzle-orm/pg-core';
```

- Before patch: Rollup emits the `Circular dependency` warning above.
- After patch (swapping in the built `dist/` from this branch): no warning.

## Changes

- `pg-core/view-common.ts`: add `PgMaterializedViewConfig` symbol.
- `pg-core/view.ts`: import symbol from `view-common.ts` (and re-export it for API compatibility); remove the local declaration.
- `pg-core/utils.ts`: import `PgMaterializedViewConfig` from `view-common.ts` instead of `view.ts`; make the remaining `view.ts` import type-only.
- Same three changes mirrored in `gel-core/`.

No runtime behavior change, no public API change.