### PR TITLE
fix: guard against null rows in mapResultRow

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -17,6 +17,7 @@ export function mapResultRow<TResult>(
 	row: unknown[],
 	joinsNotNullableMap: Record<string, boolean> | undefined,
 ): TResult {
+	const rowValues = row ?? [];
 	// Key -> nested object key, value -> table name if all fields in the nested object are from the same table, false otherwise
 	const nullifyMap: Record<string, string | false> = {};
 
@@ -40,8 +41,12 @@ export function mapResultRow<TResult>(
 					}
 					node = node[pathChunk];
 				} else {
-					const rawValue = row[columnIndex]!;
-					const value = node[pathChunk] = rawValue === null ? null : decoder.mapFromDriverValue(rawValue);
+					const rawValue = rowValues[columnIndex];
+					const value = node[pathChunk] = rawValue === undefined
+						? undefined
+						: rawValue === null
+						? null
+						: decoder.mapFromDriverValue(rawValue);
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;


### PR DESCRIPTION
## Problem
When using Bun runtime with explicit `select`, `mapResultRow` crashes with "null is not an object (evaluating 'row[columnIndex]')" because certain drivers can return sparse or null row shapes.

## Change
Add null guards in `mapResultRow` to handle cases where the row or individual column values are null/undefined, preventing the crash while preserving correct behavior for valid rows.

Fixes #5708.

Made with [Cursor](https://cursor.com)