### PR TITLE
Add selectFromDb hook for custom columns

### DIFF
--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -46,6 +46,17 @@ export type ColumnRuntimeConfig<TData, TRuntimeConfig extends object> = ColumnBu
 	TRuntimeConfig
 >;
 
+export type ColumnSelectMapper = (column: SQL) => SQL;
+
+export type ColumnWithSelectMapper = Column & {
+	selectFromDb?: ColumnSelectMapper;
+};
+
+export function mapColumnSelection(column: Column, columnSql: SQL): SQL {
+	const selectFromDb = (column as ColumnWithSelectMapper).selectFromDb;
+	return typeof selectFromDb === 'function' ? selectFromDb(columnSql) : columnSql;
+}
+
 export interface Column<
 	T extends ColumnBaseConfig<ColumnDataType, string> = ColumnBaseConfig<ColumnDataType, string>,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -245,10 +245,14 @@ export class MySqlDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-				} else {
-					chunk.push(field);
+				const columnSql = isSingleTable
+					? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+					: field.getSQL();
+				const selectionSql = mapColumnSelection(field, columnSql);
+				chunk.push(selectionSql);
+
+				if (selectionSql !== columnSql) {
+					chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`ST_AsText(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -242,10 +242,14 @@ export class PgDialect {
 						chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 					}
 				} else if (is(field, Column)) {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-					} else {
-						chunk.push(field);
+					const columnSql = isSingleTable
+						? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+						: field.getSQL();
+					const selectionSql = mapColumnSelection(field, columnSql);
+					chunk.push(selectionSql);
+
+					if (selectionSql !== columnSql) {
+						chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 					}
 				} else if (is(field, Subquery)) {
 					const entries = Object.entries(field._.selectedFields) as [string, SQL.Aliased | Column | SQL][];

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -1,7 +1,7 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
 import type { AnyColumn } from '~/column.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -220,12 +220,14 @@ export abstract class SQLiteDialect {
 						);
 					}
 				} else {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-					} else {
-						chunk.push(
-							sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
-						);
+					const columnSql = isSingleTable
+						? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+						: sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`;
+					const selectionSql = mapColumnSelection(field, columnSql);
+					chunk.push(selectionSql);
+
+					if (selectionSql !== columnSql) {
+						chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 					}
 				}
 			} else if (is(field, Subquery)) {

--- a/drizzle-orm/tests/custom-select-from-db.test.ts
+++ b/drizzle-orm/tests/custom-select-from-db.test.ts
@@ -1,0 +1,73 @@
+import { Client } from '@planetscale/database';
+import Database from 'better-sqlite3';
+import postgres from 'postgres';
+import { describe, it } from 'vitest';
+import { drizzle as sqliteDrizzle } from '~/better-sqlite3';
+import { customType as mysqlCustomType, mysqlTable } from '~/mysql-core';
+import { customType as pgCustomType, pgTable } from '~/pg-core';
+import { drizzle as planetscale } from '~/planetscale-serverless';
+import { drizzle as pgDrizzle } from '~/postgres-js';
+import { sql } from '~/sql';
+import { customType as sqliteCustomType, sqliteTable } from '~/sqlite-core';
+
+const pgLowerText = pgCustomType<{ data: string; driverData: string }>({
+	dataType: () => 'text',
+	fromDriver: (value) => value,
+	selectFromDb: (column) => sql`lower(${column})`,
+});
+
+const mysqlLowerText = mysqlCustomType<{ data: string; driverData: string }>({
+	dataType: () => 'text',
+	fromDriver: (value) => value,
+	selectFromDb: (column) => sql`lower(${column})`,
+});
+
+const sqliteLowerText = sqliteCustomType<{ data: string; driverData: string }>({
+	dataType: () => 'text',
+	fromDriver: (value) => value,
+	selectFromDb: (column) => sql`lower(${column})`,
+});
+
+const pgUsers = pgTable('users', {
+	lowerName: pgLowerText('lower_name'),
+});
+
+const mysqlUsers = mysqlTable('users', {
+	lowerName: mysqlLowerText('lower_name'),
+});
+
+const sqliteUsers = sqliteTable('users', {
+	lowerName: sqliteLowerText('lower_name'),
+});
+
+describe('custom type selectFromDb', () => {
+	it('wraps selected PostgreSQL custom columns', ({ expect }) => {
+		const db = pgDrizzle(postgres(''));
+		const query = db.select({ lowerName: pgUsers.lowerName }).from(pgUsers);
+
+		expect(query.toSQL()).toEqual({
+			sql: 'select lower("lower_name") as "lower_name" from "users"',
+			params: [],
+		});
+	});
+
+	it('wraps selected MySQL custom columns', ({ expect }) => {
+		const db = planetscale(new Client({}));
+		const query = db.select({ lowerName: mysqlUsers.lowerName }).from(mysqlUsers);
+
+		expect(query.toSQL()).toEqual({
+			sql: 'select lower(`lower_name`) as `lower_name` from `users`',
+			params: [],
+		});
+	});
+
+	it('wraps selected SQLite custom columns', ({ expect }) => {
+		const db = sqliteDrizzle(new Database(':memory:'));
+		const query = db.select({ lowerName: sqliteUsers.lowerName }).from(sqliteUsers);
+
+		expect(query.toSQL()).toEqual({
+			sql: 'select lower("lower_name") as "lower_name" from "users"',
+			params: [],
+		});
+	});
+});


### PR DESCRIPTION
Closes #554.
Closes #1083.

Adds a `selectFromDb(column)` hook to custom column types so custom database types can wrap selected columns with SQL such as `ST_AsText(column)` or `lower(column)` while still using the existing `fromDriver` decoder.

Implemented for PostgreSQL, MySQL, and SQLite custom columns, and added SQL-generation coverage for all three dialects.

Verification:
- `pnpm --filter drizzle-orm test`
- `pnpm --filter drizzle-orm exec vitest run tests/custom-select-from-db.test.ts`
- `pnpm exec dprint check drizzle-orm/src/column.ts drizzle-orm/src/pg-core/columns/custom.ts drizzle-orm/src/pg-core/dialect.ts drizzle-orm/src/mysql-core/columns/custom.ts drizzle-orm/src/mysql-core/dialect.ts drizzle-orm/src/sqlite-core/columns/custom.ts drizzle-orm/src/sqlite-core/dialect.ts drizzle-orm/tests/custom-select-from-db.test.ts`
- `pnpm --filter drizzle-orm exec tsc -p tests/tsconfig.json --noEmit`
- `pnpm --filter drizzle-orm test:types`

@algora-pbc /claim #554
@algora-pbc /claim #1083