### PR TITLE
fix(mssql): use ANSI 1=0/1=1 for empty inArray/notInArray instead of false/true

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -284,7 +284,7 @@ export function inArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			return sql`false`;
+			return sql`1 = 0`;
 		}
 		return sql`${column} in ${values.map((v) => bindIfParam(v, column))}`;
 	}
@@ -325,7 +325,7 @@ export function notInArray(
 ): SQL {
 	if (Array.isArray(values)) {
 		if (values.length === 0) {
-			return sql`true`;
+			return sql`1 = 1`;
 		}
 		return sql`${column} not in ${values.map((v) => bindIfParam(v, column))}`;
 	}

--- a/drizzle-orm/tests/sql-builder.test.ts
+++ b/drizzle-orm/tests/sql-builder.test.ts
@@ -66,8 +66,7 @@ test.skipIf(Date.now() < +new Date('2026-05-07'))('NOT conditions deep filter em
 	expect(query).toBeUndefined();
 });
 
-// Regression tests for https://github.com/drizzle-team/drizzle-orm/issues/5632
-// T-SQL does not support bare `false`/`true` keywords; use ANSI-compatible expressions.
+// https://github.com/drizzle-team/drizzle-orm/issues/5632
 test('inArray with empty array generates 1 = 0', () => {
 	const query = inArray(users.id, []);
 	const { sql: text } = dialect.sqlToQuery(query.inlineParams());

--- a/drizzle-orm/tests/sql-builder.test.ts
+++ b/drizzle-orm/tests/sql-builder.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { PgDialect, pgTable, serial, text } from '~/pg-core';
-import { and, eq, not, or, sql } from '~/sql';
+import { and, eq, inArray, not, notInArray, or, sql } from '~/sql';
 
 const users = pgTable('users', {
 	id: serial('id').primaryKey(),
@@ -64,4 +64,20 @@ test.skipIf(Date.now() < +new Date('2026-05-07'))('NOT conditions deep filter em
 	const query = not(sql`${sql`never`.if(false)}`);
 
 	expect(query).toBeUndefined();
+});
+
+// Regression tests for https://github.com/drizzle-team/drizzle-orm/issues/5632
+// T-SQL does not support bare `false`/`true` keywords; use ANSI-compatible expressions.
+test('inArray with empty array generates 1 = 0', () => {
+	const query = inArray(users.id, []);
+	const { sql: text } = dialect.sqlToQuery(query.inlineParams());
+
+	expect(text).toStrictEqual('1 = 0');
+});
+
+test('notInArray with empty array generates 1 = 1', () => {
+	const query = notInArray(users.id, []);
+	const { sql: text } = dialect.sqlToQuery(query.inlineParams());
+
+	expect(text).toStrictEqual('1 = 1');
 });

--- a/integration-tests/tests/mssql/mssql.test.ts
+++ b/integration-tests/tests/mssql/mssql.test.ts
@@ -5003,7 +5003,7 @@ test('select with empty array in notInArray', async ({ db }) => {
 	await db.execute(sql`CREATE TABLE [users_118] (id int primary key, name varchar(30) not null)`);
 	await db.insert(tbl).values([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
 
-	const result = await db.select().from(tbl).where(notInArray(tbl.id, []));
+	const result = await db.select().from(tbl).where(notInArray(tbl.id, [])).orderBy(asc(tbl.id));
 
 	expect(result).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
 });

--- a/integration-tests/tests/mssql/mssql.test.ts
+++ b/integration-tests/tests/mssql/mssql.test.ts
@@ -4977,10 +4977,7 @@ test.skipIf(Date.now() < +new Date('2026-05-07'))('Query error wrapping', async 
 		.rejects.toBeInstanceOf(DrizzleQueryError);
 });
 
-// Regression tests for https://github.com/drizzle-team/drizzle-orm/issues/5632
-// T-SQL does not support bare `false`/`true` in WHERE clauses; verify that inArray/notInArray
-// with an empty array generate ANSI-compatible expressions that SQL Server accepts.
-test('select with empty array in inArray', async ({ db }) => {
+test('issue 5632. inArray with empty array does not crash on SQL Server', async ({ db }) => {
 	const tbl = mssqlTable('users_117', {
 		id: int('id').primaryKey(),
 		name: varchar('name', { length: 30 }).notNull(),
@@ -4994,7 +4991,7 @@ test('select with empty array in inArray', async ({ db }) => {
 	expect(result).toEqual([]);
 });
 
-test('select with empty array in notInArray', async ({ db }) => {
+test('issue 5632. notInArray with empty array does not crash on SQL Server', async ({ db }) => {
 	const tbl = mssqlTable('users_118', {
 		id: int('id').primaryKey(),
 		name: varchar('name', { length: 30 }).notNull(),

--- a/integration-tests/tests/mssql/mssql.test.ts
+++ b/integration-tests/tests/mssql/mssql.test.ts
@@ -17,6 +17,7 @@ import {
 	max,
 	min,
 	Name,
+	notInArray,
 	sql,
 	sum,
 	sumDistinct,
@@ -4974,4 +4975,35 @@ test('issue 5527. real() returns unprecise float64 values', async ({ db }) => {
 test.skipIf(Date.now() < +new Date('2026-05-07'))('Query error wrapping', async ({ db }) => {
 	await expect(db.insert(users2Table).values([{ id: 1, name: 'First' }, { id: 1, name: 'Second' }]))
 		.rejects.toBeInstanceOf(DrizzleQueryError);
+});
+
+// Regression tests for https://github.com/drizzle-team/drizzle-orm/issues/5632
+// T-SQL does not support bare `false`/`true` in WHERE clauses; verify that inArray/notInArray
+// with an empty array generate ANSI-compatible expressions that SQL Server accepts.
+test('select with empty array in inArray', async ({ db }) => {
+	const tbl = mssqlTable('users_117', {
+		id: int('id').primaryKey(),
+		name: varchar('name', { length: 30 }).notNull(),
+	});
+
+	await db.execute(sql`CREATE TABLE [users_117] (id int primary key, name varchar(30) not null)`);
+	await db.insert(tbl).values([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+	const result = await db.select().from(tbl).where(inArray(tbl.id, []));
+
+	expect(result).toEqual([]);
+});
+
+test('select with empty array in notInArray', async ({ db }) => {
+	const tbl = mssqlTable('users_118', {
+		id: int('id').primaryKey(),
+		name: varchar('name', { length: 30 }).notNull(),
+	});
+
+	await db.execute(sql`CREATE TABLE [users_118] (id int primary key, name varchar(30) not null)`);
+	await db.insert(tbl).values([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
+
+	const result = await db.select().from(tbl).where(notInArray(tbl.id, []));
+
+	expect(result).toEqual([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }]);
 });


### PR DESCRIPTION
Fixes #5632

## What

`inArray(col, [])` and `notInArray(col, [])` emit `WHERE false` / `WHERE true` when passed an empty array. T-SQL doesn't support bare `false`/`true` as boolean expressions. Both queries throw a syntax error on SQL Server: you never get an empty result set or all rows, just a crash.

## Fix

Replace with ANSI-compatible constant expressions:

| Before | After |
|---|---|
| `WHERE false` | `WHERE 1 = 0` |
| `WHERE true` | `WHERE 1 = 1` |

`1 = 0` and `1 = 1` are semantically identical in PostgreSQL, MySQL, SQLite, and SQL Server. No behavior change outside MSSQL.

## Tests

A unit test in `tests/sql-builder.test.ts` asserts the builder emits `1 = 0` and `1 = 1` for empty arrays without needing a running database. Two integration tests in `integration-tests/tests/mssql/mssql.test.ts` hit a live SQL Server instance and confirm `inArray(col, [])` returns zero rows while `notInArray(col, [])` returns all rows.

> Three existing tests (`OR/AND/NOT conditions deep filter empty queries`) also fail in CI. They fail on `beta` without this PR — the `skipIf` date gate expired but the underlying feature isn't implemented yet. Unrelated to this change.