### PR TITLE
Export programmatic migration APIs for MSSQL, SQLite, and MySQL from drizzle-kit

### DIFF
--- a/drizzle-kit/build.ts
+++ b/drizzle-kit/build.ts
@@ -21,6 +21,8 @@ const driversPackages = [
 	'@sqlitecloud/drivers',
 	'@tursodatabase/database',
 	'bun',
+	// mssql drivers
+	'mssql',
 	// duckdb drivers
 	'duckdb',
 	'@duckdb/node-api',
@@ -69,7 +71,7 @@ const main = async () => {
 	});
 
 	await tsup.build({
-		entryPoints: ['./src/ext/api-postgres.ts', './src/ext/api-mysql.ts', './src/ext/api-sqlite.ts'],
+		entryPoints: ['./src/ext/api-postgres.ts', './src/ext/api-mysql.ts', './src/ext/api-sqlite.ts', './src/ext/api-mssql.ts'],
 		outDir: './dist',
 		external: [
 			'esbuild',
@@ -184,6 +186,11 @@ const main = async () => {
 	writeFileSync(
 		'./dist/api-sqlite.js',
 		readFileSync('./dist/api-sqlite.js', 'utf8').replace(/await import\(/g, 'require('),
+	);
+
+	writeFileSync(
+		'./dist/api-mssql.js',
+		readFileSync('./dist/api-mssql.js', 'utf8').replace(/await import\(/g, 'require('),
 	);
 
 	// await tsup.build({

--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -170,6 +170,18 @@
 			},
 			"types": "./api-sqlite.d.mts",
 			"default": "./api-sqlite.mjs"
+		},
+		"./api-mssql": {
+			"import": {
+				"types": "./api-mssql.d.mts",
+				"default": "./api-mssql.mjs"
+			},
+			"require": {
+				"types": "./api-mssql.d.ts",
+				"default": "./api-mssql.js"
+			},
+			"types": "./api-mssql.d.mts",
+			"default": "./api-mssql.mjs"
 		}
 	}
 }

--- a/drizzle-kit/scripts/build.ts
+++ b/drizzle-kit/scripts/build.ts
@@ -22,6 +22,8 @@ const driversPackages = [
 	'@sqlitecloud/drivers',
 	'@tursodatabase/database',
 	'bun',
+	// mssql drivers
+	'mssql',
 	// duckdb drivers
 	'duckdb',
 	'@duckdb/node-api',
@@ -108,7 +110,7 @@ async function buildDeclarations() {
 	});
 
 	await tsdown({
-		entry: ['./src/ext/api-postgres.ts', './src/ext/api-mysql.ts', './src/ext/api-sqlite.ts'],
+		entry: ['./src/ext/api-postgres.ts', './src/ext/api-mysql.ts', './src/ext/api-sqlite.ts', './src/ext/api-mssql.ts'],
 		outDir: './dist',
 		external: ['esbuild', 'drizzle-orm', ...driversPackages, /^drizzle-orm\/?/],
 		dts: { emitDtsOnly: true },
@@ -127,7 +129,7 @@ async function buildDeclarations() {
 }
 
 async function postProcessApiFiles() {
-	const apiFiles = ['dist/api-postgres.js', 'dist/api-mysql.js', 'dist/api-sqlite.js'];
+	const apiFiles = ['dist/api-postgres.js', 'dist/api-mysql.js', 'dist/api-sqlite.js', 'dist/api-mssql.js'];
 	await Promise.all(
 		apiFiles.map(async (file) => {
 			if (existsSync(file)) {
@@ -190,6 +192,18 @@ async function main() {
 			name: 'api-sqlite-esm',
 			input: './src/ext/api-sqlite.ts',
 			outputName: 'api-sqlite.mjs',
+			format: 'esm',
+		}),
+		buildBundle({
+			name: 'api-mssql-cjs',
+			input: './src/ext/api-mssql.ts',
+			outputName: 'api-mssql.js',
+			format: 'cjs',
+		}),
+		buildBundle({
+			name: 'api-mssql-esm',
+			input: './src/ext/api-mssql.ts',
+			outputName: 'api-mssql.mjs',
 			format: 'esm',
 		}),
 		buildDeclarations(),

--- a/drizzle-kit/src/dialects/mssql/drizzle.ts
+++ b/drizzle-kit/src/dialects/mssql/drizzle.ts
@@ -362,7 +362,7 @@ export const prepareFromSchemaFiles = async (imports: string[]) => {
 		const it = imports[i];
 
 		const i0: Record<string, unknown> = await loadModule(it);
-		const prepared = fromExport(i0);
+		const prepared = fromExports(i0);
 
 		tables.push(...prepared.tables);
 		schemas.push(...prepared.schemas);
@@ -378,7 +378,7 @@ export const prepareFromSchemaFiles = async (imports: string[]) => {
 	};
 };
 
-const fromExport = (exports: Record<string, unknown>) => {
+export const fromExports = (exports: Record<string, unknown>) => {
 	const tables: AnyMsSqlTable[] = [];
 	const schemas: MsSqlSchema[] = [];
 	const views: MsSqlView[] = [];

--- a/drizzle-kit/src/ext/api-mssql.ts
+++ b/drizzle-kit/src/ext/api-mssql.ts
@@ -1,0 +1,188 @@
+import type { MsSqlDatabase } from 'drizzle-orm/mssql-core';
+import type { EntitiesFilterConfig } from 'src/cli/validations/cli';
+import { upToV2 } from 'src/dialects/mssql/versions';
+import type { MssqlCredentials } from '../cli/validations/mssql';
+import type {
+	CheckConstraint,
+	Column,
+	DefaultConstraint,
+	ForeignKey,
+	Index,
+	MssqlEntities,
+	PrimaryKey,
+	Schema,
+	UniqueConstraint,
+	View,
+} from '../dialects/mssql/ddl';
+import { createDDL, interimToDDL } from '../dialects/mssql/ddl';
+import type { MssqlSnapshot } from '../dialects/mssql/snapshot';
+import { originUUID } from '../utils';
+import type { DB } from '../utils';
+
+export const generateDrizzleJson = async (
+	imports: Record<string, unknown>,
+	prevId?: string,
+	schemaFilters?: string[],
+): Promise<MssqlSnapshot> => {
+	const { prepareEntityFilter } = await import('src/dialects/pull-utils');
+	const { mssqlSchemaError } = await import('../cli/views');
+	const { toJsonSnapshot } = await import('../dialects/mssql/snapshot');
+	const { fromDrizzleSchema, fromExports } = await import('../dialects/mssql/drizzle');
+	const { extractMssqlExisting } = await import('../dialects/drizzle');
+	const prepared = fromExports(imports);
+
+	const existing = extractMssqlExisting(prepared.schemas, prepared.views);
+
+	const filter = prepareEntityFilter('mssql', {
+		schemas: schemaFilters ?? [],
+		tables: [],
+		entities: undefined,
+		extensions: [],
+	}, existing);
+
+	const { schema: interim, errors } = fromDrizzleSchema(prepared, filter);
+
+	const { ddl, errors: err2 } = interimToDDL(interim);
+
+	if (errors.length > 0) {
+		console.log(errors.map((it) => mssqlSchemaError(it)).join('\n'));
+		process.exit(1);
+	}
+
+	if (err2.length > 0) {
+		console.log(err2.map((it) => mssqlSchemaError(it)).join('\n'));
+		process.exit(1);
+	}
+
+	return toJsonSnapshot(ddl, prevId ? [prevId] : [originUUID], []);
+};
+
+export const generateMigration = async (
+	prev: MssqlSnapshot,
+	cur: MssqlSnapshot,
+) => {
+	const { resolver } = await import('../cli/prompts');
+	const { ddlDiff } = await import('../dialects/mssql/diff');
+	const from = createDDL();
+	const to = createDDL();
+
+	for (const it of prev.ddl) {
+		from.entities.push(it);
+	}
+	for (const it of cur.ddl) {
+		to.entities.push(it);
+	}
+
+	const { sqlStatements } = await ddlDiff(
+		from,
+		to,
+		resolver<Schema>('schema', 'dbo'),
+		resolver<MssqlEntities['tables']>('table', 'dbo'),
+		resolver<Column>('column', 'dbo'),
+		resolver<View>('view', 'dbo'),
+		resolver<UniqueConstraint>('unique', 'dbo'),
+		resolver<Index>('index', 'dbo'),
+		resolver<CheckConstraint>('check', 'dbo'),
+		resolver<PrimaryKey>('primary key', 'dbo'),
+		resolver<ForeignKey>('foreign key', 'dbo'),
+		resolver<DefaultConstraint>('default', 'dbo'),
+		'default',
+	);
+
+	return sqlStatements;
+};
+
+export const pushSchema = async (
+	imports: Record<string, unknown>,
+	drizzleInstance: MsSqlDatabase<any, any>,
+	entitiesConfig?: EntitiesFilterConfig,
+	migrationsConfig?: {
+		table?: string;
+		schema?: string;
+	},
+) => {
+	const { prepareEntityFilter } = await import('src/dialects/pull-utils');
+	const { resolver } = await import('../cli/prompts');
+	const { fromDatabaseForDrizzle } = await import('src/dialects/mssql/introspect');
+	const { fromDrizzleSchema, fromExports } = await import('../dialects/mssql/drizzle');
+	const { suggestions } = await import('../cli/commands/push-mssql');
+	const { extractMssqlExisting } = await import('../dialects/drizzle');
+	const { ddlDiff } = await import('../dialects/mssql/diff');
+	const { sql } = await import('drizzle-orm');
+
+	const migrations = {
+		schema: migrationsConfig?.schema || 'dbo',
+		table: migrationsConfig?.table || '__drizzle_migrations',
+	};
+
+	const db: DB = {
+		query: async (query: string, _params?: any[]) => {
+			const res = await drizzleInstance.execute(sql.raw(query));
+			return (res as any).recordset ?? res;
+		},
+	};
+	const prepared = fromExports(imports);
+
+	const filterConfig = entitiesConfig ?? {
+		tables: [],
+		schemas: [],
+		extensions: [],
+		entities: undefined,
+	} satisfies EntitiesFilterConfig;
+	const existing = extractMssqlExisting(prepared.schemas, prepared.views);
+	const filter = prepareEntityFilter('mssql', filterConfig, existing);
+
+	const prev = await fromDatabaseForDrizzle(db, filter, () => {}, migrations);
+
+	const { schema: cur } = fromDrizzleSchema(prepared, filter);
+
+	const { ddl: from, errors: _err1 } = interimToDDL(prev);
+	const { ddl: to, errors: _err2 } = interimToDDL(cur);
+
+	const { sqlStatements, statements } = await ddlDiff(
+		from,
+		to,
+		resolver<Schema>('schema', 'dbo'),
+		resolver<MssqlEntities['tables']>('table', 'dbo'),
+		resolver<Column>('column', 'dbo'),
+		resolver<View>('view', 'dbo'),
+		resolver<UniqueConstraint>('unique', 'dbo'),
+		resolver<Index>('index', 'dbo'),
+		resolver<CheckConstraint>('check', 'dbo'),
+		resolver<PrimaryKey>('primary key', 'dbo'),
+		resolver<ForeignKey>('foreign key', 'dbo'),
+		resolver<DefaultConstraint>('default', 'dbo'),
+		'push',
+	);
+
+	const hints = await suggestions(db, statements, to);
+
+	return {
+		sqlStatements,
+		hints,
+		apply: async () => {
+			const losses = hints.map((x) => x.statement).filter((x) => typeof x !== 'undefined');
+			for (const st of losses) {
+				await db.query(st);
+			}
+			for (const st of sqlStatements) {
+				await db.query(st);
+			}
+		},
+	};
+};
+
+export const startStudioServer = async (
+	_imports: Record<string, unknown>,
+	_credentials: MssqlCredentials,
+	_options?: {
+		host?: string;
+		port?: number;
+		key?: string;
+		cert?: string;
+	},
+) => {
+	throw new Error('Studio for MSSQL is not yet supported');
+};
+
+export const up = upToV2;

--- a/drizzle-kit/src/ext/api-mysql.ts
+++ b/drizzle-kit/src/ext/api-mysql.ts
@@ -1,6 +1,115 @@
 import type { Relations } from 'drizzle-orm/_relations';
 import type { AnyMySqlTable } from 'drizzle-orm/mysql-core';
+import type { Column, Table, View } from '../dialects/mysql/ddl';
+import { createDDL, interimToDDL } from '../dialects/mysql/ddl';
+import type { MysqlSnapshot } from '../dialects/mysql/snapshot';
+import { originUUID } from '../utils';
+import type { DB } from '../utils';
 import type { MysqlCredentials } from 'src/cli/validations/mysql';
+
+export const generateDrizzleJson = async (
+	imports: Record<string, unknown>,
+	prevId?: string,
+): Promise<MysqlSnapshot> => {
+	const { mysqlSchemaError } = await import('../cli/views');
+	const { toJsonSnapshot } = await import('../dialects/mysql/snapshot');
+	const { fromDrizzleSchema } = await import('../dialects/mysql/drizzle');
+	const { prepareFromExports } = await import('../dialects/mysql/drizzle');
+	const prepared = prepareFromExports(imports);
+
+	const interim = fromDrizzleSchema(prepared.tables, prepared.views);
+
+	const { ddl, errors } = interimToDDL(interim);
+
+	if (errors.length > 0) {
+		console.log(errors.map((it) => mysqlSchemaError(it)).join('\n'));
+		process.exit(1);
+	}
+
+	return toJsonSnapshot(ddl, prevId ? [prevId] : [originUUID], []);
+};
+
+export const generateMigration = async (
+	prev: MysqlSnapshot,
+	cur: MysqlSnapshot,
+) => {
+	const { resolver } = await import('../cli/prompts');
+	const { ddlDiff } = await import('../dialects/mysql/diff');
+	const from = createDDL();
+	const to = createDDL();
+
+	for (const it of prev.ddl) {
+		from.entities.push(it);
+	}
+	for (const it of cur.ddl) {
+		to.entities.push(it);
+	}
+
+	const { sqlStatements } = await ddlDiff(
+		from,
+		to,
+		resolver<Table>('table'),
+		resolver<Column>('column'),
+		resolver<View>('view'),
+		'default',
+	);
+
+	return sqlStatements;
+};
+
+export const pushSchema = async (
+	imports: Record<string, unknown>,
+	db: DB,
+	database: string,
+	migrationsConfig?: {
+		table?: string;
+		schema?: string;
+	},
+) => {
+	const { resolver } = await import('../cli/prompts');
+	const { fromDatabaseForDrizzle } = await import('src/dialects/mysql/introspect');
+	const { fromDrizzleSchema, prepareFromExports } = await import('../dialects/mysql/drizzle');
+	const { suggestions } = await import('../cli/commands/push-mysql');
+	const { ddlDiff } = await import('../dialects/mysql/diff');
+
+	const migrations = {
+		schema: migrationsConfig?.schema || '',
+		table: migrationsConfig?.table || '__drizzle_migrations',
+	};
+
+	const prepared = prepareFromExports(imports);
+
+	const prev = await fromDatabaseForDrizzle(db, database, () => true, () => {}, migrations);
+	const cur = fromDrizzleSchema(prepared.tables, prepared.views);
+
+	const { ddl: from } = interimToDDL(prev);
+	const { ddl: to, errors: _err2 } = interimToDDL(cur);
+
+	const { sqlStatements, statements } = await ddlDiff(
+		from,
+		to,
+		resolver<Table>('table'),
+		resolver<Column>('column'),
+		resolver<View>('view'),
+		'push',
+	);
+
+	const hints = await suggestions(db, statements, to);
+
+	return {
+		sqlStatements,
+		hints,
+		apply: async () => {
+			const losses = hints.map((x) => x.statement).filter((x) => typeof x !== 'undefined');
+			for (const st of losses) {
+				await db.query(st);
+			}
+			for (const st of sqlStatements) {
+				await db.query(st);
+			}
+		},
+	};
+};
 
 export const startStudioServer = async (
 	imports: Record<string, unknown>,
@@ -51,3 +160,5 @@ export const startStudioServer = async (
 		},
 	});
 };
+
+export { upToV6 as up } from '../cli/commands/up-mysql';

--- a/drizzle-kit/src/ext/api-sqlite.ts
+++ b/drizzle-kit/src/ext/api-sqlite.ts
@@ -1,7 +1,108 @@
 /// <reference types="@cloudflare/workers-types" />
 import type { Relations } from 'drizzle-orm/_relations';
 import type { AnySQLiteTable } from 'drizzle-orm/sqlite-core';
+import type { Column, Table } from '../dialects/sqlite/ddl';
+import { createDDL, interimToDDL } from '../dialects/sqlite/ddl';
+import type { SqliteSnapshot } from '../dialects/sqlite/snapshot';
+import { originUUID } from '../utils';
+import type { SQLiteClient } from '../utils';
 import type { SqliteCredentials } from 'src/cli/validations/sqlite';
+
+export const generateDrizzleJson = async (
+	imports: Record<string, unknown>,
+	prevId?: string,
+): Promise<SqliteSnapshot> => {
+	const { randomUUID } = await import('crypto');
+	const { sqliteSchemaError } = await import('../cli/views');
+	const { toJsonSnapshot } = await import('../dialects/sqlite/snapshot');
+	const { fromDrizzleSchema, fromExports } = await import('../dialects/sqlite/drizzle');
+	const prepared = fromExports(imports);
+
+	const interim = fromDrizzleSchema(prepared.tables, prepared.views);
+
+	const { ddl, errors } = interimToDDL(interim);
+
+	if (errors.length > 0) {
+		console.log(errors.map((it) => sqliteSchemaError(it)).join('\n'));
+		process.exit(1);
+	}
+
+	return toJsonSnapshot(ddl, randomUUID(), prevId ? [prevId] : [originUUID], []);
+};
+
+export const generateMigration = async (
+	prev: SqliteSnapshot,
+	cur: SqliteSnapshot,
+) => {
+	const { resolver } = await import('../cli/prompts');
+	const { ddlDiff } = await import('../dialects/sqlite/diff');
+	const from = createDDL();
+	const to = createDDL();
+
+	for (const it of prev.ddl) {
+		from.entities.push(it);
+	}
+	for (const it of cur.ddl) {
+		to.entities.push(it);
+	}
+
+	const { sqlStatements } = await ddlDiff(
+		from,
+		to,
+		resolver<Table>('table'),
+		resolver<Column>('column'),
+		'default',
+	);
+
+	return sqlStatements;
+};
+
+export const pushSchema = async (
+	imports: Record<string, unknown>,
+	db: SQLiteClient,
+	migrationsConfig?: {
+		table?: string;
+		schema?: string;
+	},
+) => {
+	const { resolver } = await import('../cli/prompts');
+	const { fromDatabaseForDrizzle } = await import('src/dialects/sqlite/introspect');
+	const { fromDrizzleSchema, fromExports } = await import('../dialects/sqlite/drizzle');
+	const { suggestions } = await import('../cli/commands/push-sqlite');
+	const { ddlDiff } = await import('../dialects/sqlite/diff');
+
+	const migrations = {
+		schema: migrationsConfig?.schema || '',
+		table: migrationsConfig?.table || '__drizzle_migrations',
+	};
+
+	const prepared = fromExports(imports);
+
+	const prev = await fromDatabaseForDrizzle(db, () => true, () => {}, migrations);
+	const cur = fromDrizzleSchema(prepared.tables, prepared.views);
+
+	const { ddl: from } = interimToDDL(prev);
+	const { ddl: to, errors: _err2 } = interimToDDL(cur);
+
+	const { sqlStatements, statements } = await ddlDiff(
+		from,
+		to,
+		resolver<Table>('table'),
+		resolver<Column>('column'),
+		'push',
+	);
+
+	const hints = await suggestions(db, statements);
+
+	return {
+		sqlStatements,
+		hints,
+		apply: async () => {
+			const losses = hints.map((x) => x.statement).filter((x) => typeof x !== 'undefined');
+			await db.batch([...losses, ...sqlStatements]);
+		},
+	};
+};
 
 export const startStudioServer = async (
 	imports: Record<string, unknown>,
@@ -55,3 +156,5 @@ export const startStudioServer = async (
 		},
 	});
 };
+
+export { updateToV7 as up } from '../cli/commands/up-sqlite';


### PR DESCRIPTION
## Summary

- Add `drizzle-kit/api-mssql` entry point exposing `generateDrizzleJson`, `generateMigration`, `pushSchema`, `up`, and `startStudioServer` — unblocking Payload's `db-mssql` adapter which needs programmatic access to the snapshot/migration/push pipeline
- Restore `generateDrizzleJson`, `generateMigration`, `pushSchema`, `up` exports to `api-sqlite` and `api-mysql` (dropped in 1.x, only had `startStudioServer`)
- Export `fromExports` from `src/dialects/mssql/drizzle.ts` (was private `fromExport`)
- Register `api-mssql` in both build systems (`build.ts`, `scripts/build.ts`) and `package.json` exports
- Add `mssql` to the external drivers list

## Context

Payload CMS uses drizzle-kit's programmatic API (`generateDrizzleJson`, `generateMigration`, `pushSchema`) to power its database adapter pattern. In drizzle-kit 1.x, only `api-postgres` retained these exports — `api-sqlite` and `api-mysql` were reduced to `startStudioServer` only, and `api-mssql` didn't exist at all. This blocks both the Payload drizzle-kit upgrade and the new `db-mssql` adapter.

All three new API surfaces follow the exact same pattern as the existing `api-postgres.ts`, adapted for each dialect's resolver set, snapshot shape, and introspection interface.

## Test plan

Verified locally:

- [x] `pnpm build` succeeds — all API bundles (CJS + ESM) and declaration files produced
- [x] All 5 exports (`generateDrizzleJson`, `generateMigration`, `pushSchema`, `startStudioServer`, `up`) resolve in CJS, ESM, and `.d.ts` for all three dialects
- [x] `generateDrizzleJson` + `generateMigration` round-trip: empty→schema produces correct `CREATE TABLE` for MSSQL, SQLite, MySQL
- [x] `generateDrizzleJson` + `generateMigration` diff: v1→v2 schema produces correct `ALTER TABLE ... ADD` for all three dialects
- [x] `pushSchema` against live in-memory SQLite: create table, add column (data preserved), no-op on re-push
- [x] `up` functions resolve to correct version upgraders (`upToV2` MSSQL, `updateToV7` SQLite, `upToV6` MySQL)