### PR TITLE
fix(orm): avoid nullifying nested objects when later fields are non-null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -47,10 +47,12 @@ export function mapResultRow<TResult>(
 						const objectName = path[0]!;
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
-						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
-						) {
-							nullifyMap[objectName] = false;
+						} else if (typeof nullifyMap[objectName] === 'string') {
+							if (value !== null) {
+								nullifyMap[objectName] = false;
+							} else if (nullifyMap[objectName] !== getTableName(field.table)) {
+								nullifyMap[objectName] = false;
+							}
 						}
 					}
 				}

--- a/drizzle-orm/tests/mapResultRow.nullify-nested.test.ts
+++ b/drizzle-orm/tests/mapResultRow.nullify-nested.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest';
+
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+test('mapResultRow does not nullify nested objects when at least one nested field is non-null', () => {
+	const orgTable = pgTable('org', {
+		name: text('name'),
+		slug: text('slug'),
+	});
+
+	const orgBrandingTable = pgTable('org_branding', {
+		logo: text('logo'),
+		panelBackground: text('panel_background_colour'),
+	});
+
+	const fields = {
+		name: orgTable.name,
+		slug: orgTable.slug,
+		branding: {
+			// bug reproduction: first nested value is null, second is not
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	};
+
+	const columns = orderSelectedFields(fields);
+	const row = ['Test org 2', 'test-org-2', null, '#1a8cff'];
+
+	const result = mapResultRow<typeof fields>(
+		columns,
+		row,
+		{
+			org: true,
+			org_branding: false, // left join -> nullable
+		},
+	);
+
+	expect(result).toEqual({
+		name: 'Test org 2',
+		slug: 'test-org-2',
+		branding: {
+			logo: null,
+			panelBackground: '#1a8cff',
+		},
+	});
+});
+


### PR DESCRIPTION
Fixes #1603.

Root cause: `mapResultRow` could nullify a nested object based on an earlier null field even when later fields from the same joined table were non-null.

Adds regression coverage: `drizzle-orm/tests/mapResultRow.nullify-nested.test.ts`.