### PR TITLE
fix(drizzle-kit): cloudflare:workers support, schemaFilter for policies, SQLite boolean defaults

### DIFF
--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -92,8 +92,55 @@ const ensureTsxRegistered = () => {
 	tsxRegistered = true;
 };
 
+let cfModulesRegistered = false;
+function ensureCFModulesAvailable() {
+	if (cfModulesRegistered) return;
+
+	const Module = require('module');
+	const fs = require('fs');
+	const os = require('os');
+	const path = require('path');
+
+	const stubDir = path.join(os.tmpdir(), 'drizzle-kit-cf-stubs');
+	if (!fs.existsSync(stubDir)) {
+		fs.mkdirSync(stubDir, { recursive: true });
+	}
+
+	const stubContent = `
+class WorkerEntrypoint { constructor(ctx, env) { this.ctx = ctx; this.env = env; } }
+class DurableObject { constructor(state, env) { this.state = state; this.env = env; } }
+class RpcTarget { constructor(value) { this.value = value; } }
+class RpcStub extends RpcTarget {}
+const env = {};
+const caches = { default: {} };
+const scheduler = {};
+const executionCtx = {};
+module.exports = { WorkerEntrypoint, DurableObject, RpcTarget, RpcStub, env, caches, scheduler, executionCtx };
+`;
+
+	const stubPath = path.join(stubDir, 'cloudflare-workers.cjs');
+	fs.writeFileSync(stubPath, stubContent);
+
+	const originalResolveFilename = Module._resolveFilename;
+
+	const resolveMap: Record<string, string> = {
+		'cloudflare:workers': stubPath,
+		'cloudflare:test': stubPath,
+	};
+
+	Module._resolveFilename = function (request: string, parent: any, ...args: any[]) {
+		if (resolveMap[request]) {
+			return resolveMap[request];
+		}
+		return originalResolveFilename.apply(this, [request, parent, ...args] as any);
+	};
+
+	cfModulesRegistered = true;
+}
+
 export const safeRegister = async <T>(fn: () => Promise<T>) => {
 	return registerMutex.withLock(async () => {
+		ensureCFModulesAvailable();
 		ensureTsxRegistered();
 		await assertES5();
 		return fn();

--- a/drizzle-kit/src/mocks/cloudflare-workers-stub.cjs
+++ b/drizzle-kit/src/mocks/cloudflare-workers-stub.cjs
@@ -1,0 +1,37 @@
+class WorkerEntrypoint {
+	constructor(ctx, env) {
+		this.ctx = ctx;
+		this.env = env;
+	}
+}
+
+class DurableObject {
+	constructor(state, env) {
+		this.state = state;
+		this.env = env;
+	}
+}
+
+class RpcTarget {
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+class RpcStub extends RpcTarget {}
+
+const env = {};
+const caches = { default: {} };
+const scheduler = {};
+const executionCtx = {};
+
+module.exports = {
+	WorkerEntrypoint,
+	DurableObject,
+	RpcTarget,
+	RpcStub,
+	env,
+	caches,
+	scheduler,
+	executionCtx,
+};

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1145,9 +1145,12 @@ WHERE
 		}
 	}
 
-	const schemasForLinkedPoliciesInSchema = Object.values(tsSchema?.policies ?? {}).map((it) => it.schema!);
+	const schemasForLinkedPoliciesInSchema = Object.values(tsSchema?.policies ?? {})
+		.map((it) => it.schema!)
+		.filter((s) => !schemaFilters.includes(s) ? false : true);
 
 	const wherePolicies = [...schemaFilters, ...schemasForLinkedPoliciesInSchema]
+		.filter((s, i, arr) => arr.indexOf(s) === i)
 		.map((t) => `schemaname = '${t}'`)
 		.join(' or ');
 

--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -91,6 +91,8 @@ export const generateSqliteSnapshot = (
 				} else {
 					columnToSet.default = typeof column.default === 'string'
 						? `'${escapeSingleQuotes(column.default)}'`
+						: typeof column.default === 'boolean'
+						? column.default ? '1' : '0'
 						: typeof column.default === 'object'
 								|| Array.isArray(column.default)
 						? `'${JSON.stringify(column.default)}'`
@@ -378,6 +380,8 @@ export const generateSqliteSnapshot = (
 					} else {
 						columnToSet.default = typeof column.default === 'string'
 							? `'${column.default}'`
+							: typeof column.default === 'boolean'
+							? column.default ? '1' : '0'
 							: typeof column.default === 'object'
 									|| Array.isArray(column.default)
 							? `'${JSON.stringify(column.default)}'`


### PR DESCRIPTION
## Summary

Three fixes across drizzle-kit:

### 1. Support `cloudflare:workers` virtual module (#5676)
When users run `drizzle-kit generate` in a Cloudflare Workers project, the CLI crashes with `Cannot find module 'cloudflare:workers'`. This adds a mock module via `Module._resolveFilename` hook that provides stubs for `Cloudflare:workers` and `cloudflare:test`, allowing schema files that import Cloudflare bindings to be loaded by drizzle-kit.

### 2. Respect `schemaFilter` for policies (#5655)
When `schemaFilter: ["public"]` is configured, drizzle-kit should not introspect or generate DROP statements for policies in other schemas (e.g., `storage`). Previously, linked policy schemas were included without filtering. This filters them to only schemas in `schemaFilter` and deduplicates the list.

### 3. Fix SQLite boolean default values (#5661)
Boolean defaults (`default(false)`) were serialized as JSON booleans (`false`) instead of SQLite integer values (`'0'`). Fixed to output `'1'` for `true` and `'0'` for `false`.

Closes #5676, closes #5655, closes #5661