### PR TITLE
Add PGlite query serializer options

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -170,7 +170,7 @@
 	"devDependencies": {
 		"@aws-sdk/client-rds-data": "^3.549.0",
 		"@cloudflare/workers-types": "^4.20241112.0",
-		"@electric-sql/pglite": "^0.2.12",
+		"@electric-sql/pglite": "^0.4.5",
 		"@libsql/client": "^0.10.0",
 		"@libsql/client-wasm": "^0.10.0",
 		"@miniflare/d1": "^2.14.4",

--- a/drizzle-orm/src/cache/core/cache.ts
+++ b/drizzle-orm/src/cache/core/cache.ts
@@ -66,8 +66,12 @@ export class NoopCache extends Cache {
 
 export type MutationOption = { tags?: string | string[]; tables?: Table<any> | Table<any>[] | string | string[] };
 
+function stringifyParamsForHash(params?: any[]): string | undefined {
+	return JSON.stringify(params, (_, value) => typeof value === 'bigint' ? { __drizzleBigInt: String(value) } : value);
+}
+
 export async function hashQuery(sql: string, params?: any[]) {
-	const dataToHash = `${sql}-${JSON.stringify(params)}`;
+	const dataToHash = `${sql}-${stringifyParamsForHash(params)}`;
 	const encoder = new TextEncoder();
 	const data = encoder.encode(dataToHash);
 	const hashBuffer = await crypto.subtle.digest('SHA-256', data);

--- a/drizzle-orm/src/pglite/driver.ts
+++ b/drizzle-orm/src/pglite/driver.ts
@@ -4,20 +4,50 @@ import { entityKind } from '~/entity.ts';
 import type { Logger } from '~/logger.ts';
 import { DefaultLogger } from '~/logger.ts';
 import { PgDatabase } from '~/pg-core/db.ts';
-import { PgDialect } from '~/pg-core/dialect.ts';
+import { PgDialect, type PgDialectConfig } from '~/pg-core/dialect.ts';
 import {
 	createTableRelationsHelpers,
 	extractTablesRelationalConfig,
 	type RelationalSchemaConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
+import type { QueryWithTypings, SQL } from '~/sql/sql.ts';
 import { type DrizzleConfig, isConfig } from '~/utils.ts';
-import type { PgliteClient, PgliteQueryResultHKT } from './session.ts';
-import { PgliteSession } from './session.ts';
+import type { PgliteClient, PgliteQueryOptions, PgliteQueryResultHKT } from './session.ts';
+import { mapPgliteParam, PgliteSession } from './session.ts';
+
+export interface PgliteDrizzleConfig<TSchema extends Record<string, unknown> = Record<string, never>>
+	extends DrizzleConfig<TSchema>
+{
+	queryOptions?: PgliteQueryOptions;
+}
 
 export interface PgDriverOptions {
 	logger?: Logger;
 	cache?: Cache;
+	queryOptions?: PgliteQueryOptions;
+}
+
+class PgliteDialect extends PgDialect {
+	constructor(
+		private readonly config: PgDialectConfig & {
+			queryOptions?: PgliteQueryOptions;
+		} = {},
+	) {
+		super(config);
+	}
+
+	override sqlToQuery(sql: SQL, invokeSource?: 'indexes' | undefined): QueryWithTypings {
+		return sql.toQuery({
+			casing: this.casing,
+			escapeName: this.escapeName,
+			escapeParam: this.escapeParam,
+			escapeString: this.escapeString,
+			prepareTyping: this.prepareTyping,
+			mapParam: (value, encoder) => mapPgliteParam(value, encoder, this.config.queryOptions),
+			invokeSource,
+		});
+	}
 }
 
 export class PgliteDriver {
@@ -36,6 +66,7 @@ export class PgliteDriver {
 		return new PgliteSession(this.client, this.dialect, schema, {
 			logger: this.options.logger,
 			cache: this.options.cache,
+			queryOptions: this.options.queryOptions,
 		});
 	}
 }
@@ -48,11 +79,11 @@ export class PgliteDatabase<
 
 function construct<TSchema extends Record<string, unknown> = Record<string, never>>(
 	client: PgliteClient,
-	config: DrizzleConfig<TSchema> = {},
+	config: PgliteDrizzleConfig<TSchema> = {},
 ): PgliteDatabase<TSchema> & {
 	$client: PgliteClient;
 } {
-	const dialect = new PgDialect({ casing: config.casing });
+	const dialect = new PgliteDialect({ casing: config.casing, queryOptions: config.queryOptions });
 	let logger;
 	if (config.logger === true) {
 		logger = new DefaultLogger();
@@ -73,7 +104,7 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 		};
 	}
 
-	const driver = new PgliteDriver(client, dialect, { logger, cache: config.cache });
+	const driver = new PgliteDriver(client, dialect, { logger, cache: config.cache, queryOptions: config.queryOptions });
 	const session = driver.createSession(schema);
 	const db = new PgliteDatabase(dialect, session, schema as any) as PgliteDatabase<TSchema>;
 	(<any> db).$client = client;
@@ -106,11 +137,11 @@ export function drizzle<
 		]
 		| [
 			TClient | string,
-			DrizzleConfig<TSchema>,
+			PgliteDrizzleConfig<TSchema>,
 		]
 		| [
 			(
-				& DrizzleConfig<TSchema>
+				& PgliteDrizzleConfig<TSchema>
 				& ({
 					connection?: (PGliteOptions & { dataDir?: string }) | string;
 				} | {
@@ -126,11 +157,11 @@ export function drizzle<
 		return construct(instance, params[1]) as any;
 	}
 
-	if (isConfig(params[0])) {
+	if (isConfig(params[0]) || isPgliteConfig(params[0])) {
 		const { connection, client, ...drizzleConfig } = params[0] as {
 			connection?: PGliteOptions & { dataDir: string };
 			client?: TClient;
-		} & DrizzleConfig<TSchema>;
+		} & PgliteDrizzleConfig<TSchema>;
 
 		if (client) return construct(client, drizzleConfig) as any;
 
@@ -147,15 +178,27 @@ export function drizzle<
 		return construct(instance, drizzleConfig) as any;
 	}
 
-	return construct(params[0] as TClient, params[1] as DrizzleConfig<TSchema> | undefined) as any;
+	return construct(params[0] as TClient, params[1] as PgliteDrizzleConfig<TSchema> | undefined) as any;
 }
 
 export namespace drizzle {
 	export function mock<TSchema extends Record<string, unknown> = Record<string, never>>(
-		config?: DrizzleConfig<TSchema>,
+		config?: PgliteDrizzleConfig<TSchema>,
 	): PgliteDatabase<TSchema> & {
 		$client: '$client is not available on drizzle.mock()';
 	} {
 		return construct({} as any, config) as any;
 	}
+}
+
+function isPgliteConfig(data: unknown): boolean {
+	if (typeof data !== 'object' || data === null) return false;
+
+	if (data.constructor.name !== 'Object') return false;
+
+	if (!('queryOptions' in data)) return false;
+
+	const queryOptions = (data as { queryOptions?: unknown }).queryOptions;
+	return queryOptions === undefined
+		|| (typeof queryOptions === 'object' && queryOptions !== null && queryOptions.constructor.name === 'Object');
 }

--- a/drizzle-orm/src/pglite/session.ts
+++ b/drizzle-orm/src/pglite/session.ts
@@ -1,13 +1,14 @@
-import type { PGlite, QueryOptions, Results, Row, Transaction } from '@electric-sql/pglite';
-import { entityKind } from '~/entity.ts';
+import type { ParserOptions, PGlite, QueryOptions, Results, Row, Transaction } from '@electric-sql/pglite';
+import { entityKind, is } from '~/entity.ts';
 import { type Logger, NoopLogger } from '~/logger.ts';
+import { PgJson, PgJsonb } from '~/pg-core/columns/index.ts';
 import type { PgDialect } from '~/pg-core/dialect.ts';
 import { PgTransaction } from '~/pg-core/index.ts';
 import type { SelectedFieldsOrdered } from '~/pg-core/query-builders/select.types.ts';
 import type { PgQueryResultHKT, PgTransactionConfig, PreparedQueryConfig } from '~/pg-core/session.ts';
 import { PgPreparedQuery, PgSession } from '~/pg-core/session.ts';
 import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
-import { fillPlaceholders, type Query, type SQL, sql } from '~/sql/sql.ts';
+import { type DriverValueEncoder, fillPlaceholders, type Query, type SQL, sql } from '~/sql/sql.ts';
 import { type Assume, mapResultRow } from '~/utils.ts';
 
 import { types } from '@electric-sql/pglite';
@@ -15,6 +16,56 @@ import { type Cache, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 
 export type PgliteClient = PGlite;
+export type PgliteSerializerOptions = Record<number, (value: any) => string>;
+
+export interface PgliteQueryOptions {
+	parsers?: ParserOptions;
+	serializers?: PgliteSerializerOptions;
+}
+
+const defaultParsers: ParserOptions = {
+	[types.TIMESTAMP]: (value) => value,
+	[types.TIMESTAMPTZ]: (value) => value,
+	[types.INTERVAL]: (value) => value,
+	[types.DATE]: (value) => value,
+	// numeric[]
+	[1231]: (value) => value,
+	// timestamp[]
+	[1115]: (value) => value,
+	// timestamp with timezone[]
+	[1185]: (value) => value,
+	// interval[]
+	[1187]: (value) => value,
+	// date[]
+	[1182]: (value) => value,
+};
+
+function buildQueryConfig(rowMode: QueryOptions['rowMode'], queryOptions: PgliteQueryOptions = {}): QueryOptions {
+	return {
+		rowMode,
+		parsers: queryOptions.parsers ? { ...defaultParsers, ...queryOptions.parsers } : defaultParsers,
+		...(queryOptions.serializers ? { serializers: queryOptions.serializers } : {}),
+	};
+}
+
+/** @internal */
+export function mapPgliteParam(
+	value: unknown,
+	encoder: DriverValueEncoder<unknown, unknown>,
+	queryOptions: PgliteQueryOptions = {},
+): unknown | SQL {
+	const serializers = queryOptions.serializers;
+
+	if (serializers?.[types.JSON] && is(encoder, PgJson)) {
+		return value;
+	}
+
+	if (serializers?.[types.JSONB] && is(encoder, PgJsonb)) {
+		return value;
+	}
+
+	return encoder.mapToDriverValue(value);
+}
 
 export class PglitePreparedQuery<T extends PreparedQueryConfig> extends PgPreparedQuery<T> {
 	static override readonly [entityKind]: string = 'PglitePreparedQuery';
@@ -36,51 +87,20 @@ export class PglitePreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 		private fields: SelectedFieldsOrdered | undefined,
 		name: string | undefined,
 		private _isResponseInArrayMode: boolean,
+		private queryOptions?: PgliteQueryOptions,
 		private customResultMapper?: (rows: unknown[][]) => T['execute'],
 	) {
 		super({ sql: queryString, params }, cache, queryMetadata, cacheConfig);
-		this.rawQueryConfig = {
-			rowMode: 'object',
-			parsers: {
-				[types.TIMESTAMP]: (value) => value,
-				[types.TIMESTAMPTZ]: (value) => value,
-				[types.INTERVAL]: (value) => value,
-				[types.DATE]: (value) => value,
-				// numeric[]
-				[1231]: (value) => value,
-				// timestamp[]
-				[1115]: (value) => value,
-				// timestamp with timezone[]
-				[1185]: (value) => value,
-				// interval[]
-				[1187]: (value) => value,
-				// date[]
-				[1182]: (value) => value,
-			},
-		};
-		this.queryConfig = {
-			rowMode: 'array',
-			parsers: {
-				[types.TIMESTAMP]: (value) => value,
-				[types.TIMESTAMPTZ]: (value) => value,
-				[types.INTERVAL]: (value) => value,
-				[types.DATE]: (value) => value,
-				// numeric[]
-				[1231]: (value) => value,
-				// timestamp[]
-				[1115]: (value) => value,
-				// timestamp with timezone[]
-				[1185]: (value) => value,
-				// interval[]
-				[1187]: (value) => value,
-				// date[]
-				[1182]: (value) => value,
-			},
-		};
+		this.rawQueryConfig = buildQueryConfig('object', queryOptions);
+		this.queryConfig = buildQueryConfig('array', queryOptions);
 	}
 
 	async execute(placeholderValues: Record<string, unknown> | undefined = {}): Promise<T['execute']> {
-		const params = fillPlaceholders(this.params, placeholderValues);
+		const params = fillPlaceholders(
+			this.params,
+			placeholderValues,
+			(value, encoder) => mapPgliteParam(value, encoder, this.queryOptions),
+		);
 
 		this.logger.logQuery(this.queryString, params);
 
@@ -102,7 +122,11 @@ export class PglitePreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 	}
 
 	all(placeholderValues: Record<string, unknown> | undefined = {}): Promise<T['all']> {
-		const params = fillPlaceholders(this.params, placeholderValues);
+		const params = fillPlaceholders(
+			this.params,
+			placeholderValues,
+			(value, encoder) => mapPgliteParam(value, encoder, this.queryOptions),
+		);
 		this.logger.logQuery(this.queryString, params);
 		return this.queryWithCache(this.queryString, params, async () => {
 			return await this.client.query<any[]>(this.queryString, params, this.rawQueryConfig);
@@ -118,6 +142,7 @@ export class PglitePreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 export interface PgliteSessionOptions {
 	logger?: Logger;
 	cache?: Cache;
+	queryOptions?: PgliteQueryOptions;
 }
 
 export class PgliteSession<
@@ -163,6 +188,7 @@ export class PgliteSession<
 			fields,
 			name,
 			isResponseInArrayMode,
+			this.options.queryOptions,
 			customResultMapper,
 		);
 	}

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -35,6 +35,8 @@ export interface BuildQueryConfig {
 	escapeParam(num: number, value: unknown): string;
 	escapeString(str: string): string;
 	prepareTyping?: (encoder: DriverValueEncoder<unknown, unknown>) => QueryTypingsValue;
+	/** @internal */
+	mapParam?: (value: unknown, encoder: DriverValueEncoder<unknown, unknown>) => unknown | SQL;
 	paramStartIndex?: { value: number };
 	inlineParams?: boolean;
 	invokeSource?: 'indexes' | undefined;
@@ -84,6 +86,10 @@ function mergeQueries(queries: QueryWithTypings[]): QueryWithTypings {
 		}
 	}
 	return result;
+}
+
+function stringifyQueryParams(params: unknown[]): string {
+	return JSON.stringify(params, (_, value) => typeof value === 'bigint' ? String(value) : value);
 }
 
 export class StringChunk implements SQLWrapper {
@@ -139,7 +145,7 @@ export class SQL<T = unknown> implements SQLWrapper {
 			const query = this.buildQueryFromSourceParams(this.queryChunks, config);
 			span?.setAttributes({
 				'drizzle.query.text': query.sql,
-				'drizzle.query.params': JSON.stringify(query.params),
+				'drizzle.query.params': stringifyQueryParams(query.params),
 			});
 			return query;
 		});
@@ -155,6 +161,7 @@ export class SQL<T = unknown> implements SQLWrapper {
 			casing,
 			escapeName,
 			escapeParam,
+			mapParam,
 			prepareTyping,
 			inlineParams,
 			paramStartIndex,
@@ -235,7 +242,11 @@ export class SQL<T = unknown> implements SQLWrapper {
 					return { sql: escapeParam(paramStartIndex.value++, chunk), params: [chunk], typings: ['none'] };
 				}
 
-				const mappedValue = chunk.value === null ? null : chunk.encoder.mapToDriverValue(chunk.value);
+				const mappedValue = chunk.value === null
+					? null
+					: mapParam
+					? mapParam(chunk.value, chunk.encoder)
+					: chunk.encoder.mapToDriverValue(chunk.value);
 
 				if (is(mappedValue, SQL)) {
 					return this.buildQueryFromSourceParams([mappedValue], config);
@@ -609,7 +620,11 @@ export function placeholder<TName extends string>(name: TName): Placeholder<TNam
 	return new Placeholder(name);
 }
 
-export function fillPlaceholders(params: unknown[], values: Record<string, unknown>): unknown[] {
+export function fillPlaceholders(
+	params: unknown[],
+	values: Record<string, unknown>,
+	mapParam?: (value: unknown, encoder: DriverValueEncoder<unknown, unknown>) => unknown | SQL,
+): unknown[] {
 	return params.map((p) => {
 		if (is(p, Placeholder)) {
 			if (!(p.name in values)) {
@@ -624,7 +639,8 @@ export function fillPlaceholders(params: unknown[], values: Record<string, unkno
 				throw new Error(`No value for placeholder "${p.value.name}" was provided`);
 			}
 
-			return p.encoder.mapToDriverValue(values[p.value.name]);
+			const value = values[p.value.name];
+			return mapParam ? mapParam(value, p.encoder) : p.encoder.mapToDriverValue(value);
 		}
 
 		return p;

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -42,7 +42,7 @@
 	"dependencies": {
 		"@aws-sdk/client-rds-data": "^3.549.0",
 		"@aws-sdk/credential-providers": "^3.549.0",
-		"@electric-sql/pglite": "0.2.12",
+		"@electric-sql/pglite": "0.4.5",
 		"@libsql/client": "^0.10.0",
 		"@miniflare/d1": "^2.14.4",
 		"@miniflare/shared": "^2.14.4",

--- a/integration-tests/tests/pg/pglite.test.ts
+++ b/integration-tests/tests/pg/pglite.test.ts
@@ -1,5 +1,6 @@
-import { PGlite } from '@electric-sql/pglite';
-import { Name, sql } from 'drizzle-orm';
+import { PGlite, types } from '@electric-sql/pglite';
+import { eq, Name, sql } from 'drizzle-orm';
+import { json, jsonb, pgTable, serial } from 'drizzle-orm/pg-core';
 import { drizzle, type PgliteDatabase } from 'drizzle-orm/pglite';
 import { migrate } from 'drizzle-orm/pglite/migrator';
 import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
@@ -82,6 +83,104 @@ test('insert via db.execute w/ query builder', async () => {
 		db.insert(usersTable).values({ name: 'John' }).returning({ id: usersTable.id, name: usersTable.name }),
 	);
 	expect(Array.prototype.slice.call(result.rows)).toEqual([{ id: 1, name: 'John' }]);
+});
+
+test('supports custom json and jsonb serializers', async () => {
+	const client = new PGlite();
+	const stringifyBigInts = (value: unknown) =>
+		JSON.stringify(
+			value,
+			(_key, nestedValue) => typeof nestedValue === 'bigint' ? nestedValue.toString() : nestedValue,
+		);
+	const db = drizzle({
+		client,
+		cache: new TestCache(),
+		queryOptions: {
+			serializers: {
+				[types.JSON]: stringifyBigInts,
+				[types.JSONB]: stringifyBigInts,
+			},
+		},
+	});
+	const jsonTable = pgTable('pglite_jsonb_bigint', {
+		id: serial('id').primaryKey(),
+		metadata: json('metadata').$type<{ xid: bigint }>(),
+		extra: jsonb('extra').$type<{ xid: bigint }>(),
+	});
+
+	try {
+		await db.execute(sql`create table ${jsonTable} (id serial primary key, metadata json, extra jsonb)`);
+
+		await db.insert(jsonTable).values({ metadata: { xid: 0n }, extra: { xid: 0n } });
+
+		const statement = db.insert(jsonTable).values({
+			metadata: sql.placeholder('metadata'),
+			extra: sql.placeholder('extra'),
+		}).prepare('pglite_json_bigint_serializers');
+
+		await statement.execute({ metadata: { xid: 1n }, extra: { xid: 1n } });
+
+		const result = await db.select({
+			metadataXid: sql<string>`${jsonTable.metadata}->>'xid'`,
+			extraXid: sql<string>`${jsonTable.extra}->>'xid'`,
+		}).from(jsonTable).orderBy(jsonTable.id);
+
+		expect(result).toEqual([
+			{ metadataXid: '0', extraXid: '0' },
+			{ metadataXid: '1', extraXid: '1' },
+		]);
+
+		const cachedResult = await db.select({
+			id: jsonTable.id,
+		}).from(jsonTable).where(eq(jsonTable.extra, { xid: 1n })).$withCache();
+
+		expect(cachedResult).toEqual([{ id: 2 }]);
+	} finally {
+		await client.close();
+	}
+});
+
+test('uses default json and jsonb serialization without custom serializers', async () => {
+	const client = new PGlite();
+	const db = drizzle(client);
+	const jsonTable = pgTable('pglite_json_defaults', {
+		id: serial('id').primaryKey(),
+		metadata: json('metadata').$type<{ xid: number }>(),
+		extra: jsonb('extra').$type<{ xid: number }>(),
+	});
+
+	try {
+		await db.execute(sql`create table ${jsonTable} (id serial primary key, metadata json, extra jsonb)`);
+
+		await db.insert(jsonTable).values({ metadata: { xid: 1 }, extra: { xid: 1 } });
+
+		const result = await db.select({
+			metadata: jsonTable.metadata,
+			extra: jsonTable.extra,
+		}).from(jsonTable);
+
+		expect(result).toEqual([{ metadata: { xid: 1 }, extra: { xid: 1 } }]);
+	} finally {
+		await client.close();
+	}
+});
+
+test('supports custom parser overrides', async () => {
+	const db = drizzle({
+		queryOptions: {
+			parsers: {
+				[types.DATE]: (value) => `parsed:${value}`,
+			},
+		},
+	});
+
+	try {
+		const result = await db.execute<{ value: string }>(sql`select date '2024-01-02' as value`);
+
+		expect(Array.prototype.slice.call(result.rows)).toEqual([{ value: 'parsed:2024-01-02' }]);
+	} finally {
+		await db.$client.close();
+	}
 });
 
 skipTests([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,8 +346,8 @@ importers:
         specifier: ^4.20241112.0
         version: 4.20250529.0
       '@electric-sql/pglite':
-        specifier: ^0.2.12
-        version: 0.2.12
+        specifier: ^0.4.5
+        version: 0.4.5
       '@libsql/client':
         specifier: ^0.10.0
         version: 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -362,7 +362,7 @@ importers:
         version: 0.10.0
       '@netlify/db':
         specifier: ^0.4.0
-        version: 0.4.0(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.2.12)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.10.0)(bufferutil@4.0.8)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(utf-8-validate@6.0.3)
+        version: 0.4.0(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.4.5)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.10.0)(bufferutil@4.0.8)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(utf-8-validate@6.0.3)
       '@op-engineering/op-sqlite':
         specifier: ^2.0.16
         version: 2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
@@ -698,8 +698,8 @@ importers:
         specifier: ^3.549.0
         version: 3.817.0
       '@electric-sql/pglite':
-        specifier: 0.2.12
-        version: 0.2.12
+        specifier: 0.4.5
+        version: 0.4.5
       '@libsql/client':
         specifier: ^0.10.0
         version: 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -711,7 +711,7 @@ importers:
         version: 2.14.4
       '@netlify/db':
         specifier: ^0.4.0
-        version: 0.4.0(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.9.1)(bufferutil@4.0.8)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(utf-8-validate@6.0.3)
+        version: 0.4.0(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.4.5)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.9.1)(bufferutil@4.0.8)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(utf-8-validate@6.0.3)
       '@planetscale/database':
         specifier: ^1.16.0
         version: 1.19.0
@@ -1607,6 +1607,9 @@ packages:
 
   '@electric-sql/pglite@0.2.12':
     resolution: {integrity: sha512-J/X42ujcoFEbOkgRyoNqZB5qcqrnJRWVlwpH3fKYoJkTz49N91uAK/rDSSG/85WRas9nC9mdV4FnMTxnQWE/rw==}
+
+  '@electric-sql/pglite@0.4.5':
+    resolution: {integrity: sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -9873,6 +9876,8 @@ snapshots:
 
   '@electric-sql/pglite@0.2.12': {}
 
+  '@electric-sql/pglite@0.4.5': {}
+
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
       esbuild: 0.18.20
@@ -10828,12 +10833,12 @@ snapshots:
     dependencies:
       '@types/pg': 8.11.6
 
-  '@netlify/db@0.4.0(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.2.12)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.10.0)(bufferutil@4.0.8)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(utf-8-validate@6.0.3)':
+  '@netlify/db@0.4.0(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.4.5)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.10.0)(bufferutil@4.0.8)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(utf-8-validate@6.0.3)':
     dependencies:
       '@neondatabase/serverless': 0.10.0
       '@netlify/runtime-utils': 2.3.0
       pg: 8.16.0
-      waddler: 0.1.1(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.2.12)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.10.0)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)
+      waddler: 0.1.1(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.4.5)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.10.0)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)
       ws: 8.18.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - '@clickhouse/client'
@@ -10857,12 +10862,12 @@ snapshots:
       - postgres
       - utf-8-validate
 
-  '@netlify/db@0.4.0(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.9.1)(bufferutil@4.0.8)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(utf-8-validate@6.0.3)':
+  '@netlify/db@0.4.0(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.4.5)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.9.1)(bufferutil@4.0.8)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)(utf-8-validate@6.0.3)':
     dependencies:
       '@neondatabase/serverless': 0.10.0
       '@netlify/runtime-utils': 2.3.0
       pg: 8.16.0
-      waddler: 0.1.1(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.9.1)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)
+      waddler: 0.1.1(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.4.5)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.9.1)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7)
       ws: 8.18.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - '@clickhouse/client'
@@ -17587,10 +17592,10 @@ snapshots:
 
   vlq@1.0.1: {}
 
-  waddler@0.1.1(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.2.12)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.10.0)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7):
+  waddler@0.1.1(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.4.5)(@libsql/client-wasm@0.10.0)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.3)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.10.0)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250529.0
-      '@electric-sql/pglite': 0.2.12
+      '@electric-sql/pglite': 0.4.5
       '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@libsql/client-wasm': 0.10.0
       '@neondatabase/serverless': 0.10.0
@@ -17606,10 +17611,10 @@ snapshots:
       pg: 8.16.0
       postgres: 3.4.7
 
-  waddler@0.1.1(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.2.12)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.9.1)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7):
+  waddler@0.1.1(@cloudflare/workers-types@4.20250529.0)(@electric-sql/pglite@0.4.5)(@libsql/client@0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(@neondatabase/serverless@0.10.0)(@planetscale/database@1.19.0)(@tidbcloud/serverless@0.1.1)(@vercel/postgres@0.8.0)(@xata.io/client@0.29.5(typescript@5.6.3))(better-sqlite3@11.9.1)(bun-types@1.2.15)(gel@2.1.0)(mysql2@3.14.1)(pg@8.16.0)(postgres@3.4.7):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20250529.0
-      '@electric-sql/pglite': 0.2.12
+      '@electric-sql/pglite': 0.4.5
       '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@neondatabase/serverless': 0.10.0
       '@planetscale/database': 1.19.0


### PR DESCRIPTION
Fixes #5737

## Summary
- Add PGlite `queryOptions` support for custom parsers and serializers.
- Preserve Drizzle's default PGlite parsers while allowing explicit parser overrides.
- Preserve raw PgJson/PgJsonb values for PGlite only when matching custom serializers are configured, so PGlite 0.4.5 can serialize JSON/JSONB BigInts.
- Pass the same query options through prepared queries and nested transaction sessions.
- Make query tracing param stringification and cache hash generation tolerate raw bigint params.
- Add focused regressions for JSON/JSONB serializers, prepared placeholders, cache hashing, parser override precedence, default JSON behavior, and `{ queryOptions }` config detection.

## Review Follow-up
- Addressed cache hashing with raw bigint JSON params.
- Added placeholder-path coverage for `fillPlaceholders()`.
- Hardened tracing param serialization for future active spans.
- Confirmed `ParserOptions` exists in PGlite 0.2.12, so the broad peer range remains compatible at the type export level.

## Verification
- `pnpm --dir integration-tests exec vitest run tests/pg/pglite.test.ts --printConsoleTrace=true --silent=false --pass-with-no-tests -t "custom|default json"`
- `pnpm --dir integration-tests exec vitest run tests/pg/pglite.test.ts --printConsoleTrace=true --silent=false --pass-with-no-tests -t "supports custom json and jsonb serializers"`
- `pnpm build:orm`
- `pnpm lint`
- `pnpm exec dprint check --list-different`
- `git diff --check origin/main...HEAD`