### PR TITLE
Allow custom types to wrap selected column SQL

### DIFF
--- a/docs/custom-types.lite.md
+++ b/docs/custom-types.lite.md
@@ -94,6 +94,23 @@ const usersTable = pgTable('users', {
 });
 ```
 
+You can also wrap a custom column when it is selected from the database. This is useful for database types
+that need a SQL function before `fromDriver` receives the raw driver value, for example PostGIS geometry:
+
+```typescript
+const customGeometry = customType<{ data: string; driverData: string }>({
+  dataType() {
+    return 'geometry';
+  },
+  selectFromDb(column) {
+    return sql`ST_AsText(${column})`;
+  },
+  fromDriver(value) {
+    return value;
+  },
+});
+```
+
 ### MySql Data Types using `mysql2` driver
 
 ---
@@ -293,5 +310,19 @@ export interface CustomTypeParams<T extends Partial<CustomTypeValues>> {
    * ```
    */
   fromDriver?: (value: T['driverData']) => T['data'];
+
+  /**
+   * Optional SQL wrapper used when this custom column is selected from the database.
+   * The returned expression is automatically aliased back to the column name and decoded
+   * with `fromDriver`, so callers should only wrap the provided column SQL.
+   *
+   * @example
+   * ```
+   * selectFromDb(column) {
+   *   return sql`lower(${column})`;
+   * }
+   * ```
+   */
+  selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 ````

--- a/docs/custom-types.md
+++ b/docs/custom-types.md
@@ -54,6 +54,21 @@ Column class has set of types/functions, that could be overridden to get needed 
 
 - `mapFromDriverValue()` - interceptor between database and select query execution. If you want to modify/map/change value for specific data type, it could be done here
 
+- `selectFromDb()` - optional SQL wrapper for custom types that need to transform the column expression before the driver value is decoded
+
+#### Usage example for selecting PostGIS geometry as text
+
+```typescript
+const customGeometry = customType<{ data: string; driverData: string }>({
+  dataType() {
+    return 'geometry';
+  },
+  selectFromDb(column) {
+    return sql`ST_AsText(${column})`;
+  },
+});
+```
+
 #### Usage example for jsonb type
 
 ```typescript

--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -46,6 +46,17 @@ export type ColumnRuntimeConfig<TData, TRuntimeConfig extends object> = ColumnBu
 	TRuntimeConfig
 >;
 
+export type ColumnSelectMapper = (column: SQL) => SQL;
+
+export type ColumnWithSelectMapper = Column & {
+	selectFromDb?: ColumnSelectMapper;
+};
+
+export function mapColumnSelection(column: Column, columnSql: SQL): SQL {
+	const selectFromDb = (column as ColumnWithSelectMapper).selectFromDb;
+	return typeof selectFromDb === 'function' ? selectFromDb(columnSql) : columnSql;
+}
+
 export interface Column<
 	T extends ColumnBaseConfig<ColumnDataType, string> = ColumnBaseConfig<ColumnDataType, string>,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/drizzle-orm/src/gel-core/columns/custom.ts
+++ b/drizzle-orm/src/gel-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnyGelTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection as mapColumnSelectionValue } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import { GelColumn, GelDecimal, GelJson, GelUUID } from '~/gel-core/columns/index.ts';
@@ -240,7 +240,13 @@ export class GelDialect {
 					// if (isSingleTable) {
 					// 	chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
 					// } else {
-					chunk.push(field);
+					const columnSql = field.getSQL();
+					const selectionSql = mapColumnSelectionValue(field, columnSql);
+					chunk.push(selectionSql);
+
+					if (selectionSql !== columnSql) {
+						chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
+					}
 					// }
 				} else if (is(field, Subquery)) {
 					const entries = Object.entries(field._.selectedFields) as [string, SQL.Aliased | Column | SQL][];
@@ -1351,6 +1357,8 @@ export class GelDialect {
 							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
 							: is(field, SQL.Aliased)
 							? field.sql
+							: is(field, Column)
+							? mapColumnSelectionValue(field, field.getSQL())
 							: field
 					),
 					sql`, `,

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection as mapColumnSelectionValue } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -245,10 +245,14 @@ export class MySqlDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-				} else {
-					chunk.push(field);
+				const columnSql = isSingleTable
+					? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+					: field.getSQL();
+				const selectionSql = mapColumnSelectionValue(field, columnSql);
+				chunk.push(selectionSql);
+
+				if (selectionSql !== columnSql) {
+					chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [
@@ -1237,7 +1241,10 @@ export class MySqlDialect {
 				sql.join(
 					selection.map(({ field }) =>
 						is(field, MySqlColumn)
-							? sql.identifier(this.casing.getColumnCasing(field))
+							? mapColumnSelectionValue(
+								field,
+								sql`${sql.identifier(this.casing.getColumnCasing(field))}`,
+							)
 							: is(field, SQL.Aliased)
 							? field.sql
 							: field

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`ST_AsText(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection as mapColumnSelectionValue } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -242,10 +242,14 @@ export class PgDialect {
 						chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 					}
 				} else if (is(field, Column)) {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-					} else {
-						chunk.push(field);
+					const columnSql = isSingleTable
+						? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+						: field.getSQL();
+					const selectionSql = mapColumnSelectionValue(field, columnSql);
+					chunk.push(selectionSql);
+
+					if (selectionSql !== columnSql) {
+						chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 					}
 				} else if (is(field, Subquery)) {
 					const entries = Object.entries(field._.selectedFields) as [string, SQL.Aliased | Column | SQL][];
@@ -1360,6 +1364,8 @@ export class PgDialect {
 							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
 							: is(field, SQL.Aliased)
 							? field.sql
+							: is(field, Column)
+							? mapColumnSelectionValue(field, field.getSQL())
 							: field
 					),
 					sql`, `,

--- a/drizzle-orm/src/singlestore-core/columns/custom.ts
+++ b/drizzle-orm/src/singlestore-core/columns/custom.ts
@@ -66,6 +66,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnySingleStoreTable<{ name: T['tableName'] }>,
@@ -75,6 +76,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -198,6 +200,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection as mapColumnSelectionValue } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -244,10 +244,14 @@ export class SingleStoreDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-				} else {
-					chunk.push(field);
+				const columnSql = isSingleTable
+					? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+					: field.getSQL();
+				const selectionSql = mapColumnSelectionValue(field, columnSql);
+				chunk.push(selectionSql);
+
+				if (selectionSql !== columnSql) {
+					chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [
@@ -848,6 +852,11 @@ export class SingleStoreDialect {
 							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
 							: is(field, SQL.Aliased)
 							? field.sql
+							: is(field, SingleStoreColumn)
+							? mapColumnSelectionValue(
+								field,
+								sql`${sql.identifier(this.casing.getColumnCasing(field))}`,
+							)
 							: field
 					),
 					sql`, `,

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -1,7 +1,7 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
 import type { AnyColumn } from '~/column.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection as mapColumnSelectionValue } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -220,12 +220,14 @@ export abstract class SQLiteDialect {
 						);
 					}
 				} else {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-					} else {
-						chunk.push(
-							sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
-						);
+					const columnSql = isSingleTable
+						? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+						: sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`;
+					const selectionSql = mapColumnSelectionValue(field, columnSql);
+					chunk.push(selectionSql);
+
+					if (selectionSql !== columnSql) {
+						chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 					}
 				}
 			} else if (is(field, Subquery)) {
@@ -839,7 +841,10 @@ export abstract class SQLiteDialect {
 				sql.join(
 					selection.map(({ field }) =>
 						is(field, SQLiteColumn)
-							? sql.identifier(this.casing.getColumnCasing(field))
+							? mapColumnSelectionValue(
+								field,
+								sql`${sql.identifier(this.casing.getColumnCasing(field))}`,
+							)
 							: is(field, SQL.Aliased)
 							? field.sql
 							: field

--- a/drizzle-orm/tests/custom-type-select.test.ts
+++ b/drizzle-orm/tests/custom-type-select.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from 'vitest';
+
+import { customType as mysqlCustomType, int, MySqlDialect, mysqlTable } from '~/mysql-core';
+import { customType as pgCustomType, integer, PgDialect, pgTable } from '~/pg-core';
+import { sql } from '~/sql';
+import {
+	customType as sqliteCustomType,
+	integer as sqliteInteger,
+	SQLiteSyncDialect,
+	sqliteTable,
+} from '~/sqlite-core';
+
+test('custom pg types can wrap selected column SQL', () => {
+	const lowerText = pgCustomType<{ data: string; driverData: string }>({
+		dataType: () => 'text',
+		selectFromDb: (column) => sql`lower(${column})`,
+	});
+
+	const users = pgTable('users', {
+		id: integer('id'),
+		name: lowerText('name'),
+	});
+
+	const dialect = new PgDialect();
+
+	const singleTableQuery = dialect.sqlToQuery(dialect.buildSelectQuery({
+		fields: { name: users.name },
+		table: users,
+		setOperators: [],
+	}));
+
+	expect(singleTableQuery.sql).toBe('select lower("name") as "name" from "users"');
+
+	const pets = pgTable('pets', {
+		ownerId: integer('owner_id'),
+	});
+
+	const joinQuery = dialect.sqlToQuery(dialect.buildSelectQuery({
+		fields: { name: users.name },
+		table: users,
+		joins: [{
+			on: sql`${users.id} = ${pets.ownerId}`,
+			table: pets,
+			alias: undefined,
+			joinType: 'left',
+		}],
+		setOperators: [],
+	}));
+
+	expect(joinQuery.sql).toBe(
+		'select lower("users"."name") as "name" from "users" left join "pets" on "users"."id" = "pets"."owner_id"',
+	);
+});
+
+test('custom mysql types can wrap selected column SQL', () => {
+	const lowerText = mysqlCustomType<{ data: string; driverData: string }>({
+		dataType: () => 'text',
+		selectFromDb: (column) => sql`lower(${column})`,
+	});
+
+	const users = mysqlTable('users', {
+		id: int('id'),
+		name: lowerText('name'),
+	});
+
+	const dialect = new MySqlDialect();
+	const query = dialect.sqlToQuery(dialect.buildSelectQuery({
+		fields: { name: users.name },
+		table: users,
+		setOperators: [],
+	}));
+
+	expect(query.sql).toBe('select lower(`name`) as `name` from `users`');
+});
+
+test('custom sqlite types can wrap selected column SQL', () => {
+	const lowerText = sqliteCustomType<{ data: string; driverData: string }>({
+		dataType: () => 'text',
+		selectFromDb: (column) => sql`lower(${column})`,
+	});
+
+	const users = sqliteTable('users', {
+		id: sqliteInteger('id'),
+		name: lowerText('name'),
+	});
+
+	const dialect = new SQLiteSyncDialect();
+	const query = dialect.sqlToQuery(dialect.buildSelectQuery({
+		fields: { name: users.name },
+		table: users,
+		setOperators: [],
+	}));
+
+	expect(query.sql).toBe('select lower("name") as "name" from "users"');
+});


### PR DESCRIPTION
/claim #554

## Summary
- add `selectFromDb(column)` to `customType` params so custom columns can wrap their selected column SQL before driver decoding
- apply the wrapper in select/returning SQL generation for PostgreSQL, MySQL, SQLite, SingleStore, and Gel custom columns, including relational JSON selection paths
- document the new option and add SQL generation coverage for PostgreSQL, MySQL, and SQLite

## Assumption
- The public API name is `selectFromDb`, and it receives already-qualified column SQL where the dialect would normally emit the selected column.

## Tests
- `corepack pnpm --dir drizzle-orm test -- custom-type-select.test.ts`
- `corepack pnpm --dir drizzle-orm test:types`
- `corepack pnpm lint`
- `git diff --check`
- `PATH="$PWD/.tmp-bin:$PATH" corepack pnpm --dir drizzle-orm build`