### PR TITLE
Keep table qualifiers for sql fields referencing other tables

### DIFF
--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -226,7 +226,9 @@ export class MySqlDialect {
 			} else if (is(field, SQL.Aliased) || is(field, SQL)) {
 				const query = is(field, SQL.Aliased) ? field.sql : field;
 
-				if (isSingleTable) {
+				// Drop the table prefix for bare column refs in a single-table select, but keep it
+				// when the expression references another table (e.g. a correlated subquery).
+				if (isSingleTable && query.usedTables.length === 0) {
 					chunk.push(
 						new SQL(
 							query.queryChunks.map((c) => {

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -223,7 +223,9 @@ export class PgDialect {
 				} else if (is(field, SQL.Aliased) || is(field, SQL)) {
 					const query = is(field, SQL.Aliased) ? field.sql : field;
 
-					if (isSingleTable) {
+					// Drop the table prefix for bare column refs in a single-table select, but keep it
+					// when the expression references another table (e.g. a correlated subquery).
+					if (isSingleTable && query.usedTables.length === 0) {
 						chunk.push(
 							new SQL(
 								query.queryChunks.map((c) => {

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -225,7 +225,9 @@ export class SingleStoreDialect {
 			} else if (is(field, SQL.Aliased) || is(field, SQL)) {
 				const query = is(field, SQL.Aliased) ? field.sql : field;
 
-				if (isSingleTable) {
+				// Drop the table prefix for bare column refs in a single-table select, but keep it
+				// when the expression references another table (e.g. a correlated subquery).
+				if (isSingleTable && query.usedTables.length === 0) {
 					chunk.push(
 						new SQL(
 							query.queryChunks.map((c) => {

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -189,7 +189,9 @@ export abstract class SQLiteDialect {
 			} else if (is(field, SQL.Aliased) || is(field, SQL)) {
 				const query = is(field, SQL.Aliased) ? field.sql : field;
 
-				if (isSingleTable) {
+				// Drop the table prefix for bare column refs in a single-table select, but keep it
+				// when the expression references another table (e.g. a correlated subquery).
+				if (isSingleTable && query.usedTables.length === 0) {
 					chunk.push(
 						new SQL(
 							query.queryChunks.map((c) => {

--- a/integration-tests/tests/mysql/mysql-common.ts
+++ b/integration-tests/tests/mysql/mysql-common.ts
@@ -1146,6 +1146,26 @@ export function tests(driver?: string) {
 			});
 		});
 
+		test('build query: sql field keeps table qualifiers in correlated subquery', async (ctx) => {
+			const { db } = ctx.mysql;
+
+			const a = mysqlTable('a', { id: int('id').primaryKey(), cId: int('c_id').notNull() });
+			const b = mysqlTable('b', { cId: int('c_id').notNull(), label: varchar('label', { length: 255 }).notNull() });
+
+			const query = db
+				.select({
+					id: a.id,
+					label: sql`select ${b.label} from ${b} where ${b.cId} = ${a.cId} limit 1`,
+				})
+				.from(a)
+				.toSQL();
+
+			expect(query).toEqual({
+				sql: 'select `id`, select `b`.`label` from `b` where `b`.`c_id` = `a`.`c_id` limit 1 from `a`',
+				params: [],
+			});
+		});
+
 		test('Query check: Insert all defaults in 1 row', async (ctx) => {
 			const { db } = ctx.mysql;
 

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -1161,6 +1161,26 @@ export function tests() {
 			});
 		});
 
+		test('build query: sql field keeps table qualifiers in correlated subquery', async (ctx) => {
+			const { db } = ctx.pg;
+
+			const a = pgTable('a', { id: integer('id').primaryKey(), cId: integer('c_id').notNull() });
+			const b = pgTable('b', { cId: integer('c_id').notNull(), label: text('label').notNull() });
+
+			const query = db
+				.select({
+					id: a.id,
+					label: sql`select ${b.label} from ${b} where ${b.cId} = ${a.cId} limit 1`,
+				})
+				.from(a)
+				.toSQL();
+
+			expect(query).toEqual({
+				sql: 'select "id", select "b"."label" from "b" where "b"."c_id" = "a"."c_id" limit 1 from "a"',
+				params: [],
+			});
+		});
+
 		test('insert sql', async (ctx) => {
 			const { db } = ctx.pg;
 

--- a/integration-tests/tests/sqlite/sqlite-common.ts
+++ b/integration-tests/tests/sqlite/sqlite-common.ts
@@ -1120,6 +1120,26 @@ export function tests() {
 			});
 		});
 
+		test('build query: sql field keeps table qualifiers in correlated subquery', async (ctx) => {
+			const { db } = ctx.sqlite;
+
+			const a = sqliteTable('a', { id: integer('id').primaryKey(), cId: integer('c_id').notNull() });
+			const b = sqliteTable('b', { cId: integer('c_id').notNull(), label: text('label').notNull() });
+
+			const query = db
+				.select({
+					id: a.id,
+					label: sql`select ${b.label} from ${b} where ${b.cId} = ${a.cId} limit 1`,
+				})
+				.from(a)
+				.toSQL();
+
+			expect(query).toEqual({
+				sql: 'select "id", select "b"."label" from "b" where "b"."c_id" = "a"."c_id" limit 1 from "a"',
+				params: [],
+			});
+		});
+
 		test('insert via db.run + select via db.all', async (ctx) => {
 			const { db } = ctx.sqlite;
 


### PR DESCRIPTION
Fixes #5734

## Problem

When a raw `sql` expression is used as a selected field in a single-table
select, Drizzle strips the table qualifier from every column inside that
expression. For a bare reference to the queried table that is harmless,
but it also rewrites columns that belong to another table — e.g. a
correlated subquery written directly in the field list. The condition

```sql
`b`.`c_id` = `a`.`c_id`
```

is emitted as

```sql
`c_id` = `c_id`
```

which is always true, so the query compiles and runs but silently returns
wrong results. The same `sql` chunk renders correctly when used in
`.where(...)`.

```ts
const raw = sql`select ${tableB.label} from ${tableB} where ${tableB.cId} = ${tableA.cId} limit 1`;

db.select({ id: tableA.id, bRaw: raw }).from(tableA).toSQL().sql;
// before: select `id`, select `label` from `b` where `c_id` = `c_id` limit 1 from `a`
// after:  select `id`, select `b`.`label` from `b` where `b`.`c_id` = `a`.`c_id` limit 1 from `a`
```

## Root cause

`buildSelection` applies the single-table optimization by walking the
expression's top-level `queryChunks` and replacing **every** column chunk
with an unqualified identifier. When a column written inline references a
different table, that qualifier is required and must not be dropped.

## Fix

Only strip the qualifier when the expression does not reference another
table, i.e. its `usedTables` is empty. A bare same-table column reference
keeps the optimization (`select id from a`), while an expression that
pulls in another table is left untouched and renders with qualifiers,
matching how the same chunk already renders in `where`.

The same buggy branch existed in the pg, mysql, sqlite and singlestore
dialects, so the change is applied to all four. gel-core already disables
this optimization and is unaffected.

## Tests

Added a `build query` regression test to the pg, mysql and sqlite common
suites asserting that a correlated subquery in a single-table select's
field list keeps its table qualifiers. The test fails before the change
and passes after it. The existing `build query` test (which covers the
plain-column optimization) still passes.