### PR TITLE
fix(eslint-plugin-drizzle): enforce-update-with-where false positive when .from() precedes .where()

### DIFF
--- a/eslint-plugin-drizzle/src/enforce-update-with-where.ts
+++ b/eslint-plugin-drizzle/src/enforce-update-with-where.ts
@@ -1,11 +1,45 @@
 import { ESLintUtils } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
 import { resolveMemberExpressionPath } from './utils/ast';
 import { isDrizzleObj, type Options } from './utils/options';
 
 const createRule = ESLintUtils.RuleCreator(() => 'https://github.com/drizzle-team/eslint-plugin-drizzle');
 type MessageIds = 'enforceUpdateWithWhere';
 
-let lastNodeName: string = '';
+function chainHasWhere(node: TSESTree.MemberExpression): boolean {
+	// Walk up ancestors to find a .where() chained after .set()
+	// e.g. .update().set().from().where()
+	let parent: TSESTree.Node | undefined = node.parent;
+	while (parent) {
+		if (parent.type === 'CallExpression') {
+			const grandparent = parent.parent;
+			if (grandparent?.type === 'MemberExpression') {
+				const gp = grandparent as TSESTree.MemberExpression;
+				if (gp.property.type === 'Identifier' && gp.property.name === 'where') {
+					return true;
+				}
+			}
+		}
+		parent = parent.parent;
+	}
+
+	// Walk down object chain to find a .where() chained before .set()
+	// e.g. .update().where().set()
+	let object: TSESTree.Expression = node.object;
+	while (object.type === 'CallExpression') {
+		if (object.callee.type === 'MemberExpression') {
+			const callee = object.callee;
+			if (callee.property.type === 'Identifier' && callee.property.name === 'where') {
+				return true;
+			}
+			object = callee.object;
+		} else {
+			break;
+		}
+	}
+
+	return false;
+}
 
 const updateRule = createRule<Options, MessageIds>({
 	defaultOptions: [{ drizzleObjectName: [] }],
@@ -35,13 +69,13 @@ const updateRule = createRule<Options, MessageIds>({
 			MemberExpression: (node) => {
 				if (node.property.type === 'Identifier') {
 					if (
-						lastNodeName !== 'where'
-						&& node.property.name === 'set'
+						node.property.name === 'set'
 						&& node.object.type === 'CallExpression'
 						&& node.object.callee.type === 'MemberExpression'
 						&& node.object.callee.property.type === 'Identifier'
 						&& node.object.callee.property.name === 'update'
 						&& isDrizzleObj(node.object.callee, options)
+						&& !chainHasWhere(node)
 					) {
 						context.report({
 							node,
@@ -51,7 +85,6 @@ const updateRule = createRule<Options, MessageIds>({
 							},
 						});
 					}
-					lastNodeName = node.property.name;
 				}
 				return;
 			},

--- a/eslint-plugin-drizzle/tests/update.test.ts
+++ b/eslint-plugin-drizzle/tests/update.test.ts
@@ -27,6 +27,17 @@ ruleTester.run('enforce update with where (default options)', myRule, {
       .update()
       .set()
       .where()`,
+		// #5612: .from() between .set() and .where() should not trigger
+		`await tx
+      .update(table)
+      .set({ val: 1 })
+      .from(sql\`(VALUES ...) AS v(id)\`)
+      .where(eq(table.id, v.id))`,
+		// .where() before .set() should also be valid
+		`db
+      .update(table)
+      .where(eq(table.id, 1))
+      .set({ val: 2 })`,
 	],
 	invalid: [
 		{


### PR DESCRIPTION
## Summary
- Fixes #5612 - `enforce-update-with-where` incorrectly reports a violation when `.from()` appears before `.where()` in an update chain

## Root Cause
The rule used a global `lastNodeName` variable to track whether `.where()` was seen before `.set()`. However, ESLint visits `MemberExpression` nodes outermost-first (pre-order traversal), so when the chain is `.update().set().from().where()`, the `.from` method overwrites `lastNodeName` before `.set()` checks it, causing a false positive.

## Fix
Replaced the global `lastNodeName` tracking with an AST traversal approach:
- Walk up ancestors to find `.where()` chained after `.set()` (e.g. `.set().from().where()`)
- Walk down the object chain to find `.where()` chained before `.set()` (e.g. `.where().set()`)

## Testing
- All 113 existing tests pass
- Added 2 new test cases: `.from()` before `.where()` and `.where()` before `.set()`