### PR TITLE
fix(pg-core): handle scale > 0 in PgNumericBigInt.mapFromDriverValue

### DIFF
--- a/drizzle-orm/src/pg-core/columns/numeric.ts
+++ b/drizzle-orm/src/pg-core/columns/numeric.ts
@@ -188,12 +188,23 @@ export class PgNumericBigInt<T extends ColumnBaseConfig<'bigint', 'PgNumericBigI
 		// The pg driver returns numeric values as strings, so a `numeric(p, s)` column
 		// with scale > 0 always produces such a string even when the underlying value
 		// is integral, causing `BigInt("123.000")` to throw `SyntaxError` and crash
-		// the request handler on every SELECT returning that column. Strip the
-		// fractional part before converting; callers requesting `bigint` semantics
-		// already accept the implicit truncation that `BigInt(integer)` produces.
+		// the request handler on every SELECT returning that column.
+		//
+		// Strip the fractional part only when it consists entirely of zeros — the
+		// value is integral and `bigint` semantics are exact. For non-zero
+		// fractional digits (e.g. `"123.45"`), the column was configured with
+		// `mode: 'bigint'` but holds non-integral data, which cannot be represented
+		// as a bigint without silent data loss. Fall through to `BigInt(s)` so the
+		// original `SyntaxError` is raised — the caller sees the mismatch loudly
+		// rather than receiving a silently-truncated value.
 		const s = String(value);
 		const dot = s.indexOf('.');
-		return BigInt(dot === -1 ? s : s.slice(0, dot));
+		if (dot === -1) return BigInt(s);
+		const frac = s.slice(dot + 1);
+		if (frac.length === 0 || /^0+$/.test(frac)) {
+			return BigInt(s.slice(0, dot));
+		}
+		return BigInt(s);
 	}
 
 	override mapToDriverValue = String;

--- a/drizzle-orm/src/pg-core/columns/numeric.ts
+++ b/drizzle-orm/src/pg-core/columns/numeric.ts
@@ -183,7 +183,18 @@ export class PgNumericBigInt<T extends ColumnBaseConfig<'bigint', 'PgNumericBigI
 		this.scale = config.scale;
 	}
 
-	override mapFromDriverValue = BigInt;
+	override mapFromDriverValue(value: unknown): bigint {
+		// `BigInt()` rejects strings containing a decimal point (e.g. `"123.000"`).
+		// The pg driver returns numeric values as strings, so a `numeric(p, s)` column
+		// with scale > 0 always produces such a string even when the underlying value
+		// is integral, causing `BigInt("123.000")` to throw `SyntaxError` and crash
+		// the request handler on every SELECT returning that column. Strip the
+		// fractional part before converting; callers requesting `bigint` semantics
+		// already accept the implicit truncation that `BigInt(integer)` produces.
+		const s = String(value);
+		const dot = s.indexOf('.');
+		return BigInt(dot === -1 ? s : s.slice(0, dot));
+	}
 
 	override mapToDriverValue = String;
 

--- a/drizzle-orm/src/pg-core/columns/numeric.ts
+++ b/drizzle-orm/src/pg-core/columns/numeric.ts
@@ -190,12 +190,12 @@ export class PgNumericBigInt<T extends ColumnBaseConfig<'bigint', 'PgNumericBigI
 		// is integral, causing `BigInt("123.000")` to throw `SyntaxError` and crash
 		// the request handler on every SELECT returning that column.
 		//
-		// Strip the fractional part only when it consists entirely of zeros — the
+		// Strip the fractional part only when it consists entirely of zeros - the
 		// value is integral and `bigint` semantics are exact. For non-zero
 		// fractional digits (e.g. `"123.45"`), the column was configured with
 		// `mode: 'bigint'` but holds non-integral data, which cannot be represented
 		// as a bigint without silent data loss. Fall through to `BigInt(s)` so the
-		// original `SyntaxError` is raised — the caller sees the mismatch loudly
+		// original `SyntaxError` is raised - the caller sees the mismatch loudly
 		// rather than receiving a silently-truncated value.
 		const s = String(value);
 		const dot = s.indexOf('.');

--- a/drizzle-orm/tests/pg-numeric-bigint.test.ts
+++ b/drizzle-orm/tests/pg-numeric-bigint.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from 'vitest';
+import { numeric, pgTable } from '~/pg-core/index.ts';
+
+const table = pgTable('test', {
+	amount: numeric('amount', { precision: 10, scale: 2, mode: 'bigint' }),
+	whole: numeric('whole', { precision: 20, scale: 0, mode: 'bigint' }),
+});
+
+describe.concurrent('PgNumericBigInt.mapFromDriverValue', () => {
+	it('parses scale-0 integer string', ({ expect }) => {
+		// `numeric(p, 0)` columns return strings without a decimal point.
+		expect(table.whole.mapFromDriverValue('123')).toEqual(123n);
+	});
+
+	it('strips all-zero fractional part (primary fix path)', ({ expect }) => {
+		// pg driver returns `"123.00"` for an integral value stored in a `numeric(p, 2)` column.
+		// Before the fix, `BigInt("123.00")` threw `SyntaxError`. After the fix, the all-zero
+		// fractional part is stripped and the integral value is returned exactly.
+		expect(table.amount.mapFromDriverValue('123.00')).toEqual(123n);
+	});
+
+	it('strips arbitrary-length all-zero fractional part', ({ expect }) => {
+		expect(table.amount.mapFromDriverValue('42.000000')).toEqual(42n);
+	});
+
+	it('throws SyntaxError on non-zero fractional part', ({ expect }) => {
+		// A `mode: 'bigint'` column holding a genuinely non-integral value cannot be represented
+		// as a bigint without silent data loss. The original `BigInt()` SyntaxError is preserved
+		// rather than silently truncating to `123n`.
+		expect(() => table.amount.mapFromDriverValue('123.45')).toThrowError(SyntaxError);
+	});
+
+	it('preserves negative integral values', ({ expect }) => {
+		expect(table.amount.mapFromDriverValue('-7.00')).toEqual(-7n);
+	});
+
+	it('handles zero', ({ expect }) => {
+		expect(table.amount.mapFromDriverValue('0.00')).toEqual(0n);
+		expect(table.whole.mapFromDriverValue('0')).toEqual(0n);
+	});
+
+	it('coerces non-string drivers values via String() before parsing', ({ expect }) => {
+		// The pg driver always returns strings, but `mapFromDriverValue` accepts `unknown` and
+		// uses `String(value)` internally. Confirm the no-dot path still works for a number.
+		expect(table.whole.mapFromDriverValue(42 as unknown)).toEqual(42n);
+	});
+});


### PR DESCRIPTION
## Summary

`PgNumericBigInt` declares its driver-to-runtime mapper as `override mapFromDriverValue = BigInt;`. The pg driver returns `numeric` values as strings, and `BigInt("123.000")` throws `SyntaxError` because the string contains a decimal point. Any `numeric(precision, scale)` column with `scale > 0` therefore crashes the request handler on every SELECT returning that column, even when the underlying value is integral.

## What changed

`mapFromDriverValue` is now an explicit method. When the driver returns a value like `"123.00"`, it strips the fractional part only when it is all zeros (the value is integral, so `bigint` is exact); for a non-zero fraction it falls through to `BigInt(s)`, which throws `SyntaxError` rather than silently truncating genuinely non-integral data. For `numeric(p, 0)` columns there is no dot, so the result is identical to the previous `BigInt`-based mapper, keeping the change non-breaking for existing scale-0 deployments.

## Repro

```ts
const t = pgTable('t', { v: numeric('v', { precision: 10, scale: 2, mode: 'bigint' }) });
// SELECT v FROM t  ->  driver returns "123.00"
// BigInt("123.00") throws SyntaxError
```

## Notes

Same pattern likely exists in `mysql-core`, `singlestore-core`, and `sqlite-core`; I'll send separate PRs if this lands well.
