### PR TITLE
[SQLite-kit] Wrap expression defaults in parentheses

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -148,6 +148,18 @@ const parseType = (schemaPrefix: string, type: string) => {
 		: `${schemaPrefix}"${withoutArrayDefinition}"${arrayDefinition}`;
 };
 
+// SQLite requires expression defaults (function calls like datetime('now'))
+// to be wrapped in parentheses: DEFAULT (datetime('now')).
+// Simple literals (strings, numbers, NULL, CURRENT_*) do not need wrapping.
+const wrapSqliteExprDefault = (val: unknown): string => {
+	const s = String(val);
+	if (typeof val !== 'string') return s;
+	if (s.startsWith('(') || s.startsWith("'") || s.startsWith('"')) return s;
+	if (/^-?\d+(\.\d+)?$/.test(s)) return s;
+	if (/^(NULL|TRUE|FALSE|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP)$/i.test(s)) return s;
+	return `(${s})`;
+};
+
 abstract class Convertor {
 	abstract can(
 		statement: JsonStatement,
@@ -677,7 +689,9 @@ export class SQLiteCreateTableConvertor extends Convertor {
 
 			const primaryKeyStatement = column.primaryKey ? ' PRIMARY KEY' : '';
 			const notNullStatement = column.notNull ? ' NOT NULL' : '';
-			const defaultStatement = column.default !== undefined ? ` DEFAULT ${column.default}` : '';
+			const defaultStatement = column.default !== undefined
+				? ` DEFAULT ${wrapSqliteExprDefault(column.default)}`
+				: '';
 
 			const autoincrementStatement = column.autoincrement
 				? ' AUTOINCREMENT'
@@ -1872,7 +1886,7 @@ export class SQLiteAlterTableAddColumnConvertor extends Convertor {
 		const { tableName, column, referenceData } = statement;
 		const { name, type, notNull, primaryKey, generated } = column;
 
-		const defaultStatement = `${column.default !== undefined ? ` DEFAULT ${column.default}` : ''}`;
+		const defaultStatement = `${column.default !== undefined ? ` DEFAULT ${wrapSqliteExprDefault(column.default)}` : ''}`;
 		const notNullStatement = `${notNull ? ' NOT NULL' : ''}`;
 		const primaryKeyStatement = `${primaryKey ? ' PRIMARY KEY' : ''}`;
 		const referenceAsObject = referenceData

--- a/drizzle-kit/tests/sqlite-columns.test.ts
+++ b/drizzle-kit/tests/sqlite-columns.test.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import {
 	AnySQLiteColumn,
 	foreignKey,
@@ -1046,4 +1047,54 @@ test('text default values escape single quotes', async (t) => {
 	expect(sqlStatements[0]).toStrictEqual(
 		"ALTER TABLE `table` ADD `text` text DEFAULT 'escape''s quotes';",
 	);
+});
+
+test('expression defaults wrap in parentheses for create table', async (t) => {
+	const schema = {
+		events: sqliteTable('events', {
+			id: integer('id').primaryKey(),
+			createdAt: text('created_at').default(sql`datetime('now')`),
+		}),
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite({}, schema, []);
+
+	expect(sqlStatements.length).toBe(1);
+	expect(sqlStatements[0]).toContain("DEFAULT (datetime('now'))");
+});
+
+test('expression defaults wrap in parentheses for add column', async (t) => {
+	const schema1 = {
+		events: sqliteTable('events', {
+			id: integer('id').primaryKey(),
+		}),
+	};
+
+	const schema2 = {
+		events: sqliteTable('events', {
+			id: integer('id').primaryKey(),
+			createdAt: text('created_at').default(sql`datetime('now')`),
+		}),
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite(schema1, schema2, []);
+
+	expect(sqlStatements.length).toBe(1);
+	expect(sqlStatements[0]).toContain("DEFAULT (datetime('now'))");
+});
+
+test('literal defaults not wrapped in extra parentheses', async (t) => {
+	const schema = {
+		users: sqliteTable('users', {
+			id: integer('id').primaryKey(),
+			name: text('name').default('hello'),
+			active: integer('active', { mode: 'boolean' }).default(true),
+		}),
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite({}, schema, []);
+
+	expect(sqlStatements.length).toBe(1);
+	expect(sqlStatements[0]).toContain("DEFAULT 'hello'");
+	expect(sqlStatements[0]).toContain('DEFAULT true');
 });


### PR DESCRIPTION
## What's Changed

Fixes #5634

When `drizzle-kit push` recreates a SQLite table (e.g. to add a named UNIQUE constraint), expression defaults like `datetime('now')` are emitted without the parentheses SQLite requires:

```sql
-- Before (broken):
`created_at` text DEFAULT datetime('now')  -- SQLITE_ERROR: near "(": syntax error

-- After (fixed):
`created_at` text DEFAULT (datetime('now'))  -- valid SQLite
```

## Root Cause

`SQLiteCreateTableConvertor` and `SQLiteAlterTableAddColumnConvertor` in `sqlgenerator.ts` interpolate `column.default` directly into the SQL without wrapping expression defaults. SQLite's grammar requires non-literal defaults (function calls, expressions) to be enclosed in parentheses.

## Fix

Added `wrapSqliteExprDefault()` — a small helper that detects whether a default value is a simple literal (string, number, `NULL`, `CURRENT_TIMESTAMP`, etc.) or an expression, and wraps expressions in parentheses. Applied to both `SQLiteCreateTableConvertor.convert()` and `SQLiteAlterTableAddColumnConvertor.convert()`.

Literal defaults (strings, numbers, booleans, `CURRENT_TIMESTAMP`) pass through unchanged — no double-wrapping.

## Tests Added

Three new test cases in `sqlite-columns.test.ts`:
1. Expression defaults wrapped in parentheses during CREATE TABLE
2. Expression defaults wrapped in parentheses during ALTER TABLE ADD COLUMN
3. Literal defaults NOT double-wrapped (regression guard)

All existing SQLite tests (columns, tables, generated, checks, libsql) continue to pass.


Made with [Cursor](https://cursor.com)