### PR TITLE
feat(orm): allow customType selectFromDb SQL transforms

### DIFF
--- a/SUBMISSION_PACKET_1083.md
+++ b/SUBMISSION_PACKET_1083.md
@@ -1,0 +1,51 @@
+# Drizzle ORM bounty submission packet (Issue #1083)
+
+Local repo:
+
+- `/Users/mavenai/Desktop/Singaw Sity Labs/Singaw Sity Codex/bounty-work/drizzle-orm-1603`
+- Branch: `feat/bounty-1083-customtype-selectfromdb`
+
+Public references:
+
+- GitHub issue: https://github.com/drizzle-team/drizzle-orm/issues/1083
+- Algora funding page (sponsor): https://algora.io/Seated/home
+
+## What’s implemented
+
+- Adds `selectFromDb` to `customType(...)` params for all supported dialects.
+- Uses `selectFromDb` during query selection generation so custom types can transform values in SQL before driver decoding.
+- Adds test: `drizzle-orm/tests/customTypeSelectFromDb.test.ts`.
+- Updates docs:
+  - `docs/custom-types.lite.md`
+  - `docs/custom-types.md`
+
+## How to verify
+
+```bash
+cd "/Users/mavenai/Desktop/Singaw Sity Labs/Singaw Sity Codex/bounty-work/drizzle-orm-1603"
+npx -y pnpm@10.6.3 -C drizzle-orm test -- --run customTypeSelectFromDb
+```
+
+## Suggested PR title
+
+`feat(orm): allow customType selectFromDb SQL transforms`
+
+## Suggested PR body
+
+- Addresses `drizzle-team/drizzle-orm#1083`.
+- Adds a new optional `selectFromDb` hook to `customType(...)` that lets custom columns customize how they are selected (useful for types requiring SQL transforms such as PostGIS geometries).
+- Includes a unit test and doc updates.
+
+## How to push branch (already safe if credentials are configured)
+
+```bash
+cd "/Users/mavenai/Desktop/Singaw Sity Labs/Singaw Sity Codex/bounty-work/drizzle-orm-1603"
+git push -u fork feat/bounty-1083-customtype-selectfromdb
+```
+
+## How to open the PR (user action)
+
+Open this compare URL (edit if GitHub suggests a different base):
+
+- https://github.com/drizzle-team/drizzle-orm/compare/main...TheDerbiedOne:feat/bounty-1083-customtype-selectfromdb?expand=1
+

--- a/docs/custom-types.lite.md
+++ b/docs/custom-types.lite.md
@@ -81,6 +81,25 @@ const customTimestamp = customType<
 });
 ```
 
+#### Selecting values with SQL transformation (`selectFromDb`)
+
+Some database types need an SQL transform to become decodable by the driver (e.g. PostGIS geometries).
+For those cases you can customize how a custom column is selected via `selectFromDb`:
+
+```typescript
+type Point = { lat: number; lng: number };
+
+const pointType = customType<{ data: Point; driverData: string }>({
+  dataType: () => 'geometry(Point,4326)',
+  selectFromDb: (column) => sql<string>`st_astext(${column})`.mapWith(column),
+  fromDriver: (value: string): Point => {
+    const matches = value.match(/POINT\\((?<lng>[\\d.-]+) (?<lat>[\\d.-]+)\\)/);
+    const { lat, lng } = matches?.groups ?? {};
+    return { lat: parseFloat(String(lat)), lng: parseFloat(String(lng)) };
+  },
+});
+```
+
 #### Usage for all types will be same as defined functions in Drizzle ORM
 
 ```typescript

--- a/docs/custom-types.md
+++ b/docs/custom-types.md
@@ -54,6 +54,10 @@ Column class has set of types/functions, that could be overridden to get needed 
 
 - `mapFromDriverValue()` - interceptor between database and select query execution. If you want to modify/map/change value for specific data type, it could be done here
 
+> [!NOTE]
+> If the driver returns a value that can only be decoded after applying an SQL transform (for example, PostGIS geometries),
+> use `selectFromDb` in `customType(...)` to customize how the column is selected.
+
 #### Usage example for jsonb type
 
 ```typescript

--- a/drizzle-orm/src/gel-core/columns/custom.ts
+++ b/drizzle-orm/src/gel-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: GelCustomColumn<T>) => SQL;
 
 	constructor(
 		table: AnyGelTable<{ name: T['tableName'] }>,
@@ -72,10 +73,16 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSQLSelect(): SQL | undefined {
+		return this.selectFromDb?.(this);
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +202,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 */
+	selectFromDb?: (column: GelCustomColumn<any>) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -240,7 +240,8 @@ export class GelDialect {
 					// if (isSingleTable) {
 					// 	chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
 					// } else {
-					chunk.push(field);
+					const fieldSelectSql = (field as any).getSQLSelect?.() as SQL | undefined;
+					chunk.push(fieldSelectSql ?? field);
 					// }
 				} else if (is(field, Subquery)) {
 					const entries = Object.entries(field._.selectedFields) as [string, SQL.Aliased | Column | SQL][];

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: MySqlCustomColumn<T>) => SQL;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -72,10 +73,16 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSQLSelect(): SQL | undefined {
+		return this.selectFromDb?.(this);
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +202,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 */
+	selectFromDb?: (column: MySqlCustomColumn<any>) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -245,7 +245,23 @@ export class MySqlDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
+				const fieldSelectSql = (field as any).getSQLSelect?.() as SQL | undefined;
+				if (fieldSelectSql) {
+					if (isSingleTable) {
+						chunk.push(
+							new SQL(
+								fieldSelectSql.queryChunks.map((c) => {
+									if (is(c, MySqlColumn)) {
+										return sql.identifier(this.casing.getColumnCasing(c));
+									}
+									return c;
+								}),
+							),
+						);
+					} else {
+						chunk.push(fieldSelectSql);
+					}
+				} else if (isSingleTable) {
 					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
 				} else {
 					chunk.push(field);

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: PgCustomColumn<T>) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,10 +73,16 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSQLSelect(): SQL | undefined {
+		return this.selectFromDb?.(this);
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +202,13 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 *
+	 * This is useful for cases where the driver returns a value that can't be decoded without transforming it in SQL first.
+	 */
+	selectFromDb?: (column: PgCustomColumn<any>) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -242,7 +242,23 @@ export class PgDialect {
 						chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 					}
 				} else if (is(field, Column)) {
-					if (isSingleTable) {
+					const fieldSelectSql = (field as any).getSQLSelect?.() as SQL | undefined;
+					if (fieldSelectSql) {
+						if (isSingleTable) {
+							chunk.push(
+								new SQL(
+									fieldSelectSql.queryChunks.map((c) => {
+										if (is(c, PgColumn)) {
+											return sql.identifier(this.casing.getColumnCasing(c));
+										}
+										return c;
+									}),
+								),
+							);
+						} else {
+							chunk.push(fieldSelectSql);
+						}
+					} else if (isSingleTable) {
 						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
 					} else {
 						chunk.push(field);

--- a/drizzle-orm/src/singlestore-core/columns/custom.ts
+++ b/drizzle-orm/src/singlestore-core/columns/custom.ts
@@ -66,6 +66,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: SingleStoreCustomColumn<T>) => SQL;
 
 	constructor(
 		table: AnySingleStoreTable<{ name: T['tableName'] }>,
@@ -75,10 +76,16 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSQLSelect(): SQL | undefined {
+		return this.selectFromDb?.(this);
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -198,6 +205,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 */
+	selectFromDb?: (column: SingleStoreCustomColumn<any>) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -244,7 +244,23 @@ export class SingleStoreDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
+				const fieldSelectSql = (field as any).getSQLSelect?.() as SQL | undefined;
+				if (fieldSelectSql) {
+					if (isSingleTable) {
+						chunk.push(
+							new SQL(
+								fieldSelectSql.queryChunks.map((c) => {
+									if (is(c, SingleStoreColumn)) {
+										return sql.identifier(this.casing.getColumnCasing(c));
+									}
+									return c;
+								}),
+							),
+						);
+					} else {
+						chunk.push(fieldSelectSql);
+					}
+				} else if (isSingleTable) {
 					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
 				} else {
 					chunk.push(field);

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: SQLiteCustomColumn<T>) => SQL;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -72,10 +73,16 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSQLSelect(): SQL | undefined {
+		return this.selectFromDb?.(this);
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +202,11 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 */
+	selectFromDb?: (column: SQLiteCustomColumn<any>) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -208,24 +208,42 @@ export abstract class SQLiteDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				const tableName = field.table[Table.Symbol.Name];
-				if (field.columnType === 'SQLiteNumericBigInt') {
+				const fieldSelectSql = (field as any).getSQLSelect?.() as SQL | undefined;
+				if (fieldSelectSql) {
 					if (isSingleTable) {
 						chunk.push(
-							sql`cast(${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							new SQL(
+								fieldSelectSql.queryChunks.map((c) => {
+									if (is(c, Column)) {
+										return sql.identifier(this.casing.getColumnCasing(c));
+									}
+									return c;
+								}),
+							),
 						);
 					} else {
-						chunk.push(
-							sql`cast(${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
-						);
+						chunk.push(fieldSelectSql);
 					}
 				} else {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+					const tableName = field.table[Table.Symbol.Name];
+					if (field.columnType === 'SQLiteNumericBigInt') {
+						if (isSingleTable) {
+							chunk.push(
+								sql`cast(${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							);
+						} else {
+							chunk.push(
+								sql`cast(${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							);
+						}
 					} else {
-						chunk.push(
-							sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
-						);
+						if (isSingleTable) {
+							chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+						} else {
+							chunk.push(
+								sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
+							);
+						}
 					}
 				}
 			} else if (is(field, Subquery)) {

--- a/drizzle-orm/tests/customTypeSelectFromDb.test.ts
+++ b/drizzle-orm/tests/customTypeSelectFromDb.test.ts
@@ -1,0 +1,36 @@
+import { RDSDataClient } from '@aws-sdk/client-rds-data';
+import { expect, test } from 'vitest';
+
+import { drizzle } from '~/aws-data-api/pg';
+import { customType, PgDialect, pgTable } from '~/pg-core';
+import { sql } from '~/sql/sql';
+
+const db = drizzle(new RDSDataClient(), {
+	database: '',
+	resourceArn: '',
+	secretArn: '',
+});
+
+test('customType selectFromDb is used in selects', () => {
+	type Point = { lat: number; lng: number };
+
+	const pointType = customType<{ data: Point; driverData: string }>({
+		dataType: () => 'geometry(Point,4326)',
+		selectFromDb: (column) => sql<string>`st_astext(${column})`.mapWith(column),
+		fromDriver: (value) => {
+			const matches = value.match(/POINT\\((?<lng>[\\d.-]+) (?<lat>[\\d.-]+)\\)/);
+			const { lat, lng } = matches?.groups ?? {};
+			return { lat: parseFloat(String(lat)), lng: parseFloat(String(lng)) };
+		},
+	});
+
+	const t = pgTable('t', {
+		coords: pointType('coords'),
+	});
+
+	const q = db.select({ coords: t.coords }).from(t);
+	const query = new PgDialect().sqlToQuery(q.getSQL());
+
+	expect(query.sql).toContain('st_astext');
+});
+


### PR DESCRIPTION
Addresses drizzle-team/drizzle-orm#1083.

## Summary

This PR adds a new optional `selectFromDb` hook to `customType(...)`, allowing custom columns to customize how they are selected from the database before driver decoding.

This is useful for custom types that require SQL-level transformation when selected, such as PostGIS geometries.

## Changes

- Adds `selectFromDb` to custom type params across supported dialects.
- Uses `selectFromDb` during select query generation.
- Adds a test covering custom select SQL generation.
- Updates custom type documentation.

## Verification

Ran:

```bash
npx -y pnpm@10.6.3 -C drizzle-orm test -- --run customTypeSelectFromDb