### PR TITLE
fix(eslint-plugin): correct rule options schema to properly type array items

### DIFF
--- a/eslint-plugin-drizzle/src/enforce-delete-with-where.ts
+++ b/eslint-plugin-drizzle/src/enforce-delete-with-where.ts
@@ -25,7 +25,13 @@ const deleteRule = createRule<Options, MessageIds>({
 			type: 'object',
 			properties: {
 				drizzleObjectName: {
-					type: ['string', 'array'],
+					oneOf: [
+						{ type: 'string' },
+						{
+							type: 'array',
+							items: { type: 'string' },
+						},
+					],
 				},
 			},
 			additionalProperties: false,

--- a/eslint-plugin-drizzle/src/enforce-update-with-where.ts
+++ b/eslint-plugin-drizzle/src/enforce-update-with-where.ts
@@ -24,7 +24,13 @@ const updateRule = createRule<Options, MessageIds>({
 			type: 'object',
 			properties: {
 				drizzleObjectName: {
-					type: ['string', 'array'],
+					oneOf: [
+						{ type: 'string' },
+						{
+							type: 'array',
+							items: { type: 'string' },
+						},
+					],
 				},
 			},
 			additionalProperties: false,


### PR DESCRIPTION
The `drizzleObjectName` option type in both of the existing rules does not constrain the type of array items, which allows to pass non-strings without any validation. This PR adds the correct constraints to schemas to prevent that. 