### PR TITLE
Add MariaDB driver support (node-mariadb)

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -68,6 +68,7 @@
 		"gel": ">=2",
 		"knex": "*",
 		"kysely": "*",
+		"mariadb": ">=3",
 		"mysql2": ">=2",
 		"@netlify/db": ">=0.4.0",
 		"pg": ">=8",
@@ -76,6 +77,9 @@
 		"sqlite3": ">=5"
 	},
 	"peerDependenciesMeta": {
+		"mariadb": {
+			"optional": true
+		},
 		"mysql2": {
 			"optional": true
 		},
@@ -198,6 +202,7 @@
 		"glob": "^11.0.1",
 		"knex": "^2.4.2",
 		"kysely": "^0.25.0",
+		"mariadb": "^3.4.0",
 		"mysql2": "^3.14.1",
 		"pg": "^8.11.0",
 		"postgres": "^3.3.5",

--- a/drizzle-orm/src/node-mariadb/driver.ts
+++ b/drizzle-orm/src/node-mariadb/driver.ts
@@ -1,0 +1,80 @@
+import { entityKind } from '~/entity.ts';
+import { DefaultLogger } from '~/logger.ts';
+import type { Logger } from '~/logger.ts';
+import { MySqlDatabase } from '~/mysql-core/db.ts';
+import { MySqlDialect } from '~/mysql-core/dialect.ts';
+import {
+	createTableRelationsHelpers,
+	extractTablesRelationalConfig,
+	type RelationalSchemaConfig,
+	type TablesRelationalConfig,
+} from '~/relations.ts';
+import type { DrizzleConfig } from '~/utils.ts';
+import {
+	type NodeMariaDbClient,
+	type NodeMariaDbPreparedQueryHKT,
+	type NodeMariaDbQueryResultHKT,
+	NodeMariaDbSession,
+} from './session.ts';
+
+export interface NodeMariaDbDriverOptions {
+	logger?: Logger;
+}
+
+export class NodeMariaDbDriver {
+	static readonly [entityKind]: string = 'NodeMariaDbDriver';
+
+	constructor(
+		private client: NodeMariaDbClient,
+		private dialect: MySqlDialect,
+		private options: NodeMariaDbDriverOptions = {},
+	) {
+	}
+
+	createSession(
+		schema: RelationalSchemaConfig<TablesRelationalConfig> | undefined,
+	): NodeMariaDbSession<Record<string, unknown>, TablesRelationalConfig> {
+		return new NodeMariaDbSession(this.client, this.dialect, schema, { logger: this.options.logger });
+	}
+}
+
+export { MySqlDatabase } from '~/mysql-core/db.ts';
+
+export class NodeMariaDbDatabase<
+	TSchema extends Record<string, unknown> = Record<string, never>,
+> extends MySqlDatabase<NodeMariaDbQueryResultHKT, NodeMariaDbPreparedQueryHKT, TSchema> {
+	static override readonly [entityKind]: string = 'NodeMariaDbDatabase';
+}
+
+export function drizzle<TSchema extends Record<string, unknown> = Record<string, never>>(
+	client: NodeMariaDbClient,
+	config: DrizzleConfig<TSchema> = {},
+): NodeMariaDbDatabase<TSchema> {
+	const dialect = new MySqlDialect({ casing: config.casing });
+	let logger;
+	if (config.logger === true) {
+		logger = new DefaultLogger();
+	} else if (config.logger !== false) {
+		logger = config.logger;
+	}
+
+	let schema: RelationalSchemaConfig<TablesRelationalConfig> | undefined;
+	if (config.schema) {
+		const tablesConfig = extractTablesRelationalConfig(
+			config.schema,
+			createTableRelationsHelpers,
+		);
+		schema = {
+			fullSchema: config.schema,
+			schema: tablesConfig.tables,
+			tableNamesMap: tablesConfig.tableNamesMap,
+		};
+	}
+
+	const driver = new NodeMariaDbDriver(client, dialect, { logger });
+	const session = driver.createSession(schema);
+	const db = new NodeMariaDbDatabase(dialect, session, schema as any, 'planetscale') as NodeMariaDbDatabase<TSchema>;
+	(<any> db).$client = client;
+
+	return db;
+}

--- a/drizzle-orm/src/node-mariadb/index.ts
+++ b/drizzle-orm/src/node-mariadb/index.ts
@@ -1,0 +1,2 @@
+export * from './driver.ts';
+export * from './session.ts';

--- a/drizzle-orm/src/node-mariadb/migrator.ts
+++ b/drizzle-orm/src/node-mariadb/migrator.ts
@@ -1,0 +1,11 @@
+import type { MigrationConfig } from '~/migrator.ts';
+import { readMigrationFiles } from '~/migrator.ts';
+import type { NodeMariaDbDatabase } from './driver.ts';
+
+export async function migrate<TSchema extends Record<string, unknown>>(
+	db: NodeMariaDbDatabase<TSchema>,
+	config: MigrationConfig,
+) {
+	const migrations = readMigrationFiles(config);
+	await db.dialect.migrate(migrations, db.session, config);
+}

--- a/drizzle-orm/src/node-mariadb/session.ts
+++ b/drizzle-orm/src/node-mariadb/session.ts
@@ -1,0 +1,206 @@
+import { entityKind } from '~/entity.ts';
+import type { Logger } from '~/logger.ts';
+import { NoopLogger } from '~/logger.ts';
+import type { MySqlDialect } from '~/mysql-core/dialect.ts';
+import type { SelectedFieldsOrdered } from '~/mysql-core/query-builders/select.types.ts';
+import {
+	type Mode,
+	MySqlPreparedQuery,
+	type MySqlPreparedQueryConfig,
+	type MySqlPreparedQueryHKT,
+	type MySqlQueryResultHKT,
+	MySqlSession,
+	MySqlTransaction,
+	type MySqlTransactionConfig,
+	type PreparedQueryKind,
+} from '~/mysql-core/session.ts';
+import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
+import { fillPlaceholders, sql } from '~/sql/sql.ts';
+import type { Query, SQL } from '~/sql/sql.ts';
+import { type Assume, mapResultRow } from '~/utils.ts';
+import type { Connection, Pool, PoolConnection, QueryOptions, UpsertResult } from 'mariadb';
+
+export type NodeMariaDbClient = Connection | Pool;
+
+export class NodeMariaDbPreparedQuery<T extends MySqlPreparedQueryConfig> extends MySqlPreparedQuery<T> {
+	static override readonly [entityKind]: string = 'NodeMariaDbPreparedQuery';
+
+	private rawQuery: QueryOptions;
+	private query: QueryOptions;
+
+	constructor(
+		private client: NodeMariaDbClient,
+		private queryString: string,
+		private params: unknown[],
+		private logger: Logger,
+		private fields: SelectedFieldsOrdered | undefined,
+		private customResultMapper?: (rows: unknown[][]) => T['execute'],
+	) {
+		super(undefined, undefined, undefined);
+		this.rawQuery = {
+			sql: queryString,
+			dateStrings: true,
+		};
+		this.query = {
+			sql: queryString,
+			rowsAsArray: true,
+			dateStrings: true,
+		};
+	}
+
+	async execute(placeholderValues: Record<string, unknown> = {}): Promise<T['execute']> {
+		const params = fillPlaceholders(this.params, placeholderValues);
+
+		this.logger.logQuery(this.queryString, params);
+
+		const { fields, client, rawQuery, query, joinsNotNullableMap, customResultMapper } = this;
+		if (!fields && !customResultMapper) {
+			return client.query(rawQuery, params);
+		}
+
+		const rows = await client.query<any[]>(query, params);
+
+		if (customResultMapper) {
+			return customResultMapper(rows);
+		}
+
+		return rows.map((row) => mapResultRow<T['execute']>(fields!, row, joinsNotNullableMap));
+	}
+
+	override iterator(_placeholderValues?: Record<string, unknown>): AsyncGenerator<T['iterator']> {
+		throw new Error('Streaming is not supported by the Node MariaDB driver');
+	}
+}
+
+export interface NodeMariaDbSessionOptions {
+	logger?: Logger;
+}
+
+export class NodeMariaDbSession<
+	TFullSchema extends Record<string, unknown>,
+	TSchema extends TablesRelationalConfig,
+> extends MySqlSession<NodeMariaDbQueryResultHKT, NodeMariaDbPreparedQueryHKT, TFullSchema, TSchema> {
+	static override readonly [entityKind]: string = 'NodeMariaDbSession';
+
+	private logger: Logger;
+
+	constructor(
+		private client: NodeMariaDbClient,
+		dialect: MySqlDialect,
+		private schema: RelationalSchemaConfig<TSchema> | undefined,
+		private options: NodeMariaDbSessionOptions,
+	) {
+		super(dialect);
+		this.logger = options.logger ?? new NoopLogger();
+	}
+
+	prepareQuery<T extends MySqlPreparedQueryConfig>(
+		query: Query,
+		fields: SelectedFieldsOrdered | undefined,
+		customResultMapper?: (rows: unknown[][]) => T['execute'],
+	): PreparedQueryKind<NodeMariaDbPreparedQueryHKT, T> {
+		return new NodeMariaDbPreparedQuery(
+			this.client,
+			query.sql,
+			query.params,
+			this.logger,
+			fields,
+			customResultMapper,
+		) as PreparedQueryKind<NodeMariaDbPreparedQueryHKT, T>;
+	}
+
+	async query(query: string, params: unknown[]): Promise<UpsertResult | any[]> {
+		this.logger.logQuery(query, params);
+		const result = await this.client.query({
+			sql: query,
+			rowsAsArray: true,
+			dateStrings: true,
+		}, params);
+		return result;
+	}
+
+	override all<T = unknown>(query: SQL): Promise<T[]> {
+		const querySql = this.dialect.sqlToQuery(query);
+		this.logger.logQuery(querySql.sql, querySql.params);
+		return this.client.execute(querySql.sql, querySql.params).then((result) => result) as Promise<T[]>;
+	}
+
+	override async transaction<T>(
+		transaction: (tx: NodeMariaDbTransaction<TFullSchema, TSchema>) => Promise<T>,
+		config?: MySqlTransactionConfig,
+	): Promise<T> {
+		const session = isPool(this.client)
+			? new NodeMariaDbSession(await this.client.getConnection(), this.dialect, this.schema, this.options)
+			: this;
+		const tx = new NodeMariaDbTransaction<TFullSchema, TSchema>(
+			this.dialect,
+			session as MySqlSession<any, any, any, any>,
+			this.schema,
+			0,
+			'planetscale',
+		);
+		if (config) {
+			const setTransactionConfigSql = this.getSetTransactionSQL(config);
+			if (setTransactionConfigSql) {
+				await tx.execute(setTransactionConfigSql);
+			}
+			const startTransactionSql = this.getStartTransactionSQL(config);
+			await (startTransactionSql ? tx.execute(startTransactionSql) : tx.execute(sql`begin`));
+		} else {
+			await tx.execute(sql`begin`);
+		}
+		try {
+			const result = await transaction(tx);
+			await tx.execute(sql`commit`);
+			return result;
+		} catch (err) {
+			await tx.execute(sql`rollback`);
+			throw err;
+		} finally {
+			if (isPool(this.client)) {
+				(session.client as PoolConnection).release();
+			}
+		}
+	}
+}
+
+export class NodeMariaDbTransaction<
+	TFullSchema extends Record<string, unknown>,
+	TSchema extends TablesRelationalConfig,
+> extends MySqlTransaction<NodeMariaDbQueryResultHKT, NodeMariaDbPreparedQueryHKT, TFullSchema, TSchema> {
+	static override readonly [entityKind]: string = 'NodeMariaDbTransaction';
+
+	override async transaction<T>(
+		transaction: (tx: NodeMariaDbTransaction<TFullSchema, TSchema>) => Promise<T>,
+	): Promise<T> {
+		const savepointName = `sp${this.nestedIndex + 1}`;
+		const tx = new NodeMariaDbTransaction<TFullSchema, TSchema>(
+			this.dialect,
+			this.session,
+			this.schema,
+			this.nestedIndex + 1,
+			this.mode,
+		);
+		await tx.execute(sql.raw(`savepoint ${savepointName}`));
+		try {
+			const result = await transaction(tx);
+			await tx.execute(sql.raw(`release savepoint ${savepointName}`));
+			return result;
+		} catch (err) {
+			await tx.execute(sql.raw(`rollback to savepoint ${savepointName}`));
+			throw err;
+		}
+	}
+}
+
+function isPool(client: NodeMariaDbClient): client is Pool {
+	return 'getConnection' in client;
+}
+
+export interface NodeMariaDbQueryResultHKT extends MySqlQueryResultHKT {
+	type: UpsertResult | any[];
+}
+
+export interface NodeMariaDbPreparedQueryHKT extends MySqlPreparedQueryHKT {
+	type: NodeMariaDbPreparedQuery<Assume<this['config'], MySqlPreparedQueryConfig>>;
+}


### PR DESCRIPTION
## Summary

Adds support for the native [`mariadb`](https://www.npmjs.com/package/mariadb) Node.js driver as a Drizzle ORM driver, extending the existing MySQL dialect.

- Implements `drizzle-orm/node-mariadb` with driver, session, and migrator
- Adds `mariadb` as an optional peer dependency
- Uses `planetscale` mode by default (MariaDB doesn't support `LEFT JOIN LATERAL`, [MDEV-33018](https://jira.mariadb.org/browse/MDEV-33018))
- Type-checks cleanly against current `main`

This is a rebase and update of #1692 by @L-Mario564 to resolve conflicts with the current codebase. The original PR has 75+ thumbs-up and has been open since Dec 2023 waiting for review.

### Usage

```typescript
import { drizzle } from 'drizzle-orm/node-mariadb';
import mariadb from 'mariadb';

const pool = mariadb.createPool({ host: 'localhost', user: 'root', database: 'test' });
const db = drizzle(pool);
```

### What's not included (yet)

- Relational Query Builder (RQB) support — to be addressed separately
- Integration tests — can be added once the approach is reviewed

## Test plan

- [x] Type-checks pass (`tsc --noEmit` — no new errors)
- [ ] Integration tests (need MariaDB instance + review of test approach)

Ref: #1692, drizzle-team/drizzle-orm#203

🤖 Generated with [Claude Code](https://claude.com/claude-code)