### PR TITLE
Add selectFromDb support for custom type selection

### DIFF
--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -46,6 +46,17 @@ export type ColumnRuntimeConfig<TData, TRuntimeConfig extends object> = ColumnBu
 	TRuntimeConfig
 >;
 
+export type ColumnSelectMapper = (column: SQL) => SQL;
+
+export type ColumnWithSelectMapper = Column & {
+	selectFromDb?: ColumnSelectMapper;
+};
+
+export function mapColumnSelection(column: Column, columnSql: SQL): SQL {
+	const selectFromDb = (column as ColumnWithSelectMapper).selectFromDb;
+	return typeof selectFromDb === 'function' ? selectFromDb(columnSql) : columnSql;
+}
+
 export interface Column<
 	T extends ColumnBaseConfig<ColumnDataType, string> = ColumnBaseConfig<ColumnDataType, string>,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/drizzle-orm/src/gel-core/columns/custom.ts
+++ b/drizzle-orm/src/gel-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnyGelTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import { GelColumn, GelDecimal, GelJson, GelUUID } from '~/gel-core/columns/index.ts';
@@ -240,7 +240,13 @@ export class GelDialect {
 					// if (isSingleTable) {
 					// 	chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
 					// } else {
-					chunk.push(field);
+					const columnSql = field.getSQL();
+					const selectionSql = mapColumnSelection(field, columnSql);
+					chunk.push(selectionSql);
+
+					if (selectionSql !== columnSql) {
+						chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
+					}
 					// }
 				} else if (is(field, Subquery)) {
 					const entries = Object.entries(field._.selectedFields) as [string, SQL.Aliased | Column | SQL][];

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -245,10 +245,14 @@ export class MySqlDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-				} else {
-					chunk.push(field);
+				const columnSql = isSingleTable
+					? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+					: field.getSQL();
+				const selectionSql = mapColumnSelection(field, columnSql);
+				chunk.push(selectionSql);
+
+				if (selectionSql !== columnSql) {
+					chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -242,10 +242,14 @@ export class PgDialect {
 						chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 					}
 				} else if (is(field, Column)) {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-					} else {
-						chunk.push(field);
+					const columnSql = isSingleTable
+						? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+						: field.getSQL();
+					const selectionSql = mapColumnSelection(field, columnSql);
+					chunk.push(selectionSql);
+
+					if (selectionSql !== columnSql) {
+						chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 					}
 				} else if (is(field, Subquery)) {
 					const entries = Object.entries(field._.selectedFields) as [string, SQL.Aliased | Column | SQL][];

--- a/drizzle-orm/src/singlestore-core/columns/custom.ts
+++ b/drizzle-orm/src/singlestore-core/columns/custom.ts
@@ -66,6 +66,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnySingleStoreTable<{ name: T['tableName'] }>,
@@ -75,6 +76,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -198,6 +200,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -1,6 +1,6 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -244,10 +244,14 @@ export class SingleStoreDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-				} else {
-					chunk.push(field);
+				const columnSql = isSingleTable
+					? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+					: field.getSQL();
+				const selectionSql = mapColumnSelection(field, columnSql);
+				chunk.push(selectionSql);
+
+				if (selectionSql !== columnSql) {
+					chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	readonly selectFromDb?: (column: SQL) => SQL;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -72,6 +73,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
@@ -195,6 +197,20 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL wrapper used when this custom column is selected from the database.
+	 * The returned expression is automatically aliased back to the column name and decoded
+	 * with `fromDriver`, so callers should only wrap the provided column SQL.
+	 *
+	 * @example
+	 * ```
+	 * selectFromDb(column) {
+	 * 	return sql`lower(${column})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: SQL) => SQL<T['data']>;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -1,7 +1,7 @@
 import { aliasedTable, aliasedTableColumn, mapColumnsInAliasedSQLToAlias, mapColumnsInSQLToAlias } from '~/alias.ts';
 import { CasingCache } from '~/casing.ts';
 import type { AnyColumn } from '~/column.ts';
-import { Column } from '~/column.ts';
+import { Column, mapColumnSelection } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
@@ -209,24 +209,19 @@ export abstract class SQLiteDialect {
 				}
 			} else if (is(field, Column)) {
 				const tableName = field.table[Table.Symbol.Name];
-				if (field.columnType === 'SQLiteNumericBigInt') {
-					if (isSingleTable) {
-						chunk.push(
-							sql`cast(${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
-						);
-					} else {
-						chunk.push(
-							sql`cast(${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
-						);
-					}
-				} else {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-					} else {
-						chunk.push(
-							sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
-						);
-					}
+				const columnName = this.casing.getColumnCasing(field);
+				const columnSql = field.columnType === 'SQLiteNumericBigInt'
+					? isSingleTable
+						? sql`cast(${sql.identifier(columnName)} as text)`
+						: sql`cast(${sql.identifier(tableName)}.${sql.identifier(columnName)} as text)`
+					: isSingleTable
+					? sql`${sql.identifier(columnName)}`
+					: sql`${sql.identifier(tableName)}.${sql.identifier(columnName)}`;
+				const selectionSql = mapColumnSelection(field, columnSql);
+				chunk.push(selectionSql);
+
+				if (selectionSql !== columnSql) {
+					chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [

--- a/drizzle-orm/tests/custom-select-from-db.test.ts
+++ b/drizzle-orm/tests/custom-select-from-db.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from 'vitest';
+import { GelDialect } from '~/gel-core/dialect.ts';
+import { customType as gelCustomType, gelTable } from '~/gel-core/index.ts';
+import { MySqlDialect } from '~/mysql-core/dialect.ts';
+import { customType as mysqlCustomType, mysqlTable } from '~/mysql-core/index.ts';
+import { PgDialect } from '~/pg-core/dialect.ts';
+import { customType as pgCustomType, pgTable } from '~/pg-core/index.ts';
+import { SingleStoreDialect } from '~/singlestore-core/dialect.ts';
+import { customType as singlestoreCustomType, singlestoreTable } from '~/singlestore-core/index.ts';
+import { sql } from '~/sql/index.ts';
+import { SQLiteSyncDialect } from '~/sqlite-core/dialect.ts';
+import { customType as sqliteCustomType, sqliteTable } from '~/sqlite-core/index.ts';
+
+const pgLowerText = pgCustomType<{ data: string; driverData: string }>({
+	dataType: () => 'text',
+	fromDriver: (value) => value,
+	selectFromDb: (column) => sql`lower(${column})`,
+});
+
+const mysqlLowerText = mysqlCustomType<{ data: string; driverData: string }>({
+	dataType: () => 'text',
+	fromDriver: (value) => value,
+	selectFromDb: (column) => sql`lower(${column})`,
+});
+
+const sqliteLowerText = sqliteCustomType<{ data: string; driverData: string }>({
+	dataType: () => 'text',
+	fromDriver: (value) => value,
+	selectFromDb: (column) => sql`lower(${column})`,
+});
+
+const gelLowerText = gelCustomType<{ data: string; driverData: string }>({
+	dataType: () => 'str',
+	fromDriver: (value) => value,
+	selectFromDb: (column) => sql`str_lower(${column})`,
+});
+
+const singlestoreLowerText = singlestoreCustomType<{ data: string; driverData: string }>({
+	dataType: () => 'text',
+	fromDriver: (value) => value,
+	selectFromDb: (column) => sql`lower(${column})`,
+});
+
+const pgUsers = pgTable('users', {
+	lowerName: pgLowerText('lower_name'),
+});
+
+const mysqlUsers = mysqlTable('users', {
+	lowerName: mysqlLowerText('lower_name'),
+});
+
+const sqliteUsers = sqliteTable('users', {
+	lowerName: sqliteLowerText('lower_name'),
+});
+
+const gelUsers = gelTable('users', {
+	lowerName: gelLowerText('lower_name'),
+});
+
+const singlestoreUsers = singlestoreTable('users', {
+	lowerName: singlestoreLowerText('lower_name'),
+});
+
+describe('custom type selectFromDb', () => {
+	it('wraps selected PostgreSQL custom columns', ({ expect }) => {
+		const dialect = new PgDialect();
+		const query = dialect.buildSelectQuery({
+			fields: {},
+			fieldsFlat: [{ path: ['lowerName'], field: pgUsers.lowerName }],
+			table: pgUsers,
+			setOperators: [],
+		});
+
+		expect(dialect.sqlToQuery(query)).toEqual({
+			sql: 'select lower("lower_name") as "lower_name" from "users"',
+			params: [],
+		});
+	});
+
+	it('wraps selected MySQL custom columns', ({ expect }) => {
+		const dialect = new MySqlDialect();
+		const query = dialect.buildSelectQuery({
+			fields: {},
+			fieldsFlat: [{ path: ['lowerName'], field: mysqlUsers.lowerName }],
+			table: mysqlUsers,
+			setOperators: [],
+		});
+
+		expect(dialect.sqlToQuery(query)).toEqual({
+			sql: 'select lower(`lower_name`) as `lower_name` from `users`',
+			params: [],
+		});
+	});
+
+	it('wraps selected SQLite custom columns', ({ expect }) => {
+		const dialect = new SQLiteSyncDialect();
+		const query = dialect.buildSelectQuery({
+			fields: {},
+			fieldsFlat: [{ path: ['lowerName'], field: sqliteUsers.lowerName }],
+			table: sqliteUsers,
+			setOperators: [],
+		});
+
+		expect(dialect.sqlToQuery(query)).toEqual({
+			sql: 'select lower("lower_name") as "lower_name" from "users"',
+			params: [],
+		});
+	});
+
+	it('wraps selected Gel custom columns', ({ expect }) => {
+		const dialect = new GelDialect();
+		const query = dialect.buildSelectQuery({
+			fields: {},
+			fieldsFlat: [{ path: ['lowerName'], field: gelUsers.lowerName }],
+			table: gelUsers,
+			setOperators: [],
+		});
+
+		expect(dialect.sqlToQuery(query)).toEqual({
+			sql: 'select str_lower("users"."lower_name") as "lower_name" from "users"',
+			params: [],
+		});
+	});
+
+	it('wraps selected SingleStore custom columns', ({ expect }) => {
+		const dialect = new SingleStoreDialect();
+		const query = dialect.buildSelectQuery({
+			fields: {},
+			fieldsFlat: [{ path: ['lowerName'], field: singlestoreUsers.lowerName }],
+			table: singlestoreUsers,
+			setOperators: [],
+		});
+
+		expect(dialect.sqlToQuery(query)).toEqual({
+			sql: 'select lower(`lower_name`) as `lower_name` from `users`',
+			params: [],
+		});
+	});
+});


### PR DESCRIPTION
# PR Summary — Drizzle ORM custom type selectFromDb

## What changed
- Adds optional `selectFromDb(column)` support to custom types across:
  - PostgreSQL
  - MySQL
  - SQLite
  - Gel
  - SingleStore
- Stores the custom `selectFromDb` mapper on custom column instances.
- Applies the mapper during SELECT query generation and aliases the wrapped expression back to the column name so result decoding still works.
- Adds regression coverage for all five supported dialects.

## Validation run locally
- `vitest run tests/custom-select-from-db.test.ts` — 5 tests passed.
- `dprint check` on all modified files — passed.
- `eslint` on all modified files — passed.
- `tsc --noEmit` was attempted but blocked by existing Prisma generation/client errors unrelated to this patch:
  - `@prisma/client` has no exported member `Prisma`
  - implicit any errors in `src/prisma/*/driver.ts`

## Notes
- No PR submitted yet.
- No bounty claimed yet.
- Harper approval needed before any external GitHub submission.
