### PR TITLE
Fix Effect query instance binding

### DIFF
--- a/drizzle-orm/src/effect-postgres/session.ts
+++ b/drizzle-orm/src/effect-postgres/session.ts
@@ -79,12 +79,13 @@ export class EffectPgSession<
 			tx: EffectPgTransaction<TQueryResult, TRelations>,
 		) => Effect.Effect<A, E, R>,
 	): Effect.Effect<A, E | SqlError, R> {
-		const { dialect, relations } = this;
+		const self = this;
+		const { dialect, relations } = self;
 
-		return this.client.withTransaction(Effect.gen({ self: this }, function*() {
+		return self.client.withTransaction(Effect.gen(function*() {
 			const tx = new EffectPgTransaction<TQueryResult, TRelations>(
 				dialect,
-				this,
+				self,
 				relations,
 			);
 

--- a/drizzle-orm/src/pg-core/effect/session.ts
+++ b/drizzle-orm/src/pg-core/effect/session.ts
@@ -64,13 +64,14 @@ export class PgEffectPreparedQuery<
 	}
 
 	override execute(placeholderValues: Record<string, unknown> = {}): QueryEffectKind<TEffectHKT, T['execute']> {
-		return Effect.gen({ self: this }, function*() {
-			const params = fillPlaceholders(this.query.params, placeholderValues);
-			const { query: { sql }, mapper, logger } = this;
+		const self = this;
+		return Effect.gen(function*() {
+			const params = fillPlaceholders(self.query.params, placeholderValues);
+			const { query: { sql }, mapper, logger } = self;
 
 			yield* logger.logQuery(sql, params);
 
-			const query = this.queryWithCache(sql, params, Effect.suspend(() => this.executor(params)));
+			const query = self.queryWithCache(sql, params, Effect.suspend(() => self.executor(params)));
 
 			if (!mapper) return yield* query;
 
@@ -83,8 +84,9 @@ export class PgEffectPreparedQuery<
 		params: any[],
 		query: Effect.Effect<A, E, R>,
 	) {
-		return Effect.gen({ self: this }, function*() {
-			const { cacheConfig, queryMetadata } = this;
+		const self = this;
+		return Effect.gen(function*() {
+			const { cacheConfig, queryMetadata } = self;
 			const cache = yield* EffectCache;
 
 			const cacheStrat: Awaited<ReturnType<typeof strategyFor>> = cache && !is(cache.cache, NoopCache)
@@ -131,7 +133,7 @@ export class PgEffectPreparedQuery<
 
 			assertUnreachable(cacheStrat);
 		}).pipe(
-			Effect.provideService(EffectCache, this.cache),
+			Effect.provideService(EffectCache, self.cache),
 			Effect.catch((e) => {
 				return Effect.fail(new EffectDrizzleQueryError({ query: queryString, params, cause: Cause.fail(e) }));
 			}),

--- a/drizzle-orm/tests/effect-session.test.ts
+++ b/drizzle-orm/tests/effect-session.test.ts
@@ -1,0 +1,31 @@
+import * as Effect from 'effect/Effect';
+import { describe, test } from 'vitest';
+import { EffectCache } from '~/cache/core/cache-effect.ts';
+import { NoopCache } from '~/cache/core/cache.ts';
+import type { EffectLoggerShape } from '~/effect-core/logger.ts';
+import { PgEffectPreparedQuery } from '~/pg-core/effect/session.ts';
+import type { PreparedQueryConfig } from '~/pg-core/session.ts';
+
+const logger: EffectLoggerShape = {
+	logQuery: () => Effect.void,
+};
+
+describe('PgEffectPreparedQuery', () => {
+	test('executes with the prepared query instance bound inside Effect.gen', async ({ expect }) => {
+		const prepared = new PgEffectPreparedQuery<PreparedQueryConfig & { execute: string[] }>(
+			(params?: unknown[]) => Effect.succeed(params),
+			{
+				sql: 'select $1',
+				params: ['ok'],
+			},
+			(rows) => rows,
+			'raw',
+			logger,
+			EffectCache.fromDrizzle(new NoopCache()),
+			undefined,
+			undefined,
+		);
+
+		await expect(Effect.runPromise(prepared.execute())).resolves.toEqual(['ok']);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the Effect PostgreSQL adapter paths that were relying on `Effect.gen({ self: this }, function*() { ... this ... })` to preserve the class instance.

In current Effect v4, the generator `this` is the adapter object passed to `Effect.gen`, not the Drizzle class instance. That made prepared query execution, cache wrapping, and transaction construction read the wrong receiver at runtime.

This patch closes over `self` explicitly before entering `Effect.gen` and uses that captured instance inside:

- `PgEffectPreparedQuery.execute`
- `PgEffectPreparedQuery.queryWithCache`
- `EffectPgSession.transaction`

It also adds a regression test that instantiates `PgEffectPreparedQuery` directly and verifies `execute()` uses the prepared query instance correctly.

## Validation

- `pnpm exec dprint fmt drizzle-orm/src/pg-core/effect/session.ts drizzle-orm/src/effect-postgres/session.ts drizzle-orm/tests/effect-session.test.ts`
- `pnpm exec dprint check drizzle-orm/src/pg-core/effect/session.ts drizzle-orm/src/effect-postgres/session.ts drizzle-orm/tests/effect-session.test.ts`
- `pnpm exec oxlint drizzle-orm/src/pg-core/effect/session.ts drizzle-orm/src/effect-postgres/session.ts drizzle-orm/tests/effect-session.test.ts --max-warnings=0`
- `pnpm --dir drizzle-orm exec vitest run tests/effect-session.test.ts`

I also hit this from a downstream Effect v4 app using `drizzle-orm/effect-postgres`; before this fix the adapter could fail by reading fields like `query` / `cache` / `client` from the wrong receiver inside `Effect.gen`.
