### PR TITLE
[Orm] Skip executing fully-commented introspect migration files

### DIFF
--- a/changelogs/drizzle-orm/0.45.4.md
+++ b/changelogs/drizzle-orm/0.45.4.md
@@ -1,0 +1,1 @@
+- Fixed `migrate` crashing on the fully commented-out introspection SQL file produced by `drizzle-kit pull`. The file is now treated as a no-op and recorded as applied, matching what users were already doing manually (fixes #4851)

--- a/drizzle-orm/src/migrator.ts
+++ b/drizzle-orm/src/migrator.ts
@@ -41,9 +41,11 @@ export function readMigrationFiles(config: MigrationConfig): MigrationMeta[] {
 		try {
 			const query = fs.readFileSync(`${migrationFolderTo}/${journalEntry.tag}.sql`).toString();
 
-			const result = query.split('--> statement-breakpoint').map((it) => {
-				return it;
-			});
+			const result = isFullyCommentedIntrospectFile(query)
+				? []
+				: query.split('--> statement-breakpoint').map((it) => {
+					return it;
+				});
 
 			migrationQueries.push({
 				sql: result,
@@ -57,4 +59,29 @@ export function readMigrationFiles(config: MigrationConfig): MigrationMeta[] {
 	}
 
 	return migrationQueries;
+}
+
+// `drizzle-kit pull` emits introspect migrations as `-- ...` notes followed by
+// the entire schema wrapped in a single `/* ... */` block. Treat such files as
+// a no-op so they get marked applied without crashing the migrator.
+function isFullyCommentedIntrospectFile(query: string): boolean {
+	let body = query;
+	while (true) {
+		const trimmed = body.replace(/^\s+/, '');
+		if (trimmed.startsWith('--')) {
+			const newlineIdx = trimmed.indexOf('\n');
+			body = newlineIdx === -1 ? '' : trimmed.slice(newlineIdx + 1);
+			continue;
+		}
+		body = trimmed;
+		break;
+	}
+
+	body = body.replace(/\s+$/, '');
+	if (!body.startsWith('/*') || !body.endsWith('*/')) {
+		return false;
+	}
+
+	const inner = body.slice(2, -2);
+	return !inner.includes('*/');
 }

--- a/drizzle-orm/tests/migrator.test.ts
+++ b/drizzle-orm/tests/migrator.test.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'vitest';
+import { readMigrationFiles } from '~/migrator.ts';
+
+let tmpFolder: string;
+
+function writeJournal(entries: { idx: number; when: number; tag: string; breakpoints: boolean }[]) {
+	fs.mkdirSync(path.join(tmpFolder, 'meta'), { recursive: true });
+	fs.writeFileSync(
+		path.join(tmpFolder, 'meta', '_journal.json'),
+		JSON.stringify({ entries }, null, 2),
+	);
+}
+
+function writeMigration(tag: string, sql: string) {
+	fs.writeFileSync(path.join(tmpFolder, `${tag}.sql`), sql);
+}
+
+beforeEach(() => {
+	tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'drizzle-migrator-'));
+});
+
+afterEach(() => {
+	fs.rmSync(tmpFolder, { recursive: true, force: true });
+});
+
+describe('readMigrationFiles', () => {
+	test('skips fully commented introspect file produced by drizzle-kit pull', ({ expect }) => {
+		const introspectSql = `-- Current sql file was generated after introspecting the database
+-- If you want to run this migration please uncomment this code before executing migrations
+/*
+CREATE TABLE "users" (
+\t"id" serial PRIMARY KEY NOT NULL,
+\t"name" text NOT NULL
+);
+*/`;
+
+		writeJournal([{ idx: 0, when: 1700000000000, tag: '0000_pull', breakpoints: true }]);
+		writeMigration('0000_pull', introspectSql);
+
+		const migrations = readMigrationFiles({ migrationsFolder: tmpFolder });
+
+		expect(migrations).toHaveLength(1);
+		expect(migrations[0]!.sql).toEqual([]);
+		expect(migrations[0]!.folderMillis).toBe(1700000000000);
+		expect(typeof migrations[0]!.hash).toBe('string');
+	});
+
+	test('splits a normal multi-statement migration on the breakpoint marker', ({ expect }) => {
+		const sql = `CREATE TABLE "a" ("id" serial PRIMARY KEY);
+--> statement-breakpoint
+CREATE TABLE "b" ("id" serial PRIMARY KEY);`;
+
+		writeJournal([{ idx: 0, when: 1700000000001, tag: '0000_init', breakpoints: true }]);
+		writeMigration('0000_init', sql);
+
+		const migrations = readMigrationFiles({ migrationsFolder: tmpFolder });
+
+		expect(migrations).toHaveLength(1);
+		expect(migrations[0]!.sql).toHaveLength(2);
+		expect(migrations[0]!.sql[0]).toContain('CREATE TABLE "a"');
+		expect(migrations[0]!.sql[1]).toContain('CREATE TABLE "b"');
+	});
+
+	test('still executes an uncommented introspect file', ({ expect }) => {
+		const sql = `-- Current sql file was generated after introspecting the database
+CREATE TABLE "users" (
+\t"id" serial PRIMARY KEY NOT NULL
+);`;
+
+		writeJournal([{ idx: 0, when: 1700000000002, tag: '0000_uncommented', breakpoints: true }]);
+		writeMigration('0000_uncommented', sql);
+
+		const migrations = readMigrationFiles({ migrationsFolder: tmpFolder });
+
+		expect(migrations).toHaveLength(1);
+		expect(migrations[0]!.sql).toHaveLength(1);
+		expect(migrations[0]!.sql[0]).toContain('CREATE TABLE "users"');
+	});
+
+	test('does not skip a file that has SQL after the trailing block comment', ({ expect }) => {
+		const sql = `/*
+ignored
+*/
+CREATE TABLE "after" ("id" serial PRIMARY KEY);`;
+
+		writeJournal([{ idx: 0, when: 1700000000003, tag: '0000_mixed', breakpoints: true }]);
+		writeMigration('0000_mixed', sql);
+
+		const migrations = readMigrationFiles({ migrationsFolder: tmpFolder });
+
+		expect(migrations).toHaveLength(1);
+		expect(migrations[0]!.sql).toHaveLength(1);
+		expect(migrations[0]!.sql[0]).toContain('CREATE TABLE "after"');
+	});
+});


### PR DESCRIPTION
```markdown
## What

`readMigrationFiles` now recognises the introspection SQL file that `drizzle-kit pull` emits — two `--` notes followed by the entire schema wrapped in a single `/* ... */` block — and returns `sql: []` for that entry instead of feeding the comment delimiters to the driver. The migration is still hashed and inserted into `__drizzle_migrations`, so it's recorded as an applied baseline.

The detection is intentionally narrow: it only kicks in when the body (after stripping leading `--` lines and whitespace) starts with `/*`, ends with `*/`, and has no nested `*/`. Anything else falls through to the existing `--> statement-breakpoint` split.

## Why

Reproduced in #4851. `drizzle-kit pull` writes the schema commented out and asks the user to uncomment before running `migrate`. People (`@joshbodily`, `@melroy89` in the thread) are using the commented file on purpose, as a "this schema is already in the DB, just record it as applied" baseline. Today `drizzle-kit migrate` crashes with a parse error because the runtime tries to execute the `/* ... */` wrapper.

Treating the no-op file as zero statements matches what users were already doing manually (deleting the file or hand-editing the journal) and keeps the journal/hash row in place so subsequent migrations diff cleanly.

## Testing

- Added `drizzle-orm/tests/migrator.test.ts` covering: the commented introspect file → `sql: []`; a normal `--> statement-breakpoint`-split file is unaffected; an uncommented introspect file still executes; a file with SQL after a trailing block comment is not skipped.
- I couldn't run `pnpm test` locally — `pnpm` errors with "unable to open database file" in this sandbox before it can install. Verified the detection logic directly with `node` against the four fixtures and the project's `tsc --noEmit` against the touched files.

## Notes

- `readMigrationFiles` is shared by every dialect migrator (pg, mysql, sqlite, libsql, neon, vercel, etc.); the change is read-only and only fires on files that today crash, so working migrations are unaffected — the "normal multi-statement" test covers that explicitly.
- Detection is conservative on purpose: nested `*/`, mixed real SQL + comment block, or any non-`--`/`/* */` content disables the skip. Risk of silently dropping a real migration is low.
- Bumped `changelogs/drizzle-orm/0.45.4.md` with a one-liner.

Fixes #4851.
```