### PR TITLE
Fix nested left join null mapping

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -51,6 +51,8 @@ export function mapResultRow<TResult>(
 							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
 						) {
 							nullifyMap[objectName] = false;
+						} else if (typeof nullifyMap[objectName] === 'string' && value !== null) {
+							nullifyMap[objectName] = false;
 						}
 					}
 				}

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from 'vitest';
+
+import { integer, pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+const org = pgTable('org', {
+	id: integer('id'),
+	name: text('name'),
+});
+
+const orgBranding = pgTable('org_branding', {
+	logo: text('logo'),
+	panelBackground: text('panel_background_colour'),
+	orgId: integer('org_id'),
+});
+
+test('mapResultRow keeps nested left join object when first field is null but later field is not', () => {
+	const fields = orderSelectedFields({
+		name: org.name,
+		branding: {
+			logo: orgBranding.logo,
+			panelBackground: orgBranding.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(fields, ['Test org 2', null, '#1a8cff'], {
+		org: true,
+		org_branding: false,
+	});
+
+	expect(result).toEqual({
+		name: 'Test org 2',
+		branding: {
+			logo: null,
+			panelBackground: '#1a8cff',
+		},
+	});
+});
+
+test('mapResultRow nullifies nested left join object when every field from the table is null', () => {
+	const fields = orderSelectedFields({
+		name: org.name,
+		branding: {
+			logo: orgBranding.logo,
+			panelBackground: orgBranding.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(fields, ['Test org 2', null, null], {
+		org: true,
+		org_branding: false,
+	});
+
+	expect(result).toEqual({
+		name: 'Test org 2',
+		branding: null,
+	});
+});


### PR DESCRIPTION
Fixes #1603.

This updates nested result mapping so a nullable joined object is only nullified when all selected fields from that joined table are null. Previously, if the first nested field was null, the mapper could nullify the whole object even when later fields from the same table had values.

Tests:
- corepack pnpm --dir drizzle-orm exec vitest run tests/utils.test.ts