### PR TITLE
[Pg-kit]: Suppress postgres.js NOTICE output in preparePostgresDB

### DIFF
--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -281,8 +281,8 @@ export const preparePostgresDB = async (
 		const { migrate } = await import('drizzle-orm/postgres-js/migrator');
 
 		const client = 'url' in credentials
-			? postgres.default(credentials.url, { max: 1 })
-			: postgres.default({ ...credentials, max: 1 });
+			? postgres.default(credentials.url, { max: 1, onnotice: () => {} })
+			: postgres.default({ ...credentials, max: 1, onnotice: () => {} });
 
 		const transparentParser = (val: any) => val;
 

--- a/drizzle-kit/tests/pg-connections-notice.test.ts
+++ b/drizzle-kit/tests/pg-connections-notice.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+const mockClient = {
+	options: {
+		parsers: {} as Record<string, unknown>,
+		serializers: {} as Record<string, unknown>,
+	},
+	unsafe: vi.fn(),
+	begin: vi.fn(),
+};
+const mockPostgres = vi.fn(() => mockClient);
+
+vi.mock('src/cli/utils', async (importOriginal) => {
+	const original = await importOriginal<typeof import('src/cli/utils')>();
+	return {
+		...original,
+		// Simulate an environment where only postgres (not pg) is installed,
+		// so preparePostgresDB takes the postgres.js branch.
+		checkPackage: vi.fn(async (pkg: string) => pkg === 'postgres'),
+	};
+});
+vi.mock('postgres', () => ({ default: mockPostgres }));
+vi.mock('drizzle-orm/postgres-js', () => ({ drizzle: vi.fn(() => ({})) }));
+vi.mock('drizzle-orm/postgres-js/migrator', () => ({ migrate: vi.fn() }));
+
+afterEach(() => {
+	mockPostgres.mockClear();
+	mockClient.options.parsers = {};
+	mockClient.options.serializers = {};
+	vi.restoreAllMocks();
+});
+
+test('preparePostgresDB passes onnotice to postgres.js (url path)', async () => {
+	vi.spyOn(console, 'log').mockImplementation(() => {});
+	const { preparePostgresDB } = await import('src/cli/connections');
+
+	await preparePostgresDB({ url: 'postgres://localhost/test' });
+
+	expect(mockPostgres).toHaveBeenCalledOnce();
+	const [, options] = mockPostgres.mock.calls[0] as [string, Record<string, unknown>];
+	expect(options).toMatchObject({ onnotice: expect.any(Function) });
+	// Must be a no-op — IF NOT EXISTS notices should be silently discarded
+	expect((options.onnotice as () => void)()).toBeUndefined();
+});
+
+test('preparePostgresDB passes onnotice to postgres.js (credentials-object path)', async () => {
+	vi.spyOn(console, 'log').mockImplementation(() => {});
+	const { preparePostgresDB } = await import('src/cli/connections');
+
+	await preparePostgresDB({
+		host: 'localhost',
+		port: 5432,
+		database: 'test',
+		user: 'postgres',
+		password: 'postgres',
+		ssl: false,
+	});
+
+	expect(mockPostgres).toHaveBeenCalledOnce();
+	const [options] = mockPostgres.mock.calls[0] as [Record<string, unknown>];
+	expect(options).toMatchObject({ onnotice: expect.any(Function) });
+	expect((options.onnotice as () => void)()).toBeUndefined();
+});


### PR DESCRIPTION
Running `drizzle-kit migrate`, `push`, `introspect`, or `studio` against PostgreSQL with the `postgres` driver prints raw NOTICE objects to stdout on every run after the first:

```
{
  severity_local: 'NOTICE',
  severity: 'NOTICE',
  code: '42P06',
  message: 'schema "drizzle" already exists, skipping',
  ...
}
```

The migration succeeds, but the output looks like errors.

## Root cause

`postgres.js` routes NOTICE messages to an `onnotice` callback. When none is set, it prints the raw message object to stdout. Drizzle's setup statements use `IF NOT EXISTS`, so PostgreSQL correctly skips them with a NOTICE on every subsequent run. `preparePostgresDB` was creating the postgres client without an `onnotice` handler, so all those NOTICEs hit stdout.

`pg` (node-postgres) handles this differently: it routes NOTICEs through client events and doesn't print them by default. The problem is specific to the `postgres.js` driver path.

## Fix

Pass `onnotice: () => {}` when constructing the client, for both the url-string and credentials-object paths:

```ts
// before
postgres.default(credentials.url, { max: 1 })
// after
postgres.default(credentials.url, { max: 1, onnotice: () => {} })
```

Two lines changed in `connections.ts`.

## Tests

Added `drizzle-kit/tests/pg-connections-notice.test.ts` with two unit tests. They mock the `postgres` module and assert that `onnotice` is passed on both code paths (url string and credentials object), and that the handler is a no-op.

All existing Postgres tests in drizzle-kit use PGlite, which doesn't exercise the `postgres.js` driver path, so these are unit tests rather than integration tests. Testing the stdout-suppression behavior directly requires a live postgres.js connection. I can set one up if you'd prefer that.

Fixes #5643