### PR TITLE
fix(drizzle-orm): guard escapeName against undefined + fix SERIAL in SQLite migrators

### DIFF
--- a/drizzle-orm/src/d1/migrator.ts
+++ b/drizzle-orm/src/d1/migrator.ts
@@ -12,7 +12,7 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 
 	const migrationTableCreate = sql`
 		CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-			id SERIAL PRIMARY KEY,
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			hash text NOT NULL,
 			created_at numeric
 		)

--- a/drizzle-orm/src/durable-sqlite/migrator.ts
+++ b/drizzle-orm/src/durable-sqlite/migrator.ts
@@ -52,7 +52,7 @@ export async function migrate<
 
 			const migrationTableCreate = sql`
 				CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-					id SERIAL PRIMARY KEY,
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
 					hash text NOT NULL,
 					created_at numeric
 				)

--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -101,6 +101,7 @@ export class GelDialect {
 	// }
 
 	escapeName(name: string): string {
+		if (name == null) return '""';
 		return `"${name}"`;
 	}
 

--- a/drizzle-orm/src/gel-core/index.ts
+++ b/drizzle-orm/src/gel-core/index.ts
@@ -18,3 +18,4 @@ export * from './unique-constraint.ts';
 export * from './utils.ts';
 export * from './view-common.ts';
 export * from './view.ts';
+export { createTableRelationsHelpers } from '~/relations.ts';

--- a/drizzle-orm/src/libsql/migrator.ts
+++ b/drizzle-orm/src/libsql/migrator.ts
@@ -12,7 +12,7 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 
 	const migrationTableCreate = sql`
 		CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-			id SERIAL PRIMARY KEY,
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			hash text NOT NULL,
 			created_at numeric
 		)

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -98,6 +98,7 @@ export class MySqlDialect {
 	}
 
 	escapeName(name: string): string {
+		if (name == null) return '``';
 		return `\`${name.replace(/`/g, '``')}\``;
 	}
 

--- a/drizzle-orm/src/mysql-core/index.ts
+++ b/drizzle-orm/src/mysql-core/index.ts
@@ -15,3 +15,4 @@ export * from './unique-constraint.ts';
 export * from './utils.ts';
 export * from './view-common.ts';
 export * from './view.ts';
+export { createTableRelationsHelpers } from '~/relations.ts';

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -112,6 +112,7 @@ export class PgDialect {
 	}
 
 	escapeName(name: string): string {
+		if (name == null) return '""';
 		return `"${name.replace(/"/g, '""')}"`;
 	}
 

--- a/drizzle-orm/src/pg-core/index.ts
+++ b/drizzle-orm/src/pg-core/index.ts
@@ -19,3 +19,4 @@ export * from './utils.ts';
 export * from './utils/index.ts';
 export * from './view-common.ts';
 export * from './view.ts';
+export { createTableRelationsHelpers } from '~/relations.ts';

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -97,6 +97,7 @@ export class SingleStoreDialect {
 	}
 
 	escapeName(name: string): string {
+		if (name == null) return '``';
 		return `\`${name.replace(/`/g, '``')}\``;
 	}
 

--- a/drizzle-orm/src/singlestore-core/index.ts
+++ b/drizzle-orm/src/singlestore-core/index.ts
@@ -13,3 +13,4 @@ export * from './unique-constraint.ts';
 export * from './utils.ts';
 /* export * from './view-common.ts';
 export * from './view.ts'; */
+export { createTableRelationsHelpers } from '~/relations.ts';

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -55,6 +55,7 @@ export abstract class SQLiteDialect {
 	}
 
 	escapeName(name: string): string {
+		if (name == null) return '""';
 		return `"${name.replace(/"/g, '""')}"`;
 	}
 
@@ -954,7 +955,7 @@ export class SQLiteSyncDialect extends SQLiteDialect {
 
 		const migrationTableCreate = sql`
 			CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-				id SERIAL PRIMARY KEY,
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				hash text NOT NULL,
 				created_at numeric
 			)
@@ -1011,7 +1012,7 @@ export class SQLiteAsyncDialect extends SQLiteDialect {
 
 		const migrationTableCreate = sql`
 			CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-				id SERIAL PRIMARY KEY,
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				hash text NOT NULL,
 				created_at numeric
 			)

--- a/drizzle-orm/src/sqlite-core/index.ts
+++ b/drizzle-orm/src/sqlite-core/index.ts
@@ -13,3 +13,4 @@ export * from './table.ts';
 export * from './unique-constraint.ts';
 export * from './utils.ts';
 export * from './view.ts';
+export { createTableRelationsHelpers } from '~/relations.ts';

--- a/drizzle-orm/src/sqlite-proxy/migrator.ts
+++ b/drizzle-orm/src/sqlite-proxy/migrator.ts
@@ -18,7 +18,7 @@ export async function migrate<TSchema extends Record<string, unknown>>(
 
 	const migrationTableCreate = sql`
 		CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
-			id SERIAL PRIMARY KEY,
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			hash text NOT NULL,
 			created_at numeric
 		)


### PR DESCRIPTION
## Summary

Three fixes across drizzle-orm:

### 1. Guard `escapeName` against undefined (#5699)
Adds a null guard in `escapeName` across all 5 dialects (pg, mysql, sqlite, singlestore, gel) to prevent:
```
TypeError: Cannot read properties of undefined (reading 'replace')
```

### 2. Fix `SERIAL` in SQLite migrators (#5678, #5669, #5679)
All SQLite-based migrators (libsql, d1, sqlite-proxy, durable-sqlite) were using PostgreSQL `SERIAL` syntax. Changed to `INTEGER PRIMARY KEY AUTOINCREMENT`. Also fixed the two `migrate` methods in `sqlite-core/dialect.ts`.

### 3. Re-export `createTableRelationsHelpers` (#5700)
Adds `createTableRelationsHelpers` export to pg-core, mysql-core, sqlite-core, singlestore-core, and gel-core sub-path modules for drizzle-graphql compatibility.

Closes #5699, closes #5678, closes #5669, closes #5679, closes #5700