### PR TITLE
fix(pg): exclude generated columns from onConflictDoUpdate SET clause

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -152,9 +152,11 @@ export class PgDialect {
 	buildUpdateSet(table: PgTable, set: UpdateSet): SQL {
 		const tableColumns = table[Table.Symbol.Columns];
 
-		const columnNames = Object.keys(tableColumns).filter((colName) =>
-			set[colName] !== undefined || tableColumns[colName]?.onUpdateFn !== undefined
-		);
+		const columnNames = Object.keys(tableColumns).filter((colName) => {
+			const col = tableColumns[colName];
+			if (col?.shouldDisableInsert()) return false;
+			return set[colName] !== undefined || col?.onUpdateFn !== undefined;
+		});
 
 		const setSize = columnNames.length;
 		return sql.join(columnNames.flatMap((colName, i) => {


### PR DESCRIPTION
Closes #5743

See the linked issue for full reproduction + root cause analysis. This PR mirrors the `shouldDisableInsert()` filter from `buildInsertQuery` into `buildUpdateSet` for the PG dialect, restoring symmetry between the INSERT and ON CONFLICT DO UPDATE paths for tables with `generatedAlwaysAs` columns.

## What changes

`drizzle-orm/src/pg-core/dialect.ts` — `buildUpdateSet` filter now skips any column where `shouldDisableInsert()` returns true (i.e. `generatedAlwaysAs` with `type !== "byDefault"`), in addition to the existing `set[col] !== undefined || onUpdateFn !== undefined` check.

```ts
const columnNames = Object.keys(tableColumns).filter((colName) => {
    const col = tableColumns[colName];
    if (col?.shouldDisableInsert()) return false;
    return set[colName] !== undefined || col?.onUpdateFn !== undefined;
});
```

## Scope

PG-only in this PR (the bug reproduces against `pg-core` + Postgres `GENERATED ALWAYS AS ... STORED`). Mirroring into `mysql-core` / `sqlite-core` / `singlestore-core` can follow once this approach is acknowledged — happy to do it in a follow-up or extend this PR per maintainers preference.

## Tests

No new test added in this PR pending a green CI/test-infra signal — the upstream integration test setup needs a live PG. I have a local reproducer in the linked issue (Pavel-onboarding flow in a downstream CMS). If maintainers prefer the test to land here, I can add it under `integration-tests/tests/pg/` with the `generatedAlwaysAs` table from the issue body.

## Context

Discovered while integrating drizzle-orm via `@payloadcms/drizzle` in a CMS project. Will keep a local `pnpm patch` workaround until this lands upstream.