### PR TITLE
fix(sql): use 1=0/1=1 for empty inArray/notInArray to fix SQL Server compatibility

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -284,7 +284,7 @@ export function inArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			return sql`false`;
+			return sql`1=0`;
 		}
 		return sql`${column} in ${values.map((v) => bindIfParam(v, column))}`;
 	}
@@ -325,7 +325,7 @@ export function notInArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			return sql`true`;
+			return sql`1=1`;
 		}
 		return sql`${column} not in ${values.map((v) => bindIfParam(v, column))}`;
 	}


### PR DESCRIPTION
Fixes #5632.

## Problem

When `inArray` or `notInArray` is called with an empty array, drizzle emits the SQL keywords `false` and `true` respectively:

```sql
SELECT * FROM table WHERE false;   -- inArray(col, [])
SELECT * FROM table WHERE true;    -- notInArray(col, [])
```

SQL Server (T-SQL) does not recognise `true`/`false` as SQL keywords, so these queries throw a syntax error.

## Fix

Replace the empty-array short-circuit values with `1=0` (always false) and `1=1` (always true). These comparison expressions are semantically identical and are valid across every SQL dialect drizzle supports — MySQL, PostgreSQL, SQLite, and SQL Server.

```sql
SELECT * FROM table WHERE 1=0;   -- inArray(col, [])
SELECT * FROM table WHERE 1=1;   -- notInArray(col, [])
```