### PR TITLE
[Pg] Fix aggregate functions returning raw string for mode:'date' columns

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -344,7 +344,25 @@ export function orderSelectedFields<TColumn extends AnyColumn>(
 				codec: codecs?.get(field, 'normalize'),
 				arrayDimensions: (<any> field).dimensions,
 			});
-		} else if (is(field, Column) || is(field, SQL) || is(field, SQL.Aliased) || is(field, Subquery)) {
+		} else if (is(field, SQL)) {
+			const decoder = field.decoder;
+			const decoderColumn = is(decoder, Column) ? decoder : undefined;
+			result.push({
+				path: newPath,
+				field,
+				codec: codecs && decoderColumn ? codecs.get(decoderColumn, 'normalize') : undefined,
+				arrayDimensions: decoderColumn ? (<any> decoderColumn).dimensions : undefined,
+			});
+		} else if (is(field, SQL.Aliased)) {
+			const decoder = field.sql.decoder;
+			const decoderColumn = is(decoder, Column) ? decoder : undefined;
+			result.push({
+				path: newPath,
+				field,
+				codec: codecs && decoderColumn ? codecs.get(decoderColumn, 'normalize') : undefined,
+				arrayDimensions: decoderColumn ? (<any> decoderColumn).dimensions : undefined,
+			});
+		} else if (is(field, Subquery)) {
 			result.push({ path: newPath, field });
 		} else if (is(field, Table)) {
 			result.push(...orderSelectedFields(field[Table.Symbol.Columns], newPath, codecs));

--- a/drizzle-orm/tests/aggregate-codec.test.ts
+++ b/drizzle-orm/tests/aggregate-codec.test.ts
@@ -1,0 +1,147 @@
+import { expect, test } from 'vitest';
+import { CodecsCollection } from '~/codecs';
+import { Column } from '~/column';
+import { is } from '~/entity';
+import { nodePgCodecs } from '~/node-postgres/codecs';
+import { date, pgTable, serial, timestamp } from '~/pg-core';
+import { resolvePgTypeAlias } from '~/pg-core/codecs';
+import { PgDialect } from '~/pg-core/dialect';
+import { max, min } from '~/sql/functions/aggregate';
+import { SQL } from '~/sql/sql';
+import { orderSelectedFields } from '~/utils';
+
+const table = pgTable('t', {
+	id: serial().primaryKey().notNull(),
+	ts: timestamp({ mode: 'date', withTimezone: true }),
+	tsNoTz: timestamp({ mode: 'date', withTimezone: false }),
+	tsString: timestamp({ mode: 'string' }),
+	d: date({ mode: 'date' }),
+	dString: date({ mode: 'string' }),
+});
+
+// Simulate the codec collection used by a real NodePgDatabase
+const pgCodecs = new CodecsCollection(resolvePgTypeAlias, nodePgCodecs);
+
+test('max(timestamptz) decoder is the column', () => {
+	const expr = max(table.ts);
+	expect(is(expr, SQL)).toBe(true);
+	expect(expr.decoder).toBeInstanceOf(Column);
+});
+
+test('max(timestamp mode:date withTimezone) orderSelectedFields attaches normalize codec', () => {
+	const fields = { maxTs: max(table.ts) };
+	const ordered = orderSelectedFields(fields, undefined, pgCodecs);
+	expect(ordered).toHaveLength(1);
+	const entry = ordered[0]!;
+	expect(entry.codec).toBeDefined();
+	const result = (entry.codec as (v: any) => any)('2026-04-01 00:00:00+00');
+	expect(result).toBeInstanceOf(Date);
+});
+
+test('min(timestamp mode:date withTimezone) orderSelectedFields attaches normalize codec', () => {
+	const fields = { minTs: min(table.ts) };
+	const ordered = orderSelectedFields(fields, undefined, pgCodecs);
+	expect(ordered).toHaveLength(1);
+	const entry = ordered[0]!;
+	expect(entry.codec).toBeDefined();
+	const result = (entry.codec as (v: any) => any)('2026-04-01 00:00:00+00');
+	expect(result).toBeInstanceOf(Date);
+});
+
+test('max(timestamp mode:date no timezone) orderSelectedFields attaches normalize codec', () => {
+	const fields = { maxTs: max(table.tsNoTz) };
+	const ordered = orderSelectedFields(fields, undefined, pgCodecs);
+	expect(ordered).toHaveLength(1);
+	const entry = ordered[0]!;
+	expect(entry.codec).toBeDefined();
+	const result = (entry.codec as (v: any) => any)('2026-04-01 00:00:00');
+	expect(result).toBeInstanceOf(Date);
+});
+
+test('max(timestamp mode:string) orderSelectedFields has no normalize codec', () => {
+	const fields = { maxTs: max(table.tsString) };
+	const ordered = orderSelectedFields(fields, undefined, pgCodecs);
+	expect(ordered).toHaveLength(1);
+	expect(ordered[0]!.codec).toBeUndefined();
+});
+
+test('max(date mode:date) orderSelectedFields attaches normalize codec', () => {
+	const fields = { maxD: max(table.d) };
+	const ordered = orderSelectedFields(fields, undefined, pgCodecs);
+	expect(ordered).toHaveLength(1);
+	const entry = ordered[0]!;
+	expect(entry.codec).toBeDefined();
+	const result = (entry.codec as (v: any) => any)('2026-04-01');
+	expect(result).toBeInstanceOf(Date);
+});
+
+test('max(date mode:string) orderSelectedFields has no normalize codec', () => {
+	const fields = { maxD: max(table.dString) };
+	const ordered = orderSelectedFields(fields, undefined, pgCodecs);
+	expect(ordered).toHaveLength(1);
+	expect(ordered[0]!.codec).toBeUndefined();
+});
+
+test('PgDialect with nodePgCodecs: rows mapper decodes max(timestamptz) to Date', () => {
+	const dialect = new PgDialect({ codecs: nodePgCodecs });
+	const fields = { maxTs: max(table.ts) };
+	const fieldsList = orderSelectedFields(fields, undefined, dialect.codecs);
+	const mapper = dialect.mapperGenerators.rows(fieldsList, undefined);
+	const [row] = mapper([['2026-04-01 00:00:00+00']] as any);
+	expect(row?.maxTs).toBeInstanceOf(Date);
+});
+
+test('PgDialect with nodePgCodecs: rows mapper decodes max(timestamp no tz) to Date', () => {
+	const dialect = new PgDialect({ codecs: nodePgCodecs });
+	const fields = { maxTs: max(table.tsNoTz) };
+	const fieldsList = orderSelectedFields(fields, undefined, dialect.codecs);
+	const mapper = dialect.mapperGenerators.rows(fieldsList, undefined);
+	const [row] = mapper([['2026-04-01 00:00:00']] as any);
+	expect(row?.maxTs).toBeInstanceOf(Date);
+});
+
+test('PgDialect with nodePgCodecs: rows mapper decodes max(date mode:date) to Date', () => {
+	const dialect = new PgDialect({ codecs: nodePgCodecs });
+	const fields = { maxD: max(table.d) };
+	const fieldsList = orderSelectedFields(fields, undefined, dialect.codecs);
+	const mapper = dialect.mapperGenerators.rows(fieldsList, undefined);
+	const [row] = mapper([['2026-04-01']] as any);
+	expect(row?.maxD).toBeInstanceOf(Date);
+});
+
+test('PgDialect with nodePgCodecs: rows mapper returns string for max(timestamp mode:string)', () => {
+	const dialect = new PgDialect({ codecs: nodePgCodecs });
+	const fields = { maxTs: max(table.tsString) };
+	const fieldsList = orderSelectedFields(fields, undefined, dialect.codecs);
+	const mapper = dialect.mapperGenerators.rows(fieldsList, undefined);
+	const [row] = mapper([['2026-04-01 00:00:00+00']] as any);
+	expect(typeof row?.maxTs).toBe('string');
+});
+
+test('PgDialect with nodePgCodecs: rows mapper returns string for max(date mode:string)', () => {
+	const dialect = new PgDialect({ codecs: nodePgCodecs });
+	const fields = { maxD: max(table.dString) };
+	const fieldsList = orderSelectedFields(fields, undefined, dialect.codecs);
+	const mapper = dialect.mapperGenerators.rows(fieldsList, undefined);
+	const [row] = mapper([['2026-04-01']] as any);
+	expect(typeof row?.maxD).toBe('string');
+});
+
+test('SQL.Aliased: max(timestamptz).as() orderSelectedFields attaches normalize codec', () => {
+	const fields = { maxTs: max(table.ts).as('maxTs') };
+	const ordered = orderSelectedFields(fields, undefined, pgCodecs);
+	expect(ordered).toHaveLength(1);
+	const entry = ordered[0]!;
+	expect(entry.codec).toBeDefined();
+	const result = (entry.codec as (v: any) => any)('2026-04-01 00:00:00+00');
+	expect(result).toBeInstanceOf(Date);
+});
+
+test('SQL.Aliased: PgDialect with nodePgCodecs rows mapper decodes max(timestamptz).as() to Date', () => {
+	const dialect = new PgDialect({ codecs: nodePgCodecs });
+	const fields = { maxTs: max(table.ts).as('maxTs') };
+	const fieldsList = orderSelectedFields(fields, undefined, dialect.codecs);
+	const mapper = dialect.mapperGenerators.rows(fieldsList, undefined);
+	const [row] = mapper([['2026-04-01 00:00:00+00']] as any);
+	expect(row?.maxTs).toBeInstanceOf(Date);
+});


### PR DESCRIPTION
Was building against rc.2 and ran into this: max(table.ts) returning a plain string when ts is declared as timestamp({ mode: 'date' }). The column itself decodes correctly through the codec path; aggregate expressions over it don't.

## Problem

orderSelectedFields pushes Column fields with a codec entry (the normalize function from CodecsCollection) so the row mapper can convert raw driver strings to typed values. SQL and SQL.Aliased (which covers all aggregate expressions) were pushed without one.

max(column) and min(column) store the column on SQL.decoder via .mapWith(column). In the rc.2 architecture, Column.mapFromDriverValue is set to noop with .isNoop = true, so both makeDefaultQueryMapper and makeJitQueryMapper fall back to codec for type conversion. With codec undefined, the raw string passes through unchanged.

## Fix

Split the SQL and SQL.Aliased branches in orderSelectedFields to resolve the normalize codec from the decoder column when one is present. Branches without a column decoder (raw SQL expressions) get codec: undefined unchanged, so there is no impact on unrelated fields.

## Impact

- max() / min() over timestamp({ mode: 'date' }), timestamp({ mode: 'date', withTimezone: true }), and date({ mode: 'date' }) columns now return Date instances, matching the behavior of selecting the column directly.
- timestamp({ mode: 'string' }) and date({ mode: 'string' }) columns continue to return strings as expected.
- .as('alias') chaining on aggregate expressions (SQL.Aliased) is also covered.

## Tests

14 unit tests added in drizzle-orm/tests/aggregate-codec.test.ts:
- Direct orderSelectedFields codec attachment for each timestamp/date variant
- Full end-to-end PgDialect rows mapper decoding for each variant
- String passthrough verification for mode: 'string' columns
- SQL.Aliased branch coverage via .as() chaining

895 tests passing (up from 893 baseline), 4 pre-existing failures unrelated to this change. dprint check clean on both files.

## Files Changed

- drizzle-orm/src/utils.ts -- SQL and SQL.Aliased branches in orderSelectedFields
- drizzle-orm/tests/aggregate-codec.test.ts -- regression tests (new file)