### PR TITLE
[Eslint Plugin] Fix enforce-update-with-where false positive when .from() precedes .where()

### DIFF
--- a/eslint-plugin-drizzle/src/enforce-update-with-where.ts
+++ b/eslint-plugin-drizzle/src/enforce-update-with-where.ts
@@ -1,11 +1,9 @@
 import { ESLintUtils } from '@typescript-eslint/utils';
-import { resolveMemberExpressionPath } from './utils/ast';
+import { isMethodCalledLaterInChain, resolveMemberExpressionPath } from './utils/ast';
 import { isDrizzleObj, type Options } from './utils/options';
 
 const createRule = ESLintUtils.RuleCreator(() => 'https://github.com/drizzle-team/eslint-plugin-drizzle');
 type MessageIds = 'enforceUpdateWithWhere';
-
-let lastNodeName: string = '';
 
 const updateRule = createRule<Options, MessageIds>({
 	defaultOptions: [{ drizzleObjectName: [] }],
@@ -35,13 +33,13 @@ const updateRule = createRule<Options, MessageIds>({
 			MemberExpression: (node) => {
 				if (node.property.type === 'Identifier') {
 					if (
-						lastNodeName !== 'where'
-						&& node.property.name === 'set'
+						node.property.name === 'set'
 						&& node.object.type === 'CallExpression'
 						&& node.object.callee.type === 'MemberExpression'
 						&& node.object.callee.property.type === 'Identifier'
 						&& node.object.callee.property.name === 'update'
 						&& isDrizzleObj(node.object.callee, options)
+						&& !isMethodCalledLaterInChain(node, 'where')
 					) {
 						context.report({
 							node,
@@ -51,7 +49,6 @@ const updateRule = createRule<Options, MessageIds>({
 							},
 						});
 					}
-					lastNodeName = node.property.name;
 				}
 				return;
 			},

--- a/eslint-plugin-drizzle/src/utils/ast.ts
+++ b/eslint-plugin-drizzle/src/utils/ast.ts
@@ -1,5 +1,43 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 
+/**
+ * Walks up the AST from a MemberExpression that is the callee of a chained
+ * method call (e.g. `.set` in `db.update().set().from(x).where(y)`) and
+ * returns `true` if any subsequent chained call uses the given method name.
+ *
+ * This is needed because ESLint visits MemberExpression nodes from the
+ * outermost call inward, so tracking the previously-visited property name
+ * fails for chains where the relevant method (e.g. `.where`) does not appear
+ * immediately after the node we are inspecting.
+ */
+export const isMethodCalledLaterInChain = (
+	node: TSESTree.MemberExpression,
+	methodName: string,
+): boolean => {
+	let current: TSESTree.Node | undefined = node;
+	while (current && current.parent) {
+		const parent: TSESTree.Node = current.parent;
+		// We expect to be the callee of a CallExpression, e.g. `.set` in `.set()`
+		if (parent.type === 'CallExpression' && parent.callee === current) {
+			const grandparent: TSESTree.Node | undefined = parent.parent;
+			if (
+				grandparent
+				&& grandparent.type === 'MemberExpression'
+				&& grandparent.object === parent
+				&& grandparent.property.type === 'Identifier'
+			) {
+				if (grandparent.property.name === methodName) {
+					return true;
+				}
+				current = grandparent;
+				continue;
+			}
+		}
+		return false;
+	}
+	return false;
+};
+
 export const resolveMemberExpressionPath = (node: TSESTree.MemberExpression) => {
 	let objectExpression = node.object;
 	let fullName = '';

--- a/eslint-plugin-drizzle/tests/update.test.ts
+++ b/eslint-plugin-drizzle/tests/update.test.ts
@@ -27,6 +27,19 @@ ruleTester.run('enforce update with where (default options)', myRule, {
       .update()
       .set()
       .where()`,
+		// Issue #5612: .where() may appear after intermediate chained calls
+		// such as .from() and the rule must still see it.
+		`db
+      .update(table)
+      .set({})
+      .from(sql)
+      .where(eq(table.id, v.id))`,
+		`db
+      .update(table)
+      .set({})
+      .from(sql)
+      .where(eq(table.id, v.id))
+      .returning()`,
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Closes #5612.

The enforce-update-with-where rule reports an update without where when .from() appears before .where() in the chain, for example:

```
await tx
  .update(table)
  .set({ ... })
  .from(sql`(VALUES ...) AS v(...)`)
  .where(eq(table.id, v.id));
```

The rule decides whether to report on the .set() MemberExpression by checking a module-level lastNodeName variable that is updated each time a MemberExpression is visited. ESLint visits MemberExpression nodes from the outermost call inward, so for the chain above the visit order is .where, then .from, then .set, then .update. By the time .set is visited, lastNodeName is "from" rather than "where", so the rule fires even though .where is present in the same chain.

The fix replaces the visit-order heuristic with a small AST walk that follows the surrounding CallExpression and MemberExpression nodes upward from the .set() MemberExpression, and reports only when no later chained call uses the name where. Behavior for chains without a trailing .from() is unchanged.

Tests:

Added two valid cases to tests/update.test.ts covering .from() before .where(), with and without a trailing .returning(). Both fail on main and pass with the fix. All 113 existing rule tests still pass.