### PR TITLE
fix(drizzle-kit): add missing policy filter in aws-introspect, align policiesQuery

### DIFF
--- a/drizzle-kit/src/dialects/postgres/aws-introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/aws-introspect.ts
@@ -1202,6 +1202,8 @@ export const fromDatabase = async (
 	progressCallback('checks', checksCount, 'done');
 	progressCallback('views', viewsCount, 'done');
 
+	const resultPolicies = policies.filter((p) => tables.some((t) => t.schema === p.schema && t.name === p.table));
+
 	return {
 		schemas,
 		tables,
@@ -1215,7 +1217,7 @@ export const fromDatabase = async (
 		sequences,
 		roles,
 		privileges,
-		policies,
+		policies: resultPolicies,
 		views,
 		viewColumns,
 	} satisfies InterimSchema;

--- a/drizzle-kit/src/dialects/postgres/introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/introspect.ts
@@ -365,42 +365,41 @@ export const fromDatabase = async (
 			})
 		: [] as SequenceListItem[];
 
-	// I'm not yet aware of how we handle policies down the pipeline for push,
-	// and since postgres does not have any default policies, we can safely fetch all of them for now
-	// and filter them out in runtime, simplifying filterings
+	type PolicyListItem = {
+		schema: string;
+		table: string;
+		name: string;
+		as: Policy['as'];
+		to: string | string[];
+		for: Policy['for'];
+		using: string | undefined | null;
+		withCheck: string | undefined | null;
+	};
 	progressCallback('policies', 0, 'fetching');
-	const policiesQuery = db.query<
-		{
-			schema: string;
-			table: string;
-			name: string;
-			as: Policy['as'];
-			to: string | string[];
-			for: Policy['for'];
-			using: string | undefined | null;
-			withCheck: string | undefined | null;
-		}
-	>(`SELECT 
-			schemaname as "schema", 
-			tablename as "table", 
-			policyname as "name", 
-			permissive as "as", 
-			roles as "to", 
-			cmd as "for", 
-			qual as "using", 
-			with_check as "withCheck" 
-		FROM pg_catalog.pg_policies
-		ORDER BY
-			pg_catalog.lower(schemaname),
-			pg_catalog.lower(tablename),
-			pg_catalog.lower(policyname);
-	`).then((rows) => {
-		queryCallback('policies', rows, null);
-		return rows;
-	}).catch((err) => {
-		queryCallback('policies', [], err);
-		throw err;
-	});
+	const policiesQuery = filteredNamespacesStringForSQL
+		? db.query<PolicyListItem>(`SELECT
+				schemaname as "schema",
+				tablename as "table",
+				policyname as "name",
+				permissive as "as",
+				roles as "to",
+				cmd as "for",
+				qual as "using",
+				with_check as "withCheck"
+			FROM pg_catalog.pg_policies
+			WHERE schemaname IN (${filteredNamespacesStringForSQL})
+			ORDER BY
+				pg_catalog.lower(schemaname),
+				pg_catalog.lower(tablename),
+				pg_catalog.lower(policyname);
+		`).then((rows) => {
+			queryCallback('policies', rows, null);
+			return rows;
+		}).catch((err) => {
+			queryCallback('policies', [], err);
+			throw err;
+		})
+		: [] as PolicyListItem[];
 
 	const rolesQuery = db.query<
 		{

--- a/drizzle-kit/tests/postgres/pg-policy.test.ts
+++ b/drizzle-kit/tests/postgres/pg-policy.test.ts
@@ -1849,33 +1849,22 @@ $$;`);
 });
 
 // Regression test for issue #5655
-// schemaFilter: ['public'] must not generate DROP POLICY for policies in excluded schemas
 test('schemaFilter: excluded schema policies are not dropped', async () => {
-	// Set up storage schema with a table, RLS, and a policy in the DB directly.
-	// This simulates a Supabase-style setup where storage.objects has built-in policies
-	// that the user did not define and must never be touched by drizzle-kit push.
+	// Simulates a Supabase-style setup: storage schema with RLS policies exists in the DB
+	// but is not managed by drizzle-kit. push({ schemas: ['public'] }) must not touch it.
 	await db.query(`CREATE SCHEMA storage`);
 	await db.query(`CREATE TABLE storage.objects (id integer PRIMARY KEY, name text)`);
 	await db.query(`ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY`);
 	await db.query(`CREATE POLICY "storage_select" ON storage.objects AS PERMISSIVE FOR SELECT TO PUBLIC USING (true)`);
 
-	// User schema: only public schema tables with their own policy.
 	const usersTable = pgTable(
 		'users',
 		{ id: integer('id').primaryKey() },
 		() => [pgPolicy('public_select', { as: 'permissive', for: 'select' })],
 	);
 
-	const to = { usersTable };
+	const { sqlStatements: pst } = await push({ db, to: { usersTable }, schemas: ['public'] });
 
-	// With schemas: ['public'], push must not generate any statement for storage.objects or its policy.
-	const { sqlStatements: pst } = await push({ db, to, schemas: ['public'] });
-
-	const dropsStorage = pst.some((s) => s.toLowerCase().includes('storage'));
-	expect(dropsStorage).toBe(false);
-
-	const dropsPolicies = pst.some(
-		(s) => s.toLowerCase().includes('drop policy') && s.toLowerCase().includes('storage'),
-	);
-	expect(dropsPolicies).toBe(false);
+	expect(pst.some((s) => s.toLowerCase().includes('storage'))).toBe(false);
+	expect(pst.some((s) => s.toLowerCase().includes('create table') && s.toLowerCase().includes('users'))).toBe(true);
 });

--- a/drizzle-kit/tests/postgres/pg-policy.test.ts
+++ b/drizzle-kit/tests/postgres/pg-policy.test.ts
@@ -1847,3 +1847,35 @@ $$;`);
 	expect(st2).toStrictEqual([]);
 	expect(pst2).toStrictEqual([]);
 });
+
+// Regression test for issue #5655
+// schemaFilter: ['public'] must not generate DROP POLICY for policies in excluded schemas
+test('schemaFilter: excluded schema policies are not dropped', async () => {
+	// Set up storage schema with a table, RLS, and a policy in the DB directly.
+	// This simulates a Supabase-style setup where storage.objects has built-in policies
+	// that the user did not define and must never be touched by drizzle-kit push.
+	await db.query(`CREATE SCHEMA storage`);
+	await db.query(`CREATE TABLE storage.objects (id integer PRIMARY KEY, name text)`);
+	await db.query(`ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY`);
+	await db.query(`CREATE POLICY "storage_select" ON storage.objects AS PERMISSIVE FOR SELECT TO PUBLIC USING (true)`);
+
+	// User schema: only public schema tables with their own policy.
+	const usersTable = pgTable(
+		'users',
+		{ id: integer('id').primaryKey() },
+		() => [pgPolicy('public_select', { as: 'permissive', for: 'select' })],
+	);
+
+	const to = { usersTable };
+
+	// With schemas: ['public'], push must not generate any statement for storage.objects or its policy.
+	const { sqlStatements: pst } = await push({ db, to, schemas: ['public'] });
+
+	const dropsStorage = pst.some((s) => s.toLowerCase().includes('storage'));
+	expect(dropsStorage).toBe(false);
+
+	const dropsPolicies = pst.some(
+		(s) => s.toLowerCase().includes('drop policy') && s.toLowerCase().includes('storage'),
+	);
+	expect(dropsPolicies).toBe(false);
+});

--- a/drizzle-orm/src/gel-core/query-builders/query.ts
+++ b/drizzle-orm/src/gel-core/query-builders/query.ts
@@ -32,7 +32,14 @@ export class RelationalQueryBuilder<
 	) {}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): PgRelationalQuery<BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return new PgRelationalQuery(
 			this.schema,
@@ -46,7 +53,14 @@ export class RelationalQueryBuilder<
 	}
 
 	findFirst<TConfig extends DBQueryConfig<'one', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'one', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'one', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): PgRelationalQuery<BuildQueryResult<TSchema, TFields, TConfig> | undefined> {
 		return new PgRelationalQuery(
 			this.schema,

--- a/drizzle-orm/src/mysql-core/query-builders/query.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/query.ts
@@ -33,6 +33,12 @@ export class RelationalQueryBuilder<
 	findMany<TConfig extends DBQueryConfigWithComment<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfigWithComment<'many', TSchema, TFields>> & {
 			comment?: SqlCommenterInput;
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfigWithComment<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
 		},
 	): MySqlRelationalQuery<TPreparedQueryHKT, BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return new MySqlRelationalQuery(
@@ -49,6 +55,12 @@ export class RelationalQueryBuilder<
 	findFirst<TSelection extends DBQueryConfigWithComment<'one', TSchema, TFields>>(
 		config?: KnownKeysOnly<TSelection, DBQueryConfigWithComment<'one', TSchema, TFields>> & {
 			comment?: SqlCommenterInput;
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TSelection['where']>,
+					NonNullable<DBQueryConfigWithComment<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
 		},
 	): MySqlRelationalQuery<TPreparedQueryHKT, BuildQueryResult<TSchema, TFields, TSelection> | undefined> {
 		return new MySqlRelationalQuery(

--- a/drizzle-orm/src/pg-core/query-builders/query.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query.ts
@@ -47,6 +47,12 @@ export class RelationalQueryBuilder<
 	findMany<TConfig extends DBQueryConfigWithComment<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfigWithComment<'many', TSchema, TFields>> & {
 			comment?: SqlCommenterInput;
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfigWithComment<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
 		},
 	): PgRelationalQueryKind<TBuilderHKT, BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return new this.builder(
@@ -64,6 +70,12 @@ export class RelationalQueryBuilder<
 	findFirst<TConfig extends DBQueryConfigWithComment<'one', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfigWithComment<'one', TSchema, TFields>> & {
 			comment?: SqlCommenterInput;
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfigWithComment<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
 		},
 	): PgRelationalQueryKind<TBuilderHKT, BuildQueryResult<TSchema, TFields, TConfig> | undefined> {
 		return new this.builder(

--- a/drizzle-orm/src/singlestore-core/query-builders/query.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/query.ts
@@ -36,7 +36,14 @@ export class RelationalQueryBuilder<
 	) {}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): SingleStoreRelationalQuery<TPreparedQueryHKT, BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return new SingleStoreRelationalQuery(
 			this.schema,
@@ -50,7 +57,14 @@ export class RelationalQueryBuilder<
 	}
 
 	findFirst<TSelection extends DBQueryConfig<'one', TSchema, TFields>>(
-		config?: KnownKeysOnly<TSelection, DBQueryConfig<'one', TSchema, TFields>>,
+		config?: KnownKeysOnly<TSelection, DBQueryConfig<'one', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TSelection['where']>,
+					NonNullable<DBQueryConfig<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): SingleStoreRelationalQuery<TPreparedQueryHKT, BuildQueryResult<TSchema, TFields, TSelection> | undefined> {
 		return new SingleStoreRelationalQuery(
 			this.schema,

--- a/drizzle-orm/src/sqlite-core/query-builders/query.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/query.ts
@@ -39,7 +39,14 @@ export class RelationalQueryBuilder<
 	}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'many', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): SQLiteRelationalQueryKind<TMode, BuildQueryResult<TSchema, TFields, TConfig>[]> {
 		return this.mode === 'sync'
 			? new SQLiteSyncRelationalQuery(
@@ -67,7 +74,14 @@ export class RelationalQueryBuilder<
 	}
 
 	findFirst<TConfig extends DBQueryConfig<'one', TSchema, TFields>>(
-		config?: KnownKeysOnly<TConfig, DBQueryConfig<'one', TSchema, TFields>>,
+		config?: KnownKeysOnly<TConfig, DBQueryConfig<'one', TSchema, TFields>> & {
+			where?:
+				| KnownKeysOnly<
+					NonNullable<TConfig['where']>,
+					NonNullable<DBQueryConfig<'one', TSchema, TFields>['where']>
+				>
+				| undefined;
+		},
 	): SQLiteRelationalQueryKind<TMode, BuildQueryResult<TSchema, TFields, TConfig> | undefined> {
 		return this.mode === 'sync'
 			? new SQLiteSyncRelationalQuery(

--- a/drizzle-orm/type-tests/pg/rqb-v2-where.ts
+++ b/drizzle-orm/type-tests/pg/rqb-v2-where.ts
@@ -1,0 +1,51 @@
+import { integer, pgTable, text } from '~/pg-core/index.ts';
+import { drizzle } from '~/postgres-js/index.ts';
+import { defineRelations } from '~/relations.ts';
+
+const contacts = pgTable('contacts', {
+	id: integer('id'),
+	name: text('name'),
+	contact1: text('contact1'),
+});
+
+// Single-table schema; no cross-table relations needed for this test
+const rels = defineRelations({ contacts }, () => ({}));
+const db = drizzle.mock({ relations: rels });
+
+// --- findFirst ---
+
+// Valid: known column keys
+db.query.contacts.findFirst({ where: { id: 1 } });
+db.query.contacts.findFirst({ where: { name: 'Alice' } });
+db.query.contacts.findFirst({ where: { contact1: '010' } });
+
+// Valid: logical combinators
+db.query.contacts.findFirst({ where: { OR: [{ id: 1 }, { id: 2 }] } });
+db.query.contacts.findFirst({ where: { AND: [{ id: 1 }, { name: 'Alice' }] } });
+db.query.contacts.findFirst({ where: { NOT: { id: 1 } } });
+
+// Valid: omitting where entirely
+db.query.contacts.findFirst({});
+db.query.contacts.findFirst({ where: undefined });
+
+// Invalid: contact2 is not a column on contacts
+// @ts-expect-error
+db.query.contacts.findFirst({ where: { contact2: '010' } });
+
+// Invalid: mix of valid and invalid keys
+// @ts-expect-error
+db.query.contacts.findFirst({ where: { id: 1, nonExistentColumn: 'bad' } });
+
+// --- findMany ---
+
+// Valid
+db.query.contacts.findMany({ where: { id: 1 } });
+db.query.contacts.findMany({});
+
+// Invalid: contact2 is not a column
+// @ts-expect-error
+db.query.contacts.findMany({ where: { contact2: 'foo' } });
+
+// Invalid: mix
+// @ts-expect-error
+db.query.contacts.findMany({ where: { id: 1, contact2: 'foo' } });


### PR DESCRIPTION
Fixes #5655

**aws-introspect.ts** (main fix): Line 357 had a comment that policies would be "filtered out in runtime" — but the filter was never written. `policies` went into the return object unfiltered, so excluded schemas leaked through on the Drizzle Studio path. `tables[]` here is already schema-filtered, so the fix is one line:

```ts
const resultPolicies = policies.filter(
  (p) => tables.some((t) => t.schema === p.schema && t.name === p.table)
);
```

**introspect.ts** (consistency): The `policiesQuery` had no `WHERE` clause. Every other entity query wraps itself in a `filteredNamespacesStringForSQL` conditional with `WHERE schemaname IN (...)`; policies was the only holdout. `filteredNamespacesStringForSQL` covers all non-system namespaces rather than just those matching `schemaFilter`, so this doesn't change behavior on the push/pull path — `resultPolicies` at line 1234 already handles that. But the inconsistency was worth closing.

The `generate` command has a pre-existing TODO at `serializer.ts:51` — `schemaFilter` isn't applied during snapshot comparison there. Out of scope here.

`aws-introspect.ts` is consumed externally by Drizzle Studio, so there's no direct test for it here. Added a regression test for the push/pull path: creates a `storage` schema with a table, RLS, and a policy in the DB, pushes with `schemas: ['public']`, and asserts no statement referencing `storage` is generated.
