### PR TITLE
fix(drizzle-zod): zod 4 coerce type inference + fix reversed int() logic

### DIFF
--- a/drizzle-zod/src/column.ts
+++ b/drizzle-zod/src/column.ts
@@ -113,9 +113,9 @@ export function columnToSchema(
 		} else if (column.dataType === 'bigint') {
 			schema = bigintColumnToSchema(column, z, coerce);
 		} else if (column.dataType === 'boolean') {
-			schema = coerce === true || coerce.boolean ? z.coerce.boolean() : z.boolean();
+			schema = coerce === true || coerce.boolean ? z.coerce.boolean<boolean>() : z.boolean();
 		} else if (column.dataType === 'date') {
-			schema = coerce === true || coerce.date ? z.coerce.date() : z.date();
+			schema = coerce === true || coerce.date ? z.coerce.date<Date>() : z.date();
 		} else if (column.dataType === 'string') {
 			schema = stringColumnToSchema(column, z, coerce);
 		} else if (column.dataType === 'json') {
@@ -241,7 +241,7 @@ function numberColumnToSchema(
 	}
 
 	let schema = coerce === true || coerce?.number
-		? integer ? z.coerce.number() : z.coerce.number().int()
+		? integer ? z.coerce.number<number>().int() : z.coerce.number<number>()
 		: integer
 		? z.int()
 		: z.number();
@@ -260,7 +260,7 @@ function bigintColumnToSchema(
 	const min = unsigned ? 0n : CONSTANTS.INT64_MIN;
 	const max = unsigned ? CONSTANTS.INT64_UNSIGNED_MAX : CONSTANTS.INT64_MAX;
 
-	const schema = coerce === true || coerce?.bigint ? z.coerce.bigint() : z.bigint();
+	const schema = coerce === true || coerce?.bigint ? z.coerce.bigint<bigint>() : z.bigint();
 	return schema.gte(min).lte(max);
 }
 
@@ -313,7 +313,7 @@ function stringColumnToSchema(
 		max = column.dimensions;
 	}
 
-	let schema = coerce === true || coerce?.string ? z.coerce.string() : z.string();
+	let schema = coerce === true || coerce?.string ? z.coerce.string<string>() : z.string();
 	schema = regex ? schema.regex(regex) : schema;
 	return max && fixed ? schema.length(max) : max ? schema.max(max) : schema;
 }

--- a/drizzle-zod/src/column.types.ts
+++ b/drizzle-zod/src/column.types.ts
@@ -18,7 +18,7 @@ export type GetZodType<
 		? z.ZodEnum<{ [K in Assume<TColumn['_']['enumValues'], [string, ...string[]]>[number]]: K }>
 	: TColumn['_']['columnType'] extends 'PgGeometry' | 'PgPointTuple' ? z.ZodTuple<[z.ZodNumber, z.ZodNumber], null>
 	: TColumn['_']['columnType'] extends 'PgLine' ? z.ZodTuple<[z.ZodNumber, z.ZodNumber, z.ZodNumber], null>
-	: TColumn['_']['data'] extends Date ? CanCoerce<TCoerce, 'date'> extends true ? z.coerce.ZodCoercedDate : z.ZodDate
+	: TColumn['_']['data'] extends Date ? CanCoerce<TCoerce, 'date'> extends true ? z.coerce.ZodCoercedDate<Date> : z.ZodDate
 	: TColumn['_']['data'] extends Buffer ? z.ZodType<Buffer>
 	: TColumn['_']['dataType'] extends 'array'
 		? z.ZodArray<GetZodPrimitiveType<Assume<TColumn['_']['data'], any[]>[number], '', TCoerce>>
@@ -66,11 +66,11 @@ type GetZodPrimitiveType<
 	| 'SingleStoreSerial'
 	| 'SQLiteInteger'
 	| 'MySqlYear'
-	| 'SingleStoreYear' ? CanCoerce<TCoerce, 'number'> extends true ? z.coerce.ZodCoercedNumber : z.ZodInt
-	: TData extends number ? CanCoerce<TCoerce, 'number'> extends true ? z.coerce.ZodCoercedNumber : z.ZodNumber
-	: TData extends bigint ? CanCoerce<TCoerce, 'bigint'> extends true ? z.coerce.ZodCoercedBigInt : z.ZodBigInt
-	: TData extends boolean ? CanCoerce<TCoerce, 'boolean'> extends true ? z.coerce.ZodCoercedBoolean : z.ZodBoolean
-	: TData extends string ? CanCoerce<TCoerce, 'string'> extends true ? z.coerce.ZodCoercedString : z.ZodString
+	| 'SingleStoreYear' ? CanCoerce<TCoerce, 'number'> extends true ? z.coerce.ZodCoercedNumber<number> : z.ZodInt
+	: TData extends number ? CanCoerce<TCoerce, 'number'> extends true ? z.coerce.ZodCoercedNumber<number> : z.ZodNumber
+	: TData extends bigint ? CanCoerce<TCoerce, 'bigint'> extends true ? z.coerce.ZodCoercedBigInt<bigint> : z.ZodBigInt
+	: TData extends boolean ? CanCoerce<TCoerce, 'boolean'> extends true ? z.coerce.ZodCoercedBoolean<boolean> : z.ZodBoolean
+	: TData extends string ? CanCoerce<TCoerce, 'string'> extends true ? z.coerce.ZodCoercedString<string> : z.ZodString
 	: z.ZodType;
 
 type HandleSelectColumn<


### PR DESCRIPTION
## Summary

Fixes zod 4 compatibility and a logic bug in `drizzle-zod`:

### 1. Zod 4 coerce type inference (#5659)
In zod 4, `z.coerce.*()` methods have input type `unknown` by default, causing TypeScript to infer coerced fields as `unknown`. Fixed by adding explicit type parameters:
- `z.coerce.number<number>()`
- `z.coerce.boolean<boolean>()`
- `z.coerce.date<Date>()`
- `z.coerce.bigint<bigint>()`
- `z.coerce.string<string>()`

Also updates the type-level references in `column.types.ts` accordingly.

### 2. Fix reversed `int()` logic
The `numberColumnToSchema` function had reversed logic: `.int()` was called when `integer=false` instead of `integer=true`. This meant:
- Integer columns got `z.coerce.number()` (no `.int()`)
- Non-integer columns got `z.coerce.number().int()` (wrong!)

Fixed to match the original 0.7.1 behavior: `.int()` is only called when `integer=true`.

Closes #5659