### PR TITLE
fix: type isNull and isNotNull as boolean in select queries

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -349,8 +349,8 @@ export function notInArray(
  *
  * @see isNotNull for the inverse of this test
  */
-export function isNull(value: SQLWrapper): SQL {
-	return sql`${value} is null`;
+export function isNull(value: SQLWrapper): SQL<boolean | null> {
+	return sql<boolean | null>`${value} is null`;
 }
 
 /**
@@ -369,8 +369,8 @@ export function isNull(value: SQLWrapper): SQL {
  *
  * @see isNull for the inverse of this test
  */
-export function isNotNull(value: SQLWrapper): SQL {
-	return sql`${value} is not null`;
+export function isNotNull(value: SQLWrapper): SQL<boolean | null> {
+	return sql<boolean | null>`${value} is not null`;
 }
 
 /**

--- a/drizzle-orm/type-tests/pg/is-null-select.ts
+++ b/drizzle-orm/type-tests/pg/is-null-select.ts
@@ -1,0 +1,21 @@
+import type { Equal } from 'type-tests/utils.ts';
+import { Expect } from 'type-tests/utils.ts';
+
+import { isNotNull } from '~/sql/expressions/index.ts';
+import { sql } from '~/sql/sql.ts';
+
+import { db } from './db.ts';
+import { users } from './tables.ts';
+
+const results = await db
+	.select({
+		id: users.id,
+		hasTitleOrm: isNotNull(users.name),
+		hasTitleSql: sql<boolean>`${users.name} IS NOT NULL`,
+	})
+	.from(users);
+
+type Result = (typeof results)[number];
+
+Expect<Equal<Result['hasTitleOrm'], boolean>>();
+Expect<Equal<Result['hasTitleSql'], boolean>>();


### PR DESCRIPTION
Fixes #1826. Minimal scope: only isNull/isNotNull return SQL<boolean | null>. Note: related to open #5226 - happy to close in favor of that if maintainers prefer.