### PR TITLE
fix(drizzle-kit): remove stray console.log in MySQL/SingleStore introspection

### DIFF
--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -811,7 +811,6 @@ const column = (
 		return out;
 	}
 
-	console.log('uknown', type);
 	return `// Warning: Can't parse ${type} from database\n\t// ${type}Type: ${type}("${name}")`;
 };
 

--- a/drizzle-kit/src/introspect-singlestore.ts
+++ b/drizzle-kit/src/introspect-singlestore.ts
@@ -791,7 +791,6 @@ const column = (
 		return out;
 	}
 
-	console.log('uknown', type);
 	return `// Warning: Can't parse ${type} from database\n\t// ${type}Type: ${type}("${name}")`;
 };
 


### PR DESCRIPTION
## Summary
Removes two stray `console.log('uknown', type)` debug statements that were accidentally left in the MySQL and SingleStore column introspection code.

These logs fire for every unknown column type encountered during `drizzle-kit pull`, polluting the CLI output with unhelpful debug information.

## Changes
- `drizzle-kit/src/introspect-mysql.ts`: Remove `console.log('uknown', type)` from unknown column type path
- `drizzle-kit/src/introspect-singlestore.ts`: Remove `console.log('uknown', type)` from unknown column type path

The warning comment that follows (`// Warning: Can't parse ${type} from database...`) remains in place and is the intended output for unknown types.