### PR TITLE
Add selectFromDb hook for custom types

### DIFF
--- a/docs/custom-types.lite.md
+++ b/docs/custom-types.lite.md
@@ -81,6 +81,30 @@ const customTimestamp = customType<
 });
 ```
 
+#### **Custom select SQL**
+
+```typescript
+type Point = {
+  lat: number;
+  lng: number;
+};
+
+const customPoint = customType<{ data: Point; driverData: string }>({
+  dataType() {
+    return 'geometry(Point,4326)';
+  },
+  fromDriver(value: string): Point {
+    const matches = value.match(/POINT\((?<lng>[\d.-]+) (?<lat>[\d.-]+)\)/);
+    const { lat, lng } = matches?.groups ?? {};
+
+    return { lat: Number(lat), lng: Number(lng) };
+  },
+  selectFromDb(column, decoder, columnName) {
+    return sql`st_astext(${column})`.mapWith(decoder).as(columnName);
+  },
+});
+```
+
 #### Usage for all types will be same as defined functions in Drizzle ORM
 
 ```typescript
@@ -293,5 +317,15 @@ export interface CustomTypeParams<T extends Partial<CustomTypeValues>> {
    * ```
    */
   fromDriver?: (value: T['driverData']) => T['data'];
+
+  /**
+   * Optional SQL wrapper for selecting this custom type from the database.
+   * The returned SQL is used before the selected value is passed to `fromDriver`.
+   */
+  selectFromDb?: (
+    column: SQL<T['driverData']>,
+    decoder: DriverValueMapper<T['data'], T['driverData']>,
+    columnName: string,
+  ) => SQL | SQL.Aliased;
 }
 ````

--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -112,6 +112,10 @@ export abstract class Column<
 
 	abstract getSQLType(): string;
 
+	getSQLForSelect(column: SQL<T['driverParam']>): SQL | SQL.Aliased {
+		return column;
+	}
+
 	mapFromDriverValue(value: unknown): unknown {
 		return value;
 	}

--- a/drizzle-orm/src/gel-core/columns/custom.ts
+++ b/drizzle-orm/src/gel-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyGelTable } from '~/gel-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { GelColumn, GelColumnBuilder } from './common.ts';
 
@@ -63,6 +63,11 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (
+		column: SQL<T['driverParam']>,
+		decoder: DriverValueMapper<T['data'], T['driverParam']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnyGelTable<{ name: T['tableName'] }>,
@@ -72,6 +77,7 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -84,6 +90,10 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 
 	override mapToDriverValue(value: T['data']): T['driverParam'] {
 		return typeof this.mapTo === 'function' ? this.mapTo(value) : value as T['data'];
+	}
+
+	override getSQLForSelect(column: SQL<T['driverParam']>): SQL | SQL.Aliased {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(column, this, this.name) : column;
 	}
 }
 
@@ -195,6 +205,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper for selecting this custom type from the database.
+	 *
+	 * This is useful when the database returns a custom type in a format that should be converted
+	 * by SQL before the value is passed to `fromDriver`.
+	 */
+	selectFromDb?: (
+		column: SQL<T['driverData']>,
+		decoder: DriverValueMapper<T['data'], T['driverData']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -38,7 +38,13 @@ import {
 } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import {
+	type Casing,
+	getColumnExpressionForRelationalJson,
+	getColumnSelectionExpression,
+	orderSelectedFields,
+	type UpdateSet,
+} from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import { GelTimestamp } from './columns/timestamp.ts';
 import { GelViewBase } from './view-base.ts';
@@ -240,7 +246,7 @@ export class GelDialect {
 					// if (isSingleTable) {
 					// 	chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
 					// } else {
-					chunk.push(field);
+					chunk.push(getColumnSelectionExpression(field, sql`${field}`));
 					// }
 				} else if (is(field, Subquery)) {
 					const entries = Object.entries(field._.selectedFields) as [string, SQL.Aliased | Column | SQL][];
@@ -1351,6 +1357,8 @@ export class GelDialect {
 							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
 							: is(field, SQL.Aliased)
 							? field.sql
+							: is(field, Column)
+							? getColumnExpressionForRelationalJson(field, sql`${field}`)
 							: field
 					),
 					sql`, `,

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
@@ -63,6 +63,11 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (
+		column: SQL<T['driverParam']>,
+		decoder: DriverValueMapper<T['data'], T['driverParam']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -72,6 +77,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -84,6 +90,10 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 
 	override mapToDriverValue(value: T['data']): T['driverParam'] {
 		return typeof this.mapTo === 'function' ? this.mapTo(value) : value as T['data'];
+	}
+
+	override getSQLForSelect(column: SQL<T['driverParam']>): SQL | SQL.Aliased {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(column, this, this.name) : column;
 	}
 }
 
@@ -195,6 +205,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper for selecting this custom type from the database.
+	 *
+	 * This is useful when the database returns a custom type in a format that should be converted
+	 * by SQL before the value is passed to `fromDriver`, for example spatial text conversion.
+	 */
+	selectFromDb?: (
+		column: SQL<T['driverData']>,
+		decoder: DriverValueMapper<T['data'], T['driverData']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -21,7 +21,13 @@ import { Param, SQL, sql, View } from '~/sql/sql.ts';
 import type { Name, Placeholder, QueryWithTypings, SQLChunk } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import {
+	type Casing,
+	getColumnExpressionForRelationalJson,
+	getColumnSelectionExpression,
+	orderSelectedFields,
+	type UpdateSet,
+} from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import { MySqlColumn } from './columns/common.ts';
 import type { MySqlDeleteConfig } from './query-builders/delete.ts';
@@ -246,9 +252,9 @@ export class MySqlDialect {
 				}
 			} else if (is(field, Column)) {
 				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+					chunk.push(getColumnSelectionExpression(field, sql`${sql.identifier(this.casing.getColumnCasing(field))}`));
 				} else {
-					chunk.push(field);
+					chunk.push(getColumnSelectionExpression(field, sql`${field}`));
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [
@@ -898,6 +904,8 @@ export class MySqlDialect {
 							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
 							: is(field, SQL.Aliased)
 							? field.sql
+							: is(field, Column)
+							? getColumnExpressionForRelationalJson(field, sql`${field}`)
 							: field
 					),
 					sql`, `,
@@ -1237,7 +1245,10 @@ export class MySqlDialect {
 				sql.join(
 					selection.map(({ field }) =>
 						is(field, MySqlColumn)
-							? sql.identifier(this.casing.getColumnCasing(field))
+							? getColumnExpressionForRelationalJson(
+								field,
+								sql`${sql.identifier(this.casing.getColumnCasing(field))}`,
+							)
 							: is(field, SQL.Aliased)
 							? field.sql
 							: field

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyPgTable } from '~/pg-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { PgColumn, PgColumnBuilder } from './common.ts';
 
@@ -63,6 +63,11 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (
+		column: SQL<T['driverParam']>,
+		decoder: DriverValueMapper<T['data'], T['driverParam']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,6 +77,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -84,6 +90,10 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 
 	override mapToDriverValue(value: T['data']): T['driverParam'] {
 		return typeof this.mapTo === 'function' ? this.mapTo(value) : value as T['data'];
+	}
+
+	override getSQLForSelect(column: SQL<T['driverParam']>): SQL | SQL.Aliased {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(column, this, this.name) : column;
 	}
 }
 
@@ -195,6 +205,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper for selecting this custom type from the database.
+	 *
+	 * This is useful when the database returns a custom type in a format that should be converted
+	 * by SQL before the value is passed to `fromDriver`, for example PostGIS `ST_AsText(column)`.
+	 */
+	selectFromDb?: (
+		column: SQL<T['driverData']>,
+		decoder: DriverValueMapper<T['data'], T['driverData']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -50,7 +50,13 @@ import {
 } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import {
+	type Casing,
+	getColumnExpressionForRelationalJson,
+	getColumnSelectionExpression,
+	orderSelectedFields,
+	type UpdateSet,
+} from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type { PgSession } from './session.ts';
 import { PgViewBase } from './view-base.ts';
@@ -243,9 +249,9 @@ export class PgDialect {
 					}
 				} else if (is(field, Column)) {
 					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+						chunk.push(getColumnSelectionExpression(field, sql`${sql.identifier(this.casing.getColumnCasing(field))}`));
 					} else {
-						chunk.push(field);
+						chunk.push(getColumnSelectionExpression(field, sql`${field}`));
 					}
 				} else if (is(field, Subquery)) {
 					const entries = Object.entries(field._.selectedFields) as [string, SQL.Aliased | Column | SQL][];
@@ -1360,6 +1366,8 @@ export class PgDialect {
 							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
 							: is(field, SQL.Aliased)
 							? field.sql
+							: is(field, Column)
+							? getColumnExpressionForRelationalJson(field, sql`${field}`)
 							: field
 					),
 					sql`, `,

--- a/drizzle-orm/src/singlestore-core/columns/custom.ts
+++ b/drizzle-orm/src/singlestore-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnySingleStoreTable } from '~/singlestore-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { SingleStoreColumn, SingleStoreColumnBuilder } from './common.ts';
 
@@ -66,6 +66,11 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (
+		column: SQL<T['driverParam']>,
+		decoder: DriverValueMapper<T['data'], T['driverParam']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnySingleStoreTable<{ name: T['tableName'] }>,
@@ -75,6 +80,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -87,6 +93,10 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 
 	override mapToDriverValue(value: T['data']): T['driverParam'] {
 		return typeof this.mapTo === 'function' ? this.mapTo(value) : value as T['data'];
+	}
+
+	override getSQLForSelect(column: SQL<T['driverParam']>): SQL | SQL.Aliased {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(column, this, this.name) : column;
 	}
 }
 
@@ -198,6 +208,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper for selecting this custom type from the database.
+	 *
+	 * This is useful when the database returns a custom type in a format that should be converted
+	 * by SQL before the value is passed to `fromDriver`.
+	 */
+	selectFromDb?: (
+		column: SQL<T['driverData']>,
+		decoder: DriverValueMapper<T['data'], T['driverData']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -21,7 +21,13 @@ import type { Name, Placeholder, QueryWithTypings, SQLChunk } from '~/sql/sql.ts
 import { Param, SQL, sql, View } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import {
+	type Casing,
+	getColumnExpressionForRelationalJson,
+	getColumnSelectionExpression,
+	orderSelectedFields,
+	type UpdateSet,
+} from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import { SingleStoreColumn } from './columns/common.ts';
 import type { SingleStoreDeleteConfig } from './query-builders/delete.ts';
@@ -245,9 +251,9 @@ export class SingleStoreDialect {
 				}
 			} else if (is(field, Column)) {
 				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+					chunk.push(getColumnSelectionExpression(field, sql`${sql.identifier(this.casing.getColumnCasing(field))}`));
 				} else {
-					chunk.push(field);
+					chunk.push(getColumnSelectionExpression(field, sql`${field}`));
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [
@@ -848,6 +854,8 @@ export class SingleStoreDialect {
 							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
 							: is(field, SQL.Aliased)
 							? field.sql
+							: is(field, Column)
+							? getColumnExpressionForRelationalJson(field, sql`${field}`)
 							: field
 					),
 					sql`, `,

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -1,7 +1,7 @@
 import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnConfig } from '~/column-builder.ts';
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import type { AnySQLiteTable } from '~/sqlite-core/table.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { SQLiteColumn, SQLiteColumnBuilder } from './common.ts';
@@ -63,6 +63,11 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (
+		column: SQL<T['driverParam']>,
+		decoder: DriverValueMapper<T['data'], T['driverParam']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -72,6 +77,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -84,6 +90,10 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 
 	override mapToDriverValue(value: T['data']): T['driverParam'] {
 		return typeof this.mapTo === 'function' ? this.mapTo(value) : value as T['data'];
+	}
+
+	override getSQLForSelect(column: SQL<T['driverParam']>): SQL | SQL.Aliased {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(column, this, this.name) : column;
 	}
 }
 
@@ -195,6 +205,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper for selecting this custom type from the database.
+	 *
+	 * This is useful when the database returns a custom type in a format that should be converted
+	 * by SQL before the value is passed to `fromDriver`.
+	 */
+	selectFromDb?: (
+		column: SQL<T['driverData']>,
+		decoder: DriverValueMapper<T['data'], T['driverData']>,
+		columnName: string,
+	) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -30,7 +30,13 @@ import type {
 import { SQLiteTable } from '~/sqlite-core/table.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import {
+	type Casing,
+	getColumnExpressionForRelationalJson,
+	getColumnSelectionExpression,
+	orderSelectedFields,
+	type UpdateSet,
+} from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type {
 	SelectedFieldsOrdered,
@@ -212,19 +218,28 @@ export abstract class SQLiteDialect {
 				if (field.columnType === 'SQLiteNumericBigInt') {
 					if (isSingleTable) {
 						chunk.push(
-							sql`cast(${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							getColumnSelectionExpression(
+								field,
+								sql`cast(${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							),
 						);
 					} else {
 						chunk.push(
-							sql`cast(${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							getColumnSelectionExpression(
+								field,
+								sql`cast(${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							),
 						);
 					}
 				} else {
 					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+						chunk.push(getColumnSelectionExpression(field, sql`${sql.identifier(this.casing.getColumnCasing(field))}`));
 					} else {
 						chunk.push(
-							sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
+							getColumnSelectionExpression(
+								field,
+								sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
+							),
 						);
 					}
 				}
@@ -839,7 +854,10 @@ export abstract class SQLiteDialect {
 				sql.join(
 					selection.map(({ field }) =>
 						is(field, SQLiteColumn)
-							? sql.identifier(this.casing.getColumnCasing(field))
+							? getColumnExpressionForRelationalJson(
+								field,
+								sql`${sql.identifier(this.casing.getColumnCasing(field))}`,
+							)
 							: is(field, SQL.Aliased)
 							? field.sql
 							: field

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -5,7 +5,7 @@ import { is } from './entity.ts';
 import type { Logger } from './logger.ts';
 import type { SelectedFieldsOrdered } from './operations.ts';
 import type { TableLike } from './query-builders/select.types.ts';
-import { Param, SQL, View } from './sql/sql.ts';
+import { Param, SQL, sql, View } from './sql/sql.ts';
 import type { DriverValueDecoder } from './sql/sql.ts';
 import { Subquery } from './subquery.ts';
 import { getTableName, Table } from './table.ts';
@@ -92,6 +92,20 @@ export function orderSelectedFields<TColumn extends AnyColumn>(
 		}
 		return result;
 	}, []) as SelectedFieldsOrdered<TColumn>;
+}
+
+/** @internal */
+export function getColumnSelectionExpression(column: AnyColumn, expression: SQL): SQL {
+	const selectedExpression = column.getSQLForSelect(expression);
+	return is(selectedExpression, SQL.Aliased)
+		? sql`${selectedExpression.sql} as ${sql.identifier(selectedExpression.fieldAlias)}`
+		: selectedExpression;
+}
+
+/** @internal */
+export function getColumnExpressionForRelationalJson(column: AnyColumn, expression: SQL): SQL {
+	const selectedExpression = column.getSQLForSelect(expression);
+	return is(selectedExpression, SQL.Aliased) ? selectedExpression.sql : selectedExpression;
 }
 
 export function haveSameKeys(left: Record<string, unknown>, right: Record<string, unknown>) {

--- a/drizzle-orm/tests/custom-select-from-db.test.ts
+++ b/drizzle-orm/tests/custom-select-from-db.test.ts
@@ -1,0 +1,161 @@
+import postgres from 'postgres';
+import { describe, it } from 'vitest';
+import { customType as gelCustomType, gelTable, integer as gelInteger } from '~/gel-core';
+import { QueryBuilder as GelQueryBuilder } from '~/gel-core/query-builders/query-builder.ts';
+import { customType as mysqlCustomType, int, mysqlTable } from '~/mysql-core';
+import { QueryBuilder as MySqlQueryBuilder } from '~/mysql-core/query-builders/query-builder.ts';
+import { customType as pgCustomType, integer, pgTable } from '~/pg-core';
+import { QueryBuilder as PgQueryBuilder } from '~/pg-core/query-builders/query-builder.ts';
+import { drizzle } from '~/postgres-js';
+import { relations } from '~/relations';
+import { customType as singlestoreCustomType, int as singlestoreInt, singlestoreTable } from '~/singlestore-core';
+import { QueryBuilder as SingleStoreQueryBuilder } from '~/singlestore-core/query-builders/query-builder.ts';
+import { sql } from '~/sql/sql.ts';
+import { customType as sqliteCustomType, integer as sqliteInteger, sqliteTable } from '~/sqlite-core';
+import { QueryBuilder as SQLiteQueryBuilder } from '~/sqlite-core/query-builders/query-builder.ts';
+import { mapResultRow } from '~/utils.ts';
+
+type Point = {
+	lat: number;
+	lng: number;
+};
+
+function parsePoint(value: string): Point {
+	const [, lng, lat] = /POINT\(([\d.-]+) ([\d.-]+)\)/.exec(value)!;
+	return { lat: Number(lat), lng: Number(lng) };
+}
+
+const pgPoint = pgCustomType<{ data: Point; driverData: string }>({
+	dataType: () => 'geometry(Point,4326)',
+	fromDriver: parsePoint,
+	selectFromDb: (column, decoder, columnName) => sql`st_astext(${column})`.mapWith(decoder).as(columnName),
+});
+
+const mysqlPoint = mysqlCustomType<{ data: Point; driverData: string }>({
+	dataType: () => 'geometry',
+	fromDriver: parsePoint,
+	selectFromDb: (column, decoder, columnName) => sql`st_astext(${column})`.mapWith(decoder).as(columnName),
+});
+
+const sqlitePoint = sqliteCustomType<{ data: Point; driverData: string }>({
+	dataType: () => 'text',
+	fromDriver: parsePoint,
+	selectFromDb: (column, decoder, columnName) => sql`astext(${column})`.mapWith(decoder).as(columnName),
+});
+
+const singlestorePoint = singlestoreCustomType<{ data: Point; driverData: string }>({
+	dataType: () => 'geography',
+	fromDriver: parsePoint,
+	selectFromDb: (column, decoder, columnName) => sql`geography_to_text(${column})`.mapWith(decoder).as(columnName),
+});
+
+const gelPoint = gelCustomType<{ data: Point; driverData: string }>({
+	dataType: () => 'str',
+	fromDriver: parsePoint,
+	selectFromDb: (column, decoder, columnName) => sql`to_str(${column})`.mapWith(decoder).as(columnName),
+});
+
+const pgLocations = pgTable('locations', {
+	id: integer('id'),
+	userId: integer('user_id'),
+	coords: pgPoint('coords'),
+});
+
+const pgUsers = pgTable('users', {
+	id: integer('id'),
+});
+
+const pgUsersRelations = relations(pgUsers, ({ many }) => ({
+	locations: many(pgLocations),
+}));
+
+const pgLocationsRelations = relations(pgLocations, ({ one }) => ({
+	user: one(pgUsers, {
+		fields: [pgLocations.userId],
+		references: [pgUsers.id],
+	}),
+}));
+
+const mysqlLocations = mysqlTable('locations', {
+	id: int('id'),
+	coords: mysqlPoint('coords'),
+});
+
+const sqliteLocations = sqliteTable('locations', {
+	id: sqliteInteger('id'),
+	coords: sqlitePoint('coords'),
+});
+
+const singlestoreLocations = singlestoreTable('locations', {
+	id: singlestoreInt('id'),
+	coords: singlestorePoint('coords'),
+});
+
+const gelLocations = gelTable('locations', {
+	id: gelInteger('id'),
+	coords: gelPoint('coords'),
+});
+
+describe('custom type selectFromDb', () => {
+	it('wraps selected custom columns for each SQL dialect', ({ expect }) => {
+		expect(new PgQueryBuilder().select({ coords: pgLocations.coords }).from(pgLocations).toSQL()).toEqual({
+			sql: 'select st_astext("coords") as "coords" from "locations"',
+			params: [],
+		});
+
+		expect(new MySqlQueryBuilder().select({ coords: mysqlLocations.coords }).from(mysqlLocations).toSQL()).toEqual({
+			sql: 'select st_astext(`coords`) as `coords` from `locations`',
+			params: [],
+		});
+
+		expect(new SQLiteQueryBuilder().select({ coords: sqliteLocations.coords }).from(sqliteLocations).toSQL()).toEqual({
+			sql: 'select astext("coords") as "coords" from "locations"',
+			params: [],
+		});
+
+		expect(
+			new SingleStoreQueryBuilder().select({ coords: singlestoreLocations.coords }).from(singlestoreLocations).toSQL(),
+		).toEqual({
+			sql: 'select geography_to_text(`coords`) as `coords` from `locations`',
+			params: [],
+		});
+
+		expect(new GelQueryBuilder().select({ coords: gelLocations.coords }).from(gelLocations).toSQL()).toEqual({
+			sql: 'select to_str("locations"."coords") as "coords" from "locations"',
+			params: [],
+		});
+	});
+
+	it('keeps the custom column decoder for wrapped selects', ({ expect }) => {
+		expect(
+			mapResultRow([{ path: ['coords'], field: pgLocations.coords }], ['POINT(30 50)'], undefined),
+		).toEqual({
+			coords: { lat: 50, lng: 30 },
+		});
+	});
+
+	it('wraps custom columns selected through relational query columns', ({ expect }) => {
+		const db = drizzle(postgres(''), {
+			schema: { pgUsers, pgUsersRelations, pgLocations, pgLocationsRelations },
+		});
+
+		const query = db.query.pgUsers.findMany({
+			columns: {
+				id: true,
+			},
+			with: {
+				locations: {
+					columns: {
+						coords: true,
+					},
+				},
+			},
+		});
+
+		expect(query.toSQL()).toEqual({
+			sql:
+				'select "pgUsers"."id", "pgUsers_locations"."data" as "locations" from "users" "pgUsers" left join lateral (select coalesce(json_agg(json_build_array(st_astext("pgUsers_locations"."coords"))), \'[]\'::json) as "data" from "locations" "pgUsers_locations" where "pgUsers_locations"."user_id" = "pgUsers"."id") "pgUsers_locations" on true',
+			params: [],
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add an optional `selectFromDb(column, decoder, columnName)` hook to `customType()` for PostgreSQL, MySQL, SQLite, SingleStore, and Gel custom columns
- route selected columns through the hook in normal selects, returning selections, and relational query JSON selections while preserving the existing `fromDriver` decoder path
- document the hook and add focused SQL-generation/decoder coverage across dialects, including relational query `columns`

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter drizzle-orm exec vitest run tests/custom-select-from-db.test.ts`
- `corepack pnpm exec dprint check docs/custom-types.lite.md drizzle-orm/src/column.ts drizzle-orm/src/utils.ts drizzle-orm/src/pg-core/columns/custom.ts drizzle-orm/src/mysql-core/columns/custom.ts drizzle-orm/src/sqlite-core/columns/custom.ts drizzle-orm/src/singlestore-core/columns/custom.ts drizzle-orm/src/gel-core/columns/custom.ts drizzle-orm/src/pg-core/dialect.ts drizzle-orm/src/mysql-core/dialect.ts drizzle-orm/src/sqlite-core/dialect.ts drizzle-orm/src/singlestore-core/dialect.ts drizzle-orm/src/gel-core/dialect.ts drizzle-orm/tests/custom-select-from-db.test.ts`
- `corepack pnpm --filter drizzle-orm exec tsc -p tests/tsconfig.json --noEmit`
- `corepack pnpm --filter drizzle-orm test`
- `corepack pnpm --filter drizzle-orm test:types`
- `PATH=/tmp/corepack-bin:$PATH corepack pnpm --filter drizzle-orm build`

/claim #1083