### PR TITLE
fix(orm): use 1=0/1=1 for empty inArray/notInArray for cross-dialect support

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -284,7 +284,10 @@ export function inArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			return sql`false`;
+			// Use `1=0` instead of the boolean literal `false` so dialects that
+			// don't have a native boolean type (e.g. SQL Server / T-SQL) still
+			// parse this correctly. See drizzle-team/drizzle-orm#5632.
+			return sql`1=0`;
 		}
 		return sql`${column} in ${values.map((v) => bindIfParam(v, column))}`;
 	}
@@ -325,7 +328,10 @@ export function notInArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			return sql`true`;
+			// Use `1=1` instead of the boolean literal `true` so dialects that
+			// don't have a native boolean type (e.g. SQL Server / T-SQL) still
+			// parse this correctly. See drizzle-team/drizzle-orm#5632.
+			return sql`1=1`;
 		}
 		return sql`${column} not in ${values.map((v) => bindIfParam(v, column))}`;
 	}


### PR DESCRIPTION
Per #5632, `inArray(col, [])` and `notInArray(col, [])` currently emit the boolean literals `false` and `true` respectively. SQL Server / T-SQL has no native boolean type, so the resulting query (`WHERE false` or `WHERE true`) fails to parse against the mssql driver.

Replace with `1=0` and `1=1` — semantically identical, ANSI SQL, and accepted by every supported dialect (Postgres, MySQL, SQLite, SQL Server). PostgreSQL accepts these in addition to native booleans, so existing dialects keep behaving the same.

Closes #5632