### PR TITLE
fix(pg): restore lazy evaluation of `$onUpdate` callbacks in `buildUpdateSet`

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -160,7 +160,7 @@ export class PgDialect {
 		return sql.join(columnNames.flatMap((colName, i) => {
 			const col = tableColumns[colName]!;
 
-			const onUpdateFnResult = col.onUpdateFn?.();
+			const onUpdateFnResult = set[colName] === undefined ? col.onUpdateFn?.() : undefined;                                
 			const value = set[colName] ?? (is(onUpdateFnResult, SQL) ? onUpdateFnResult : sql.param(onUpdateFnResult, col));
 			const res = sql`${sql.identifier(this.casing.getColumnCasing(col))} = ${value}`;
 


### PR DESCRIPTION
0.45.x introduced a regression where `$onUpdate` callbacks are invoked unconditionally for every column that defines one, even when an explicit value is provided in set. The callback result is then discarded via `??`, but side effects in the callback always fire.

Restores the pre-0.45 behaviour: the callback is only invoked when the column is absent from set.

Fixes #5780