### PR TITLE
fix(durable-sqlite): surface migration error via Error.cause on rollback

### DIFF
--- a/drizzle-orm/src/durable-sqlite/migrator.ts
+++ b/drizzle-orm/src/durable-sqlite/migrator.ts
@@ -78,7 +78,16 @@ export async function migrate<
 				}
 			}
 		} catch (error: any) {
-			tx.rollback();
+			// tx.rollback() throws a sentinel TransactionRollbackError to abort
+			// the surrounding transaction. Attach the original migration error
+			// as the cause so callers can surface it instead of seeing only the
+			// "Rollback" message.
+			try {
+				tx.rollback();
+			} catch (rollbackError: any) {
+				rollbackError.cause = error;
+				throw rollbackError;
+			}
 			throw error;
 		}
 	});


### PR DESCRIPTION
Fixes #5763.

In the `durable-sqlite` migrator, `tx.rollback()` throws a sentinel `TransactionRollbackError` to abort the surrounding transaction. The previous code looked like:

\`\`\`ts
} catch (error: any) {
  tx.rollback();   // throws TransactionRollbackError
  throw error;     // never reached
}
\`\`\`

Because \`tx.rollback()\` throws synchronously, the \`throw error\` below it never executes. The caller only ever saw the generic \`"Rollback"\` message — the real cause (failed SQL statement, schema mismatch, etc.) was discarded. This matched the symptom @Craig-J described in #5763.

The fix wraps the rollback in a try/catch and attaches the original migration error as \`rollbackError.cause\` before re-throwing, so callers can recover the underlying failure:

\`\`\`ts
} catch (error: any) {
  try {
    tx.rollback();
  } catch (rollbackError: any) {
    rollbackError.cause = error;
    throw rollbackError;
  }
  throw error;
}
\`\`\`

## Behaviour change

Standalone verification (mocking the tx interface):

\`\`\`
--- before ---
caller sees: TransactionRollbackError / Rollback
caller sees .cause: undefined

--- after ---
caller sees: TransactionRollbackError / Rollback
caller sees .cause: Migration 0003 failed: column "x" does not exist
\`\`\`

## Test plan

- \`pnpm test:types\` clean
- Manual repro via a standalone script reproducing the mocked transaction/rollback flow (script not committed; behaviour above)
- No durable-sqlite test infra exists in the repo; a Workers-runtime test would require miniflare and is out of scope for this fix