### PR TITLE
[drizzle-kit]: add columnTypeMapper to introspect config

### DIFF
--- a/drizzle-kit/src/cli/commands/introspect.ts
+++ b/drizzle-kit/src/cli/commands/introspect.ts
@@ -9,6 +9,7 @@ import { drySingleStore, SingleStoreSchema, squashSingleStoreScheme } from 'src/
 import { assertUnreachable, originUUID } from '../../global';
 import { schemaToTypeScript as gelSchemaToTypeScript } from '../../introspect-gel';
 import { schemaToTypeScript as mysqlSchemaToTypeScript } from '../../introspect-mysql';
+import type { ColumnTypeMapper } from '../../index';
 import { paramNameFor, schemaToTypeScript as postgresSchemaToTypeScript } from '../../introspect-pg';
 import { schemaToTypeScript as singlestoreSchemaToTypeScript } from '../../introspect-singlestore';
 import { schemaToTypeScript as sqliteSchemaToTypeScript } from '../../introspect-sqlite';
@@ -61,6 +62,7 @@ export const introspectPostgres = async (
 	schemasFilter: string[],
 	prefix: Prefix,
 	entities: Entities,
+	columnTypeMapper?: ColumnTypeMapper,
 ) => {
 	const { preparePostgresDB } = await import('../connections');
 	const db = await preparePostgresDB(credentials);
@@ -108,7 +110,7 @@ export const introspectPostgres = async (
 	);
 
 	const schema = { id: originUUID, prevId: '', ...res } as PgSchema;
-	const ts = postgresSchemaToTypeScript(schema, casing);
+	const ts = postgresSchemaToTypeScript(schema, casing, columnTypeMapper);
 	const relationsTs = relationsToTypeScript(schema, casing);
 	const { internal, ...schemaWithoutInternals } = schema;
 
@@ -311,6 +313,7 @@ export const introspectMysql = async (
 	credentials: MysqlCredentials,
 	tablesFilter: string[],
 	prefix: Prefix,
+	columnTypeMapper?: ColumnTypeMapper,
 ) => {
 	const { connectToMySQL } = await import('../connections');
 	const { db, database } = await connectToMySQL(credentials);
@@ -351,7 +354,7 @@ export const introspectMysql = async (
 	);
 
 	const schema = { id: originUUID, prevId: '', ...res } as MySqlSchema;
-	const ts = mysqlSchemaToTypeScript(schema, casing);
+	const ts = mysqlSchemaToTypeScript(schema, casing, columnTypeMapper);
 	const relationsTs = relationsToTypeScript(schema, casing);
 	const { internal, ...schemaWithoutInternals } = schema;
 

--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -7,6 +7,7 @@ import { getTablesFilterByExtensions } from '../../extensions/getTablesFilterByE
 import { assertUnreachable } from '../../global';
 import { type Dialect, dialect } from '../../schemaValidator';
 import { prepareFilenames } from '../../serializer';
+import type { ColumnTypeMapper } from '../../index';
 import type { Entities } from '../validations/cli';
 import { pullParams, pushParams } from '../validations/cli';
 import type { Casing, CasingType, CliConfig, Driver, Prefix } from '../validations/common';
@@ -271,6 +272,10 @@ const flattenPull = (config: any) => {
 	return config;
 };
 
+const extractColumnTypeMapper = (config: any): ColumnTypeMapper | undefined => {
+	return config?.introspect?.columnTypeMapper;
+};
+
 export const preparePushConfig = async (
 	options: Record<string, unknown>,
 	from: 'cli' | 'config',
@@ -496,13 +501,15 @@ export const preparePullConfig = async (
 		schemasFilter: string[];
 		prefix: Prefix;
 		entities: Entities;
+		columnTypeMapper: ColumnTypeMapper | undefined;
 	}
 > => {
-	const raw = flattenPull(
-		from === 'config'
-			? await drizzleConfigFromFile(options.config as string | undefined)
-			: options,
-	);
+	const rawConfig = from === 'config'
+		? await drizzleConfigFromFile(options.config as string | undefined)
+		: options;
+
+	const columnTypeMapper = extractColumnTypeMapper(rawConfig);
+	const raw = flattenPull(rawConfig);
 	const parsed = pullParams.safeParse(raw);
 
 	if (parsed.error) {
@@ -556,6 +563,7 @@ export const preparePullConfig = async (
 			schemasFilter,
 			prefix: config.migrations?.prefix || 'index',
 			entities: config.entities,
+			columnTypeMapper,
 		};
 	}
 
@@ -575,6 +583,7 @@ export const preparePullConfig = async (
 			schemasFilter,
 			prefix: config.migrations?.prefix || 'index',
 			entities: config.entities,
+			columnTypeMapper,
 		};
 	}
 
@@ -595,6 +604,7 @@ export const preparePullConfig = async (
 			schemasFilter,
 			prefix: config.migrations?.prefix || 'index',
 			entities: config.entities,
+			columnTypeMapper,
 		};
 	}
 
@@ -614,6 +624,7 @@ export const preparePullConfig = async (
 			schemasFilter,
 			prefix: config.migrations?.prefix || 'index',
 			entities: config.entities,
+			columnTypeMapper,
 		};
 	}
 
@@ -633,6 +644,7 @@ export const preparePullConfig = async (
 			schemasFilter,
 			prefix: config.migrations?.prefix || 'index',
 			entities: config.entities,
+			columnTypeMapper,
 		};
 	}
 
@@ -652,6 +664,7 @@ export const preparePullConfig = async (
 			schemasFilter,
 			prefix: config.migrations?.prefix || 'index',
 			entities: config.entities,
+			columnTypeMapper,
 		};
 	}
 

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -520,6 +520,7 @@ export const pull = command({
 			schemasFilter,
 			prefix,
 			entities,
+			columnTypeMapper,
 		} = config;
 		mkdirSync(out, { recursive: true });
 
@@ -567,6 +568,7 @@ export const pull = command({
 					schemasFilter,
 					prefix,
 					entities,
+					columnTypeMapper,
 				);
 			} else if (dialect === 'mysql') {
 				const { introspectMysql } = await import('./commands/introspect');
@@ -577,6 +579,7 @@ export const pull = command({
 					credentials,
 					tablesFilter,
 					prefix,
+					columnTypeMapper,
 				);
 			} else if (dialect === 'sqlite') {
 				const { introspectSqlite } = await import('./commands/introspect');

--- a/drizzle-kit/src/index.ts
+++ b/drizzle-kit/src/index.ts
@@ -106,6 +106,84 @@ type Verify<T, U extends T> = U;
  *
  * See https://orm.drizzle.team/kit-docs/config-reference#strict
  */
+/**
+ * Input passed to `columnTypeMapper` for each column encountered during `drizzle-kit pull`.
+ */
+export type ColumnTypeMapperInput = {
+	/** Column name as reported by the database. */
+	column: string;
+	/** Table name as reported by the database. */
+	table: string;
+	/** Schema name (PostgreSQL only). `undefined` for dialects without schemas. */
+	schema: string | undefined;
+	/** Raw SQL type string as reported by the database, e.g. `"timestamp with time zone"`. */
+	sqlType: string;
+	/** Whether the column allows NULL values. */
+	nullable: boolean;
+};
+
+/**
+ * Returned from `columnTypeMapper` to override how a column is rendered.
+ *
+ * Two shapes are supported:
+ *
+ * 1. **Built-in mode override** – sets the `mode` option on a Drizzle-native column type:
+ *    ```ts
+ *    return { mode: 'date' };
+ *    ```
+ *
+ * 2. **Custom type reference** – replaces the built-in column call entirely with a
+ *    user-defined `customType()`. The generator will import `typeName` from `typeImport.from`
+ *    and emit `typeName('col_name')` instead of e.g. `timestamp('col_name', { mode: 'string' })`:
+ *    ```ts
+ *    return {
+ *      typeName: 'dayjsTimestamp',
+ *      typeImport: { name: 'dayjsTimestamp', from: './custom-types' },
+ *    };
+ *    ```
+ */
+export type ColumnTypeMapperOutput =
+	| { mode: 'string' | 'date' }
+	| {
+		/** Identifier of the custom type factory to use in generated code. */
+		typeName: string;
+		/** Import statement info so the generated file can reference the custom type. */
+		typeImport: {
+			/** Exported symbol name (may differ from `typeName` if re-exported). */
+			name: string;
+			/** Module specifier, e.g. `"./custom-types"` or `"my-drizzle-types"`. */
+			from: string;
+		};
+	};
+
+/**
+ * Callback invoked once per column during `drizzle-kit pull`.
+ * Return a {@link ColumnTypeMapperOutput} to override the generated column definition,
+ * or `undefined`/`null` to fall back to the default behaviour.
+ *
+ * @example – use native `Date` for all timestamps
+ * ```ts
+ * columnTypeMapper: ({ sqlType }) => {
+ *   if (sqlType.startsWith('timestamp')) return { mode: 'date' };
+ * }
+ * ```
+ *
+ * @example – replace timestamps with a dayjs custom type
+ * ```ts
+ * columnTypeMapper: ({ sqlType }) => {
+ *   if (sqlType.startsWith('timestamp')) {
+ *     return {
+ *       typeName: 'dayjsTimestamp',
+ *       typeImport: { name: 'dayjsTimestamp', from: './custom-types' },
+ *     };
+ *   }
+ * }
+ * ```
+ */
+export type ColumnTypeMapper = (
+	input: ColumnTypeMapperInput,
+) => ColumnTypeMapperOutput | null | undefined;
+
 export type Config =
 	& {
 		dialect: Dialect;
@@ -125,6 +203,11 @@ export type Config =
 		};
 		introspect?: {
 			casing: 'camel' | 'preserve';
+			/**
+			 * Customize how columns are rendered during `drizzle-kit pull`.
+			 * See {@link ColumnTypeMapper} for full documentation and examples.
+			 */
+			columnTypeMapper?: ColumnTypeMapper;
 		};
 		entities?: {
 			roles?: boolean | { provider?: 'supabase' | 'neon' | string & {}; exclude?: string[]; include?: string[] };

--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -2,6 +2,7 @@
 import { toCamelCase } from 'drizzle-orm/casing';
 import './@types/utils';
 import type { Casing } from './cli/validations/common';
+import type { ColumnTypeMapper, ColumnTypeMapperOutput } from './index';
 import { assertUnreachable } from './global';
 import {
 	CheckConstraint,
@@ -133,6 +134,7 @@ const dbColumnName = ({ name, casing, withMode = false }: { name: string; casing
 export const schemaToTypeScript = (
 	schema: MySqlSchemaInternal,
 	casing: Casing,
+	columnTypeMapper?: ColumnTypeMapper,
 ) => {
 	const withCasing = prepareCasing(casing);
 	// collectFKs
@@ -142,6 +144,9 @@ export const schemaToTypeScript = (
 			relations.add(relation);
 		});
 	});
+
+	// Accumulates custom type imports emitted by columnTypeMapper: from → Set<name>
+	const customImports = new Map<string, Set<string>>();
 
 	const imports = Object.values(schema.tables).reduce(
 		(res, it) => {
@@ -164,6 +169,17 @@ export const schemaToTypeScript = (
 			res.mysql.push(...checkImports);
 
 			const columnImports = Object.values(it.columns)
+				.filter((col) => {
+					if (!columnTypeMapper) return true;
+					const result = columnTypeMapper({
+						column: col.name,
+						table: it.name,
+						schema: undefined,
+						sqlType: col.type.toLowerCase(),
+						nullable: !col.notNull,
+					});
+					return !(result && 'typeName' in result);
+				})
 				.map((col) => {
 					let patched = importsPatch[col.type] ?? col.type;
 					patched = patched.startsWith('varchar(') ? 'varchar' : patched;
@@ -243,6 +259,8 @@ export const schemaToTypeScript = (
 			casing,
 			table.name,
 			schema,
+			columnTypeMapper,
+			customImports,
 		);
 		statement += '}';
 
@@ -305,6 +323,8 @@ export const schemaToTypeScript = (
 			casing,
 			name,
 			schema,
+			columnTypeMapper,
+			customImports,
 		);
 		statement += '})';
 
@@ -322,11 +342,18 @@ export const schemaToTypeScript = (
 		'AnyMySqlColumn',
 		...new Set(imports.mysql),
 	];
+
+	const customImportsTs = customImports.size > 0
+		? [...customImports.entries()]
+			.map(([from, names]) => `import { ${[...names].join(', ')} } from "${from}";`)
+			.join('\n') + '\n'
+		: '';
+
 	const importsTs = `import { ${
 		uniqueMySqlImports.join(
 			', ',
 		)
-	} } from "drizzle-orm/mysql-core"\nimport { sql } from "drizzle-orm"\n\n`;
+	} } from "drizzle-orm/mysql-core"\nimport { sql } from "drizzle-orm"\n${customImportsTs}\n`;
 
 	let decalrations = '';
 	decalrations += tableStatements.join('\n\n');
@@ -388,15 +415,38 @@ const column = (
 	name: string,
 	casing: (value: string) => string,
 	rawCasing: Casing,
+	tableName: string,
+	notNull: boolean,
 	defaultValue?: any,
 	autoincrement?: boolean,
 	onUpdate?: boolean,
 	isExpression?: boolean,
+	columnTypeMapper?: ColumnTypeMapper,
+	customImports?: Map<string, Set<string>>,
 ) => {
 	let lowered = type;
 	if (!type.startsWith('enum(')) {
 		lowered = type.toLowerCase();
 	}
+
+	const applyCustomType = (result: ColumnTypeMapperOutput & { typeName: string; typeImport: { name: string; from: string } }) => {
+		const { typeName, typeImport } = result;
+		if (customImports) {
+			const existing = customImports.get(typeImport.from) ?? new Set<string>();
+			existing.add(typeImport.name);
+			customImports.set(typeImport.from, existing);
+		}
+		return `${casing(name)}: ${typeName}(${dbColumnName({ name, casing: rawCasing })})`;
+	};
+
+	const invokeMapper = (sqlType: string) =>
+		columnTypeMapper?.({
+			column: name,
+			table: tableName,
+			schema: undefined,
+			sqlType,
+			nullable: !notNull,
+		});
 
 	if (lowered === 'serial') {
 		return `${casing(name)}: serial(${dbColumnName({ name, casing: rawCasing })})`;
@@ -530,13 +580,28 @@ const column = (
 	}
 
 	if (lowered.startsWith('timestamp')) {
+		const mapperResult = invokeMapper(lowered);
+
+		if (mapperResult && 'typeName' in mapperResult) {
+			let out = applyCustomType(mapperResult as any);
+			defaultValue = defaultValue === 'now()' || defaultValue === '(CURRENT_TIMESTAMP)'
+				? '.defaultNow()'
+				: defaultValue
+				? `.default(${mapColumnDefault(defaultValue, isExpression)})`
+				: '';
+			out += defaultValue;
+			out += onUpdate ? '.onUpdateNow()' : '';
+			return out;
+		}
+
 		const keyLength = 'timestamp'.length + 1;
 		let fsp = lowered.length > keyLength
 			? Number(lowered.substring(keyLength, lowered.length - 1))
 			: null;
 		fsp = fsp ? fsp : null;
 
-		const params = timeConfig({ fsp, mode: "'string'" });
+		const mode = mapperResult?.mode ?? 'string';
+		const params = timeConfig({ fsp, mode: `'${mode}'` });
 
 		let out = params
 			? `${casing(name)}: timestamp(${
@@ -583,11 +648,25 @@ const column = (
 	}
 
 	if (lowered === 'date') {
-		let out = `// you can use { mode: 'date' }, if you want to have Date as type for this column\n\t${
-			casing(
-				name,
-			)
-		}: date(${dbColumnName({ name, casing: rawCasing, withMode: true })}{ mode: 'string' })`;
+		const mapperResult = invokeMapper(lowered);
+
+		if (mapperResult && 'typeName' in mapperResult) {
+			let out = applyCustomType(mapperResult as any);
+			defaultValue = defaultValue === 'now()'
+				? '.defaultNow()'
+				: defaultValue
+				? `.default(${mapColumnDefault(defaultValue, isExpression)})`
+				: '';
+			out += defaultValue;
+			return out;
+		}
+
+		const mode = mapperResult?.mode ?? 'string';
+		let out = mode === 'date'
+			? `${casing(name)}: date(${dbColumnName({ name, casing: rawCasing, withMode: true })}{ mode: 'date' })`
+			: `// you can use { mode: 'date' }, if you want to have Date as type for this column\n\t${
+				casing(name)
+			}: date(${dbColumnName({ name, casing: rawCasing, withMode: true })}{ mode: 'string' })`;
 
 		defaultValue = defaultValue === 'now()'
 			? '.defaultNow()'
@@ -692,24 +771,35 @@ const column = (
 	}
 
 	if (lowered.startsWith('datetime')) {
-		let out = `// you can use { mode: 'date' }, if you want to have Date as type for this column\n\t`;
+		const mapperResult = invokeMapper(lowered);
+
+		if (mapperResult && 'typeName' in mapperResult) {
+			let out = applyCustomType(mapperResult as any);
+			defaultValue = defaultValue === 'now()'
+				? '.defaultNow()'
+				: defaultValue
+				? `.default(${mapColumnDefault(defaultValue, isExpression)})`
+				: '';
+			out += defaultValue;
+			return out;
+		}
 
 		const fsp = lowered.startsWith('datetime(')
 			? lowered.substring('datetime'.length + 1, lowered.length - 1)
 			: undefined;
 
-		out = fsp
-			? `${
-				casing(
-					name,
-				)
-			}: datetime(${dbColumnName({ name, casing: rawCasing, withMode: true })}{ mode: 'string', fsp: ${
-				lowered.substring(
-					'datetime'.length + 1,
-					lowered.length - 1,
-				)
-			} })`
-			: `${casing(name)}: datetime(${dbColumnName({ name, casing: rawCasing, withMode: true })}{ mode: 'string'})`;
+		const mode = mapperResult?.mode ?? 'string';
+		let out = fsp
+			? `${casing(name)}: datetime(${
+				dbColumnName({ name, casing: rawCasing, withMode: true })
+			}{ mode: '${mode}', fsp: ${fsp} })`
+			: `${casing(name)}: datetime(${
+				dbColumnName({ name, casing: rawCasing, withMode: true })
+			}{ mode: '${mode}'})`;
+
+		if (mode === 'string' && !fsp) {
+			out = `// you can use { mode: 'date' }, if you want to have Date as type for this column\n\t` + out;
+		}
 
 		defaultValue = defaultValue === 'now()'
 			? '.defaultNow()'
@@ -822,6 +912,8 @@ const createTableColumns = (
 	rawCasing: Casing,
 	tableName: string,
 	schema: MySqlSchemaInternal,
+	columnTypeMapper?: ColumnTypeMapper,
+	customImports?: Map<string, Set<string>>,
 ): string => {
 	let statement = '';
 
@@ -846,11 +938,15 @@ const createTableColumns = (
 			it.name,
 			casing,
 			rawCasing,
+			tableName,
+			it.notNull,
 			it.default,
 			it.autoincrement,
 			it.onUpdate,
 			schema.internal?.tables![tableName]?.columns[it.name]
 				?.isDefaultAnExpression ?? false,
+			columnTypeMapper,
+			customImports,
 		);
 		statement += it.primaryKey ? '.primaryKey()' : '';
 		statement += it.notNull ? '.notNull()' : '';

--- a/drizzle-kit/src/introspect-pg.ts
+++ b/drizzle-kit/src/introspect-pg.ts
@@ -1,4 +1,5 @@
 import { getTableName, is } from 'drizzle-orm';
+import type { ColumnTypeMapper, ColumnTypeMapperOutput } from './index';
 import { AnyPgTable } from 'drizzle-orm/pg-core';
 import {
 	createTableRelationsHelpers,
@@ -306,7 +307,11 @@ export const paramNameFor = (name: string, schema?: string) => {
 	return `${name}${schemaSuffix}`;
 };
 
-export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => {
+export const schemaToTypeScript = (
+	schema: PgSchemaInternal,
+	casing: Casing,
+	columnTypeMapper?: ColumnTypeMapper,
+) => {
 	// collectFKs
 	Object.values(schema.tables).forEach((table) => {
 		Object.values(table.foreignKeys).forEach((fk) => {
@@ -325,6 +330,9 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 		acc.add(`${cur.schema}.${cur.name}`);
 		return acc;
 	}, new Set<string>());
+
+	// Accumulates custom type imports emitted by columnTypeMapper: from → Set<name>
+	const customImports = new Map<string, Set<string>>();
 
 	const imports = Object.values(schema.tables).reduce(
 		(res, it) => {
@@ -356,6 +364,19 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 			res.pg.push(...checkImports);
 
 			const columnImports = Object.values(it.columns)
+				.filter((col) => {
+					// If the mapper returns a custom type for this column, skip adding
+					// the built-in Drizzle import so the generated file stays clean.
+					if (!columnTypeMapper) return true;
+					const result = columnTypeMapper({
+						column: col.name,
+						table: it.name,
+						schema: it.schema || undefined,
+						sqlType: col.type.toLowerCase().replace('[]', ''),
+						nullable: !col.notNull,
+					});
+					return !(result && 'typeName' in result);
+				})
 				.map((col) => {
 					let patched: string = (importsPatch[col.type] || col.type).replace('[]', '');
 					patched = patched === 'double precision' ? 'doublePrecision' : patched;
@@ -513,12 +534,15 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 		let statement = `export const ${withCasing(paramName, casing)} = ${func}("${table.name}", {\n`;
 		statement += createTableColumns(
 			table.name,
+			table.schema || undefined,
 			Object.values(table.columns),
 			Object.values(table.foreignKeys),
 			enumTypes,
 			schemas,
 			casing,
 			schema.internal,
+			columnTypeMapper,
+			customImports,
 		);
 		statement += '}';
 
@@ -582,33 +606,43 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 
 			const tablespace = it.tablespace ?? '';
 
-			const columns = createTableColumns(
-				'',
-				Object.values(it.columns),
-				[],
-				enumTypes,
-				schemas,
-				casing,
-				schema.internal,
-			);
+		const columns = createTableColumns(
+			'',
+			it.schema || undefined,
+			Object.values(it.columns),
+			[],
+			enumTypes,
+			schemas,
+			casing,
+			schema.internal,
+			columnTypeMapper,
+			customImports,
+		);
 
-			let statement = `export const ${withCasing(paramName, casing)} = ${func}("${it.name}", {${columns}})`;
-			statement += tablespace ? `.tablespace("${tablespace}")` : '';
-			statement += withOption ? `.with(${JSON.stringify(withOption)})` : '';
-			statement += `.as(${as});`;
+		let statement = `export const ${withCasing(paramName, casing)} = ${func}("${it.name}", {${columns}})`;
+		statement += tablespace ? `.tablespace("${tablespace}")` : '';
+		statement += withOption ? `.with(${JSON.stringify(withOption)})` : '';
+		statement += `.as(${as});`;
 
-			return statement;
-		})
-		.join('\n\n');
+		return statement;
+	})
+	.join('\n\n');
 
-	const uniquePgImports = ['pgTable', ...new Set(imports.pg)];
+const uniquePgImports = ['pgTable', ...new Set(imports.pg)];
 
-	const importsTs = `import { ${
-		uniquePgImports.join(
-			', ',
-		)
-	} } from "drizzle-orm/pg-core"
-import { sql } from "drizzle-orm"\n\n`;
+const customImportsTs = customImports.size > 0
+	? [...customImports.entries()]
+		.map(([from, names]) => `import { ${[...names].join(', ')} } from "${from}";`)
+		.join('\n') + '\n'
+	: '';
+
+const importsTs = `import { ${
+	uniquePgImports.join(
+		', ',
+	)
+} } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
+${customImportsTs}\n`;
 
 	let decalrations = schemaStatements;
 	decalrations += rolesStatements;
@@ -837,16 +871,30 @@ const mapDefault = (
 
 const column = (
 	tableName: string,
+	tableSchema: string | undefined,
 	type: string,
 	name: string,
 	enumTypes: Set<string>,
 	typeSchema: string,
 	casing: Casing,
+	notNull: boolean,
 	defaultValue?: any,
 	internals?: PgKitInternals,
+	columnTypeMapper?: ColumnTypeMapper,
+	customImports?: Map<string, Set<string>>,
 ) => {
 	const isExpression = internals?.tables[tableName]?.columns[name]?.isDefaultAnExpression ?? false;
 	const lowered = type.toLowerCase().replace('[]', '');
+
+	const applyCustomType = (result: ColumnTypeMapperOutput & { typeName: string; typeImport: { name: string; from: string } }) => {
+		const { typeName, typeImport } = result;
+		if (customImports) {
+			const existing = customImports.get(typeImport.from) ?? new Set<string>();
+			existing.add(typeImport.name);
+			customImports.set(typeImport.from, existing);
+		}
+		return `${withCasing(name, casing)}: ${typeName}(${dbColumnName({ name, casing })})`;
+	};
 
 	if (enumTypes.has(`${typeSchema}.${type.replace('[]', '')}`)) {
 		let out = `${withCasing(name, casing)}: ${withCasing(paramNameFor(type.replace('[]', ''), typeSchema), casing)}(${
@@ -922,17 +970,29 @@ const column = (
 	}
 
 	if (lowered.startsWith('timestamp')) {
+		const mapperResult = columnTypeMapper?.({
+			column: name,
+			table: tableName,
+			schema: tableSchema,
+			sqlType: lowered,
+			nullable: !notNull,
+		});
+
+		if (mapperResult && 'typeName' in mapperResult) {
+			return applyCustomType(mapperResult as any);
+		}
+
 		const withTimezone = lowered.includes('with time zone');
-		// const split = lowered.split(" ");
 		let precision = lowered.startsWith('timestamp(')
 			? Number(lowered.split(' ')[0].substring('timestamp('.length, lowered.split(' ')[0].length - 1))
 			: null;
 		precision = precision ? precision : null;
 
+		const mode = mapperResult?.mode ?? 'string';
 		const params = timeConfig({
 			precision,
 			withTimezone,
-			mode: "'string'",
+			mode: `'${mode}'`,
 		});
 
 		let out = params
@@ -975,7 +1035,23 @@ const column = (
 	}
 
 	if (lowered === 'date') {
-		let out = `${withCasing(name, casing)}: date(${dbColumnName({ name, casing })})`;
+		const mapperResult = columnTypeMapper?.({
+			column: name,
+			table: tableName,
+			schema: tableSchema,
+			sqlType: lowered,
+			nullable: !notNull,
+		});
+
+		if (mapperResult && 'typeName' in mapperResult) {
+			return applyCustomType(mapperResult as any);
+		}
+
+		const mode = mapperResult?.mode;
+		const params = mode ? `{ mode: '${mode}' }` : undefined;
+		let out = params
+			? `${withCasing(name, casing)}: date(${dbColumnName({ name, casing, withMode: true })}${params})`
+			: `${withCasing(name, casing)}: date(${dbColumnName({ name, casing })})`;
 
 		return out;
 	}
@@ -1111,12 +1187,15 @@ const dimensionsInArray = (size?: number): string => {
 
 const createTableColumns = (
 	tableName: string,
+	tableSchema: string | undefined,
 	columns: Column[],
 	fks: ForeignKey[],
 	enumTypes: Set<string>,
 	schemas: Record<string, string>,
 	casing: Casing,
 	internals: PgKitInternals,
+	columnTypeMapper?: ColumnTypeMapper,
+	customImports?: Map<string, Set<string>>,
 ): string => {
 	let statement = '';
 
@@ -1137,13 +1216,17 @@ const createTableColumns = (
 	columns.forEach((it) => {
 		const columnStatement = column(
 			tableName,
+			tableSchema,
 			it.type,
 			it.name,
 			enumTypes,
 			it.typeSchema ?? 'public',
 			casing,
+			it.notNull,
 			it.default,
 			internals,
+			columnTypeMapper,
+			customImports,
 		);
 		statement += '\t';
 		statement += columnStatement;

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -926,3 +926,132 @@ test('multiple policies with roles from schema', async () => {
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
 });
+
+// ---------------------------------------------------------------------------
+// columnTypeMapper tests
+// ---------------------------------------------------------------------------
+
+test('columnTypeMapper: mode override — timestamp columns use mode: date', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		events: pgTable('events', {
+			id: integer('id').primaryKey(),
+			createdAt: timestamp('created_at'),
+			startsAt: timestamp('starts_at', { withTimezone: true }),
+			endsAt: timestamp('ends_at', { precision: 3 }),
+		}),
+	};
+
+	const { file } = await introspectPgToFile(
+		client,
+		schema,
+		'column-type-mapper-mode-date',
+		['public'],
+		undefined,
+		undefined,
+		({ sqlType }) => {
+			if (sqlType.startsWith('timestamp')) return { mode: 'date' };
+		},
+	);
+
+	expect(file).toContain("mode: 'date'");
+	expect(file).not.toContain("mode: 'string'");
+});
+
+test('columnTypeMapper: custom type — timestamp columns replaced with custom type', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+			createdAt: timestamp('created_at'),
+			updatedAt: timestamp('updated_at', { withTimezone: true }),
+			name: text('name'),
+		}),
+	};
+
+	const { file } = await introspectPgToFile(
+		client,
+		schema,
+		'column-type-mapper-custom-type',
+		['public'],
+		undefined,
+		undefined,
+		({ sqlType }) => {
+			if (sqlType.startsWith('timestamp')) {
+				return {
+					typeName: 'dayjsTimestamp',
+					typeImport: { name: 'dayjsTimestamp', from: './custom-types' },
+				};
+			}
+		},
+	);
+
+	expect(file).toContain('import { dayjsTimestamp } from "./custom-types"');
+	expect(file).toContain('dayjsTimestamp(');
+	expect(file).not.toContain("mode: 'string'");
+	expect(file).toContain('text(');
+});
+
+test('columnTypeMapper: per-table targeting — only specific table uses custom type', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+			createdAt: timestamp('created_at'),
+		}),
+		events: pgTable('events', {
+			id: integer('id').primaryKey(),
+			startsAt: timestamp('starts_at'),
+		}),
+	};
+
+	const { file } = await introspectPgToFile(
+		client,
+		schema,
+		'column-type-mapper-per-table',
+		['public'],
+		undefined,
+		undefined,
+		({ table, sqlType }) => {
+			if (!sqlType.startsWith('timestamp')) return undefined;
+			if (table === 'events') {
+				return {
+					typeName: 'luxonTimestamp',
+					typeImport: { name: 'luxonTimestamp', from: './custom-types' },
+				};
+			}
+			return { mode: 'date' };
+		},
+	);
+
+	expect(file).toContain('import { luxonTimestamp } from "./custom-types"');
+	expect(file).toContain('luxonTimestamp(');
+	expect(file).toContain("mode: 'date'");
+	expect(file).not.toContain("mode: 'string'");
+});
+
+test('columnTypeMapper: undefined return — falls back to default string mode', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		logs: pgTable('logs', {
+			id: integer('id').primaryKey(),
+			loggedAt: timestamp('logged_at'),
+		}),
+	};
+
+	const { file } = await introspectPgToFile(
+		client,
+		schema,
+		'column-type-mapper-fallback',
+		['public'],
+		undefined,
+		undefined,
+		() => undefined,
+	);
+
+	expect(file).toContain("mode: 'string'");
+});

--- a/drizzle-kit/tests/introspect/postgres/custom-types.ts
+++ b/drizzle-kit/tests/introspect/postgres/custom-types.ts
@@ -1,0 +1,21 @@
+/**
+ * Stub custom type definitions used by the columnTypeMapper test fixtures.
+ * These use plain Date / string so no third-party date library is required.
+ */
+import { customType } from 'drizzle-orm/pg-core';
+
+export const dayjsTimestamp = customType<{ data: Date; driverData: string }>({
+	dataType() {
+		return 'timestamp';
+	},
+	fromDriver: (v: string) => new Date(v),
+	toDriver: (v: Date) => v.toISOString(),
+});
+
+export const luxonTimestamp = customType<{ data: Date; driverData: string }>({
+	dataType() {
+		return 'timestamp with time zone';
+	},
+	fromDriver: (v: string) => new Date(v),
+	toDriver: (v: Date) => v.toISOString(),
+});

--- a/drizzle-kit/tests/schemaDiffer.ts
+++ b/drizzle-kit/tests/schemaDiffer.ts
@@ -44,6 +44,7 @@ import { logSuggestionsAndReturn as singleStoreLogSuggestionsAndReturn } from 's
 import { logSuggestionsAndReturn } from 'src/cli/commands/sqlitePushUtils';
 import { Entities } from 'src/cli/validations/cli';
 import { CasingType } from 'src/cli/validations/common';
+import type { ColumnTypeMapper } from 'src/index';
 import { schemaToTypeScript as schemaToTypeScriptGel } from 'src/introspect-gel';
 import { schemaToTypeScript as schemaToTypeScriptMySQL } from 'src/introspect-mysql';
 import { schemaToTypeScript } from 'src/introspect-pg';
@@ -2307,6 +2308,7 @@ export const introspectPgToFile = async (
 	schemas: string[] = ['public'],
 	entities?: Entities,
 	casing?: CasingType | undefined,
+	columnTypeMapper?: ColumnTypeMapper,
 ) => {
 	// put in db
 	const { sqlStatements } = await applyPgDiffs(initSchema, casing);
@@ -2341,7 +2343,7 @@ export const introspectPgToFile = async (
 	const validatedCur = pgSchema.parse(initSch);
 
 	// write to ts file
-	const file = schemaToTypeScript(introspectedSchema, 'camel');
+	const file = schemaToTypeScript(introspectedSchema, 'camel', columnTypeMapper);
 
 	fs.writeFileSync(`tests/introspect/postgres/${testName}.ts`, file.file);
 
@@ -2399,6 +2401,7 @@ export const introspectPgToFile = async (
 	return {
 		sqlStatements: afterFileSqlStatements,
 		statements: afterFileStatements,
+		file: file.file,
 	};
 };
 

--- a/examples/introspect-column-type-mapper/custom-types.ts
+++ b/examples/introspect-column-type-mapper/custom-types.ts
@@ -1,0 +1,76 @@
+/**
+ * Example custom column type definitions for use with `columnTypeMapper`.
+ *
+ * Run `drizzle-kit pull` with one of the drizzle.config.*.ts files in this
+ * directory to see how the generated schema.ts changes based on the mapper.
+ *
+ * This file is written once by you and never overwritten by `drizzle-kit pull`.
+ */
+
+import { customType } from 'drizzle-orm/pg-core';
+
+// ---------------------------------------------------------------------------
+// dayjs example
+// Requires: npm install dayjs
+// ---------------------------------------------------------------------------
+
+import dayjs from 'dayjs';
+
+export const dayjsTimestamp = customType<{
+	data: dayjs.Dayjs;
+	driverData: string;
+}>({
+	dataType() {
+		return 'timestamp';
+	},
+	fromDriver(value: string): dayjs.Dayjs {
+		return dayjs(value);
+	},
+	toDriver(value: dayjs.Dayjs): string {
+		return value.toISOString();
+	},
+});
+
+// ---------------------------------------------------------------------------
+// luxon example
+// Requires: npm install luxon @types/luxon
+// ---------------------------------------------------------------------------
+
+import { DateTime } from 'luxon';
+
+export const luxonTimestamp = customType<{
+	data: DateTime;
+	driverData: string;
+}>({
+	dataType() {
+		return 'timestamp with time zone';
+	},
+	fromDriver(value: string): DateTime {
+		return DateTime.fromISO(value);
+	},
+	toDriver(value: DateTime): string {
+		return value.toISO()!;
+	},
+});
+
+// ---------------------------------------------------------------------------
+// Temporal (TC39 proposal) example
+// Requires: npm install @js-temporal/polyfill
+// ---------------------------------------------------------------------------
+
+import { Temporal } from '@js-temporal/polyfill';
+
+export const temporalInstant = customType<{
+	data: Temporal.Instant;
+	driverData: string;
+}>({
+	dataType() {
+		return 'timestamp with time zone';
+	},
+	fromDriver(value: string): Temporal.Instant {
+		return Temporal.Instant.from(value);
+	},
+	toDriver(value: Temporal.Instant): string {
+		return value.toString();
+	},
+});

--- a/examples/introspect-column-type-mapper/drizzle.config.date-mode.ts
+++ b/examples/introspect-column-type-mapper/drizzle.config.date-mode.ts
@@ -1,0 +1,31 @@
+/**
+ * Example 1 — Built-in mode override
+ *
+ * The simplest case: use Drizzle's native `Date` mode for all timestamp and
+ * date columns instead of the default `'string'` mode.
+ *
+ * Generated output changes from:
+ *   createdAt: timestamp("created_at", { mode: 'string' })
+ * to:
+ *   createdAt: timestamp("created_at", { mode: 'date' })
+ */
+
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+	dialect: 'postgresql',
+	dbCredentials: {
+		url: process.env.DATABASE_URL!,
+	},
+	out: './drizzle',
+	schema: './schema.ts',
+
+	introspect: {
+		casing: 'camel',
+		columnTypeMapper: ({ sqlType }) => {
+			if (sqlType.startsWith('timestamp') || sqlType === 'date') {
+				return { mode: 'date' };
+			}
+		},
+	},
+});

--- a/examples/introspect-column-type-mapper/drizzle.config.dayjs.ts
+++ b/examples/introspect-column-type-mapper/drizzle.config.dayjs.ts
@@ -1,0 +1,39 @@
+/**
+ * Example 2 — Custom type: dayjs
+ *
+ * Replace all timestamp columns with a custom `dayjsTimestamp` type defined in
+ * `./custom-types.ts`. The generated schema.ts will import `dayjsTimestamp`
+ * from `./custom-types` and use it instead of the built-in `timestamp()`.
+ *
+ * Generated output changes from:
+ *   import { timestamp, pgTable } from "drizzle-orm/pg-core"
+ *   createdAt: timestamp("created_at", { mode: 'string' })
+ *
+ * to:
+ *   import { pgTable } from "drizzle-orm/pg-core"
+ *   import { dayjsTimestamp } from "./custom-types";
+ *   createdAt: dayjsTimestamp("created_at")
+ */
+
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+	dialect: 'postgresql',
+	dbCredentials: {
+		url: process.env.DATABASE_URL!,
+	},
+	out: './drizzle',
+	schema: './schema.ts',
+
+	introspect: {
+		casing: 'camel',
+		columnTypeMapper: ({ sqlType }) => {
+			if (sqlType.startsWith('timestamp')) {
+				return {
+					typeName: 'dayjsTimestamp',
+					typeImport: { name: 'dayjsTimestamp', from: './custom-types' },
+				};
+			}
+		},
+	},
+});

--- a/examples/introspect-column-type-mapper/drizzle.config.mixed.ts
+++ b/examples/introspect-column-type-mapper/drizzle.config.mixed.ts
@@ -1,0 +1,49 @@
+/**
+ * Example 3 — Mixed strategy: jOOQ-style rule matching
+ *
+ * Demonstrates matching by column name, table name, and SQL type — the same
+ * flexibility that jOOQ's `forcedTypes` provides, expressed as plain TypeScript.
+ *
+ * Rules:
+ *  - `created_at` / `updated_at` / `deleted_at` on any table → dayjsTimestamp
+ *  - All other timestamps on the `events` table → luxonTimestamp
+ *  - All remaining timestamps → native Date mode
+ *  - Everything else → default (no override)
+ */
+
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+	dialect: 'postgresql',
+	dbCredentials: {
+		url: process.env.DATABASE_URL!,
+	},
+	out: './drizzle',
+	schema: './schema.ts',
+
+	introspect: {
+		casing: 'camel',
+		columnTypeMapper: ({ column, table, sqlType }) => {
+			if (!sqlType.startsWith('timestamp')) return undefined;
+
+			// Audit columns everywhere → dayjs
+			if (/^(created_at|updated_at|deleted_at)$/.test(column)) {
+				return {
+					typeName: 'dayjsTimestamp',
+					typeImport: { name: 'dayjsTimestamp', from: './custom-types' },
+				};
+			}
+
+			// Events table → luxon (for timezone-aware handling)
+			if (table === 'events') {
+				return {
+					typeName: 'luxonTimestamp',
+					typeImport: { name: 'luxonTimestamp', from: './custom-types' },
+				};
+			}
+
+			// All other timestamps → native Date
+			return { mode: 'date' };
+		},
+	},
+});


### PR DESCRIPTION
## Summary

- Adds `introspect.columnTypeMapper` to `drizzle.config.ts` — a callback invoked once per column during `drizzle-kit pull` that gives callers full control over how database column types are rendered in the generated schema file.
- Fixes #3843 — `timestamp` columns no longer need to be manually edited after every `pull` to remove or change the hardcoded `mode: 'string'`.
- Inspired by jOOQ's `forcedTypes` system: the same expressive power (match by SQL type, column name, table, schema, nullability) expressed as plain TypeScript instead of XML.

## Two return shapes

**1. Built-in mode override** — set `mode` on a Drizzle-native column:
```ts
introspect: {
  columnTypeMapper: ({ sqlType }) => {
    if (sqlType.startsWith('timestamp')) return { mode: 'date' };
  },
}
```

**2. Custom type reference** — replace the built-in call entirely with a user-defined `customType()`. The generator imports the symbol and emits it in place of e.g. `timestamp(...)`:
```ts
introspect: {
  columnTypeMapper: ({ sqlType }) => {
    if (sqlType.startsWith('timestamp')) {
      return {
        typeName: 'dayjsTimestamp',
        typeImport: { name: 'dayjsTimestamp', from: './custom-types' },
      };
    }
  },
}
```

Generated output changes from:
```ts
import { timestamp, pgTable } from "drizzle-orm/pg-core"
createdAt: timestamp("created_at", { mode: 'string' })
```
to:
```ts
import { pgTable } from "drizzle-orm/pg-core"
import { dayjsTimestamp } from "./custom-types";
createdAt: dayjsTimestamp("created_at")
```

## Affected dialects

- **PostgreSQL** — `timestamp`, `date`
- **MySQL** — `timestamp`, `date`, `datetime`

## Files changed

| File | Change |
|---|---|
| `src/index.ts` | New exported types: `ColumnTypeMapperInput`, `ColumnTypeMapperOutput`, `ColumnTypeMapper`; extended `Config.introspect` |
| `src/cli/commands/utils.ts` | Extract mapper from raw config before Zod parsing; thread through all dialect branches of `preparePullConfig` |
| `src/cli/schema.ts` | Destructure and forward `columnTypeMapper` to dialect introspect functions |
| `src/cli/commands/introspect.ts` | Updated `introspectPostgres` and `introspectMysql` signatures |
| `src/introspect-pg.ts` | Core changes: mapper param through `schemaToTypeScript` → `createTableColumns` → `column`; custom import deduplication via `Map<from, Set<name>>`; timestamp and date branches updated |
| `src/introspect-mysql.ts` | Same as above for timestamp, date, datetime |
| `tests/introspect/pg.test.ts` | 4 new test cases |
| `tests/schemaDiffer.ts` | `introspectPgToFile` accepts optional `columnTypeMapper` and returns `file` string |
| `tests/introspect/postgres/custom-types.ts` | Stub custom type definitions for tests |
| `examples/introspect-column-type-mapper/` | 4 example files covering date mode, dayjs, luxon, and mixed per-table rules |

## Test plan

- [x] All 38 existing + new pg introspect tests pass (`pnpm test -- tests/introspect/pg.test.ts`)
- [x] TypeScript type check passes (`pnpm tsc`)
- [ ] MySQL introspect tests (no new MySQL tests added yet — follow-up)

Made with [Cursor](https://cursor.com)