### PR TITLE
fix(sqlite): prevent silent ON DELETE CASCADE data loss during table-rebuild migrations

### DIFF
--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -933,6 +933,12 @@ export abstract class SQLiteDialect {
 	}
 }
 
+// SQLite ignores PRAGMA foreign_keys inside a transaction; hoist it before BEGIN when needed.
+// fkOffRe / fkPragmaRe match drizzle-kit's table-rebuild output shape — update both if drizzle-kit changes its FK pragma format.
+const fkOffRe = /^\s*PRAGMA\s+foreign_keys\s*=\s*(OFF|0)\s*;?\s*$/i;
+const fkPragmaRe = /^\s*PRAGMA\s+foreign_keys\s*=/i;
+const hasFkOffPragma = (migrations: MigrationMeta[]) => migrations.some((m) => m.sql.some((s) => fkOffRe.test(s)));
+
 export class SQLiteSyncDialect extends SQLiteDialect {
 	static override readonly [entityKind]: string = 'SQLiteSyncDialect';
 
@@ -966,31 +972,38 @@ export class SQLiteSyncDialect extends SQLiteDialect {
 		);
 
 		const lastDbMigration = dbMigrations[0] ?? undefined;
+		const migrationsToRun = migrations.filter((m) => !lastDbMigration || Number(lastDbMigration[2])! < m.folderMillis);
+		const needsFkHoist = hasFkOffPragma(migrationsToRun);
+		let prevFkEnabled = 1;
+		if (needsFkHoist) {
+			const row = session.get<{ foreign_keys: number }>(sql`PRAGMA foreign_keys`);
+			prevFkEnabled = row?.foreign_keys ?? 1;
+			if (prevFkEnabled) session.run(sql`PRAGMA foreign_keys=OFF`);
+		}
+
 		session.run(sql`BEGIN`);
 
 		try {
-			for (const migration of migrations) {
-				if (
-					!lastDbMigration
-					|| Number(lastDbMigration[2])! < migration.folderMillis
-				) {
-					for (const stmt of migration.sql) {
-						session.run(sql.raw(stmt));
-					}
-					session.run(
-						sql`INSERT INTO ${
-							sql.identifier(
-								migrationsTable,
-							)
-						} ("hash", "created_at") VALUES(${migration.hash}, ${migration.folderMillis})`,
-					);
+			for (const migration of migrationsToRun) {
+				for (const stmt of migration.sql) {
+					if (needsFkHoist && fkPragmaRe.test(stmt)) continue;
+					session.run(sql.raw(stmt));
 				}
+				session.run(
+					sql`INSERT INTO ${
+						sql.identifier(
+							migrationsTable,
+						)
+					} ("hash", "created_at") VALUES(${migration.hash}, ${migration.folderMillis})`,
+				);
 			}
 
 			session.run(sql`COMMIT`);
 		} catch (e) {
 			session.run(sql`ROLLBACK`);
 			throw e;
+		} finally {
+			if (needsFkHoist && prevFkEnabled) session.run(sql`PRAGMA foreign_keys=ON`);
 		}
 	}
 }
@@ -1023,14 +1036,20 @@ export class SQLiteAsyncDialect extends SQLiteDialect {
 		);
 
 		const lastDbMigration = dbMigrations[0] ?? undefined;
+		const migrationsToRun = migrations.filter((m) => !lastDbMigration || Number(lastDbMigration[2])! < m.folderMillis);
+		const needsFkHoist = hasFkOffPragma(migrationsToRun);
+		let prevFkEnabled = 1;
+		if (needsFkHoist) {
+			const row = await session.get<{ foreign_keys: number }>(sql`PRAGMA foreign_keys`);
+			prevFkEnabled = row?.foreign_keys ?? 1;
+			if (prevFkEnabled) await session.run(sql`PRAGMA foreign_keys=OFF`);
+		}
 
-		await session.transaction(async (tx) => {
-			for (const migration of migrations) {
-				if (
-					!lastDbMigration
-					|| Number(lastDbMigration[2])! < migration.folderMillis
-				) {
+		try {
+			await session.transaction(async (tx) => {
+				for (const migration of migrationsToRun) {
 					for (const stmt of migration.sql) {
+						if (needsFkHoist && fkPragmaRe.test(stmt)) continue;
 						await tx.run(sql.raw(stmt));
 					}
 					await tx.run(
@@ -1041,7 +1060,9 @@ export class SQLiteAsyncDialect extends SQLiteDialect {
 						} ("hash", "created_at") VALUES(${migration.hash}, ${migration.folderMillis})`,
 					);
 				}
-			}
-		});
+			});
+		} finally {
+			if (needsFkHoist && prevFkEnabled) await session.run(sql`PRAGMA foreign_keys=ON`);
+		}
 	}
 }

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -934,7 +934,10 @@ export abstract class SQLiteDialect {
 }
 
 // SQLite ignores PRAGMA foreign_keys inside a transaction; hoist it before BEGIN when needed.
-// fkOffRe / fkPragmaRe match drizzle-kit's table-rebuild output shape — update both if drizzle-kit changes its FK pragma format.
+// fkOffRe / fkPragmaRe assume drizzle-kit's current rebuild signature: OFF/ON pragmas in a
+// single migration file, outside any savepoint. If drizzle-kit ever splits the pragmas
+// across files or wraps the rebuild in a savepoint, the hoist-to-session strategy below
+// needs revisiting.
 const fkOffRe = /^\s*PRAGMA\s+foreign_keys\s*=\s*(OFF|0)\s*;?\s*$/i;
 const fkPragmaRe = /^\s*PRAGMA\s+foreign_keys\s*=/i;
 const hasFkOffPragma = (migrations: MigrationMeta[]) => migrations.some((m) => m.sql.some((s) => fkOffRe.test(s)));

--- a/integration-tests/tests/sqlite/better-sqlite.test.ts
+++ b/integration-tests/tests/sqlite/better-sqlite.test.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import { sql } from 'drizzle-orm';
 import { type BetterSQLite3Database, drizzle } from 'drizzle-orm/better-sqlite3';
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
 import { skipTests } from '~/common';
 import { anotherUsersMigratorTable, tests, usersMigratorTable } from './sqlite-common';
@@ -46,6 +47,66 @@ test('migrator', async () => {
 	db.run(sql`drop table another_users`);
 	db.run(sql`drop table users12`);
 	db.run(sql`drop table __drizzle_migrations`);
+});
+
+test('migrator: table-rebuild migration preserves child rows with ON DELETE CASCADE FK', () => {
+	const migrationDir = './migrations/sqlite-fk-cascade-test';
+	if (existsSync(migrationDir)) rmSync(migrationDir, { recursive: true });
+	mkdirSync(migrationDir, { recursive: true });
+
+	db.run(sql`drop table if exists \`child_fk_test\``);
+	db.run(sql`drop table if exists \`parent_fk_test\``);
+	db.run(sql`drop table if exists \`__drizzle_migrations\``);
+
+	// Initial schema: parent + child with ON DELETE CASCADE
+	mkdirSync(`${migrationDir}/20240101000000_initial`, { recursive: true });
+	writeFileSync(
+		`${migrationDir}/20240101000000_initial/migration.sql`,
+		[
+			"CREATE TABLE `parent_fk_test` (`id` integer PRIMARY KEY NOT NULL, `mode` text DEFAULT 'a');",
+			'--> statement-breakpoint',
+			"CREATE TABLE `child_fk_test` (`id` integer PRIMARY KEY NOT NULL, `parent_id` integer NOT NULL REFERENCES `parent_fk_test`(`id`) ON DELETE CASCADE);",
+		].join('\n'),
+	);
+	migrate(db, { migrationsFolder: migrationDir });
+
+	db.run(sql`PRAGMA foreign_keys=ON`);
+	db.run(sql`INSERT INTO parent_fk_test VALUES (1, 'a')`);
+	db.run(sql`INSERT INTO child_fk_test VALUES (1, 1), (2, 1)`);
+
+	// Table-rebuild migration in the exact drizzle-kit output shape
+	mkdirSync(`${migrationDir}/20240102000000_rebuild`, { recursive: true });
+	writeFileSync(
+		`${migrationDir}/20240102000000_rebuild/migration.sql`,
+		[
+			'PRAGMA foreign_keys=OFF;',
+			'--> statement-breakpoint',
+			"CREATE TABLE `__new_parent_fk_test` (`id` integer PRIMARY KEY NOT NULL, `mode` text DEFAULT 'b');",
+			'--> statement-breakpoint',
+			'INSERT INTO `__new_parent_fk_test` SELECT `id`, `mode` FROM `parent_fk_test`;',
+			'--> statement-breakpoint',
+			'DROP TABLE `parent_fk_test`;',
+			'--> statement-breakpoint',
+			'ALTER TABLE `__new_parent_fk_test` RENAME TO `parent_fk_test`;',
+			'--> statement-breakpoint',
+			'PRAGMA foreign_keys=ON;',
+		].join('\n'),
+	);
+	migrate(db, { migrationsFolder: migrationDir });
+
+	// Child rows must survive; without the fix they are silently wiped by CASCADE
+	const childRows = db.all<{ id: number; parent_id: number }>(
+		sql`SELECT id, parent_id FROM child_fk_test ORDER BY id`,
+	);
+	expect(childRows).toStrictEqual([
+		{ id: 1, parent_id: 1 },
+		{ id: 2, parent_id: 1 },
+	]);
+
+	db.run(sql`DROP TABLE IF EXISTS child_fk_test`);
+	db.run(sql`DROP TABLE IF EXISTS parent_fk_test`);
+	db.run(sql`DROP TABLE IF EXISTS \`__drizzle_migrations\``);
+	rmSync(migrationDir, { recursive: true });
 });
 
 skipTests([

--- a/integration-tests/tests/sqlite/better-sqlite.test.ts
+++ b/integration-tests/tests/sqlite/better-sqlite.test.ts
@@ -52,21 +52,28 @@ test('migrator', async () => {
 test('migrator: table-rebuild migration preserves child rows with ON DELETE CASCADE FK', () => {
 	const migrationDir = './migrations/sqlite-fk-cascade-test';
 	if (existsSync(migrationDir)) rmSync(migrationDir, { recursive: true });
-	mkdirSync(migrationDir, { recursive: true });
+	mkdirSync(`${migrationDir}/meta`, { recursive: true });
 
 	db.run(sql`drop table if exists \`child_fk_test\``);
 	db.run(sql`drop table if exists \`parent_fk_test\``);
 	db.run(sql`drop table if exists \`__drizzle_migrations\``);
 
 	// Initial schema: parent + child with ON DELETE CASCADE
-	mkdirSync(`${migrationDir}/20240101000000_initial`, { recursive: true });
 	writeFileSync(
-		`${migrationDir}/20240101000000_initial/migration.sql`,
+		`${migrationDir}/0000_initial.sql`,
 		[
 			"CREATE TABLE `parent_fk_test` (`id` integer PRIMARY KEY NOT NULL, `mode` text DEFAULT 'a');",
 			'--> statement-breakpoint',
 			"CREATE TABLE `child_fk_test` (`id` integer PRIMARY KEY NOT NULL, `parent_id` integer NOT NULL REFERENCES `parent_fk_test`(`id`) ON DELETE CASCADE);",
 		].join('\n'),
+	);
+	writeFileSync(
+		`${migrationDir}/meta/_journal.json`,
+		JSON.stringify({
+			version: '5',
+			dialect: 'sqlite',
+			entries: [{ idx: 0, version: '5', when: 1704067200000, tag: '0000_initial', breakpoints: true }],
+		}),
 	);
 	migrate(db, { migrationsFolder: migrationDir });
 
@@ -75,9 +82,8 @@ test('migrator: table-rebuild migration preserves child rows with ON DELETE CASC
 	db.run(sql`INSERT INTO child_fk_test VALUES (1, 1), (2, 1)`);
 
 	// Table-rebuild migration in the exact drizzle-kit output shape
-	mkdirSync(`${migrationDir}/20240102000000_rebuild`, { recursive: true });
 	writeFileSync(
-		`${migrationDir}/20240102000000_rebuild/migration.sql`,
+		`${migrationDir}/0001_rebuild.sql`,
 		[
 			'PRAGMA foreign_keys=OFF;',
 			'--> statement-breakpoint',
@@ -91,6 +97,17 @@ test('migrator: table-rebuild migration preserves child rows with ON DELETE CASC
 			'--> statement-breakpoint',
 			'PRAGMA foreign_keys=ON;',
 		].join('\n'),
+	);
+	writeFileSync(
+		`${migrationDir}/meta/_journal.json`,
+		JSON.stringify({
+			version: '5',
+			dialect: 'sqlite',
+			entries: [
+				{ idx: 0, version: '5', when: 1704067200000, tag: '0000_initial', breakpoints: true },
+				{ idx: 1, version: '5', when: 1704153600000, tag: '0001_rebuild', breakpoints: true },
+			],
+		}),
 	);
 	migrate(db, { migrationsFolder: migrationDir });
 


### PR DESCRIPTION
Fixes #5782

Credit to @truffle-dev for the root-cause analysis in the thread.

Every table-rebuild migration from drizzle-kit starts with `PRAGMA foreign_keys=OFF` — correct, since the rename dance needs cascades disarmed. But [SQLite documents](https://www.sqlite.org/pragma.html#pragma_foreign_keys) that this pragma is a no-op inside a transaction: "foreign key constraint enforcement may only be enabled or disabled when there is no pending BEGIN or SAVEPOINT." The migrator wraps each migration in `BEGIN … COMMIT`. So the pragma drizzle-kit generates to protect data is neutralized by the very transaction that protects atomicity.

With `ON DELETE CASCADE`: the `DROP TABLE` inside the rebuild fires the cascade, child rows are deleted, the migration commits, and `__drizzle_migrations` records it as applied. No error. No rollback. Users find out when their tables are empty.

This is the silent variant of #1813 and #4089. Those throw `SQLITE_CONSTRAINT`, roll back, give the user an error message. This one succeeds.

**Fix**

Before `BEGIN`, scan pending migrations for `PRAGMA foreign_keys=OFF` (the drizzle-kit rebuild signature). If found, read the current FK state, issue the pragma at session level where SQLite actually honors it, skip `PRAGMA foreign_keys` statements inside the transaction loop (they'd be no-ops anyway), and restore in a `finally` block. The migrator saves FK state before the hoist and restores it conditionally. Always restoring ON would change the caller's connection state if they never had FK enforcement enabled, since SQLite defaults to OFF.

Both `SQLiteSyncDialect` and `SQLiteAsyncDialect` paths are covered. All SQLite drivers flow through these two methods.

- The hoist applies to the full migration batch. If a batch contains a rebuild alongside simple migrations, FK enforcement is off for all of them. drizzle-kit generates one migration per schema change in practice, so this won't come up.
- For HTTP-backed drivers (D1, sqlite-proxy), `db.session.run()` and `db.session.transaction()` can land on different connections, so the session-level pragma may not carry over. Those drivers don't support `PRAGMA foreign_keys` anyway, so `needsFkHoist` stays false.

**Test**

Test in `integration-tests/tests/sqlite/better-sqlite.test.ts` seeds a parent + child schema with `ON DELETE CASCADE`, runs a table-rebuild migration in the exact drizzle-kit output shape (`PRAGMA foreign_keys=OFF;` → create `__new_*` → INSERT SELECT → DROP → RENAME → `PRAGMA foreign_keys=ON;`), and asserts the child rows survive.