### PR TITLE
[Pg-kit] collect enums from table columns when not directly exported

### DIFF
--- a/drizzle-kit/src/serializer/pgImports.ts
+++ b/drizzle-kit/src/serializer/pgImports.ts
@@ -1,4 +1,4 @@
-import { is } from 'drizzle-orm';
+import { getTableColumns, is } from 'drizzle-orm';
 import type { AnyPgTable, PgEnum, PgMaterializedView, PgSequence, PgView } from 'drizzle-orm/pg-core';
 import {
 	isPgEnum,
@@ -62,6 +62,18 @@ export const prepareFromExports = (exports: Record<string, unknown>) => {
 			relations.push(t);
 		}
 	});
+
+	// Collect enums referenced by table columns that were not directly exported.
+	// This handles the case where enums are defined in a separate file and imported
+	// into the schema file without being re-exported.
+	for (const table of tables) {
+		for (const column of Object.values(getTableColumns(table))) {
+			const enumCol = column as any;
+			if (enumCol.enum !== undefined && isPgEnum(enumCol.enum) && !enums.includes(enumCol.enum)) {
+				enums.push(enumCol.enum);
+			}
+		}
+	}
 
 	return { tables, enums, schemas, sequences, views, matViews, roles, policies, relations };
 };

--- a/drizzle-kit/tests/pg-imports.test.ts
+++ b/drizzle-kit/tests/pg-imports.test.ts
@@ -1,0 +1,48 @@
+import { pgEnum, pgTable, text } from 'drizzle-orm/pg-core';
+import { expect, test } from 'vitest';
+import { prepareFromExports } from 'src/serializer/pgImports';
+
+test('prepareFromExports: collects enums used in table columns but not directly exported', () => {
+	// Simulates the pattern where enums are defined in a separate file (e.g. enums.ts)
+	// and imported into schema.ts for use in tables, but not re-exported from schema.ts.
+	// drizzle-kit push reads only the direct exports of the schema file, so without this
+	// fix the enums would be invisible and CREATE TYPE statements would be omitted.
+
+	const statusEnum = pgEnum('status', ['active', 'inactive', 'banned']);
+	const roleEnum = pgEnum('role', ['admin', 'user']);
+
+	const users = pgTable('users', {
+		id: text('id').primaryKey(),
+		status: statusEnum('status').notNull(),
+		role: roleEnum('role').notNull(),
+	});
+
+	// Exports object does NOT include the enums — only the table (as would happen
+	// when enums.ts exports the enums but schema.ts does not re-export them)
+	const exportsWithoutEnums = { users };
+
+	const { tables, enums } = prepareFromExports(exportsWithoutEnums);
+
+	expect(tables).toHaveLength(1);
+	expect(enums).toHaveLength(2);
+
+	const enumNames = enums.map((e) => e.enumName).sort();
+	expect(enumNames).toEqual(['role', 'status']);
+});
+
+test('prepareFromExports: does not duplicate enums that are both exported and used in columns', () => {
+	const statusEnum = pgEnum('status', ['active', 'inactive']);
+
+	const users = pgTable('users', {
+		id: text('id').primaryKey(),
+		status: statusEnum('status').notNull(),
+	});
+
+	// Both the enum and the table are exported (the normal case)
+	const exportsWithBoth = { statusEnum, users };
+
+	const { enums } = prepareFromExports(exportsWithBoth);
+
+	expect(enums).toHaveLength(1);
+	expect(enums[0].enumName).toBe('status');
+});


### PR DESCRIPTION
## Problem

When enums are defined in a separate file (e.g. `enums.ts`) and imported into `schema.ts` only for use in table columns — without being re-exported — `prepareFromExports` never sees them.

`generatePgSnapshot` then receives `enums = []`, so pushing to a clean database emits the `CREATE TABLE` statements that reference the types but skips the `CREATE TYPE` statements entirely, producing:

```
PostgresError: type "my_enum" does not exist
```

This is a common pattern: splitting schema definitions across multiple files is encouraged in the drizzle docs, and there is no obvious reason a user would know they must re-export every enum that a table column references.

## Root cause

`prepareFromExports` only scans `Object.values(exports)`. Enums that are imported transitively (used in columns but not re-exported) are never present in that object.

## Fix

After collecting tables, walk each table's columns via `getTableColumns` (already imported). If a column carries a `.enum` property that satisfies `isPgEnum` (already imported) and the enum hasn't been collected yet, add it to the list.

```ts
for (const table of tables) {
  for (const column of Object.values(getTableColumns(table))) {
    const enumCol = column as any;
    if (enumCol.enum !== undefined && isPgEnum(enumCol.enum) && !enums.includes(enumCol.enum)) {
      enums.push(enumCol.enum);
    }
  }
}
```

No new imports or dependencies required.

## Tests

Added `drizzle-kit/tests/pg-imports.test.ts` with two cases:

1. **Enum used in column but not exported** → must be found
2. **Enum both exported and used in column** → must not be duplicated