### PR TITLE
Fix nested left join null detection

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'vitest';
+import { text } from '~/sqlite-core/columns/text.ts';
+import { sqliteTable } from '~/sqlite-core/table.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const users = sqliteTable('users', {
+	name: text('name'),
+});
+
+const pets = sqliteTable('pets', {
+	name: text('name'),
+	species: text('species'),
+});
+
+describe('mapResultRow', () => {
+	it('does not nullify a nullable joined object when a later column from the same table is not null', ({ expect }) => {
+		const result = mapResultRow(
+			[
+				{ path: ['user', 'name'], field: users.name },
+				{ path: ['pet', 'name'], field: pets.name },
+				{ path: ['pet', 'species'], field: pets.species },
+			],
+			['Jane', null, 'cat'],
+			{ users: true, pets: false },
+		);
+
+		expect(result).toEqual({
+			user: { name: 'Jane' },
+			pet: { name: null, species: 'cat' },
+		});
+	});
+
+	it('nullifies a nullable joined object when all columns from the same table are null', ({ expect }) => {
+		const result = mapResultRow(
+			[
+				{ path: ['user', 'name'], field: users.name },
+				{ path: ['pet', 'name'], field: pets.name },
+				{ path: ['pet', 'species'], field: pets.species },
+			],
+			['Jane', null, null],
+			{ users: true, pets: false },
+		);
+
+		expect(result).toEqual({
+			user: { name: 'Jane' },
+			pet: null,
+		});
+	});
+});


### PR DESCRIPTION
Closes #1603

## Summary
- Fixes nested select result mapping for left joins when the first selected column from a joined table is null but later columns from the same table are not null.
- Keeps nullable joined objects only when at least one selected column from that table has a non-null value.
- Adds regression coverage for both the partial-null and all-null joined object cases.

## Test plan
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --dir drizzle-orm exec vitest run tests/utils.test.ts`
- `corepack pnpm exec dprint check drizzle-orm/src/utils.ts drizzle-orm/tests/utils.test.ts`

Note: local full install with lifecycle scripts is blocked on this Windows/Node 24 environment by native optional dependency builds (`better-sqlite3`/`cpu-features`). The focused test above is pure and passes locally.

/claim #1603