### PR TITLE
fix(drizzle-zod): fix coerce schema input types and inverted integer condition for Zod 4

### DIFF
--- a/drizzle-zod/src/column.ts
+++ b/drizzle-zod/src/column.ts
@@ -113,9 +113,9 @@ export function columnToSchema(
 		} else if (column.dataType === 'bigint') {
 			schema = bigintColumnToSchema(column, z, coerce);
 		} else if (column.dataType === 'boolean') {
-			schema = coerce === true || coerce.boolean ? z.coerce.boolean() : z.boolean();
+			schema = coerce === true || coerce.boolean ? z.coerce.boolean<boolean>() : z.boolean();
 		} else if (column.dataType === 'date') {
-			schema = coerce === true || coerce.date ? z.coerce.date() : z.date();
+			schema = coerce === true || coerce.date ? z.coerce.date<Date>() : z.date();
 		} else if (column.dataType === 'string') {
 			schema = stringColumnToSchema(column, z, coerce);
 		} else if (column.dataType === 'json') {
@@ -241,7 +241,7 @@ function numberColumnToSchema(
 	}
 
 	let schema = coerce === true || coerce?.number
-		? integer ? z.coerce.number() : z.coerce.number().int()
+		? integer ? z.coerce.number<number>().int() : z.coerce.number<number>()
 		: integer
 		? z.int()
 		: z.number();
@@ -260,7 +260,7 @@ function bigintColumnToSchema(
 	const min = unsigned ? 0n : CONSTANTS.INT64_MIN;
 	const max = unsigned ? CONSTANTS.INT64_UNSIGNED_MAX : CONSTANTS.INT64_MAX;
 
-	const schema = coerce === true || coerce?.bigint ? z.coerce.bigint() : z.bigint();
+	const schema = coerce === true || coerce?.bigint ? z.coerce.bigint<bigint>() : z.bigint();
 	return schema.gte(min).lte(max);
 }
 
@@ -313,7 +313,7 @@ function stringColumnToSchema(
 		max = column.dimensions;
 	}
 
-	let schema = coerce === true || coerce?.string ? z.coerce.string() : z.string();
+	let schema = coerce === true || coerce?.string ? z.coerce.string<string>() : z.string();
 	schema = regex ? schema.regex(regex) : schema;
 	return max && fixed ? schema.length(max) : max ? schema.max(max) : schema;
 }

--- a/drizzle-zod/src/column.types.ts
+++ b/drizzle-zod/src/column.types.ts
@@ -18,7 +18,7 @@ export type GetZodType<
 		? z.ZodEnum<{ [K in Assume<TColumn['_']['enumValues'], [string, ...string[]]>[number]]: K }>
 	: TColumn['_']['columnType'] extends 'PgGeometry' | 'PgPointTuple' ? z.ZodTuple<[z.ZodNumber, z.ZodNumber], null>
 	: TColumn['_']['columnType'] extends 'PgLine' ? z.ZodTuple<[z.ZodNumber, z.ZodNumber, z.ZodNumber], null>
-	: TColumn['_']['data'] extends Date ? CanCoerce<TCoerce, 'date'> extends true ? z.coerce.ZodCoercedDate : z.ZodDate
+	: TColumn['_']['data'] extends Date ? CanCoerce<TCoerce, 'date'> extends true ? z.coerce.ZodCoercedDate<Date> : z.ZodDate
 	: TColumn['_']['data'] extends Buffer ? z.ZodType<Buffer>
 	: TColumn['_']['dataType'] extends 'array'
 		? z.ZodArray<GetZodPrimitiveType<Assume<TColumn['_']['data'], any[]>[number], '', TCoerce>>
@@ -66,11 +66,11 @@ type GetZodPrimitiveType<
 	| 'SingleStoreSerial'
 	| 'SQLiteInteger'
 	| 'MySqlYear'
-	| 'SingleStoreYear' ? CanCoerce<TCoerce, 'number'> extends true ? z.coerce.ZodCoercedNumber : z.ZodInt
-	: TData extends number ? CanCoerce<TCoerce, 'number'> extends true ? z.coerce.ZodCoercedNumber : z.ZodNumber
-	: TData extends bigint ? CanCoerce<TCoerce, 'bigint'> extends true ? z.coerce.ZodCoercedBigInt : z.ZodBigInt
-	: TData extends boolean ? CanCoerce<TCoerce, 'boolean'> extends true ? z.coerce.ZodCoercedBoolean : z.ZodBoolean
-	: TData extends string ? CanCoerce<TCoerce, 'string'> extends true ? z.coerce.ZodCoercedString : z.ZodString
+	| 'SingleStoreYear' ? CanCoerce<TCoerce, 'number'> extends true ? z.coerce.ZodCoercedNumber<number> : z.ZodInt
+	: TData extends number ? CanCoerce<TCoerce, 'number'> extends true ? z.coerce.ZodCoercedNumber<number> : z.ZodNumber
+	: TData extends bigint ? CanCoerce<TCoerce, 'bigint'> extends true ? z.coerce.ZodCoercedBigInt<bigint> : z.ZodBigInt
+	: TData extends boolean ? CanCoerce<TCoerce, 'boolean'> extends true ? z.coerce.ZodCoercedBoolean<boolean> : z.ZodBoolean
+	: TData extends string ? CanCoerce<TCoerce, 'string'> extends true ? z.coerce.ZodCoercedString<string> : z.ZodString
 	: z.ZodType;
 
 type HandleSelectColumn<

--- a/drizzle-zod/tests/pg.test.ts
+++ b/drizzle-zod/tests/pg.test.ts
@@ -519,19 +519,30 @@ test('type coercion - all', (t) => {
 		text: text().notNull(),
 	}));
 
-	const { createSelectSchema } = createSchemaFactory({
+	const { createSelectSchema, createInsertSchema } = createSchemaFactory({
 		coerce: true,
 	});
 	const result = createSelectSchema(table);
 	const expected = z.object({
-		bigint: z.coerce.bigint().gte(CONSTANTS.INT64_MIN).lte(CONSTANTS.INT64_MAX),
-		boolean: z.coerce.boolean(),
-		timestamp: z.coerce.date(),
-		integer: z.coerce.number().gte(CONSTANTS.INT32_MIN).lte(CONSTANTS.INT32_MAX).int(),
-		text: z.coerce.string(),
+		bigint: z.coerce.bigint<bigint>().gte(CONSTANTS.INT64_MIN).lte(CONSTANTS.INT64_MAX),
+		boolean: z.coerce.boolean<boolean>(),
+		timestamp: z.coerce.date<Date>(),
+		integer: z.coerce.number<number>().int().gte(CONSTANTS.INT32_MIN).lte(CONSTANTS.INT32_MAX),
+		text: z.coerce.string<string>(),
 	});
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
+
+	// Verify that createInsertSchema with coerce gives proper input types, not `unknown` (GH#5659)
+	const insertResult = createInsertSchema(table);
+	const insertExpected = z.object({
+		bigint: z.coerce.bigint<bigint>().gte(CONSTANTS.INT64_MIN).lte(CONSTANTS.INT64_MAX),
+		boolean: z.coerce.boolean<boolean>(),
+		timestamp: z.coerce.date<Date>(),
+		integer: z.coerce.number<number>().int().gte(CONSTANTS.INT32_MIN).lte(CONSTANTS.INT32_MAX),
+		text: z.coerce.string<string>(),
+	});
+	Expect<Equal<z.input<typeof insertResult>, z.input<typeof insertExpected>>>();
 });
 
 test('type coercion - mixed', (t) => {
@@ -550,7 +561,7 @@ test('type coercion - mixed', (t) => {
 	});
 	const result = createSelectSchema(table);
 	const expected = z.object({
-		timestamp: z.coerce.date(),
+		timestamp: z.coerce.date<Date>(),
 		integer: z.int().gte(CONSTANTS.INT32_MIN).lte(CONSTANTS.INT32_MAX),
 	});
 	expectSchemaShape(t, expected).from(result);


### PR DESCRIPTION
## Problem

Closes #5659

When using `createSchemaFactory({ coerce: true })` or `createInsertSchema` with coerce options in Zod 4, the TypeScript input types for coerced fields are `unknown` instead of the expected primitive types.

In Zod 4, `z.coerce.boolean()` and friends default their generic `T` to `unknown`, so `z.input<typeof insertSchema>` returns `unknown` for every coerced field.

There's also an inverted condition in `numberColumnToSchema`: `.int()` was being applied to non-integer columns and skipped for integer ones.

## Fix

1. Pass explicit generics to all `z.coerce.*()` calls so the input type is preserved:
   `z.coerce.boolean<boolean>()`, `z.coerce.date<Date>()`, `z.coerce.number<number>()`, `z.coerce.bigint<bigint>()`, `z.coerce.string<string>()`

2. Fix the inverted integer condition in `numberColumnToSchema`:
   ```ts
   // before
   integer ? z.coerce.number() : z.coerce.number().int()
   // after
   integer ? z.coerce.number<number>().int() : z.coerce.number<number>()
   ```

3. Update tests to assert correct input types on both `createSelectSchema` and `createInsertSchema` with coerce enabled.