### PR TITLE
[Pg] Add `MERGE` statement support

### DIFF
--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -4,6 +4,7 @@ import type { PgDialect } from '~/pg-core/dialect.ts';
 import {
 	PgDeleteBase,
 	PgInsertBuilder,
+	PgMergeBuilder,
 	PgSelectBuilder,
 	PgUpdateBuilder,
 	QueryBuilder,
@@ -393,7 +394,11 @@ export class PgDatabase<
 			return new PgDeleteBase(table, self.session, self.dialect, queries);
 		}
 
-		return { select, selectDistinct, selectDistinctOn, update, insert, delete: delete_ };
+		function merge<TTable extends PgTable>(table: TTable): PgMergeBuilder<TTable, TQueryResult> {
+			return new PgMergeBuilder(table, self.session, self.dialect, queries);
+		}
+
+		return { select, selectDistinct, selectDistinctOn, update, insert, delete: delete_, merge };
 	}
 
 	/**
@@ -604,6 +609,43 @@ export class PgDatabase<
 	 */
 	delete<TTable extends PgTable>(table: TTable): PgDeleteBase<TTable, TQueryResult> {
 		return new PgDeleteBase(table, this.session, this.dialect);
+	}
+
+	/**
+	 * Creates a MERGE statement (upsert / conditional insert-update-delete).
+	 *
+	 * Use `.using()` to specify the source, then chain `.whenMatched()` and `.whenNotMatched()` clauses.
+	 * Each clause requires a terminal action (`.thenUpdate()`, `.thenDelete()`, `.thenInsert()`, or `.thenDoNothing()`).
+	 *
+	 * **Requires PostgreSQL 15+.** The `.returning()` clause requires PostgreSQL 17+.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/merge}
+	 *
+	 * @param table The target table to merge into.
+	 *
+	 * @example
+	 * ```ts
+	 * // Upsert: update existing rows, insert new ones
+	 * await db.merge(users)
+	 *   .using(newUsers, eq(users.id, newUsers.id))
+	 *   .whenMatched()
+	 *   .update({ name: newUsers.name, email: newUsers.email })
+	 *   .whenNotMatched()
+	 *   .insert({ id: newUsers.id, name: newUsers.name, email: newUsers.email });
+	 *
+	 * // Conditional update or delete
+	 * await db.merge(users)
+	 *   .using(updates, eq(users.id, updates.id))
+	 *   .whenMatched(eq(updates.status, 'active'))
+	 *   .update({ name: updates.name })
+	 *   .whenMatched()
+	 *   .delete()
+	 *   .whenNotMatched()
+	 *   .doNothing();
+	 * ```
+	 */
+	merge<TTable extends PgTable>(table: TTable): PgMergeBuilder<TTable, TQueryResult> {
+		return new PgMergeBuilder(table, this.session, this.dialect);
 	}
 
 	refreshMaterializedView<TView extends PgMaterializedView>(view: TView): PgRefreshMaterializedView<TQueryResult> {

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -87,8 +87,9 @@ export class PgDialect {
 		await session.execute(migrationTableCreate);
 
 		const dbMigrations = await session.all<{ id: number; hash: string; created_at: string }>(
-			sql`select id, hash, created_at from ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)
-				} order by created_at desc limit 1`,
+			sql`select id, hash, created_at from ${sql.identifier(migrationsSchema)}.${
+				sql.identifier(migrationsTable)
+			} order by created_at desc limit 1`,
 		);
 
 		const lastDbMigration = dbMigrations[0];
@@ -102,8 +103,9 @@ export class PgDialect {
 						await tx.execute(sql.raw(stmt));
 					}
 					await tx.execute(
-						sql`insert into ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)
-							} ("hash", "created_at") values(${migration.hash}, ${migration.folderMillis})`,
+						sql`insert into ${sql.identifier(migrationsSchema)}.${
+							sql.identifier(migrationsTable)
+						} ("hash", "created_at") values(${migration.hash}, ${migration.folderMillis})`,
 					);
 				}
 			}
@@ -177,8 +179,9 @@ export class PgDialect {
 		const tableSchema = table[PgTable.Symbol.Schema];
 		const origTableName = table[PgTable.Symbol.OriginalName];
 		const alias = tableName === origTableName ? undefined : tableName;
-		const tableSql = sql`${tableSchema ? sql`${sql.identifier(tableSchema)}.` : undefined}${sql.identifier(origTableName)
-			}${alias && sql` ${sql.identifier(alias)}`}`;
+		const tableSql = sql`${tableSchema ? sql`${sql.identifier(tableSchema)}.` : undefined}${
+			sql.identifier(origTableName)
+		}${alias && sql` ${sql.identifier(alias)}`}`;
 
 		const setSql = this.buildUpdateSet(table, set);
 
@@ -254,8 +257,8 @@ export class PgDialect {
 						const fieldDecoder = is(entry, SQL)
 							? entry.decoder
 							: is(entry, Column)
-								? { mapFromDriverValue: (v: any) => entry.mapFromDriverValue(v) }
-								: entry.sql.decoder;
+							? { mapFromDriverValue: (v: any) => entry.mapFromDriverValue(v) }
+							: entry.sql.decoder;
 
 						if (fieldDecoder) {
 							field._.sql.decoder = fieldDecoder;
@@ -295,8 +298,9 @@ export class PgDialect {
 				const origTableName = table[PgTable.Symbol.OriginalName];
 				const alias = tableName === origTableName ? undefined : joinMeta.alias;
 				joinsArray.push(
-					sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${tableSchema ? sql`${sql.identifier(tableSchema)}.` : undefined
-						}${sql.identifier(origTableName)}${alias && sql` ${sql.identifier(alias)}`}${onSql}`,
+					sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${
+						tableSchema ? sql`${sql.identifier(tableSchema)}.` : undefined
+					}${sql.identifier(origTableName)}${alias && sql` ${sql.identifier(alias)}`}${onSql}`,
 				);
 			} else if (is(table, View)) {
 				const viewName = table[ViewBaseConfig].name;
@@ -304,8 +308,9 @@ export class PgDialect {
 				const origViewName = table[ViewBaseConfig].originalName;
 				const alias = viewName === origViewName ? undefined : joinMeta.alias;
 				joinsArray.push(
-					sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${viewSchema ? sql`${sql.identifier(viewSchema)}.` : undefined
-						}${sql.identifier(origViewName)}${alias && sql` ${sql.identifier(alias)}`}${onSql}`,
+					sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${
+						viewSchema ? sql`${sql.identifier(viewSchema)}.` : undefined
+					}${sql.identifier(origViewName)}${alias && sql` ${sql.identifier(alias)}`}${onSql}`,
 				);
 			} else {
 				joinsArray.push(
@@ -357,13 +362,13 @@ export class PgDialect {
 			if (
 				is(f.field, Column)
 				&& getTableName(f.field.table)
-				!== (is(table, Subquery)
-					? table._.alias
-					: is(table, PgViewBase)
+					!== (is(table, Subquery)
+						? table._.alias
+						: is(table, PgViewBase)
 						? table[ViewBaseConfig].name
 						: is(table, SQL)
-							? undefined
-							: getTableName(table))
+						? undefined
+						: getTableName(table))
 				&& !((table) =>
 					joins?.some(({ alias }) =>
 						alias === (table[Table.Symbol.IsAlias] ? getTableName(table) : table[Table.Symbol.BaseName])
@@ -371,7 +376,8 @@ export class PgDialect {
 			) {
 				const tableName = getTableName(f.field.table);
 				throw new Error(
-					`Your "${f.path.join('->')
+					`Your "${
+						f.path.join('->')
 					}" field references a column "${tableName}"."${f.field.name}", but the table "${tableName}" is not part of the query! Did you forget to join it?`,
 				);
 			}
@@ -417,11 +423,12 @@ export class PgDialect {
 			const clauseSql = sql` for ${sql.raw(lockingClause.strength)}`;
 			if (lockingClause.config.of) {
 				clauseSql.append(
-					sql` of ${sql.join(
-						Array.isArray(lockingClause.config.of) ? lockingClause.config.of : [lockingClause.config.of],
-						sql`, `,
-					)
-						}`,
+					sql` of ${
+						sql.join(
+							Array.isArray(lockingClause.config.of) ? lockingClause.config.of : [lockingClause.config.of],
+							sql`, `,
+						)
+					}`,
 				);
 			}
 			if (lockingClause.config.noWait) {
@@ -1388,20 +1395,22 @@ export class PgDialect {
 		where = and(joinOn, where);
 
 		if (nestedQueryRelation) {
-			let field = sql`json_build_array(${sql.join(
-				selection.map(({ field, tsKey, isJson }) =>
-					isJson
-						? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
-						: is(field, SQL.Aliased)
+			let field = sql`json_build_array(${
+				sql.join(
+					selection.map(({ field, tsKey, isJson }) =>
+						isJson
+							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
+							: is(field, SQL.Aliased)
 							? field.sql
 							: field
-				),
-				sql`, `,
-			)
-				})`;
+					),
+					sql`, `,
+				)
+			})`;
 			if (is(nestedQueryRelation, Many)) {
-				field = sql`coalesce(json_agg(${field}${orderBy.length > 0 ? sql` order by ${sql.join(orderBy, sql`, `)}` : undefined
-					}), '[]'::json)`;
+				field = sql`coalesce(json_agg(${field}${
+					orderBy.length > 0 ? sql` order by ${sql.join(orderBy, sql`, `)}` : undefined
+				}), '[]'::json)`;
 				// orderBy = [];
 			}
 			const nestedSelection = [{

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -20,6 +20,7 @@ import type {
 	AnyPgSelectQueryBuilder,
 	PgDeleteConfig,
 	PgInsertConfig,
+	PgMergeConfig,
 	PgSelectJoinConfig,
 	PgUpdateConfig,
 } from '~/pg-core/query-builders/index.ts';
@@ -86,9 +87,8 @@ export class PgDialect {
 		await session.execute(migrationTableCreate);
 
 		const dbMigrations = await session.all<{ id: number; hash: string; created_at: string }>(
-			sql`select id, hash, created_at from ${sql.identifier(migrationsSchema)}.${
-				sql.identifier(migrationsTable)
-			} order by created_at desc limit 1`,
+			sql`select id, hash, created_at from ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)
+				} order by created_at desc limit 1`,
 		);
 
 		const lastDbMigration = dbMigrations[0];
@@ -102,9 +102,8 @@ export class PgDialect {
 						await tx.execute(sql.raw(stmt));
 					}
 					await tx.execute(
-						sql`insert into ${sql.identifier(migrationsSchema)}.${
-							sql.identifier(migrationsTable)
-						} ("hash", "created_at") values(${migration.hash}, ${migration.folderMillis})`,
+						sql`insert into ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)
+							} ("hash", "created_at") values(${migration.hash}, ${migration.folderMillis})`,
 					);
 				}
 			}
@@ -178,9 +177,8 @@ export class PgDialect {
 		const tableSchema = table[PgTable.Symbol.Schema];
 		const origTableName = table[PgTable.Symbol.OriginalName];
 		const alias = tableName === origTableName ? undefined : tableName;
-		const tableSql = sql`${tableSchema ? sql`${sql.identifier(tableSchema)}.` : undefined}${
-			sql.identifier(origTableName)
-		}${alias && sql` ${sql.identifier(alias)}`}`;
+		const tableSql = sql`${tableSchema ? sql`${sql.identifier(tableSchema)}.` : undefined}${sql.identifier(origTableName)
+			}${alias && sql` ${sql.identifier(alias)}`}`;
 
 		const setSql = this.buildUpdateSet(table, set);
 
@@ -256,8 +254,8 @@ export class PgDialect {
 						const fieldDecoder = is(entry, SQL)
 							? entry.decoder
 							: is(entry, Column)
-							? { mapFromDriverValue: (v: any) => entry.mapFromDriverValue(v) }
-							: entry.sql.decoder;
+								? { mapFromDriverValue: (v: any) => entry.mapFromDriverValue(v) }
+								: entry.sql.decoder;
 
 						if (fieldDecoder) {
 							field._.sql.decoder = fieldDecoder;
@@ -297,9 +295,8 @@ export class PgDialect {
 				const origTableName = table[PgTable.Symbol.OriginalName];
 				const alias = tableName === origTableName ? undefined : joinMeta.alias;
 				joinsArray.push(
-					sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${
-						tableSchema ? sql`${sql.identifier(tableSchema)}.` : undefined
-					}${sql.identifier(origTableName)}${alias && sql` ${sql.identifier(alias)}`}${onSql}`,
+					sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${tableSchema ? sql`${sql.identifier(tableSchema)}.` : undefined
+						}${sql.identifier(origTableName)}${alias && sql` ${sql.identifier(alias)}`}${onSql}`,
 				);
 			} else if (is(table, View)) {
 				const viewName = table[ViewBaseConfig].name;
@@ -307,9 +304,8 @@ export class PgDialect {
 				const origViewName = table[ViewBaseConfig].originalName;
 				const alias = viewName === origViewName ? undefined : joinMeta.alias;
 				joinsArray.push(
-					sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${
-						viewSchema ? sql`${sql.identifier(viewSchema)}.` : undefined
-					}${sql.identifier(origViewName)}${alias && sql` ${sql.identifier(alias)}`}${onSql}`,
+					sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${viewSchema ? sql`${sql.identifier(viewSchema)}.` : undefined
+						}${sql.identifier(origViewName)}${alias && sql` ${sql.identifier(alias)}`}${onSql}`,
 				);
 			} else {
 				joinsArray.push(
@@ -361,13 +357,13 @@ export class PgDialect {
 			if (
 				is(f.field, Column)
 				&& getTableName(f.field.table)
-					!== (is(table, Subquery)
-						? table._.alias
-						: is(table, PgViewBase)
+				!== (is(table, Subquery)
+					? table._.alias
+					: is(table, PgViewBase)
 						? table[ViewBaseConfig].name
 						: is(table, SQL)
-						? undefined
-						: getTableName(table))
+							? undefined
+							: getTableName(table))
 				&& !((table) =>
 					joins?.some(({ alias }) =>
 						alias === (table[Table.Symbol.IsAlias] ? getTableName(table) : table[Table.Symbol.BaseName])
@@ -375,8 +371,7 @@ export class PgDialect {
 			) {
 				const tableName = getTableName(f.field.table);
 				throw new Error(
-					`Your "${
-						f.path.join('->')
+					`Your "${f.path.join('->')
 					}" field references a column "${tableName}"."${f.field.name}", but the table "${tableName}" is not part of the query! Did you forget to join it?`,
 				);
 			}
@@ -422,12 +417,11 @@ export class PgDialect {
 			const clauseSql = sql` for ${sql.raw(lockingClause.strength)}`;
 			if (lockingClause.config.of) {
 				clauseSql.append(
-					sql` of ${
-						sql.join(
-							Array.isArray(lockingClause.config.of) ? lockingClause.config.of : [lockingClause.config.of],
-							sql`, `,
-						)
-					}`,
+					sql` of ${sql.join(
+						Array.isArray(lockingClause.config.of) ? lockingClause.config.of : [lockingClause.config.of],
+						sql`, `,
+					)
+						}`,
 				);
 			}
 			if (lockingClause.config.noWait) {
@@ -577,6 +571,47 @@ export class PgDialect {
 		const overridingSql = overridingSystemValue_ === true ? sql`overriding system value ` : undefined;
 
 		return sql`${withSql}insert into ${table} ${insertOrder} ${overridingSql}${valuesSql}${onConflictSql}${returningSql}`;
+	}
+
+	buildMergeQuery({ table, source, on, whenClauses, returning, withList }: PgMergeConfig): SQL {
+		const withSql = this.buildWithCTE(withList);
+
+		const sourceSql = this.buildFromTable(source as Parameters<typeof this.buildFromTable>[0]);
+
+		const whenSqls: SQL[] = [];
+		for (const clause of whenClauses) {
+			const predicateSql = clause.predicate ? sql` and ${clause.predicate}` : undefined;
+
+			if (clause.type === 'matched') {
+				if (clause.action === 'update') {
+					const setSql = this.buildUpdateSet(table, clause.set);
+					whenSqls.push(sql`when matched${predicateSql} then update set ${setSql}`);
+				} else if (clause.action === 'delete') {
+					whenSqls.push(sql`when matched${predicateSql} then delete`);
+				} else {
+					whenSqls.push(sql`when matched${predicateSql} then do nothing`);
+				}
+			} else if (clause.type === 'not_matched') {
+				if (clause.action === 'insert') {
+					const tableColumns = table[Table.Symbol.Columns];
+					const colEntries = Object.entries(tableColumns).filter(([key]) => key in clause.values);
+					const insertOrder = colEntries.map(([, col]) => sql.identifier(this.casing.getColumnCasing(col)));
+					const valuesSql = colEntries.map(([key]) => clause.values[key]!);
+
+					whenSqls.push(sql`when not matched${predicateSql} then insert ${insertOrder} values ${valuesSql}`);
+				} else {
+					whenSqls.push(sql`when not matched${predicateSql} then do nothing`);
+				}
+			}
+		}
+
+		const whenSql = sql.join(whenSqls, sql` `);
+
+		const returningSql = returning
+			? sql` returning ${this.buildSelection(returning, { isSingleTable: true })}`
+			: undefined;
+
+		return sql`${withSql}merge into ${table} using ${sourceSql} on ${on} ${whenSql}${returningSql}`;
 	}
 
 	buildRefreshMaterializedViewQuery(
@@ -1353,22 +1388,20 @@ export class PgDialect {
 		where = and(joinOn, where);
 
 		if (nestedQueryRelation) {
-			let field = sql`json_build_array(${
-				sql.join(
-					selection.map(({ field, tsKey, isJson }) =>
-						isJson
-							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
-							: is(field, SQL.Aliased)
+			let field = sql`json_build_array(${sql.join(
+				selection.map(({ field, tsKey, isJson }) =>
+					isJson
+						? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
+						: is(field, SQL.Aliased)
 							? field.sql
 							: field
-					),
-					sql`, `,
-				)
-			})`;
+				),
+				sql`, `,
+			)
+				})`;
 			if (is(nestedQueryRelation, Many)) {
-				field = sql`coalesce(json_agg(${field}${
-					orderBy.length > 0 ? sql` order by ${sql.join(orderBy, sql`, `)}` : undefined
-				}), '[]'::json)`;
+				field = sql`coalesce(json_agg(${field}${orderBy.length > 0 ? sql` order by ${sql.join(orderBy, sql`, `)}` : undefined
+					}), '[]'::json)`;
 				// orderBy = [];
 			}
 			const nestedSelection = [{

--- a/drizzle-orm/src/pg-core/query-builders/index.ts
+++ b/drizzle-orm/src/pg-core/query-builders/index.ts
@@ -1,5 +1,6 @@
 export * from './delete.ts';
 export * from './insert.ts';
+export * from './merge.ts';
 export * from './query-builder.ts';
 export * from './refresh-materialized-view.ts';
 export * from './select.ts';

--- a/drizzle-orm/src/pg-core/query-builders/merge.ts
+++ b/drizzle-orm/src/pg-core/query-builders/merge.ts
@@ -15,7 +15,7 @@ import type { SelectResultFields } from '~/query-builders/select.types.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { RunnableQuery } from '~/runnable-query.ts';
 import { SelectionProxyHandler } from '~/selection-proxy.ts';
-import { type ColumnsSelection, type Query, SQL, type SQLWrapper, Param } from '~/sql/sql.ts';
+import { type ColumnsSelection, Param, type Query, SQL, type SQLWrapper } from '~/sql/sql.ts';
 import type { Subquery } from '~/subquery.ts';
 import { getTableName, Table } from '~/table.ts';
 import { mapUpdateSet, type NeonAuthToken, orderSelectedFields, type UpdateSet } from '~/utils.ts';
@@ -27,26 +27,30 @@ import type { PgUpdateSetSource } from './update.ts';
 export type PgMergeInsertValue<TTable extends PgTable> =
 	& {
 		[Key in keyof TTable['$inferInsert']]?:
-		| GetColumnData<TTable['_']['columns'][Key]>
-		| SQL
-		| PgColumn
-		| undefined;
+			| GetColumnData<TTable['_']['columns'][Key]>
+			| SQL
+			| PgColumn
+			| undefined;
 	}
 	& {};
 
-export type PgMergeWhenMatchedClause = {
-	type: 'matched';
-	predicate?: SQL;
-} & (
+export type PgMergeWhenMatchedClause =
+	& {
+		type: 'matched';
+		predicate?: SQL;
+	}
+	& (
 		| { action: 'update'; set: UpdateSet }
 		| { action: 'delete' }
 		| { action: 'do_nothing' }
 	);
 
-export type PgMergeWhenNotMatchedClause = {
-	type: 'not_matched';
-	predicate?: SQL;
-} & (
+export type PgMergeWhenNotMatchedClause =
+	& {
+		type: 'not_matched';
+		predicate?: SQL;
+	}
+	& (
 		| { action: 'insert'; values: Record<string, SQL | Param | AnyColumn> }
 		| { action: 'do_nothing' }
 	);
@@ -66,7 +70,7 @@ export interface PgMergeConfig {
 export type PgMergePrepare<T extends AnyPgMerge> = PgPreparedQuery<
 	PreparedQueryConfig & {
 		execute: T['_']['returning'] extends undefined ? PgQueryResultKind<T['_']['queryResult'], never>
-		: T['_']['returning'][];
+			: T['_']['returning'][];
 	}
 >;
 
@@ -94,7 +98,8 @@ export interface PgMergeBase<
 	>,
 	QueryPromise<TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[]>,
 	RunnableQuery<TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[], 'pg'>,
-	SQLWrapper {
+	SQLWrapper
+{
 	readonly _: {
 		readonly dialect: 'pg';
 		readonly table: TTarget;
@@ -118,8 +123,9 @@ export class PgMergeBase<
 	TDynamic extends boolean = false,
 > extends QueryPromise<TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[]>
 	implements
-	RunnableQuery<TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[], 'pg'>,
-	SQLWrapper {
+		RunnableQuery<TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[], 'pg'>,
+		SQLWrapper
+{
 	static override readonly [entityKind]: string = 'PgMerge';
 
 	/** @internal */
@@ -322,7 +328,7 @@ export class PgMergeMatchedActionBuilder<
 	constructor(
 		private parent: TParent,
 		private predicate?: SQL,
-	) { }
+	) {}
 
 	/**
 	 * Updates the matched row with the provided values.
@@ -397,7 +403,7 @@ export class PgMergeNotMatchedActionBuilder<
 	constructor(
 		private parent: TParent,
 		private predicate?: SQL,
-	) { }
+	) {}
 
 	/**
 	 * Inserts the unmatched source row into the target table.
@@ -462,7 +468,7 @@ export class PgMergeBuilder<TTarget extends PgTable, TQueryResult extends PgQuer
 		private session: PgSession,
 		private dialect: PgDialect,
 		private withList?: Subquery[],
-	) { }
+	) {}
 
 	private authToken?: NeonAuthToken;
 	setToken(token?: NeonAuthToken) {

--- a/drizzle-orm/src/pg-core/query-builders/merge.ts
+++ b/drizzle-orm/src/pg-core/query-builders/merge.ts
@@ -1,0 +1,506 @@
+import type { AnyColumn, GetColumnData } from '~/column.ts';
+import { Column } from '~/column.ts';
+import { entityKind, is } from '~/entity.ts';
+import type { PgDialect } from '~/pg-core/dialect.ts';
+import type {
+	PgPreparedQuery,
+	PgQueryResultHKT,
+	PgQueryResultKind,
+	PgSession,
+	PreparedQueryConfig,
+} from '~/pg-core/session.ts';
+import type { PgTable } from '~/pg-core/table.ts';
+import type { TypedQueryBuilder } from '~/query-builders/query-builder.ts';
+import type { SelectResultFields } from '~/query-builders/select.types.ts';
+import { QueryPromise } from '~/query-promise.ts';
+import type { RunnableQuery } from '~/runnable-query.ts';
+import { SelectionProxyHandler } from '~/selection-proxy.ts';
+import { type ColumnsSelection, type Query, SQL, type SQLWrapper, Param } from '~/sql/sql.ts';
+import type { Subquery } from '~/subquery.ts';
+import { getTableName, Table } from '~/table.ts';
+import { mapUpdateSet, type NeonAuthToken, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import type { PgColumn } from '../columns/common.ts';
+import { extractUsedTable } from '../utils.ts';
+import type { SelectedFieldsFlat, SelectedFieldsOrdered } from './select.types.ts';
+import type { PgUpdateSetSource } from './update.ts';
+
+export type PgMergeInsertValue<TTable extends PgTable> =
+	& {
+		[Key in keyof TTable['$inferInsert']]?:
+		| GetColumnData<TTable['_']['columns'][Key]>
+		| SQL
+		| PgColumn
+		| undefined;
+	}
+	& {};
+
+export type PgMergeWhenMatchedClause = {
+	type: 'matched';
+	predicate?: SQL;
+} & (
+		| { action: 'update'; set: UpdateSet }
+		| { action: 'delete' }
+		| { action: 'do_nothing' }
+	);
+
+export type PgMergeWhenNotMatchedClause = {
+	type: 'not_matched';
+	predicate?: SQL;
+} & (
+		| { action: 'insert'; values: Record<string, SQL | Param | AnyColumn> }
+		| { action: 'do_nothing' }
+	);
+
+export type PgMergeWhenClause = PgMergeWhenMatchedClause | PgMergeWhenNotMatchedClause;
+
+export interface PgMergeConfig {
+	table: PgTable;
+	source: PgTable | Subquery | SQL;
+	on: SQL;
+	whenClauses: PgMergeWhenClause[];
+	returningFields?: SelectedFieldsFlat;
+	returning?: SelectedFieldsOrdered;
+	withList?: Subquery[];
+}
+
+export type PgMergePrepare<T extends AnyPgMerge> = PgPreparedQuery<
+	PreparedQueryConfig & {
+		execute: T['_']['returning'] extends undefined ? PgQueryResultKind<T['_']['queryResult'], never>
+		: T['_']['returning'][];
+	}
+>;
+
+export type AnyPgMerge = PgMergeBase<any, any, any, any, any, any>;
+
+export type PgMerge<
+	TTarget extends PgTable = PgTable,
+	TSource extends PgTable | Subquery | SQL = PgTable | Subquery | SQL,
+	TQueryResult extends PgQueryResultHKT = PgQueryResultHKT,
+	TSelectedFields extends ColumnsSelection | undefined = ColumnsSelection | undefined,
+	TReturning extends Record<string, unknown> | undefined = Record<string, unknown> | undefined,
+> = PgMergeBase<TTarget, TSource, TQueryResult, TSelectedFields, TReturning, true>;
+
+export interface PgMergeBase<
+	TTarget extends PgTable,
+	TSource extends PgTable | Subquery | SQL,
+	TQueryResult extends PgQueryResultHKT,
+	TSelectedFields extends ColumnsSelection | undefined = undefined,
+	TReturning extends Record<string, unknown> | undefined = undefined,
+	TDynamic extends boolean = false,
+> extends
+	TypedQueryBuilder<
+		TSelectedFields,
+		TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[]
+	>,
+	QueryPromise<TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[]>,
+	RunnableQuery<TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[], 'pg'>,
+	SQLWrapper {
+	readonly _: {
+		readonly dialect: 'pg';
+		readonly table: TTarget;
+		readonly source: TSource;
+		readonly queryResult: TQueryResult;
+		readonly selectedFields: TSelectedFields;
+		readonly returning: TReturning;
+		readonly dynamic: TDynamic;
+		readonly result: TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[];
+	};
+}
+
+export class PgMergeBase<
+	TTarget extends PgTable,
+	TSource extends PgTable | Subquery | SQL,
+	TQueryResult extends PgQueryResultHKT,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	TSelectedFields extends ColumnsSelection | undefined = undefined,
+	TReturning extends Record<string, unknown> | undefined = undefined,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	TDynamic extends boolean = false,
+> extends QueryPromise<TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[]>
+	implements
+	RunnableQuery<TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[], 'pg'>,
+	SQLWrapper {
+	static override readonly [entityKind]: string = 'PgMerge';
+
+	/** @internal */
+	readonly config: PgMergeConfig;
+
+	constructor(
+		table: TTarget,
+		source: TSource,
+		on: SQL,
+		private session: PgSession,
+		private dialect: PgDialect,
+		withList?: Subquery[],
+	) {
+		super();
+		this.config = {
+			table,
+			source,
+			on,
+			whenClauses: [],
+			withList,
+		};
+	}
+
+	/**
+	 * Adds a `WHEN MATCHED` clause to the MERGE statement.
+	 *
+	 * This clause defines what to do when a row in the target table matches a row in the source.
+	 * Optionally, a condition can be provided to further filter matched rows.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/merge}
+	 *
+	 * @param predicate An optional SQL condition to filter which matched rows this clause applies to.
+	 *
+	 * @example
+	 * ```ts
+	 * // Update matched rows
+	 * await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenMatched()
+	 *   .update({ name: source.name });
+	 *
+	 * // Delete matched rows with a condition
+	 * await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenMatched(eq(source.status, 'inactive'))
+	 *   .delete();
+	 * ```
+	 */
+	whenMatched(predicate?: SQL): PgMergeMatchedActionBuilder<TTarget, TSource, TQueryResult, this> {
+		return new PgMergeMatchedActionBuilder(this, predicate);
+	}
+
+	/**
+	 * Adds a `WHEN NOT MATCHED` clause to the MERGE statement.
+	 *
+	 * This clause defines what to do when a row in the source table has no matching row in the target.
+	 * Optionally, a condition can be provided to further filter unmatched rows.
+	 *
+	 * Requires PostgreSQL 15+.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/merge}
+	 *
+	 * @param predicate An optional SQL condition to filter which unmatched rows this clause applies to.
+	 *
+	 * @example
+	 * ```ts
+	 * // Insert unmatched rows
+	 * await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenNotMatched()
+	 *   .insert({ id: source.id, name: source.name });
+	 *
+	 * // Do nothing for unmatched rows with a condition
+	 * await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenNotMatched(eq(source.status, 'inactive'))
+	 *   .doNothing();
+	 * ```
+	 */
+	whenNotMatched(predicate?: SQL): PgMergeNotMatchedActionBuilder<TTarget, TSource, TQueryResult, this> {
+		return new PgMergeNotMatchedActionBuilder(this, predicate);
+	}
+
+	/**
+	 * Adds a `RETURNING` clause to the MERGE statement.
+	 *
+	 * Calling this method will return the specified fields of the affected rows.
+	 * If no fields are specified, all target table fields will be returned.
+	 *
+	 * **Requires PostgreSQL 17+.**
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/merge}
+	 *
+	 * @example
+	 * ```ts
+	 * // Merge and return all affected rows
+	 * const result = await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenMatched().update({ name: source.name })
+	 *   .whenNotMatched().insert({ id: source.id, name: source.name })
+	 *   .returning();
+	 *
+	 * // Merge and return specific fields
+	 * const result = await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenMatched().update({ name: source.name })
+	 *   .returning({ id: target.id, name: target.name });
+	 * ```
+	 */
+	returning(): PgMergeBase<
+		TTarget,
+		TSource,
+		TQueryResult,
+		TTarget['_']['columns'],
+		TTarget['$inferSelect']
+	>;
+	returning<TSelectedFields extends SelectedFieldsFlat>(
+		fields: TSelectedFields,
+	): PgMergeBase<
+		TTarget,
+		TSource,
+		TQueryResult,
+		TSelectedFields,
+		SelectResultFields<TSelectedFields>
+	>;
+	returning(
+		fields: SelectedFieldsFlat = this.config.table[Table.Symbol.Columns],
+	): PgMergeBase<TTarget, TSource, TQueryResult, any, any> {
+		this.config.returningFields = fields;
+		this.config.returning = orderSelectedFields<PgColumn>(fields);
+		return this as any;
+	}
+
+	/** @internal */
+	getSQL(): SQL {
+		return this.dialect.buildMergeQuery(this.config);
+	}
+
+	toSQL(): Query {
+		const { typings: _typings, ...rest } = this.dialect.sqlToQuery(this.getSQL());
+		return rest;
+	}
+
+	/** @internal */
+	_prepare(name?: string): PgMergePrepare<this> {
+		return this.session.prepareQuery<
+			PreparedQueryConfig & {
+				execute: TReturning extends undefined ? PgQueryResultKind<TQueryResult, never> : TReturning[];
+			}
+		>(this.dialect.sqlToQuery(this.getSQL()), this.config.returning, name, true, undefined, {
+			type: 'insert',
+			tables: extractUsedTable(this.config.table),
+		});
+	}
+
+	prepare(name: string): PgMergePrepare<this> {
+		return this._prepare(name);
+	}
+
+	private authToken?: NeonAuthToken;
+	/** @internal */
+	setToken(token?: NeonAuthToken) {
+		this.authToken = token;
+		return this;
+	}
+
+	override execute: ReturnType<this['prepare']>['execute'] = (placeholderValues) => {
+		return this._prepare().execute(placeholderValues, this.authToken);
+	};
+
+	/** @internal */
+	getSelectedFields(): this['_']['selectedFields'] {
+		return (
+			this.config.returningFields
+				? new Proxy(
+					this.config.returningFields,
+					new SelectionProxyHandler({
+						alias: getTableName(this.config.table),
+						sqlAliasedBehavior: 'alias',
+						sqlBehavior: 'error',
+					}),
+				)
+				: undefined
+		) as this['_']['selectedFields'];
+	}
+
+	$dynamic(): PgMerge<TTarget, TSource, TQueryResult, TSelectedFields, TReturning> {
+		return this as any;
+	}
+}
+
+export class PgMergeMatchedActionBuilder<
+	TTarget extends PgTable,
+	TSource extends PgTable | Subquery | SQL,
+	TQueryResult extends PgQueryResultHKT,
+	TParent extends PgMergeBase<TTarget, TSource, TQueryResult, any, any, any>,
+> {
+	static readonly [entityKind]: string = 'PgMergeMatchedActionBuilder';
+
+	constructor(
+		private parent: TParent,
+		private predicate?: SQL,
+	) { }
+
+	/**
+	 * Updates the matched row with the provided values.
+	 *
+	 * @example
+	 * ```ts
+	 * await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenMatched()
+	 *   .update({ name: source.name, updatedAt: sql`now()` });
+	 * ```
+	 */
+	update(values: PgUpdateSetSource<TTarget>): TParent {
+		this.parent.config.whenClauses.push({
+			type: 'matched',
+			predicate: this.predicate,
+			action: 'update',
+			set: mapUpdateSet(this.parent.config.table, values),
+		});
+		return this.parent;
+	}
+
+	/**
+	 * Deletes the matched row from the target table.
+	 *
+	 * @example
+	 * ```ts
+	 * await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenMatched(eq(source.status, 'deleted'))
+	 *   .delete();
+	 * ```
+	 */
+	delete(): TParent {
+		this.parent.config.whenClauses.push({
+			type: 'matched',
+			predicate: this.predicate,
+			action: 'delete',
+		});
+		return this.parent;
+	}
+
+	/**
+	 * Does nothing for the matched row.
+	 *
+	 * @example
+	 * ```ts
+	 * await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenMatched(gt(target.version, source.version))
+	 *   .doNothing();
+	 * ```
+	 */
+	doNothing(): TParent {
+		this.parent.config.whenClauses.push({
+			type: 'matched',
+			predicate: this.predicate,
+			action: 'do_nothing',
+		});
+		return this.parent;
+	}
+}
+
+export class PgMergeNotMatchedActionBuilder<
+	TTarget extends PgTable,
+	TSource extends PgTable | Subquery | SQL,
+	TQueryResult extends PgQueryResultHKT,
+	TParent extends PgMergeBase<TTarget, TSource, TQueryResult, any, any, any>,
+> {
+	static readonly [entityKind]: string = 'PgMergeNotMatchedActionBuilder';
+
+	constructor(
+		private parent: TParent,
+		private predicate?: SQL,
+	) { }
+
+	/**
+	 * Inserts the unmatched source row into the target table.
+	 *
+	 * Values can reference source table columns directly (as `PgColumn`) or use SQL expressions.
+	 *
+	 * @example
+	 * ```ts
+	 * await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenNotMatched()
+	 *   .insert({ id: source.id, name: source.name });
+	 * ```
+	 */
+	insert(values: PgMergeInsertValue<TTarget>): TParent {
+		const tableColumns = this.parent.config.table[Table.Symbol.Columns];
+		const mapped: Record<string, SQL | Param | AnyColumn> = {};
+		for (const key of Object.keys(values)) {
+			const colValue = values[key as keyof typeof values];
+			if (colValue === undefined) continue;
+			mapped[key] = is(colValue, SQL) || is(colValue, Column) ? colValue : new Param(colValue, tableColumns[key]);
+		}
+		this.parent.config.whenClauses.push({
+			type: 'not_matched',
+			predicate: this.predicate,
+			action: 'insert',
+			values: mapped,
+		});
+		return this.parent;
+	}
+
+	/**
+	 * Does nothing for the unmatched source row.
+	 *
+	 * @example
+	 * ```ts
+	 * await db.merge(target)
+	 *   .using(source, eq(target.id, source.id))
+	 *   .whenNotMatched(lt(source.priority, 5))
+	 *   .doNothing();
+	 * ```
+	 */
+	doNothing(): TParent {
+		this.parent.config.whenClauses.push({
+			type: 'not_matched',
+			predicate: this.predicate,
+			action: 'do_nothing',
+		});
+		return this.parent;
+	}
+}
+
+export class PgMergeBuilder<TTarget extends PgTable, TQueryResult extends PgQueryResultHKT> {
+	static readonly [entityKind]: string = 'PgMergeBuilder';
+
+	declare readonly _: {
+		readonly table: TTarget;
+	};
+
+	constructor(
+		private table: TTarget,
+		private session: PgSession,
+		private dialect: PgDialect,
+		private withList?: Subquery[],
+	) { }
+
+	private authToken?: NeonAuthToken;
+	setToken(token?: NeonAuthToken) {
+		this.authToken = token;
+		return this;
+	}
+
+	/**
+	 * Specifies the source table or subquery and the join condition for the MERGE statement.
+	 *
+	 * See docs: {@link https://orm.drizzle.team/docs/merge}
+	 *
+	 * @param source The source table, subquery, or SQL expression to merge from.
+	 * @param on The SQL condition that joins the target and source.
+	 *
+	 * @example
+	 * ```ts
+	 * // Using a table as source
+	 * db.merge(target).using(source, eq(target.id, source.id))
+	 *
+	 * // Using a subquery as source
+	 * db.merge(target).using(
+	 *   db.select().from(source).where(eq(source.active, true)).as('active_source'),
+	 *   eq(target.id, sql`active_source.id`)
+	 * )
+	 * ```
+	 */
+	using<TSource extends PgTable | Subquery | SQL>(
+		source: TSource,
+		on: SQL,
+	): PgMergeBase<TTarget, TSource, TQueryResult> {
+		return new PgMergeBase<TTarget, TSource, TQueryResult>(
+			this.table,
+			source,
+			on,
+			this.session,
+			this.dialect,
+			this.withList,
+		).setToken(this.authToken);
+	}
+}

--- a/drizzle-orm/tests/merge.test.ts
+++ b/drizzle-orm/tests/merge.test.ts
@@ -1,0 +1,273 @@
+import { expect, test, describe } from 'vitest';
+import { PgDialect, pgTable, integer, text } from '~/pg-core/index.ts';
+import { PgMergeBuilder, QueryBuilder } from '~/pg-core/query-builders/index.ts';
+import { eq, isNotNull, sql } from '~/sql/index.ts';
+
+const users = pgTable('users', {
+	id: integer('id').primaryKey(),
+	name: text('name'),
+});
+
+const source = pgTable('source_users', {
+	id: integer('id').primaryKey(),
+	name: text('name'),
+});
+
+function makeBuilder() {
+	const dialect = new PgDialect();
+	return { dialect, builder: new PgMergeBuilder(users, {} as any, dialect) };
+}
+
+describe('MERGE SQL generation', () => {
+	test('whenMatched update', () => {
+		const { builder } = makeBuilder();
+		const { sql: query, params } = builder
+			.using(source, eq(users.id, source.id))
+			.whenMatched()
+			.update({ name: source.name })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when matched then update set "name" = "source_users"."name"',
+		);
+		expect(params).toEqual([]);
+	});
+
+	test('whenMatched delete', () => {
+		const { builder } = makeBuilder();
+		const { sql: query } = builder
+			.using(source, eq(users.id, source.id))
+			.whenMatched()
+			.delete()
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when matched then delete',
+		);
+	});
+
+	test('whenMatched doNothing', () => {
+		const { builder } = makeBuilder();
+		const { sql: query } = builder
+			.using(source, eq(users.id, source.id))
+			.whenMatched()
+			.doNothing()
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when matched then do nothing',
+		);
+	});
+
+	test('whenNotMatched insert', () => {
+		const { builder } = makeBuilder();
+		const { sql: query, params } = builder
+			.using(source, eq(users.id, source.id))
+			.whenNotMatched()
+			.insert({ id: source.id, name: source.name })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when not matched then insert ("id", "name") values ("source_users"."id", "source_users"."name")',
+		);
+		expect(params).toEqual([]);
+	});
+
+	test('whenNotMatched doNothing', () => {
+		const { builder } = makeBuilder();
+		const { sql: query } = builder
+			.using(source, eq(users.id, source.id))
+			.whenNotMatched()
+			.doNothing()
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when not matched then do nothing',
+		);
+	});
+
+	test('full upsert: whenMatched update + whenNotMatched insert', () => {
+		const { builder } = makeBuilder();
+		const { sql: query } = builder
+			.using(source, eq(users.id, source.id))
+			.whenMatched()
+			.update({ name: source.name })
+			.whenNotMatched()
+			.insert({ id: source.id, name: source.name })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id"'
+			+ ' when matched then update set "name" = "source_users"."name"'
+			+ ' when not matched then insert ("id", "name") values ("source_users"."id", "source_users"."name")',
+		);
+	});
+
+	test('whenMatched with predicate condition', () => {
+		const { builder } = makeBuilder();
+		const { sql: query, params } = builder
+			.using(source, eq(users.id, source.id))
+			.whenMatched(eq(source.name, 'inactive'))
+			.delete()
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when matched and "source_users"."name" = $1 then delete',
+		);
+		expect(params).toEqual(['inactive']);
+	});
+
+	test('whenNotMatched with predicate condition', () => {
+		const { builder } = makeBuilder();
+		const { sql: query, params } = builder
+			.using(source, eq(users.id, source.id))
+			.whenNotMatched(eq(source.name, 'active'))
+			.insert({ id: source.id, name: source.name })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when not matched and "source_users"."name" = $1 then insert ("id", "name") values ("source_users"."id", "source_users"."name")',
+		);
+		expect(params).toEqual(['active']);
+	});
+
+	test('multiple whenMatched clauses (first match wins)', () => {
+		const { builder } = makeBuilder();
+		const { sql: query, params } = builder
+			.using(source, eq(users.id, source.id))
+			.whenMatched(eq(source.name, 'delete-me'))
+			.delete()
+			.whenMatched()
+			.update({ name: source.name })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id"'
+			+ ' when matched and "source_users"."name" = $1 then delete'
+			+ ' when matched then update set "name" = "source_users"."name"',
+		);
+		expect(params).toEqual(['delete-me']);
+	});
+
+	test('insert with literal value param', () => {
+		const { builder } = makeBuilder();
+		const { sql: query, params } = builder
+			.using(source, eq(users.id, source.id))
+			.whenNotMatched()
+			.insert({ id: source.id, name: 'default_name' })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when not matched then insert ("id", "name") values ("source_users"."id", $1)',
+		);
+		expect(params).toEqual(['default_name']);
+	});
+
+	test('update with literal value param', () => {
+		const { builder } = makeBuilder();
+		const { sql: query, params } = builder
+			.using(source, eq(users.id, source.id))
+			.whenMatched()
+			.update({ name: 'fixed_name' })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when matched then update set "name" = $1',
+		);
+		expect(params).toEqual(['fixed_name']);
+	});
+
+	test('insert with sql expression', () => {
+		const { builder } = makeBuilder();
+		const { sql: query } = builder
+			.using(source, eq(users.id, source.id))
+			.whenNotMatched()
+			.insert({ id: source.id, name: sql`upper(${source.name})` })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id" when not matched then insert ("id", "name") values ("source_users"."id", upper("source_users"."name"))',
+		);
+	});
+
+	test('with RETURNING clause (PG 17+)', () => {
+		const { builder } = makeBuilder();
+		const { sql: query } = builder
+			.using(source, eq(users.id, source.id))
+			.whenMatched()
+			.update({ name: source.name })
+			.whenNotMatched()
+			.insert({ id: source.id, name: source.name })
+			.returning()
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id"'
+			+ ' when matched then update set "name" = "source_users"."name"'
+			+ ' when not matched then insert ("id", "name") values ("source_users"."id", "source_users"."name")'
+			+ ' returning "id", "name"',
+		);
+	});
+
+	test('with RETURNING specific fields (PG 17+)', () => {
+		const { builder } = makeBuilder();
+		const { sql: query } = builder
+			.using(source, eq(users.id, source.id))
+			.whenMatched()
+			.update({ name: source.name })
+			.returning({ id: users.id })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users" using "source_users" on "users"."id" = "source_users"."id"'
+			+ ' when matched then update set "name" = "source_users"."name"'
+			+ ' returning "id"',
+		);
+	});
+
+	test('using raw SQL as source', () => {
+		const { builder } = makeBuilder();
+
+		const { sql: query } = builder
+			.using(
+				sql`(select * from ${source} where ${source.name} is not null) as "filtered"`,
+				sql`${users.id} = "filtered"."id"`,
+			)
+			.whenMatched()
+			.update({ name: sql`"filtered"."name"` })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users"'
+			+ ' using (select * from "source_users" where "source_users"."name" is not null) as "filtered"'
+			+ ' on "users"."id" = "filtered"."id"'
+			+ ' when matched then update set "name" = "filtered"."name"',
+		);
+	});
+
+	test('using a filtered subquery as source', () => {
+		const { builder, dialect } = makeBuilder();
+		const qb = new QueryBuilder(dialect);
+		const filteredSource = qb
+			.select({ id: source.id, name: source.name })
+			.from(source)
+			.where(isNotNull(source.name))
+			.as('filtered_source');
+
+		const { sql: query } = builder
+			.using(filteredSource, eq(users.id, filteredSource.id))
+			.whenMatched()
+			.update({ name: filteredSource.name })
+			.whenNotMatched()
+			.insert({ id: filteredSource.id, name: filteredSource.name })
+			.toSQL();
+
+		expect(query).toBe(
+			'merge into "users"'
+			+ ' using (select "id", "name" from "source_users" where "source_users"."name" is not null) "filtered_source"'
+			+ ' on "users"."id" = "filtered_source"."id"'
+			+ ' when matched then update set "name" = "filtered_source"."name"'
+			+ ' when not matched then insert ("id", "name") values ("filtered_source"."id", "filtered_source"."name")',
+		);
+	});
+});

--- a/drizzle-orm/tests/merge.test.ts
+++ b/drizzle-orm/tests/merge.test.ts
@@ -1,5 +1,5 @@
-import { expect, test, describe } from 'vitest';
-import { PgDialect, pgTable, integer, text } from '~/pg-core/index.ts';
+import { describe, expect, test } from 'vitest';
+import { integer, PgDialect, pgTable, text } from '~/pg-core/index.ts';
 import { PgMergeBuilder, QueryBuilder } from '~/pg-core/query-builders/index.ts';
 import { eq, isNotNull, sql } from '~/sql/index.ts';
 
@@ -98,8 +98,8 @@ describe('MERGE SQL generation', () => {
 
 		expect(query).toBe(
 			'merge into "users" using "source_users" on "users"."id" = "source_users"."id"'
-			+ ' when matched then update set "name" = "source_users"."name"'
-			+ ' when not matched then insert ("id", "name") values ("source_users"."id", "source_users"."name")',
+				+ ' when matched then update set "name" = "source_users"."name"'
+				+ ' when not matched then insert ("id", "name") values ("source_users"."id", "source_users"."name")',
 		);
 	});
 
@@ -143,8 +143,8 @@ describe('MERGE SQL generation', () => {
 
 		expect(query).toBe(
 			'merge into "users" using "source_users" on "users"."id" = "source_users"."id"'
-			+ ' when matched and "source_users"."name" = $1 then delete'
-			+ ' when matched then update set "name" = "source_users"."name"',
+				+ ' when matched and "source_users"."name" = $1 then delete'
+				+ ' when matched then update set "name" = "source_users"."name"',
 		);
 		expect(params).toEqual(['delete-me']);
 	});
@@ -203,9 +203,9 @@ describe('MERGE SQL generation', () => {
 
 		expect(query).toBe(
 			'merge into "users" using "source_users" on "users"."id" = "source_users"."id"'
-			+ ' when matched then update set "name" = "source_users"."name"'
-			+ ' when not matched then insert ("id", "name") values ("source_users"."id", "source_users"."name")'
-			+ ' returning "id", "name"',
+				+ ' when matched then update set "name" = "source_users"."name"'
+				+ ' when not matched then insert ("id", "name") values ("source_users"."id", "source_users"."name")'
+				+ ' returning "id", "name"',
 		);
 	});
 
@@ -220,8 +220,8 @@ describe('MERGE SQL generation', () => {
 
 		expect(query).toBe(
 			'merge into "users" using "source_users" on "users"."id" = "source_users"."id"'
-			+ ' when matched then update set "name" = "source_users"."name"'
-			+ ' returning "id"',
+				+ ' when matched then update set "name" = "source_users"."name"'
+				+ ' returning "id"',
 		);
 	});
 
@@ -239,9 +239,9 @@ describe('MERGE SQL generation', () => {
 
 		expect(query).toBe(
 			'merge into "users"'
-			+ ' using (select * from "source_users" where "source_users"."name" is not null) as "filtered"'
-			+ ' on "users"."id" = "filtered"."id"'
-			+ ' when matched then update set "name" = "filtered"."name"',
+				+ ' using (select * from "source_users" where "source_users"."name" is not null) as "filtered"'
+				+ ' on "users"."id" = "filtered"."id"'
+				+ ' when matched then update set "name" = "filtered"."name"',
 		);
 	});
 
@@ -264,10 +264,10 @@ describe('MERGE SQL generation', () => {
 
 		expect(query).toBe(
 			'merge into "users"'
-			+ ' using (select "id", "name" from "source_users" where "source_users"."name" is not null) "filtered_source"'
-			+ ' on "users"."id" = "filtered_source"."id"'
-			+ ' when matched then update set "name" = "filtered_source"."name"'
-			+ ' when not matched then insert ("id", "name") values ("filtered_source"."id", "filtered_source"."name")',
+				+ ' using (select "id", "name" from "source_users" where "source_users"."name" is not null) "filtered_source"'
+				+ ' on "users"."id" = "filtered_source"."id"'
+				+ ' when matched then update set "name" = "filtered_source"."name"'
+				+ ' when not matched then insert ("id", "name") values ("filtered_source"."id", "filtered_source"."name")',
 		);
 	});
 });

--- a/drizzle-orm/type-tests/pg/merge.ts
+++ b/drizzle-orm/type-tests/pg/merge.ts
@@ -1,0 +1,101 @@
+import type { QueryResult } from 'pg';
+import type { Equal } from 'type-tests/utils.ts';
+import { Expect } from 'type-tests/utils.ts';
+import { eq, sql } from '~/index.ts';
+import { db } from './db.ts';
+import { cities, users } from './tables.ts';
+
+// MERGE with whenMatched update + whenNotMatched insert (no RETURNING)
+{
+	const result = await db.merge(users)
+		.using(cities, eq(users.id, cities.id))
+		.whenMatched()
+		.update({ text: cities.name })
+		.whenNotMatched()
+		.insert({ id: 1, text: 'new user' });
+
+	Expect<Equal<QueryResult<never>, typeof result>>;
+}
+
+// MERGE with whenMatched delete
+{
+	const result = await db.merge(users)
+		.using(cities, eq(users.id, cities.id))
+		.whenMatched()
+		.delete();
+
+	Expect<Equal<QueryResult<never>, typeof result>>;
+}
+
+// MERGE with whenMatched doNothing
+{
+	const result = await db.merge(users)
+		.using(cities, eq(users.id, cities.id))
+		.whenMatched()
+		.doNothing()
+		.whenNotMatched()
+		.doNothing();
+
+	Expect<Equal<QueryResult<never>, typeof result>>;
+}
+
+// MERGE with conditional whenMatched
+{
+	const result = await db.merge(users)
+		.using(cities, eq(users.id, cities.id))
+		.whenMatched(eq(cities.id, 1))
+		.update({ text: cities.name })
+		.whenMatched()
+		.delete()
+		.whenNotMatched()
+		.insert({ id: 1, text: 'new user' });
+
+	Expect<Equal<QueryResult<never>, typeof result>>;
+}
+
+// MERGE with RETURNING all columns (PG 17+)
+{
+	const result = await db.merge(users)
+		.using(cities, eq(users.id, cities.id))
+		.whenMatched()
+		.update({ text: cities.name })
+		.whenNotMatched()
+		.insert({ id: 1, text: 'new user' })
+		.returning();
+
+	Expect<Equal<(typeof users.$inferSelect)[], typeof result>>;
+}
+
+// MERGE with RETURNING specific fields (PG 17+)
+{
+	const result = await db.merge(users)
+		.using(cities, eq(users.id, cities.id))
+		.whenMatched()
+		.update({ text: cities.name })
+		.returning({ id: users.id, name: users.text });
+
+	Expect<Equal<{ id: number; name: string | null }[], typeof result>>;
+}
+
+// MERGE with SQL expression in insert
+{
+	const result = await db.merge(users)
+		.using(cities, eq(users.id, cities.id))
+		.whenNotMatched()
+		.insert({ id: sql<number>`${cities.id}`, text: cities.name });
+
+	Expect<Equal<QueryResult<never>, typeof result>>;
+}
+
+// MERGE toSQL
+{
+	const { sql: query } = db.merge(users)
+		.using(cities, eq(users.id, cities.id))
+		.whenMatched()
+		.update({ text: cities.name })
+		.whenNotMatched()
+		.insert({ id: 1, text: 'new user' })
+		.toSQL();
+
+	Expect<Equal<string, typeof query>>;
+}


### PR DESCRIPTION
Adds `MERGE` statement support for PostgreSQL 15+ via a new `db.merge()` query builder, following the same fluent API style as `UPDATE .. FROM` and `INSERT INTO .. SELECT`.

Resolves #1298

## API

```ts
// Upsert: update on match, insert otherwise
await db.merge(users)
  .using(newUsers, eq(users.id, newUsers.id))
  .whenMatched()
    .update({ name: newUsers.name, email: newUsers.email })
  .whenNotMatched()
    .insert({ id: newUsers.id, name: newUsers.name, email: newUsers.email });
```

```typescript
// Multiple conditional clauses
await db.merge(users)
  .using(updates, eq(users.id, updates.id))
  .whenMatched(eq(updates.status, 'deleted'))
    .delete()
  .whenMatched()
    .update({ name: updates.name })
  .whenNotMatched()
    .doNothing();
```

```typescript
// RETURNING (requires PostgreSQL 17+)
const result = await db.merge(users)
  .using(newUsers, eq(users.id, newUsers.id))
  .whenMatched()
    .update({ name: newUsers.name })
  .returning();
```

```typescript
// Subquery as source
const filtered = qb.select({ id: src.id, name: src.name })
  .from(src)
  .where(isNotNull(src.name))
  .as('filtered_source');

await db.merge(users)
  .using(filtered, eq(users.id, filtered.id))
  .whenMatched()
    .update({ name: filtered.name })
  .whenNotMatched()
    .insert({ id: filtered.id, name: filtered.name });
```

```typescript
// Works with .with() CTEs
await db.with(cte).merge(users)
  .using(cte, eq(users.id, cte.id))
  .whenMatched()
    .update({ name: cte.name });
```

## What was changed

- **`drizzle-orm/src/pg-core/query-builders/merge.ts`** — New file. Implements `PgMergeBuilder` (returned by `db.merge()`), `PgMergeBase` (the main builder after `.using()`), `PgMergeMatchedActionBuilder` (`.whenMatched()` actions), and `PgMergeNotMatchedActionBuilder` (`.whenNotMatched()` actions). Supports `.returning()` for PostgreSQL 17+, `.toSQL()`, `.prepare()`, and CTE integration via `db.with()`.

- **`drizzle-orm/src/pg-core/dialect.ts`** — Added `buildMergeQuery()` to `PgDialect`. Generates the full `MERGE INTO … USING … ON … WHEN … THEN …` SQL, including conditional predicates on each clause and an optional `RETURNING` clause.

- **`drizzle-orm/src/pg-core/query-builders/index.ts`** — Re-exports all public types and classes from `merge.ts`.

- **`drizzle-orm/src/pg-core/db.ts`** — Added `db.merge(table)` to `PgDatabase` and to the `db.with(…)` builder chain.

- **`drizzle-orm/tests/merge.test.ts`** — 16 unit tests covering all clause types (`.update()`, `.delete()`, `.doNothing()`, `.insert()`), conditional predicates, literal params, column references, SQL expressions, `RETURNING`, and subquery sources.

- **`drizzle-orm/type-tests/pg/merge.ts`** — Compile-time type tests verifying the return types of all builder combinations.
