### PR TITLE
fix(rqb-v2): report type error for unknown column keys in where filter

### DIFF
--- a/drizzle-orm/src/gel-core/query-builders/query.ts
+++ b/drizzle-orm/src/gel-core/query-builders/query.ts
@@ -32,7 +32,14 @@ export class RelationalQueryBuilder<
 	) {}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): PgRelationalQuery<BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return new PgRelationalQuery(
 			this.schema,
@@ -46,7 +53,14 @@ export class RelationalQueryBuilder<
 	}
 
 	findFirst<TConfig extends DBQueryConfig<'one', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'one', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'one', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): PgRelationalQuery<BuildQueryResult<TSchema, TFields, TConfig> | undefined> {
 		return new PgRelationalQuery(
 			this.schema,

--- a/drizzle-orm/src/mysql-core/query-builders/query.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/query.ts
@@ -33,6 +33,12 @@ export class RelationalQueryBuilder<
 	findMany<TConfig extends DBQueryConfigWithComment<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfigWithComment<'many', TSchema, TFields>> & {
 			comment?: SqlCommenterInput;
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfigWithComment<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
 		},
 	): MySqlRelationalQuery<TPreparedQueryHKT, BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return new MySqlRelationalQuery(
@@ -49,6 +55,12 @@ export class RelationalQueryBuilder<
 	findFirst<TSelection extends DBQueryConfigWithComment<'one', TSchema, TFields>>(
 		config?: KnownKeysOnly<TSelection, DBQueryConfigWithComment<'one', TSchema, TFields>> & {
 			comment?: SqlCommenterInput;
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TSelection['where']>,
+					NonNullable<DBQueryConfigWithComment<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
 		},
 	): MySqlRelationalQuery<TPreparedQueryHKT, BuildQueryResult<TSchema, TFields, TSelection> | undefined> {
 		return new MySqlRelationalQuery(

--- a/drizzle-orm/src/pg-core/query-builders/query.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query.ts
@@ -47,6 +47,12 @@ export class RelationalQueryBuilder<
 	findMany<TConfig extends DBQueryConfigWithComment<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfigWithComment<'many', TSchema, TFields>> & {
 			comment?: SqlCommenterInput;
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfigWithComment<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
 		},
 	): PgRelationalQueryKind<TBuilderHKT, BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return new this.builder(
@@ -64,6 +70,12 @@ export class RelationalQueryBuilder<
 	findFirst<TConfig extends DBQueryConfigWithComment<'one', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfigWithComment<'one', TSchema, TFields>> & {
 			comment?: SqlCommenterInput;
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfigWithComment<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
 		},
 	): PgRelationalQueryKind<TBuilderHKT, BuildQueryResult<TSchema, TFields, TConfig> | undefined> {
 		return new this.builder(

--- a/drizzle-orm/src/singlestore-core/query-builders/query.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/query.ts
@@ -36,7 +36,14 @@ export class RelationalQueryBuilder<
 	) {}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): SingleStoreRelationalQuery<TPreparedQueryHKT, BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return new SingleStoreRelationalQuery(
 			this.schema,
@@ -50,7 +57,14 @@ export class RelationalQueryBuilder<
 	}
 
 	findFirst<TSelection extends DBQueryConfig<'one', TSchema, TFields>>(
-		config?: KnownKeysOnly<TSelection, DBQueryConfig<'one', TSchema, TFields>>,
+		config?: KnownKeysOnly<TSelection, DBQueryConfig<'one', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TSelection['where']>,
+					NonNullable<DBQueryConfig<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): SingleStoreRelationalQuery<TPreparedQueryHKT, BuildQueryResult<TSchema, TFields, TSelection> | undefined> {
 		return new SingleStoreRelationalQuery(
 			this.schema,

--- a/drizzle-orm/src/sqlite-core/query-builders/query.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/query.ts
@@ -39,7 +39,14 @@ export class RelationalQueryBuilder<
 	}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): SQLiteRelationalQueryKind<TMode, BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return this.mode === 'sync'
 			? new SQLiteSyncRelationalQuery(
@@ -67,7 +74,14 @@ export class RelationalQueryBuilder<
 	}
 
 	findFirst<TConfig extends DBQueryConfig<'one', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'one', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'one', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): SQLiteRelationalQueryKind<TMode, BuildQueryResult<TSchema, TFields, TConfig> | undefined> {
 		return this.mode === 'sync'
 			? new SQLiteSyncRelationalQuery(

--- a/drizzle-orm/type-tests/pg/rqb-v2-where.ts
+++ b/drizzle-orm/type-tests/pg/rqb-v2-where.ts
@@ -1,0 +1,51 @@
+import { integer, pgTable, text } from '~/pg-core/index.ts';
+import { drizzle } from '~/postgres-js/index.ts';
+import { defineRelations } from '~/relations.ts';
+
+const contacts = pgTable('contacts', {
+	id: integer('id'),
+	name: text('name'),
+	contact1: text('contact1'),
+});
+
+// Single-table schema; no cross-table relations needed for this test
+const rels = defineRelations({ contacts }, () => ({}));
+const db = drizzle.mock({ relations: rels });
+
+// --- findFirst ---
+
+// Valid: known column keys
+db.query.contacts.findFirst({ where: { id: 1 } });
+db.query.contacts.findFirst({ where: { name: 'Alice' } });
+db.query.contacts.findFirst({ where: { contact1: '010' } });
+
+// Valid: logical combinators
+db.query.contacts.findFirst({ where: { OR: [{ id: 1 }, { id: 2 }] } });
+db.query.contacts.findFirst({ where: { AND: [{ id: 1 }, { name: 'Alice' }] } });
+db.query.contacts.findFirst({ where: { NOT: { id: 1 } } });
+
+// Valid: omitting where entirely
+db.query.contacts.findFirst({});
+db.query.contacts.findFirst({ where: undefined });
+
+// Invalid: contact2 is not a column on contacts
+// @ts-expect-error
+db.query.contacts.findFirst({ where: { contact2: '010' } });
+
+// Invalid: mix of valid and invalid keys
+// @ts-expect-error
+db.query.contacts.findFirst({ where: { id: 1, nonExistentColumn: 'bad' } });
+
+// --- findMany ---
+
+// Valid
+db.query.contacts.findMany({ where: { id: 1 } });
+db.query.contacts.findMany({});
+
+// Invalid: contact2 is not a column
+// @ts-expect-error
+db.query.contacts.findMany({ where: { contact2: 'foo' } });
+
+// Invalid: mix
+// @ts-expect-error
+db.query.contacts.findMany({ where: { id: 1, contact2: 'foo' } });


### PR DESCRIPTION
**Fixes #5644**

When using RQB v2, passing a non-existent column name in a `where` filter compiles without any TypeScript error:

```ts
db.query.contacts.findFirst({
  where: { contact2: '010' }  // contact2 doesn't exist — no error today
})
```

The root cause is TypeScript's structural subtyping. When an object literal is passed through a generic type parameter (`TConfig extends DBQueryConfig<...>`), TypeScript doesn't apply excess property checking to nested objects. So `KnownKeysOnly` at the top level of `config` catches unknown *config* keys but lets unknown *column* keys inside `where` pass silently.

The fix adds a second `KnownKeysOnly` constraint specifically for the `where` value in an intersection type on each `findFirst`/`findMany` signature. When a key isn't in `keyof RelationsFilter`, it maps to `never`, making any value for a non-existent column a compile error. Valid usage (known columns, OR/AND/NOT/RAW operators, omitting where) is unaffected.

Applied to all five v2 dialects: SQLite, PostgreSQL, MySQL, SingleStore, and Gel. The PR also adds `type-tests/pg/rqb-v2-where.ts` with both the valid and invalid cases to prevent regression.

No runtime changes.