### PR TITLE
fix: preserve partial nested left join results

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -45,10 +45,12 @@ export function mapResultRow<TResult>(
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;
+						const tableName = getTableName(field.table);
 						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
+							nullifyMap[objectName] = value === null ? tableName : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== tableName || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'vitest';
+
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+const orgs = pgTable('org', {
+	name: text('name'),
+	slug: text('slug'),
+});
+
+const orgBranding = pgTable('org_branding', {
+	logo: text('logo'),
+	panelBackground: text('panel_background_colour'),
+});
+
+test('mapResultRow keeps partially-null left-joined nested objects intact', () => {
+	const fields = orderSelectedFields({
+		name: orgs.name,
+		slug: orgs.slug,
+		branding: {
+			logo: orgBranding.logo,
+			panelBackground: orgBranding.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(fields, ['Test org 2', 'test-org-2', null, '#1a8cff'], {
+		org: true,
+		org_branding: false,
+	});
+
+	expect(result).toEqual({
+		name: 'Test org 2',
+		slug: 'test-org-2',
+		branding: {
+			logo: null,
+			panelBackground: '#1a8cff',
+		},
+	});
+});
+
+test('mapResultRow still nullifies left-joined nested objects when every field is null', () => {
+	const fields = orderSelectedFields({
+		name: orgs.name,
+		slug: orgs.slug,
+		branding: {
+			logo: orgBranding.logo,
+			panelBackground: orgBranding.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(fields, ['Test org 2', 'test-org-2', null, null], {
+		org: true,
+		org_branding: false,
+	});
+
+	expect(result).toEqual({
+		name: 'Test org 2',
+		slug: 'test-org-2',
+		branding: null,
+	});
+});


### PR DESCRIPTION
Fixes #1603
/claim #1603

## Summary
- preserve nested partial-select objects from nullable left joins once any field from that join is non-null
- keep the existing full-null nullification behavior for missing joined rows
- add a regression test covering the order-dependent case reported in the issue

## Testing
- vitest run tests/utils.test.ts