### PR TITLE
fix(drizzle-kit): LibSQLModifyColumn DROP INDEX scope and IF EXISTS (#5564)

### DIFF
--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -2396,7 +2396,7 @@ export class LibSQLModifyColumn extends Convertor {
 
 		const sqlStatements: string[] = [];
 
-		// collect index info
+		// collect index info for the table being modified
 		const indexes: {
 			name: string;
 			tableName: string;
@@ -2404,11 +2404,12 @@ export class LibSQLModifyColumn extends Convertor {
 			isUnique: boolean;
 			where?: string | undefined;
 		}[] = [];
-		for (const table of Object.values(json2.tables)) {
-			for (const index of Object.values(table.indexes)) {
+		const targetTable = json2.tables[tableName];
+		if (targetTable) {
+			for (const index of Object.values(targetTable.indexes)) {
 				const unsquashed = SQLiteSquasher.unsquashIdx(index);
-				sqlStatements.push(`DROP INDEX "${unsquashed.name}";`);
-				indexes.push({ ...unsquashed, tableName: table.name });
+				sqlStatements.push(`DROP INDEX IF EXISTS "${unsquashed.name}";`);
+				indexes.push({ ...unsquashed, tableName: targetTable.name });
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Fixes #5564 - LibSQLModifyColumn generates duplicate DROP INDEX without IF EXISTS causing "no such index" errors on db:push

## Root Cause
The `LibSQLModifyColumn.convert()` method was dropping ALL indexes from ALL tables in the schema, not just from the table being modified. When multiple column modifications are processed in the same push, the second call tries to drop indexes that don't exist (already dropped/recreated by the first call).

Additionally, the `DROP INDEX` statement didn't include `IF EXISTS`, so if an index was already missing for any reason, the push would fail with a "no such index" error.

## Fix
1. Only drop indexes from the specific table being modified (using `statement.tableName`) instead of iterating all tables
2. Add `IF EXISTS` to the DROP INDEX statement: `DROP INDEX IF EXISTS "name"`

Both changes align with SQLite 3.40+ and libSQL/Turso syntax support.