### PR TITLE
[Sqlite]: surface durable-sqlite migration error instead of rollback

### DIFF
--- a/drizzle-orm/src/durable-sqlite/migrator.ts
+++ b/drizzle-orm/src/durable-sqlite/migrator.ts
@@ -53,14 +53,15 @@ export function migrate<
 ): void | MigratorInitFailResponse {
 	const migrations = readMigrationFiles(config);
 
-	return db.transaction((tx) => {
-		try {
-			const migrationsTable = '__drizzle_migrations';
+	// `storage.transactionSync` rolls back when the callback throws; a manual
+	// `tx.rollback()` would replace the real migration error with `Rollback`.
+	return db.transaction(() => {
+		const migrationsTable = '__drizzle_migrations';
 
-			const { newDb } = upgradeSyncIfNeeded(migrationsTable, db.session, migrations);
+		const { newDb } = upgradeSyncIfNeeded(migrationsTable, db.session, migrations);
 
-			if (newDb) {
-				const migrationTableCreate = sql`
+		if (newDb) {
+			const migrationTableCreate = sql`
 				CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsTable)} (
 					id INTEGER PRIMARY KEY,
 					hash text NOT NULL,
@@ -69,55 +70,51 @@ export function migrate<
 					applied_at TEXT
 				)
 			`;
-				db.run(migrationTableCreate);
+			db.run(migrationTableCreate);
+		}
+
+		const dbMigrations = (db.values<[number, string, string, string | null]>(
+			sql`SELECT id, hash, created_at, name FROM ${sql.identifier(migrationsTable)}`,
+		)).map(([id, hash, created_at, name]) => ({ id, hash, created_at, name }));
+
+		if (config.init) {
+			if (dbMigrations.length) {
+				return { exitCode: 'databaseMigrations' as const };
 			}
 
-			const dbMigrations = (db.values<[number, string, string, string | null]>(
-				sql`SELECT id, hash, created_at, name FROM ${sql.identifier(migrationsTable)}`,
-			)).map(([id, hash, created_at, name]) => ({ id, hash, created_at, name }));
-
-			if (config.init) {
-				if (dbMigrations.length) {
-					return { exitCode: 'databaseMigrations' as const };
-				}
-
-				if (migrations.length > 1) {
-					return { exitCode: 'localMigrations' as const };
-				}
-
-				const [migration] = migrations;
-
-				if (!migration) return;
-
-				db.run(
-					sql`insert into ${
-						sql.identifier(migrationsTable)
-					} ("hash", "created_at", "name", "applied_at") values(${migration.hash}, ${migration.folderMillis}, ${migration.name}, ${
-						new Date().toISOString()
-					})`,
-				);
-
-				return;
+			if (migrations.length > 1) {
+				return { exitCode: 'localMigrations' as const };
 			}
 
-			const migrationsToRun = getMigrationsToRun({ localMigrations: migrations, dbMigrations });
-			for (const migration of migrationsToRun) {
-				for (const stmt of migration.sql) {
-					db.run(sql.raw(stmt));
-				}
-				db.run(
-					sql`INSERT INTO ${
-						sql.identifier(migrationsTable)
-					} ("hash", "created_at", "name", "applied_at") VALUES(${migration.hash}, ${migration.folderMillis}, ${migration.name}, ${
-						new Date().toISOString()
-					})`,
-				);
-			}
+			const [migration] = migrations;
+
+			if (!migration) return;
+
+			db.run(
+				sql`insert into ${
+					sql.identifier(migrationsTable)
+				} ("hash", "created_at", "name", "applied_at") values(${migration.hash}, ${migration.folderMillis}, ${migration.name}, ${
+					new Date().toISOString()
+				})`,
+			);
 
 			return;
-		} catch (error: any) {
-			tx.rollback();
-			throw error;
 		}
+
+		const migrationsToRun = getMigrationsToRun({ localMigrations: migrations, dbMigrations });
+		for (const migration of migrationsToRun) {
+			for (const stmt of migration.sql) {
+				db.run(sql.raw(stmt));
+			}
+			db.run(
+				sql`INSERT INTO ${
+					sql.identifier(migrationsTable)
+				} ("hash", "created_at", "name", "applied_at") VALUES(${migration.hash}, ${migration.folderMillis}, ${migration.name}, ${
+					new Date().toISOString()
+				})`,
+			);
+		}
+
+		return;
 	});
 }


### PR DESCRIPTION
Closes #5763.

## Summary

`migrate()` in `drizzle-orm/durable-sqlite/migrator.ts` wrapped its work in:

```ts
return db.transaction((tx) => {
  try {
    /* run migrations */
  } catch (error) {
    tx.rollback();
    throw error;
  }
});
```

Cloudflare's `DurableObjectStorage.transactionSync` already rolls back automatically when the callback throws, so the explicit `tx.rollback()` runs first and throws `TransactionRollbackError` (`'Rollback'`), which replaces the real migration error on its way out. The `throw error` line below it is unreachable.

End result: a migration that fails with e.g. `SqliteError: near "INVALID": syntax error` is reported to the caller as `TransactionRollbackError: Rollback`, with no way to see what actually broke.

## Fix

Drop the `try`/`catch`. The original error now propagates untouched and the underlying transaction is rolled back by `transactionSync` exactly as before.

This matches the pattern used by `drizzle-orm/src/sqlite-core/dialect.ts`'s `SQLiteSyncDialect.migrate`, which uses explicit SQL (`session.run(sql\`ROLLBACK\`)`) rather than `tx.rollback()` precisely so the underlying error isn't masked.

## Test plan

- [x] `pnpm tsc --noEmit` clean on the package.
- [x] `pnpm dprint check drizzle-orm/src/durable-sqlite/migrator.ts` clean.
- [x] Husky `lint-staged` (format:check + lint:check) clean on commit.
- [ ] No unit tests added — the durable-sqlite migrator is exercised only via the Wrangler-based suite at `integration-tests/tests/sqlite/durable-objects/`, which would need a new failure-path fixture. Happy to add one if maintainers want it; the existing `migrate1` happy-path test is unaffected.

## Manual repro

In a Durable Object using `drizzle-orm/durable-sqlite`, register a migration with deliberately invalid SQL (e.g. `CREATE TABLE x (id INVALID)`):

- Before: caller sees `TransactionRollbackError: Rollback`.
- After: caller sees the underlying `Error: near "INVALID": syntax error: SQLITE_ERROR`.

## Notes

Credit to @Craig-J for filing #5763 with a clear diagnosis.