### PR TITLE
fix(pg-core): use hash-membership to skip applied migrations

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -88,16 +88,13 @@ export class PgDialect {
 		const dbMigrations = await session.all<{ id: number; hash: string; created_at: string }>(
 			sql`select id, hash, created_at from ${sql.identifier(migrationsSchema)}.${
 				sql.identifier(migrationsTable)
-			} order by created_at desc limit 1`,
+			}`,
 		);
 
-		const lastDbMigration = dbMigrations[0];
+		const appliedHashes = new Set(dbMigrations.map((m) => m.hash));
 		await session.transaction(async (tx) => {
 			for await (const migration of migrations) {
-				if (
-					!lastDbMigration
-					|| Number(lastDbMigration.created_at) < migration.folderMillis
-				) {
+				if (!appliedHashes.has(migration.hash)) {
 					for (const stmt of migration.sql) {
 						await tx.execute(sql.raw(stmt));
 					}

--- a/integration-tests/tests/pg/node-postgres.test.ts
+++ b/integration-tests/tests/pg/node-postgres.test.ts
@@ -1,5 +1,6 @@
 import retry from 'async-retry';
 import { sql } from 'drizzle-orm';
+import type { MigrationMeta } from 'drizzle-orm/migrator';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
@@ -148,6 +149,48 @@ test('migrator : migrate with custom table and custom schema', async () => {
 	await db.execute(sql`drop table all_columns`);
 	await db.execute(sql`drop table users12`);
 	await db.execute(sql`drop table ${sql.identifier(customSchema)}.${sql.identifier(customTable)}`);
+});
+
+test('migrator : applies pending migration whose folderMillis predates the latest applied one', async () => {
+	// Regression for #5769. The original gate compared the max created_at in
+	// __drizzle_migrations against each pending entry's folderMillis and skipped
+	// anything older. Cherry-picking a feature branch (whose journal `when` is
+	// older than what's already applied on main) produced silent skips. The gate
+	// is now hash-membership.
+	await db.execute(sql`drop table if exists out_of_order_users`);
+	await db.execute(sql`drop table if exists "drizzle"."__drizzle_migrations"`);
+
+	const createTable: MigrationMeta = {
+		sql: ['create table "out_of_order_users" (id serial primary key)'],
+		bps: false,
+		folderMillis: 2000,
+		hash: 'create-table-newer-when',
+	};
+	const addColumn: MigrationMeta = {
+		sql: ['alter table "out_of_order_users" add column "name" text'],
+		bps: false,
+		folderMillis: 1000,
+		hash: 'add-column-older-when',
+	};
+
+	await db.dialect.migrate([createTable], db.session, { migrationsFolder: '' });
+	await db.dialect.migrate([createTable, addColumn], db.session, { migrationsFolder: '' });
+
+	const applied = await db.execute<{ hash: string }>(
+		sql`select hash from "drizzle"."__drizzle_migrations"`,
+	);
+	const appliedHashes = applied.rows.map((r) => r.hash);
+	expect(appliedHashes).toContain('create-table-newer-when');
+	expect(appliedHashes).toContain('add-column-older-when');
+
+	const { rows } = await db.execute<{ column_name: string }>(
+		sql`select column_name from information_schema.columns where table_name = 'out_of_order_users'`,
+	);
+	const cols = rows.map((r) => r.column_name);
+	expect(cols).toContain('name');
+
+	await db.execute(sql`drop table "out_of_order_users"`);
+	await db.execute(sql`drop table "drizzle"."__drizzle_migrations"`);
 });
 
 test('all date and time columns without timezone first case mode string', async () => {


### PR DESCRIPTION
Closes #5769.

`PgDialect.migrate` selected only the latest applied row and gated each pending migration on `Number(lastDbMigration.created_at) < migration.folderMillis`. The gate silently skips any pending migration whose journal `when` is older than the maximum `created_at` already in `__drizzle_migrations`. This happens routinely when a feature-branch migration with an earlier timestamp lands after a main-branch migration, after a backport, or after rebasing a long-running branch.

The fix loads all applied hashes into a `Set` and gates on `!appliedHashes.has(migration.hash)`. Hash already uniquely identifies a migration; `created_at` was only ever a proxy.

Regression test in `integration-tests/tests/pg/node-postgres.test.ts` reproduces the scenario by applying a migration with `folderMillis: 2000` then re-running migrate with that plus a second migration at `folderMillis: 1000`; without the fix the older entry silently skips, with the fix both apply.

Note for review scope: the same `order by created_at desc limit 1` + `lastDbMigration.created_at < migration.folderMillis` shape exists in `mysql-core/dialect.ts`, `singlestore-core/dialect.ts`, and the per-driver `migrator.ts` files for neon-http, xata-http, pg-proxy, mysql-proxy, sqlite-proxy, singlestore-proxy, libsql, expo-sqlite, d1, durable-sqlite, op-sqlite. Happy to follow up with a multi-dialect sweep if you want it in one place or separate PRs.