### PR TITLE
[Pg] AWS Data API: emit explicit cast for column-bound params

### DIFF
--- a/drizzle-orm/src/aws-data-api/common/index.ts
+++ b/drizzle-orm/src/aws-data-api/common/index.ts
@@ -39,6 +39,14 @@ export function getValueFromDataApi(field: Field) {
 	}
 }
 
+/**
+ * The Data API only exposes six `typeHint` values — JSON, UUID, TIMESTAMP, DATE, TIME, DECIMAL.
+ * For everything else (enums, arrays, custom domains, citext, ltree, geometry, hstore, ...),
+ * there is no hint and the value arrives at Postgres as `text` — see `AwsPgDialect.wrapParam`
+ * which emits explicit `cast(...)` SQL for those.
+ *
+ * Reference: https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_SqlParameter.html
+ */
 export function typingsToAwsTypeHint(typings?: QueryTypingsValue): TypeHint | undefined {
 	if (typings === 'date') {
 		return TypeHint.DATE;
@@ -66,6 +74,10 @@ export function toValueParam(value: any, typings?: QueryTypingsValue): { value: 
 	if (value === null) {
 		response.value = { isNull: true };
 	} else if (typeof value === 'string') {
+		// Format requirements per https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_SqlParameter.html#rdsdtataservice-Type-SqlParameter-typeHint:
+		//   DATE      → YYYY-MM-DD
+		//   TIMESTAMP → YYYY-MM-DD HH:MM:SS[.FFF]
+		//   TIME      → HH:MM:SS[.FFF]
 		switch (response.typeHint) {
 			case TypeHint.DATE: {
 				response.value = { stringValue: value.split('T')[0]! };

--- a/drizzle-orm/src/aws-data-api/pg/driver.ts
+++ b/drizzle-orm/src/aws-data-api/pg/driver.ts
@@ -1,11 +1,11 @@
 import { RDSDataClient, type RDSDataClientConfig } from '@aws-sdk/client-rds-data';
+import type { AnyColumn } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { PgDatabase } from '~/pg-core/db.ts';
 import { PgDialect } from '~/pg-core/dialect.ts';
-import type { PgColumn, PgInsertConfig, PgTable, TableConfig } from '~/pg-core/index.ts';
-import { PgArray } from '~/pg-core/index.ts';
+import { PgEnumColumn, PgEnumObjectColumn } from '~/pg-core/index.ts';
 import type { PgRaw } from '~/pg-core/query-builders/raw.ts';
 import {
 	createTableRelationsHelpers,
@@ -13,9 +13,8 @@ import {
 	type RelationalSchemaConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
-import { Param, type SQL, sql, type SQLWrapper } from '~/sql/sql.ts';
-import { Table } from '~/table.ts';
-import type { DrizzleConfig, UpdateSet } from '~/utils.ts';
+import type { SQL, SQLWrapper } from '~/sql/sql.ts';
+import type { DrizzleConfig } from '~/utils.ts';
 import type { AwsDataApiClient, AwsDataApiPgQueryResult, AwsDataApiPgQueryResultHKT } from './session.ts';
 import { AwsDataApiSession } from './session.ts';
 
@@ -54,41 +53,29 @@ export class AwsPgDialect extends PgDialect {
 		return `:${num + 1}`;
 	}
 
-	override buildInsertQuery(
-		{ table, values, onConflict, returning, select, withList }: PgInsertConfig<PgTable<TableConfig>>,
-	): SQL<unknown> {
-		const columns: Record<string, PgColumn> = table[Table.Symbol.Columns];
-
-		if (!select) {
-			for (const value of (values as Record<string, Param | SQL>[])) {
-				for (const fieldName of Object.keys(columns)) {
-					const colValue = value[fieldName];
-					if (
-						is(colValue, Param) && colValue.value !== undefined && is(colValue.encoder, PgArray)
-						&& Array.isArray(colValue.value)
-					) {
-						value[fieldName] = sql`cast(${colValue} as ${sql.raw(colValue.encoder.getSQLType())})`;
-					}
-				}
-			}
-		}
-
-		return super.buildInsertQuery({ table, values, onConflict, returning, withList });
+	/**
+	 * AWS RDS Data API ships parameters over JSON without parameter type negotiation.
+	 * String values arrive at Postgres typed as `text`, and Postgres has no implicit cast
+	 * from `text` to types like `uuid`, enums, arrays, or custom domains — so queries like
+	 * `where uuid_col = $1` fail with "operator does not exist: uuid = text".
+	 *
+	 * `typeHint` covers only JSON, UUID, TIMESTAMP, DATE, TIME, and DECIMAL — nothing else
+	 * (see https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_SqlParameter.html).
+	 * To make the driver work with every column type, we emit an explicit `cast(...)` for
+	 * every parameter bound to a `PgColumn` encoder. Redundant casts (e.g. `cast($1 as uuid)`
+	 * on top of `typeHint: UUID`) are harmless.
+	 */
+	override wrapParam(paramSql: string, column?: AnyColumn): string {
+		if (!column) return paramSql;
+		return `cast(${paramSql} as ${this.castTypeFor(column)})`;
 	}
 
-	override buildUpdateSet(table: PgTable<TableConfig>, set: UpdateSet): SQL<unknown> {
-		const columns: Record<string, PgColumn> = table[Table.Symbol.Columns];
-
-		for (const [colName, colValue] of Object.entries(set)) {
-			const currentColumn = columns[colName];
-			if (
-				currentColumn && is(colValue, Param) && colValue.value !== undefined && is(colValue.encoder, PgArray)
-				&& Array.isArray(colValue.value)
-			) {
-				set[colName] = sql`cast(${colValue} as ${sql.raw(colValue.encoder.getSQLType())})`;
-			}
+	private castTypeFor(column: AnyColumn): string {
+		if (is(column, PgEnumColumn) || is(column, PgEnumObjectColumn)) {
+			const { schema, enumName } = column.enum;
+			return schema ? `${this.escapeName(schema)}.${this.escapeName(enumName)}` : this.escapeName(enumName);
 		}
-		return super.buildUpdateSet(table, set);
+		return column.getSQLType();
 	}
 }
 

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { type AnyColumn, Column } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -606,6 +606,19 @@ export class PgDialect {
 		}
 	}
 
+	/**
+	 * Hook a subclass can override to wrap each emitted parameter (e.g. to inject an
+	 * explicit `cast(...)` for drivers that can't rely on parameter type negotiation,
+	 * such as AWS RDS Data API — see `AwsPgDialect.wrapParam` and
+	 * https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_SqlParameter.html).
+	 * `column` is the column the param is bound to, or `undefined` for params without
+	 * a column encoder (e.g. literals in a `sql` tag).
+	 * The default implementation is a no-op.
+	 */
+	wrapParam(paramSql: string, _column?: AnyColumn): string {
+		return paramSql;
+	}
+
 	sqlToQuery(sql: SQL, invokeSource?: 'indexes' | undefined): QueryWithTypings {
 		return sql.toQuery({
 			casing: this.casing,
@@ -613,6 +626,7 @@ export class PgDialect {
 			escapeParam: this.escapeParam,
 			escapeString: this.escapeString,
 			prepareTyping: this.prepareTyping,
+			wrapParam: this.wrapParam.bind(this),
 			invokeSource,
 		});
 	}

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -35,6 +35,19 @@ export interface BuildQueryConfig {
 	escapeParam(num: number, value: unknown): string;
 	escapeString(str: string): string;
 	prepareTyping?: (encoder: DriverValueEncoder<unknown, unknown>) => QueryTypingsValue;
+	/**
+	 * Optional hook that lets a dialect transform the SQL emitted for a single bound parameter.
+	 *
+	 * Returning a different string replaces the `$1` (or `:1`, etc.) emitted by `escapeParam`.
+	 * The `column` argument is the column the param is bound to (via `eq`, `set`, `values`, etc.)
+	 * or `undefined` when the param has no column encoder (e.g. a raw `${value}` in `sql` tag).
+	 * Used by drivers that cannot rely on parameter type negotiation (e.g. AWS RDS Data API,
+	 * which only exposes a small fixed set of `typeHint` values —
+	 * https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_SqlParameter.html)
+	 * to inject explicit `cast(...)` expressions for column types Postgres won't implicitly
+	 * coerce from text — enums, uuid, arrays, custom domains, etc.
+	 */
+	wrapParam?: (paramSql: string, column?: AnyColumn) => string;
 	paramStartIndex?: { value: number };
 	inlineParams?: boolean;
 	invokeSource?: 'indexes' | undefined;
@@ -156,6 +169,7 @@ export class SQL<T = unknown> implements SQLWrapper {
 			escapeName,
 			escapeParam,
 			prepareTyping,
+			wrapParam,
 			inlineParams,
 			paramStartIndex,
 		} = config;
@@ -232,7 +246,14 @@ export class SQL<T = unknown> implements SQLWrapper {
 
 			if (is(chunk, Param)) {
 				if (is(chunk.value, Placeholder)) {
-					return { sql: escapeParam(paramStartIndex.value++, chunk), params: [chunk], typings: ['none'] };
+					let placeholderSql = escapeParam(paramStartIndex.value++, chunk);
+					if (wrapParam) {
+						placeholderSql = wrapParam(
+							placeholderSql,
+							is(chunk.encoder, Column) ? chunk.encoder : undefined,
+						);
+					}
+					return { sql: placeholderSql, params: [chunk], typings: ['none'] };
 				}
 
 				const mappedValue = chunk.value === null ? null : chunk.encoder.mapToDriverValue(chunk.value);
@@ -250,7 +271,11 @@ export class SQL<T = unknown> implements SQLWrapper {
 					typings = [prepareTyping(chunk.encoder)];
 				}
 
-				return { sql: escapeParam(paramStartIndex.value++, mappedValue), params: [mappedValue], typings };
+				let paramSql = escapeParam(paramStartIndex.value++, mappedValue);
+				if (wrapParam) {
+					paramSql = wrapParam(paramSql, is(chunk.encoder, Column) ? chunk.encoder : undefined);
+				}
+				return { sql: paramSql, params: [mappedValue], typings };
 			}
 
 			if (is(chunk, Placeholder)) {

--- a/drizzle-orm/tests/type-hints.test.ts
+++ b/drizzle-orm/tests/type-hints.test.ts
@@ -2,8 +2,22 @@ import { RDSDataClient } from '@aws-sdk/client-rds-data';
 import crypto from 'crypto';
 import { expect, test } from 'vitest';
 
-import { drizzle } from '~/aws-data-api/pg';
-import { customType, json, PgDialect, pgTable, text, timestamp, uuid, varchar } from '~/pg-core';
+import { AwsPgDialect, drizzle } from '~/aws-data-api/pg';
+import {
+	boolean,
+	customType,
+	integer,
+	json,
+	PgDialect,
+	pgEnum,
+	pgSchema,
+	pgTable,
+	text,
+	timestamp,
+	uuid,
+	varchar,
+} from '~/pg-core';
+import { eq, inArray } from '~/sql/expressions/conditions';
 import { sql } from '~/sql/sql';
 
 const db = drizzle(new RDSDataClient(), {
@@ -40,6 +54,229 @@ test('type hints - case #1', () => {
 	const query = new PgDialect().sqlToQuery(q.getSQL());
 
 	expect(query.typings).toEqual(['none', 'none', 'none', 'json', 'none', 'none', 'none', 'timestamp']);
+});
+
+test('AwsPgDialect wraps enum params in WHERE with explicit cast', () => {
+	const status = pgEnum('agent_status', ['idle', 'running', 'stopped']);
+	const tasks = pgTable('tasks', {
+		id: uuid('id').primaryKey(),
+		status: status('status').notNull(),
+	});
+
+	const q = db.select().from(tasks).where(eq(tasks.status, 'running'));
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	// enums have no typeHint in AWS Data API — must be cast explicitly
+	expect(query.sql).toContain(`cast(:1 as "agent_status")`);
+});
+
+test('AwsPgDialect wraps schema-qualified enum with quoted schema', () => {
+	const app = pgSchema('app');
+	const status = app.enum('agent_status', ['idle', 'running']);
+	const tasks = app.table('tasks', {
+		id: uuid('id').primaryKey(),
+		status: status('status').notNull(),
+	});
+
+	const q = db.update(tasks).set({ status: 'idle' }).where(eq(tasks.id, '00000000-0000-0000-0000-000000000000'));
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	expect(query.sql).toContain(`cast(:1 as "app"."agent_status")`);
+	expect(query.sql).toContain(`cast(:2 as uuid)`);
+});
+
+test('AwsPgDialect wraps array params with element type', () => {
+	const t = pgTable('t', {
+		id: uuid('id').primaryKey(),
+		tags: text('tags').array().notNull(),
+	});
+
+	const q = db.insert(t).values({
+		id: '00000000-0000-0000-0000-000000000000',
+		tags: ['a', 'b'],
+	});
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	expect(query.sql).toMatch(/cast\(:\d+ as text\[\]\)/);
+});
+
+test('AwsPgDialect wraps INSERT params: enum + uuid + array + customType', () => {
+	const role = pgEnum('user_role', ['admin', 'member']);
+	const ulid = customType<{ data: string; driverData: string }>({
+		dataType: () => 'citext',
+		toDriver: (v) => v,
+	});
+	const users = pgTable('users', {
+		id: uuid('id').primaryKey(),
+		role: role('role').notNull(),
+		tags: text('tags').array().notNull(),
+		handle: ulid('handle').notNull(),
+		name: text('name').notNull(),
+	});
+
+	const q = db.insert(users).values({
+		id: '00000000-0000-0000-0000-000000000000',
+		role: 'admin',
+		tags: ['x', 'y'],
+		handle: 'abc',
+		name: 'Ada',
+	});
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	// Every column-bound INSERT VALUES param is wrapped in cast()
+	expect(query.sql).toMatch(/cast\(:\d+ as uuid\)/);
+	expect(query.sql).toMatch(/cast\(:\d+ as "user_role"\)/);
+	expect(query.sql).toMatch(/cast\(:\d+ as text\[\]\)/);
+	expect(query.sql).toMatch(/cast\(:\d+ as citext\)/);
+	expect(query.sql).toMatch(/cast\(:\d+ as text\)/);
+});
+
+test('AwsPgDialect wraps SELECT/WHERE params for enum, uuid, varchar, numeric', () => {
+	const role = pgEnum('user_role', ['admin', 'member']);
+	const users = pgTable('users', {
+		id: uuid('id').primaryKey(),
+		role: role('role').notNull(),
+		login: varchar('login', { length: 64 }).notNull(),
+	});
+
+	const q = db.select().from(users).where(
+		sql`${eq(users.id, '00000000-0000-0000-0000-000000000000')} and ${eq(users.role, 'admin')} and ${
+			eq(users.login, 'ada')
+		}`,
+	);
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	expect(query.sql).toContain(`cast(:1 as uuid)`);
+	expect(query.sql).toContain(`cast(:2 as "user_role")`);
+	expect(query.sql).toContain(`cast(:3 as varchar(64))`);
+});
+
+test('AwsPgDialect wraps UPDATE/SET and WHERE simultaneously', () => {
+	const role = pgEnum('user_role', ['admin', 'member']);
+	const users = pgTable('users', {
+		id: uuid('id').primaryKey(),
+		role: role('role').notNull(),
+	});
+
+	const q = db.update(users).set({ role: 'member' }).where(eq(users.id, '00000000-0000-0000-0000-000000000000'));
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	expect(query.sql).toContain(`cast(:1 as "user_role")`);
+	expect(query.sql).toContain(`cast(:2 as uuid)`);
+});
+
+test('AwsPgDialect wraps DELETE/WHERE enum predicate', () => {
+	const role = pgEnum('user_role', ['admin', 'member']);
+	const users = pgTable('users', {
+		id: uuid('id').primaryKey(),
+		role: role('role').notNull(),
+	});
+
+	const q = db.delete(users).where(eq(users.role, 'member'));
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	expect(query.sql).toContain(`cast(:1 as "user_role")`);
+});
+
+test('AwsPgDialect: bare sql.placeholder() does NOT auto-wrap (known limitation)', () => {
+	const role = pgEnum('user_role', ['admin', 'member']);
+	const users = pgTable('users', {
+		id: uuid('id').primaryKey(),
+		role: role('role').notNull(),
+	});
+
+	// `bindIfParam` (sql/expressions/conditions.ts) skips wrapping when the value is a
+	// Placeholder, so the column encoder is never attached. The placeholder reaches
+	// sql.ts as a bare `Placeholder` chunk, which doesn't carry the column it's bound to,
+	// so wrapParam can't fire. Users hitting this with AWS Data API need to cast
+	// explicitly: `eq(col, sql\`${sql.placeholder('x')}::user_role\`)`.
+	const q = db.select().from(users).where(eq(users.role, sql.placeholder('role')));
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	expect(query.sql).not.toContain('cast(:1');
+	expect(query.sql).toContain(`"users"."role" = :1`);
+});
+
+test('AwsPgDialect wraps every param in IN (...) clauses with the column type', () => {
+	const role = pgEnum('user_role', ['admin', 'member', 'guest']);
+	const users = pgTable('users', {
+		id: uuid('id').primaryKey(),
+		role: role('role').notNull(),
+	});
+
+	const q = db.select().from(users).where(inArray(users.role, ['admin', 'member', 'guest']));
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	// All three params must be cast — partial casting would still hit the error
+	expect(query.sql).toContain(`cast(:1 as "user_role")`);
+	expect(query.sql).toContain(`cast(:2 as "user_role")`);
+	expect(query.sql).toContain(`cast(:3 as "user_role")`);
+});
+
+test('AwsPgDialect wraps NULL values bound to column with cast(NULL as <type>)', () => {
+	const role = pgEnum('user_role', ['admin', 'member']);
+	const users = pgTable('users', {
+		id: uuid('id').primaryKey(),
+		role: role('role'),
+	});
+
+	// `cast(NULL as <enum>)` is valid Postgres and required for AWS Data API since
+	// there's no implicit text→enum cast even for NULL values
+	const q = db.insert(users).values({ id: '00000000-0000-0000-0000-000000000000', role: null });
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	expect(query.sql).toContain(`cast(:1 as uuid)`);
+	expect(query.sql).toContain(`cast(:2 as "user_role")`);
+});
+
+test('AwsPgDialect leaves user-written explicit ::cast literals untouched', () => {
+	const tasks = pgTable('tasks', { id: uuid('id').primaryKey() });
+
+	// User wrote their own ::uuid cast on a primitive (not bound to a column)
+	const q = db.select().from(tasks).where(sql`${tasks.id} = ${'00000000-0000-0000-0000-000000000000'}::uuid`);
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	// :1 is a primitive without a column encoder → no auto-wrap, the user's ::uuid stands
+	expect(query.sql).toContain(`= :1::uuid`);
+	expect(query.sql).not.toContain(`cast(:1`);
+});
+
+test('AwsPgDialect: explicit cast on left side disables auto-wrap on right', () => {
+	const role = pgEnum('user_role', ['admin', 'member']);
+	const users = pgTable('users', {
+		id: uuid('id').primaryKey(),
+		role: role('role').notNull(),
+	});
+
+	// User wraps the column with a manual ::text cast — eq's right side is bound
+	// to a SQL fragment (not a column), so it stays a plain :1 with no wrapper
+	const q = db.select().from(users).where(eq(sql`${users.role}::text`, 'admin'));
+	const query = new AwsPgDialect().sqlToQuery(q.getSQL());
+
+	expect(query.sql).toContain(`"users"."role"::text = :1`);
+	expect(query.sql).not.toContain(`cast(:1`);
+});
+
+test('AwsPgDialect leaves no-encoder sql.raw fragments unchanged', () => {
+	const q = sql`select 1 where ${sql.raw('true')}`;
+	const query = new AwsPgDialect().sqlToQuery(q);
+	expect(query.sql).not.toContain('cast(');
+});
+
+test('PgDialect wrapParam is a no-op (default)', () => {
+	const status = pgEnum('agent_status', ['idle', 'running']);
+	const tasks = pgTable('tasks', {
+		id: uuid('id').primaryKey(),
+		status: status('status').notNull(),
+		ready: boolean('ready').notNull(),
+		count: integer('count').notNull(),
+	});
+
+	const q = db.select().from(tasks).where(eq(tasks.status, 'running'));
+	const query = new PgDialect().sqlToQuery(q.getSQL());
+
+	// non-AWS dialects must not insert casts — pg/postgres-js negotiate parameter types
+	expect(query.sql).not.toContain('cast(');
 });
 
 test('type hints - case #2', () => {

--- a/integration-tests/tests/pg/awsdatapi.test.ts
+++ b/integration-tests/tests/pg/awsdatapi.test.ts
@@ -12,6 +12,7 @@ import {
 	date,
 	integer,
 	jsonb,
+	pgEnum,
 	pgTable,
 	pgTableCreator,
 	serial,
@@ -72,6 +73,19 @@ const userRelations = relations(user, (ctx) => ({
 const todoUser = pgTable('todo_user', {
 	todoId: uuid('todo_id').references(() => todo.id),
 	userId: uuid('user_id').references(() => user.id),
+});
+
+// Regression coverage for #2583 / #3409: AWS Data API has no `typeHint` for enums or arrays,
+// so column-bound params must be cast explicitly in the SQL.
+const accountRole = pgEnum('account_role', ['admin', 'member', 'guest']);
+
+const account = pgTable('account', {
+	id: uuid('id').primaryKey(),
+	role: accountRole('role').notNull(),
+	tags: text('tags')
+		.array()
+		.notNull()
+		.default(sql`'{}'`),
 });
 
 const todoToGroupRelations = relations(todoUser, (ctx) => ({
@@ -152,6 +166,17 @@ beforeEach(async () => {
 			create table todo_user (
 				todo_id uuid references todo(id),
 				user_id uuid references "user"(id)
+			)
+		`,
+	);
+
+	await db.execute(sql`create type account_role as enum ('admin', 'member', 'guest')`);
+	await db.execute(
+		sql`
+			create table account (
+				id uuid primary key,
+				role account_role not null,
+				tags text[] not null default '{}'
 			)
 		`,
 	);
@@ -1610,7 +1635,43 @@ test('Typehints mix for findFirst', async () => {
 	expect(res).toStrictEqual({ id: 'd997d46d-5769-4c78-9a35-93acadbe6076', email: 'd' });
 });
 
+// Regression tests for #2583 / #3409.
+// AWS RDS Data API exposes typeHint values only for JSON, UUID, TIMESTAMP, DATE, TIME, DECIMAL
+// (https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_SqlParameter.html).
+// Without an explicit `cast(...)`, params for enums, arrays, and other custom types arrive at
+// Postgres as `text` and the comparison fails with "operator does not exist: <T> = text".
+test('aws data api: insert + select-where with enum and uuid columns', async () => {
+	const id = '00000000-0000-0000-0000-000000000001';
+	await db.insert(account).values({ id, role: 'admin', tags: ['a', 'b'] });
+
+	const rows = await db.select().from(account).where(eq(account.role, 'admin'));
+
+	expect(rows).toEqual([{ id, role: 'admin', tags: ['a', 'b'] }]);
+});
+
+test('aws data api: update set + where on enum/uuid columns', async () => {
+	const id = '00000000-0000-0000-0000-000000000002';
+	await db.insert(account).values({ id, role: 'member' });
+
+	await db.update(account).set({ role: 'admin' }).where(eq(account.id, id));
+
+	const rows = await db.select().from(account).where(eq(account.id, id));
+	expect(rows[0]?.role).toBe('admin');
+});
+
+test('aws data api: delete where on enum predicate', async () => {
+	const id = '00000000-0000-0000-0000-000000000003';
+	await db.insert(account).values({ id, role: 'guest' });
+
+	await db.delete(account).where(eq(account.role, 'guest'));
+
+	const rows = await db.select().from(account);
+	expect(rows.length).toBe(0);
+});
+
 afterAll(async () => {
+	await db.execute(sql`drop table if exists "account"`);
+	await db.execute(sql`drop type if exists "account_role"`);
 	await db.execute(sql`drop table if exists "users"`);
 	await db.execute(sql`drop table if exists "todo_user"`);
 	await db.execute(sql`drop table if exists "user"`);


### PR DESCRIPTION
## Problem

When using the AWS RDS Data API driver against Aurora Serverless v2, queries against `uuid`, `pgEnum`, custom-typed, or array columns fail with:

```
DatabaseErrorException: ERROR: operator does not exist: <type> = text;
Hint: No operator matches the given name and argument types.
You might need to add explicit type casts.
```

The Data API only exposes 6 `typeHint` values — JSON, UUID, TIMESTAMP, DATE, TIME, DECIMAL ([SqlParameter API ref](https://docs.aws.amazon.com/rdsdataservice/latest/APIReference/API_SqlParameter.html)). Anything else arrives at Postgres as `text`, and Postgres has no implicit cast to those types.

The previous fix (`AwsPgDialect.buildInsertQuery` / `buildUpdateSet`) only handled `PgArray` in INSERT VALUES and UPDATE SET. WHERE / JOIN / HAVING / ORDER BY / DELETE clauses, and every non-array type (uuid, enum, custom domain, citext, ...), still hit the bug.

Closes #2583, #3409.

## Fix

Adds an optional `wrapParam` hook to `BuildQueryConfig` and threads it through `PgDialect`. The hook receives the column the parameter is bound to (or `undefined` for non-column-bound primitives in raw `sql` templates) and returns the SQL to emit in place of the bare parameter placeholder. `PgDialect` ships a no-op default; `AwsPgDialect` overrides it to emit:

```
cast(:N as <columnSqlType>)
```

for every column-bound param. Enum types are schema-qualified and identifier-quoted via `escapeName`. Redundant casts on top of existing `typeHint` (e.g. `cast(:1 as uuid)` over `typeHint: UUID`) are harmless and accepted by Postgres.

## Impact

- **AWS Data API**: enum / uuid / array / custom-type CRUD now works end-to-end (INSERT, SELECT-WHERE, UPDATE-SET-WHERE, DELETE-WHERE, JOIN-ON, ORDER-BY).
- **All other Pg drivers** (`pg`, `postgres-js`, `neon`, `vercel-postgres`, `pglite`): identical SQL output, no behavior change. The default `wrapParam` is a no-op.
- **Non-Pg dialects** (MySQL, SQLite, Gel, SingleStore, MS SQL): identical SQL output, zero overhead — `wrapParam` is only consulted when set.
- Removes the narrow `buildInsertQuery` / `buildUpdateSet` array-only overrides in `AwsPgDialect` (replaced by the broader hook).
- User-written explicit casts in raw `sql` templates are preserved unchanged (covered by tests).

## Tests

- 16 unit tests in `drizzle-orm/tests/type-hints.test.ts` covering INSERT / SELECT / UPDATE / DELETE for `pgEnum`, schema-qualified enum, `text[]`, `uuid`, `varchar(N)`, `numeric(p,s)`, customType, plus explicit-cast pass-through, `inArray`, NULL handling, and the documented placeholder limitation.
- New entry added to `integration-tests/tests/pg/awsdatapi.test.ts` exercising enum CRUD against a real Aurora cluster.
- All existing 575 `drizzle-orm` unit tests pass.
- `tsc --noEmit` clean, `dprint check` clean.

## Verified end-to-end against a real Aurora cluster

A full-CRUD smoke test against Aurora Serverless v2 / PostgreSQL using a temporary schema with two `pgEnum`s, a `customType` over a Postgres `DOMAIN`, a `customType` over `inet`, `text({enum:[...]})`, `text[]`, `jsonb`, `numeric(p,s)`, `date`, `timestamp`, `varchar(N)`, `boolean`, and `uuid` PKs/FKs — exercising:

- `db.insert / update / delete / select` with column-bound predicates
- `db.query.X.findFirst / findMany` (relational query API)
- Relational queries with `with` (subqueries + json aggregation), including nested `where` on related tables
- `inArray`, `and / or / eq / gte / lte`
- Array operators: `=`, `@>` (`arrayContains`), `<@` (`arrayContained`), `&&` (`arrayOverlaps`)
- INSERT … RETURNING
- INNER JOIN with column-to-column predicates (regression: must NOT cast columns)


## Files changed

- `drizzle-orm/src/sql/sql.ts` — add `wrapParam?` to `BuildQueryConfig`; thread it through both Param branches.
- `drizzle-orm/src/pg-core/dialect.ts` — declare `wrapParam` method with no-op default; pass into `sqlToQuery`.
- `drizzle-orm/src/aws-data-api/common/index.ts` — JSDoc / inline references to AWS docs (no behavior change).
- `drizzle-orm/src/aws-data-api/pg/driver.ts` — `AwsPgDialect.wrapParam` override; remove old array-only INSERT / UPDATE overrides.
- `drizzle-orm/tests/type-hints.test.ts` — new test cases.
- `integration-tests/tests/pg/awsdatapi.test.ts` — new enum CRUD case.

## Out of scope

- **Prepared statements with `sql.placeholder()` against typed columns**: `bindIfParam` strips the column encoder for placeholders. Documented as a known limitation in `tests/type-hints.test.ts` and a workaround is included (`eq(col, sql\`${sql.placeholder('x')}::enum_name\`)`). 
- **`bytea` / `Buffer` parameters**: `toValueParam` throws on `Buffer`/`Uint8Array` today. Pre-existing, unrelated to this PR.
- **`time with time zone` `typeHint` formatting**: pre-existing, unrelated.

Quick note on the placeholder limitation flagged under "Out of scope":

  It's a one-line fix in `bindIfParam` — drop the `!is(value, Placeholder)` guard in `drizzle-orm/src/sql/expressions/conditions.ts:17` so `eq(col, sql.placeholder('x'))` produces `Param(Placeholder, col_encoder)` instead of a bare `Placeholder`. From there,
  the placeholder hits the `Param` branch in `sql.ts`, the `wrapParam` hook this PR adds fires for it, and `fillPlaceholders` already has the matching `Param(Placeholder, encoder)` path that runs `mapToDriverValue` at execute time.

  The dependency is the other direction: that one-liner only produces correct AWS Data API output **after** this PR's `wrapParam` infrastructure is in place. Without it, the placeholder chunk would still arrive at the AWS session as text-without-typeHint.

  So: easy follow-up PR, but explicitly downstream of this one. Happy to send it as soon as #5729 lands.