### PR TITLE
fix(relations): throw on undefined values in RQB v2 where filters

### DIFF
--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -1296,7 +1296,14 @@ function relationsFieldFilterToSQL(column: SQLWrapper, filter: RelationsFieldFil
 
 	const parts: (SQL)[] = [];
 	for (const [target, value] of entries) {
-		if (value === undefined) continue;
+		if (value === undefined) {
+			throw new DrizzleError({
+				message: `Undefined value passed to filter operator "${target}". `
+					+ `This is most likely a bug in your application — passing undefined to a filter silently removes the condition, `
+					+ `which can lead to security vulnerabilities (e.g., returning the first arbitrary row). `
+					+ `Use "isNull" / "isNotNull" operators to filter for null values, or explicitly check for undefined before passing values to the query builder.`,
+			});
+		}
 
 		switch (target as keyof RelationFieldsFilterInternals<unknown>) {
 			case 'NOT': {
@@ -1396,7 +1403,14 @@ export function relationsFilterToSQL(
 
 	const parts: SQL[] = [];
 	for (const [target, value] of entries) {
-		if (value === undefined) continue;
+		if (value === undefined) {
+			throw new DrizzleError({
+				message: `Undefined value passed to filter field "${target}". `
+					+ `This is most likely a bug in your application — passing undefined to a where filter silently removes the condition, `
+					+ `which can lead to security vulnerabilities (e.g., returning the first arbitrary row instead of no results). `
+					+ `Use "isNull" / "isNotNull" operators to filter for null values, or explicitly check for undefined before passing values to the query builder.`,
+			});
+		}
 
 		switch (target) {
 			case 'RAW': {


### PR DESCRIPTION
## Summary

Fixes #5636

Passing `undefined` as a filter value in RQB v2 relational queries silently removes the filter condition, which can lead to **security vulnerabilities**.

### The Bug

```ts
const session = await db.query.sessions.findFirst({
  where: { token: undefined },  // token is undefined due to missing input
});
// Returns the FIRST ARBITRARY ROW instead of no results
```

Both `relationsFilterToSQL` and `relationsFieldFilterToSQL` in `drizzle-orm/src/relations.ts` had `if (value === undefined) continue` guards that silently skipped filter entries with undefined values. When all entries were skipped, the function returned `undefined` (no WHERE clause), causing `findFirst` to return the first row in the table.

The issue reporter demonstrated that this caused **unauthenticated users to be recognized as admins** because the admin was the first user row.

### The Fix

Replace `if (value === undefined) continue` with a `throw new DrizzleError(...)` in both functions:

- **`relationsFilterToSQL`** (line 1399) — handles top-level `where: { field: undefined }`
- **`relationsFieldFilterToSQL`** (line 1299) — handles operator-level `where: { field: { eq: undefined } }`

The error message explains:
- What happened (undefined value in filter)
- Why it's dangerous (silent condition removal → security vulnerability)
- What to do instead (use `isNull`/`isNotNull`, or check for undefined before querying)

### Why throw instead of treating as `WHERE false`?

Silently returning no results (`WHERE false`) would mask application bugs. An explicit error forces developers to handle the undefined case, which is the safer default for a query builder. The error message provides clear guidance on how to fix it.

## Test plan

- [ ] Verify `where: { field: undefined }` now throws `DrizzleError`
- [ ] Verify `where: { field: { eq: undefined } }` now throws `DrizzleError`
- [ ] Verify `where: { field: value }` with defined values still works normally
- [ ] Verify `where: { field: { isNull: true } }` still works for null checks