### PR TITLE
[SQLite]: replace SERIAL with INTEGER PRIMARY KEY AUTOINCREMENT in __drizzle_migrations

### DIFF
--- a/drizzle-orm/src/d1/migrator.ts
+++ b/drizzle-orm/src/d1/migrator.ts
@@ -12,7 +12,7 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 
 	const migrationTableCreate = sql`
 		CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-			id SERIAL PRIMARY KEY,
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			hash text NOT NULL,
 			created_at numeric
 		)

--- a/drizzle-orm/src/durable-sqlite/migrator.ts
+++ b/drizzle-orm/src/durable-sqlite/migrator.ts
@@ -52,7 +52,7 @@ export async function migrate<
 
 			const migrationTableCreate = sql`
 				CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-					id SERIAL PRIMARY KEY,
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
 					hash text NOT NULL,
 					created_at numeric
 				)

--- a/drizzle-orm/src/libsql/migrator.ts
+++ b/drizzle-orm/src/libsql/migrator.ts
@@ -12,7 +12,7 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 
 	const migrationTableCreate = sql`
 		CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-			id SERIAL PRIMARY KEY,
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			hash text NOT NULL,
 			created_at numeric
 		)

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -954,7 +954,7 @@ export class SQLiteSyncDialect extends SQLiteDialect {
 
 		const migrationTableCreate = sql`
 			CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-				id SERIAL PRIMARY KEY,
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				hash text NOT NULL,
 				created_at numeric
 			)
@@ -1011,7 +1011,7 @@ export class SQLiteAsyncDialect extends SQLiteDialect {
 
 		const migrationTableCreate = sql`
 			CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-				id SERIAL PRIMARY KEY,
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				hash text NOT NULL,
 				created_at numeric
 			)

--- a/drizzle-orm/src/sqlite-proxy/migrator.ts
+++ b/drizzle-orm/src/sqlite-proxy/migrator.ts
@@ -18,7 +18,7 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 
 	const migrationTableCreate = sql`
 		CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-			id SERIAL PRIMARY KEY,
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			hash text NOT NULL,
 			created_at numeric
 		)


### PR DESCRIPTION
Closes #5669.

`__drizzle_migrations` is created with `id SERIAL PRIMARY KEY,` across every SQLite migrator path. SQLite has no SERIAL type. It parses without error but the column ends up with no type affinity, so any INSERT that omits `id` (which is what the migrator does on every run) writes NULL.

### Files changed

```
drizzle-orm/src/sqlite-core/dialect.ts   (sync + async)
drizzle-orm/src/libsql/migrator.ts
drizzle-orm/src/d1/migrator.ts
drizzle-orm/src/durable-sqlite/migrator.ts
drizzle-orm/src/sqlite-proxy/migrator.ts
```

All six sites use the same CREATE TABLE block. `INTEGER PRIMARY KEY AUTOINCREMENT` makes the column the rowid alias and NULL-on-INSERT auto-fills as intended.

### Reproduction

```ts
import { Database } from 'bun:sqlite';

let db = new Database(':memory:');
db.run(`CREATE TABLE m (id SERIAL PRIMARY KEY, hash text)`);
db.run(`INSERT INTO m (hash) VALUES ('h1')`);
db.run(`INSERT INTO m (hash) VALUES ('h2')`);
console.log(db.query('SELECT * FROM m').all());
// [{"id":null,"hash":"h1"},{"id":null,"hash":"h2"}]

db = new Database(':memory:');
db.run(`CREATE TABLE m (id INTEGER PRIMARY KEY AUTOINCREMENT, hash text)`);
db.run(`INSERT INTO m (hash) VALUES ('h1')`);
db.run(`INSERT INTO m (hash) VALUES ('h2')`);
console.log(db.query('SELECT * FROM m').all());
// [{"id":1,"hash":"h1"},{"id":2,"hash":"h2"}]
```

### Existing tables

`CREATE TABLE IF NOT EXISTS` means already-created `__drizzle_migrations` tables keep the broken schema. New databases get the correct schema. The migrator only reads `created_at`, not `id`, so the NULL ids don't currently break user workflows, but the row type signature `[number, string, string]` no longer lies.

A follow-up that rebuilds the table on first run is possible but has backward-compat considerations beyond this fix.