### PR TITLE
fix(bun-sql): disable buggy tagged template query generation in postgres driver

### DIFF
--- a/drizzle-orm/src/bun-sql/postgres/driver.ts
+++ b/drizzle-orm/src/bun-sql/postgres/driver.ts
@@ -43,7 +43,7 @@ function construct<
 		logger,
 		cache: config.cache,
 	});
-	const db = new BunSQLDatabase(dialect, session, relations, false, true) as BunSQLDatabase<TRelations>;
+	const db = new BunSQLDatabase(dialect, session, relations, false, false) as BunSQLDatabase<TRelations>;
 	(<any> db).$client = client;
 	(<any> db).$cache = config.cache;
 	if ((<any> db).$cache) {


### PR DESCRIPTION
Hey everyone!

I ran into a problem using the new `snakeCase.table` casing options with the `bun-sql` driver on Postgres, where it would throw a syntax error:
`DrizzleQueryError: Failed query: select from "users"`

### Root cause
The constructor for `BunSQLDatabase` was hardcoded to enable `tagged = true` for Postgres:
`const db = new BunSQLDatabase(dialect, session, relations, false, true)`

This directs select queries down the `_sqlToQuery()` path, converting them into segment arrays. But Bun's tagged template parser strictly expects the segments array length to match the parameter values length + 1. Since Drizzle generates separate segments for intermediate column references, identifiers, and select fields, the arrays get completely misaligned and collapse to empty column strings.

### Fix
I changed `tagged` to `false` in the constructor. This correctly routes Postgres queries down `client.unsafe(query.sql, params)` (matching how SQLite/MySQL bun-sql drivers and `neon-http` behave). It compiles the entire query string properly and maps selection fields successfully with zero bugs.

Tested locally, and all package type checks pass cleanly. Let me know if you need any adjustments!
