### PR TITLE
[Pg-kit] preserve string `schema` field on altered tables (#5761)

### DIFF
--- a/drizzle-kit/src/jsonDiffer.js
+++ b/drizzle-kit/src/jsonDiffer.js
@@ -152,9 +152,11 @@ export function diffColumns(left, right) {
 					deleted: deletedColumns,
 				};
 				const table = left[tableEntry[0]];
+				// spread first so explicit strings win over any
+				// `{__old, __new}` from json-diff when name/schema changed.
 				return [
 					tableEntry[0],
-					{ name: table.name, schema: table.schema, ...tableEntry[1] },
+					{ ...tableEntry[1], name: table.name, schema: table.schema },
 				];
 			}),
 	);
@@ -197,7 +199,7 @@ export function diffPolicies(left, right) {
 				const table = left[tableEntry[0]];
 				return [
 					tableEntry[0],
-					{ name: table.name, schema: table.schema, ...tableEntry[1] },
+					{ ...tableEntry[1], name: table.name, schema: table.schema },
 				];
 			}),
 	);
@@ -238,12 +240,14 @@ export function applyJsonDiff(json1, json2) {
 			continue;
 		}
 
-		// supply table name and schema for altered tables
+		// supply table name and schema for altered tables. spread first so
+		// the explicit strings override any `{__old, __new}` from json-diff
+		// when name/schema themselves changed.
 		const table = json1.tables[key];
 		difference.tables[key] = {
+			...difference.tables[key],
 			name: table.name,
 			schema: table.schema,
-			...difference.tables[key],
 		};
 	}
 

--- a/drizzle-kit/tests/jsonDiffer.test.ts
+++ b/drizzle-kit/tests/jsonDiffer.test.ts
@@ -1,0 +1,55 @@
+import { applyJsonDiff } from 'src/jsonDiffer';
+import { expect, test } from 'vitest';
+
+// #5761 regression: when a table's schema changes alongside another diffed
+// field (e.g. a partial index whose `where` clause picks up the schema
+// qualifier), `applyJsonDiff` used to leave `schema` as the json-diff
+// `{ __old, __new }` object instead of a string, breaking the downstream
+// Zod check.
+test('applyJsonDiff keeps schema a string when it changes alongside another field', () => {
+	const baseTable = {
+		name: 'widgets',
+		schema: '',
+		columns: {
+			id: { name: 'id', type: 'uuid', primaryKey: true, notNull: true },
+			deleted_at: { name: 'deleted_at', type: 'timestamp', notNull: false },
+		},
+		indexes: {
+			idx_widgets_active: {
+				name: 'idx_widgets_active',
+				columns: [{ expression: 'id', isExpression: false, asc: true }],
+				isUnique: true,
+				where: '"deleted_at" IS NULL',
+				concurrently: false,
+				method: 'btree',
+				with: {},
+			},
+		},
+		foreignKeys: {},
+		compositePrimaryKeys: {},
+		uniqueConstraints: {},
+		checkConstraints: {},
+		policies: {},
+		isRLSEnabled: false,
+	};
+
+	const json1 = {
+		tables: { 'public.widgets': baseTable },
+		schemas: {},
+		enums: {},
+		sequences: {},
+		roles: {},
+		policies: {},
+		views: {},
+	};
+
+	const json2 = JSON.parse(JSON.stringify(json1));
+	json2.tables['public.widgets'].schema = 'public';
+	json2.tables['public.widgets'].indexes.idx_widgets_active.where =
+		'"public"."widgets"."deleted_at" IS NULL';
+
+	const result = applyJsonDiff(json1, json2);
+	const altered = result.alteredTablesWithColumns[0];
+	expect(typeof altered.schema).toBe('string');
+	expect(altered.name).toBe('widgets');
+});


### PR DESCRIPTION
Fixes #5761.

- Flip the spread order in `applyJsonDiff`, `diffColumns`, and `diffPolicies` so the explicit `{ name, schema }` strings override any `{ __old, __new }` produced by `json-diff` when those fields themselves change between snapshots.
- Add a focused unit test against `applyJsonDiff` for the schema-change-plus-partial-index shape from the report.

Repro: snapshot `schema: ""` -> `schema: "public"` on a table that also has a partial index whose `where` clause picks up the schema qualifier (`"deleted_at" IS NULL` -> `"public"."widgets"."deleted_at" IS NULL`). Before this patch, `diffResultScheme` fails the `alteredTablesWithColumns[i].schema` Zod check and surfaces as `Cannot read properties of undefined (reading 'value')` during `drizzle-kit generate`.

Stash-bisect against the new test confirms regression evidence.