### PR TITLE
drizzle-kit: load pg enums referenced from filtered schemas

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1069,6 +1069,7 @@ WHERE
 	}
 
 	const whereEnums = schemaFilters.map((t) => `n.nspname = '${t}'`).join(' or ');
+	const whereReferencedEnums = schemaFilters.map((t) => `ns.nspname = '${t}'`).join(' or ');
 
 	const allEnums = await db.query(
 		`select n.nspname as enum_schema,
@@ -1078,7 +1079,18 @@ WHERE
   from pg_type t
   join pg_enum e on t.oid = e.enumtypid
   join pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-  ${whereEnums === '' ? '' : ` WHERE ${whereEnums}`}
+  ${
+			whereEnums === '' ? '' : ` WHERE (${whereEnums}) OR t.oid IN (
+    SELECT a.atttypid
+    FROM pg_attribute a
+    JOIN pg_class cls ON cls.oid = a.attrelid
+    JOIN pg_namespace ns ON ns.oid = cls.relnamespace
+    WHERE cls.relkind IN ('r', 'v', 'm')
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+      AND (${whereReferencedEnums})
+  )`
+		}
   order by enum_schema, enum_name, sort_order;`,
 	);
 

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -408,6 +408,30 @@ test('introspect enum from different schema', async () => {
 	expect(sqlStatements.length).toBe(0);
 });
 
+test('introspect enum referenced from non-filtered schema', async () => {
+	const client = new PGlite();
+
+	const schema2 = pgSchema('schema2');
+	const myEnum = pgEnum('my_enum', ['a', 'b', 'c']);
+	const schema = {
+		schema2,
+		myEnum,
+		providers: schema2.table('providers', {
+			authType: myEnum('auth_type'),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'introspect-enum-referenced-from-non-filtered-schema',
+		['schema2'],
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
 test('introspect enum with same names across different schema', async () => {
 	const client = new PGlite();
 


### PR DESCRIPTION
## What

Broadens the `pg_enum` introspection query in `pgSerializer.fromDatabase` so it also returns enums referenced by columns in any table/view/materialized view inside `schemaFilters`, not only enums declared in those schemas.

## Why

The reported "SET STORAGE PLAIN" symptom in #5801 is incidental — the real bug is cross-schema enum references on Nile (and any setup that hides `public`).

`public.provider_auth_type` is declared in `public`, but `auth.oidc_providers.auth_type` references it. With `schemaFilter: ['auth']`, the enums query filters by `n.nspname = 'auth'`, so the enum is never loaded. The column then falls back to:

```ts
auth_type: unknown("auth_type")
// TODO: failed to parse database type 'provider_auth_type'
```

Pulling enums in by oid-reference fixes the introspection without changing what gets loaded when the enum's own schema is already in the filter. Empty-filter fall-through is preserved.

## Testing

- added `introspect enum referenced from non-filtered schema` in `drizzle-kit/tests/introspect/pg.test.ts` — declares `my_enum` in `public`, a `providers` table in `schema2` using it, runs `introspectPgToFile` with `['schema2']`, asserts no diff statements
- ran the new test plus all existing enum tests in that file: green
- ran the full `tests/introspect/pg.test.ts` suite: 35 passed, 1 todo
- `pnpm tsc` clean

## Notes

- The OR-branch widens enums loaded → these enums now appear as `export const ... = pgEnum(...)` declarations in the generated schema file. That's the intended outcome; the column wouldn't otherwise resolve.
- Scoped to enums — domain types are out of scope. Confirmed via `niledatabase/niledatabase` source that `provider_auth_type` is an enum.
- `cls.relkind IN ('r','v','m')` matches `getColumnsInfoQuery` so we only pull enums referenced by columns we actually introspect.

Fixes #5801.