### PR TITLE
fix: allow not() to accept return types of and() and or()

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -174,7 +174,10 @@ export function or(
  *   .where(not(inArray(cars.make, ['GM', 'Ford'])))
  * ```
  */
-export function not(condition: SQLWrapper): SQL {
+export function not(condition: SQLWrapper | undefined): SQL | undefined {
+	if (condition === undefined) {
+		return undefined;
+	}
 	return sql`not ${condition}`;
 }
 


### PR DESCRIPTION
## Summary

- Updated the `not()` function type signature to accept `SQLWrapper | undefined` (instead of just `SQLWrapper`) and return `SQL | undefined` (instead of just `SQL`)
- When `undefined` is passed (e.g. from `and()` or `or()` returning `undefined`), `not()` now returns `undefined` instead of producing a type error
- This makes `not()` composable with `and()` and `or()` without requiring type assertions

## Problem

`and()` and `or()` return `SQL | undefined`, but `not()` only accepted `SQLWrapper`. This caused a TypeScript error when composing them:

```ts
// Type error: Argument of type 'SQL<unknown> | undefined' is not assignable to parameter of type 'SQLWrapper'.
not(and(ilike(users.name, '%asdf%')))
```

Fixes #1818

## Test plan

- [x] Verify `not(and(...))` compiles without type errors
- [x] Verify `not(or(...))` compiles without type errors
- [x] Verify `not(undefined)` returns `undefined`
- [x] Verify `not(someCondition)` still returns `SQL` as before when given a defined condition
- [x] Verify existing tests pass