### PR TITLE
chore(drizzle-kit): drop deprecated @esbuild-kit/esm-loader dependency

### DIFF
--- a/drizzle-kit/build.dev.ts
+++ b/drizzle-kit/build.dev.ts
@@ -24,7 +24,7 @@ esbuild.buildSync({
 	platform: 'node',
 	external: ['drizzle-orm', 'esbuild', ...driversPackages],
 	banner: {
-		js: `#!/usr/bin/env -S node --loader @esbuild-kit/esm-loader --no-warnings`,
+		js: `#!/usr/bin/env node`,
 	},
 });
 

--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -44,7 +44,6 @@
 	},
 	"dependencies": {
 		"@drizzle-team/brocli": "^0.10.2",
-		"@esbuild-kit/esm-loader": "^2.5.5",
 		"esbuild": "^0.25.4",
 		"tsx": "^4.21.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,6 @@ importers:
       '@drizzle-team/brocli':
         specifier: ^0.10.2
         version: 0.10.2
-      '@esbuild-kit/esm-loader':
-        specifier: ^2.5.5
-        version: 2.6.5
       esbuild:
         specifier: ^0.25.4
         version: 0.25.5


### PR DESCRIPTION
## Summary

`drizzle-kit` ships `@esbuild-kit/esm-loader` as a runtime dependency. It was deprecated in favor of `tsx` (already a runtime dep of drizzle-kit), so every consumer install prints:

```
npm warn deprecated @esbuild-kit/esm-loader@2.6.5: Merged into tsx: https://tsx.is
npm warn deprecated @esbuild-kit/core-utils@3.3.2: Merged into tsx: https://tsx.is
```

The package is vestigial: `src/cli/commands/utils.ts` already loads TypeScript via `require('tsx/cjs/api')`, and nothing under `src/` imports `@esbuild-kit/esm-loader`. The only remaining reference was a stale shebang in `build.dev.ts`.

## Changes

- Remove `@esbuild-kit/esm-loader` from `drizzle-kit/package.json` `dependencies`.
- `build.dev.ts`: change the `dist/utils.js` shebang from `#!/usr/bin/env -S node --loader @esbuild-kit/esm-loader --no-warnings` to plain `#!/usr/bin/env node` (matches `build.ts`; `utils.js` is not a bin entry, so the loader was unused).
- Regenerated `pnpm-lock.yaml`. `@esbuild-kit/esm-loader` and its transitive `@esbuild-kit/core-utils` (which pulled `esbuild@0.18.20`) are gone from the drizzle-kit importer.

`tsx` stays in `dependencies` — it is not deprecated; it is the package the `@esbuild-kit/*` modules were merged into. It is still needed at runtime for the `drizzle-kit/api` subpath, where tsup leaves `require("tsx/cjs/api")` as a deferred runtime require.

## Related

- Partially addresses #5481 — removes the deprecated `@esbuild-kit/*` chain and the `esbuild@0.18.20` copy it carried. Does **not** bump the direct `esbuild` dep (still `^0.25.4`); that's a separate change.
- Related: #5290

## Test plan

- [x] `pnpm tsc -p tsconfig.build.json --noEmit` — passes
- [x] `pnpm build` (tsup + esbuild + attw) — passes; `attw` reports green for node10 / node16 CJS / node16 ESM / bundler
- [x] `pnpm build:dev` — passes
- [x] `node dist/bin.cjs --help` and `node dist/index.cjs --help` (dev bin) — both run
- [x] `grep -r "@esbuild-kit" dist/` — zero hits
- [x] Fresh consumer install of the packed tarball into a throwaway project: `npm install drizzle-kit-0.31.10.tgz` completes with zero deprecation warnings, and `node_modules/@esbuild-kit` does not exist.
- [ ] CI green