### PR TITLE
fix(drizzle-kit): silence raw NOTICE objects from postgres-js driver

### DIFF
--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -280,9 +280,14 @@ export const preparePostgresDB = async (
 		const { drizzle } = await import('drizzle-orm/postgres-js');
 		const { migrate } = await import('drizzle-orm/postgres-js/migrator');
 
+		// Silence raw NOTICE objects that postgres.js logs to stdout by default.
+		// The CLI runs internal `CREATE SCHEMA/TABLE IF NOT EXISTS` statements
+		// that emit NOTICE on subsequent runs, which would otherwise dump
+		// unstructured payloads on top of drizzle-kit's own output (#5643).
+		const onnotice = () => {};
 		const client = 'url' in credentials
-			? postgres.default(credentials.url, { max: 1 })
-			: postgres.default({ ...credentials, max: 1 });
+			? postgres.default(credentials.url, { max: 1, onnotice })
+			: postgres.default({ ...credentials, max: 1, onnotice });
 
 		const transparentParser = (val: any) => val;
 


### PR DESCRIPTION
When the postgres-js driver path runs internal idempotent statements like `CREATE SCHEMA IF NOT EXISTS drizzle` and `CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations`, PostgreSQL emits NOTICE messages on subsequent runs. postgres.js's default `onnotice` handler prints the raw NOTICE objects to stdout, which dumps unstructured payloads on top of drizzle-kit's own output during `drizzle-kit migrate`.

Pass an empty `onnotice` to suppress this. Errors are still surfaced through the normal query rejection path, so this is purely cosmetic output cleanup.

Before:
```
{
  severity_local: 'NOTICE',
  severity: 'NOTICE',
  code: '42P06',
  message: 'schema "drizzle" already exists, skipping',
  file: 'schemacmds.c',
  line: '132',
  routine: 'CreateSchemaCommand'
}
{
  severity_local: 'NOTICE',
  severity: 'NOTICE',
  code: '42P07',
  message: 'relation "__drizzle_migrations" already exists, skipping',
  ...
}
```

After: clean drizzle-kit output, no raw NOTICE dump.

Closes #5643