### PR TITLE
fix(mssql): guard parseDefault against null definition in sys.default_constraints

### DIFF
--- a/drizzle-kit/src/dialects/mssql/grammar.ts
+++ b/drizzle-kit/src/dialects/mssql/grammar.ts
@@ -133,7 +133,8 @@ export const bufferToBinary = (str: Buffer) => {
 	return '0x' + (str.toString('hex')).toUpperCase();
 };
 
-export const parseDefault = (type: string, def: string) => {
+export const parseDefault = (type: string, def: string | null): DefaultConstraint['default'] => {
+	if (def === null) return null;
 	const grammarType = typeFor(type);
 	return grammarType.defaultFromIntrospect(def);
 };

--- a/drizzle-kit/src/dialects/mssql/introspect.ts
+++ b/drizzle-kit/src/dialects/mssql/introspect.ts
@@ -199,16 +199,16 @@ ORDER BY lower(name)
 		schema_id: number;
 		parent_table_id: number;
 		parent_column_id: number;
-		definition: string;
+		definition: string | null;
 		is_system_named: boolean;
 	}>(`
-SELECT 
-	name as name, 
-	schema_id as schema_id, 
-	parent_object_id as parent_table_id, 
-	parent_column_id as parent_column_id, 
-	definition as definition, 
-	is_system_named as is_system_named 
+SELECT
+	name as name,
+	schema_id as schema_id,
+	parent_object_id as parent_table_id,
+	parent_column_id as parent_column_id,
+	definition as definition,
+	is_system_named as is_system_named
 FROM sys.default_constraints
 ${filterByTableIds ? 'WHERE parent_object_id in ' + filterByTableIds : ''}
 ORDER BY lower(name)

--- a/drizzle-kit/tests/mssql/grammar.test.ts
+++ b/drizzle-kit/tests/mssql/grammar.test.ts
@@ -1,0 +1,29 @@
+import { parseDefault } from 'src/dialects/mssql/grammar';
+import { expect, test } from 'vitest';
+
+// Regression test for https://github.com/drizzle-team/drizzle-orm/issues/5726
+// `drizzle-kit pull` crashed with "Cannot read properties of null (reading 'replace')"
+// when a decimal (or any numeric) column had a null definition in sys.default_constraints.
+test.each([
+	'decimal',
+	'decimal(18,2)',
+	'numeric',
+	'numeric(10,0)',
+	'int',
+	'tinyint',
+	'smallint',
+	'bigint',
+	'float',
+	'real',
+])('parseDefault(%s, null) returns null without throwing', (type) => {
+	expect(parseDefault(type, null)).toBeNull();
+});
+
+test.each([
+	['decimal', '((3.14))', '((3.14))'],
+	['numeric', '((100))', '((100))'],
+	['int', '((10))', '((10))'],
+	['float', '((1.5))', '((1.5))'],
+])('parseDefault(%s, %s) still works correctly', (type, input, expected) => {
+	expect(parseDefault(type, input)).toBe(expected);
+});

--- a/drizzle-kit/tests/mssql/pull.test.ts
+++ b/drizzle-kit/tests/mssql/pull.test.ts
@@ -716,7 +716,7 @@ test('pull does not crash when sys.default_constraints.definition is null', asyn
 	);
 
 	const nullingDb: DB = {
-		query: async <T = any>(queryStr: string, params?: any[]): Promise<T[]> => {
+		query: async <T extends any = any>(queryStr: string, params?: any[]): Promise<T[]> => {
 			const rows = await db.query<T>(queryStr, params);
 			if (queryStr.includes('sys.default_constraints')) {
 				return rows.map((row: any) => ({ ...row, definition: null })) as T[];

--- a/drizzle-kit/tests/mssql/pull.test.ts
+++ b/drizzle-kit/tests/mssql/pull.test.ts
@@ -707,3 +707,32 @@ test('pull after migrate with custom migrations table #3', async () => {
 		},
 	]);
 });
+
+// Regression test for https://github.com/drizzle-team/drizzle-orm/issues/5726
+// sys.default_constraints.definition can be null at runtime; pull must not crash
+test('pull does not crash when sys.default_constraints.definition is null', async () => {
+	await db.query(
+		`CREATE TABLE [test_null_def] ([amount] decimal(10,2) CONSTRAINT [DF_test_null_def_amount] DEFAULT ((3.14)))`,
+	);
+
+	const nullingDb: DB = {
+		query: async <T = any>(queryStr: string, params?: any[]): Promise<T[]> => {
+			const rows = await db.query<T>(queryStr, params);
+			if (queryStr.includes('sys.default_constraints')) {
+				return rows.map((row: any) => ({ ...row, definition: null })) as T[];
+			}
+			return rows;
+		},
+	};
+
+	const schema = await fromDatabaseForDrizzle(nullingDb, () => true, () => true, {
+		table: '__drizzle_migrations',
+		schema: 'drizzle',
+	});
+
+	const constraint = schema.defaults.find(
+		(d) => d.table === 'test_null_def' && d.column === 'amount',
+	);
+	expect(constraint).toBeDefined();
+	expect(constraint!.default).toBeNull();
+});


### PR DESCRIPTION
Fixes #5726

\`drizzle-kit pull\` crashes with \`Cannot read properties of null (reading 'replace')\` when a decimal (or any numeric) column has a null \`definition\` in \`sys.default_constraints\`. SQL Server returns null there when a constraint has no parsed definition, which is a valid runtime state but wasn't reflected in the types.

- \`parseDefault\` in \`grammar.ts\` now accepts \`string | null\` and returns null early, keeping the null out of all eight numeric type handlers (which all call \`.replace()\` internally).
- \`defaultsConstraintQuery\` in \`introspect.ts\` updated to type \`definition\` as \`string | null\`, matching what the server actually returns.
- New unit test in \`tests/mssql/grammar.test.ts\` covers all ten numeric types with a null definition (no Docker needed) and four cases confirming non-null behavior is unchanged.
- New integration test in \`tests/mssql/pull.test.ts\` creates a real table via Docker, wraps the DB to inject null for \`definition\`, and verifies \`fromDatabaseForDrizzle\` completes without throwing and produces a \`DefaultConstraint\` with \`default: null\`.