### PR TITLE
fix(orm): keep nested partial-select object when leftJoin first column is null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -45,10 +45,12 @@ export function mapResultRow<TResult>(
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;
+						const tableName = getTableName(field.table);
 						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
+							nullifyMap[objectName] = value === null ? tableName : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== tableName || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/mapResultRow.test.ts
+++ b/drizzle-orm/tests/mapResultRow.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'vitest';
+
+import type { AnyColumn } from '~/column.ts';
+import type { SelectedFieldsOrdered } from '~/operations.ts';
+import { integer, pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const org = pgTable('org', {
+	id: integer('id').notNull(),
+	name: text('name').notNull(),
+	slug: text('slug').notNull(),
+});
+
+const branding = pgTable('org_branding', {
+	orgId: integer('org_id').notNull(),
+	logo: text('logo'),
+	panelBackground: text('panel_background_colour'),
+});
+
+const owner = pgTable('owner', {
+	id: integer('id').notNull(),
+	displayName: text('display_name'),
+});
+
+describe('mapResultRow — nested partial select with leftJoin (#1603)', () => {
+	test('regression: first nested column null, later non-null — object preserved', () => {
+		const columns: SelectedFieldsOrdered<AnyColumn> = [
+			{ path: ['name'], field: org.name },
+			{ path: ['slug'], field: org.slug },
+			{ path: ['branding', 'logo'], field: branding.logo },
+			{ path: ['branding', 'panelBackground'], field: branding.panelBackground },
+		];
+		const row = ['Test org 2', 'test-org-2', null, '#1a8cff'];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		expect(mapResultRow(columns, row, joinsNotNullableMap)).toEqual({
+			name: 'Test org 2',
+			slug: 'test-org-2',
+			branding: { logo: null, panelBackground: '#1a8cff' },
+		});
+	});
+
+	test('control: last nested column null, earlier non-null — object preserved', () => {
+		const columns: SelectedFieldsOrdered<AnyColumn> = [
+			{ path: ['name'], field: org.name },
+			{ path: ['branding', 'panelBackground'], field: branding.panelBackground },
+			{ path: ['branding', 'logo'], field: branding.logo },
+		];
+		const row = ['Test org', '#1a8cff', null];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		expect(mapResultRow(columns, row, joinsNotNullableMap)).toEqual({
+			name: 'Test org',
+			branding: { panelBackground: '#1a8cff', logo: null },
+		});
+	});
+
+	test('all nested columns null on nullable join — object nullified', () => {
+		const columns: SelectedFieldsOrdered<AnyColumn> = [
+			{ path: ['name'], field: org.name },
+			{ path: ['branding', 'logo'], field: branding.logo },
+			{ path: ['branding', 'panelBackground'], field: branding.panelBackground },
+		];
+		const row = ['Test org', null, null];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		expect(mapResultRow(columns, row, joinsNotNullableMap)).toEqual({
+			name: 'Test org',
+			branding: null,
+		});
+	});
+
+	test('all nested columns null on non-nullable join — object preserved', () => {
+		const columns: SelectedFieldsOrdered<AnyColumn> = [
+			{ path: ['name'], field: org.name },
+			{ path: ['branding', 'logo'], field: branding.logo },
+			{ path: ['branding', 'panelBackground'], field: branding.panelBackground },
+		];
+		const row = ['Test org', null, null];
+		const joinsNotNullableMap = { org: true, org_branding: true };
+
+		expect(mapResultRow(columns, row, joinsNotNullableMap)).toEqual({
+			name: 'Test org',
+			branding: { logo: null, panelBackground: null },
+		});
+	});
+
+	test('columns from multiple tables under same nested key — never nullified', () => {
+		const columns: SelectedFieldsOrdered<AnyColumn> = [
+			{ path: ['data', 'orgName'], field: org.name },
+			{ path: ['data', 'logo'], field: branding.logo },
+		];
+		const row = [null, null];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		expect(mapResultRow(columns, row, joinsNotNullableMap)).toEqual({
+			data: { orgName: null, logo: null },
+		});
+	});
+
+	test('two independent nested objects from different nullable tables', () => {
+		const columns: SelectedFieldsOrdered<AnyColumn> = [
+			{ path: ['name'], field: org.name },
+			{ path: ['branding', 'logo'], field: branding.logo },
+			{ path: ['branding', 'panelBackground'], field: branding.panelBackground },
+			{ path: ['owner', 'displayName'], field: owner.displayName },
+		];
+		const row = ['Test org', null, '#1a8cff', null];
+		const joinsNotNullableMap = { org: true, org_branding: false, owner: false };
+
+		expect(mapResultRow(columns, row, joinsNotNullableMap)).toEqual({
+			name: 'Test org',
+			branding: { logo: null, panelBackground: '#1a8cff' },
+			owner: null,
+		});
+	});
+
+	test('non-Column nested field (no row) — unchanged behaviour', () => {
+		const columns: SelectedFieldsOrdered<AnyColumn> = [
+			{ path: ['name'], field: org.name },
+			{ path: ['branding', 'logo'], field: branding.logo },
+		];
+		const row = ['Test org', null];
+
+		expect(mapResultRow(columns, row, undefined)).toEqual({
+			name: 'Test org',
+			branding: { logo: null },
+		});
+	});
+});


### PR DESCRIPTION
Closes #1603.

### Root cause

`mapResultRow` (`drizzle-orm/src/utils.ts`) builds a per-row `nullifyMap` that decides which nested-object paths should be replaced with `null` when their left-joined table didn't match. The flag for a path is set on the first column it sees being `null`, and only cleared when a column from a *different* table later appears under the same path.

When the second (and later) columns under that path come from the *same* nullable left-joined table, the existing branch isn't taken — even if those columns are non-null. So a select like:

```ts
db.select({
  name: org.name,
  branding: {
    logo: brand.logo,             // null in the joined row
    panelBackground: brand.panel, // "#1a8cff"
  },
}).from(org).leftJoin(brand, ...)
```

returns `branding: null` instead of `branding: { logo: null, panelBackground: "#1a8cff" }`. Swapping the column order in the select hides the bug, which matches every report on the issue.

### Fix

Also clear the flag when a non-null value arrives for the same path, not only on a table mismatch. Two-line condition change in `mapResultRow`:

```ts
} else if (
    typeof nullifyMap[objectName] === 'string'
    && (nullifyMap[objectName] !== tableName || value !== null)
) {
    nullifyMap[objectName] = false;
}
```

### Tests

New `drizzle-orm/tests/mapResultRow.test.ts` (`pnpm test` → 7 new, 573 total passing):

- repro from the issue (first nested col null, later non-null → object preserved)
- column-order control (last col null, earlier non-null → object preserved)
- all-null on nullable join → object nullified
- all-null on inner join → object preserved (join guarantees non-null)
- mixed-table nested keys → never nullified
- two independent nested objects with different null patterns
- non-Column field with no `joinsNotNullableMap` → unchanged behaviour

### Prior art

Equivalent one-line variants land in #1825 (2024), #5436, #5750, #5765, #5785, #5793. None of those PRs ship a regression-test file; the new test covers the surrounding invariants so the bug stays fixed under future refactors of `nullifyMap`.
