### PR TITLE
fix: release pooled connection in iterator() instead of deprecated conn.end()

### DIFF
--- a/drizzle-orm/src/mysql2/session.ts
+++ b/drizzle-orm/src/mysql2/session.ts
@@ -146,9 +146,8 @@ export class MySql2PreparedQuery<T extends MySqlPreparedQueryConfig> extends MyS
 		placeholderValues: Record<string, unknown> = {},
 	): AsyncGenerator<T['execute'] extends any[] ? T['execute'][number] : T['execute']> {
 		const params = fillPlaceholders(this.params, placeholderValues);
-		const conn = ((isPool(this.client) ? await this.client.getConnection() : this.client) as {} as {
-			connection: CallbackConnection;
-		}).connection;
+		const rawClient = isPool(this.client) ? await this.client.getConnection() : this.client;
+		const conn = (rawClient as {} as { connection: CallbackConnection }).connection;
 
 		const { fields, query, rawQuery, joinsNotNullableMap, client, customResultMapper } = this;
 		const hasRowsMapper = Boolean(fields || customResultMapper);
@@ -189,7 +188,9 @@ export class MySql2PreparedQuery<T extends MySqlPreparedQueryConfig> extends MyS
 		} finally {
 			stream.off('data', dataListener);
 			if (isPool(client)) {
-				conn.end();
+				// `.end()` on a pooled connection is deprecated in mysql2 (it warns and
+				// delegates to `.release()`); release it directly to avoid the warning.
+				(rawClient as PoolConnection).release();
 			}
 		}
 	}

--- a/drizzle-orm/src/singlestore/session.ts
+++ b/drizzle-orm/src/singlestore/session.ts
@@ -163,6 +163,7 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 
 		stream.on('data', dataListener);
 
+		let streamEnded = false;
 		try {
 			const onEnd = once(stream, 'end');
 			const onError = once(stream, 'error');
@@ -171,6 +172,7 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 				stream.resume();
 				const row = await Promise.race([onEnd, onError, new Promise((resolve) => stream.once('data', resolve))]);
 				if (row === undefined || (Array.isArray(row) && row.length === 0)) {
+					streamEnded = true;
 					break;
 				} else if (row instanceof Error) { // eslint-disable-line no-instanceof/no-instanceof
 					throw row;
@@ -190,10 +192,20 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 		} finally {
 			stream.off('data', dataListener);
 			if (isPool(client)) {
-				// Release the PoolConnection back to the pool rather than calling
-				// `conn.end()` on the inner CallbackConnection, which permanently
-				// destroys the TCP socket (matches the pattern on L314 below).
-				(rawClient as PoolConnection).release();
+				if (streamEnded) {
+					// Stream reached its natural `end` — the socket is drained and can
+					// be safely returned to the pool for reuse.
+					(rawClient as PoolConnection).release();
+				} else {
+					// Consumer exited the iterator early (`break`, `return`, exception in
+					// the loop body, or a stream `error` event). Unread result packets
+					// may still be pending on the wire — returning the connection to the
+					// pool would let a subsequent query receive interleaved packets and
+					// fail with a protocol error. Destroy the socket instead, which
+					// matches the pre-fix `conn.end()` behaviour for early-exit cases
+					// while still allowing pool reuse on the common natural-end path.
+					(rawClient as PoolConnection).destroy();
+				}
 			}
 		}
 	}

--- a/drizzle-orm/src/singlestore/session.ts
+++ b/drizzle-orm/src/singlestore/session.ts
@@ -145,9 +145,11 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 		placeholderValues: Record<string, unknown> = {},
 	): AsyncGenerator<T['execute'] extends any[] ? T['execute'][number] : T['execute']> {
 		const params = fillPlaceholders(this.params, placeholderValues);
-		const conn = ((isPool(this.client) ? await this.client.getConnection() : this.client) as {} as {
-			connection: CallbackConnection;
-		}).connection;
+		// Retain a reference to the original PoolConnection so we can `.release()` it
+		// in `finally` instead of `.end()`-ing the inner CallbackConnection, which
+		// destroys the TCP socket rather than returning it to the pool.
+		const rawClient = isPool(this.client) ? await this.client.getConnection() : this.client;
+		const conn = (rawClient as {} as { connection: CallbackConnection }).connection;
 
 		const { fields, query, rawQuery, joinsNotNullableMap, client, customResultMapper } = this;
 		const hasRowsMapper = Boolean(fields || customResultMapper);
@@ -188,7 +190,10 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 		} finally {
 			stream.off('data', dataListener);
 			if (isPool(client)) {
-				conn.end();
+				// Release the PoolConnection back to the pool rather than calling
+				// `conn.end()` on the inner CallbackConnection, which permanently
+				// destroys the TCP socket (matches the pattern on L314 below).
+				(rawClient as PoolConnection).release();
 			}
 		}
 	}

--- a/drizzle-orm/src/singlestore/session.ts
+++ b/drizzle-orm/src/singlestore/session.ts
@@ -145,9 +145,8 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 		placeholderValues: Record<string, unknown> = {},
 	): AsyncGenerator<T['execute'] extends any[] ? T['execute'][number] : T['execute']> {
 		const params = fillPlaceholders(this.params, placeholderValues);
-		const conn = ((isPool(this.client) ? await this.client.getConnection() : this.client) as {} as {
-			connection: CallbackConnection;
-		}).connection;
+		const rawClient = isPool(this.client) ? await this.client.getConnection() : this.client;
+		const conn = (rawClient as {} as { connection: CallbackConnection }).connection;
 
 		const { fields, query, rawQuery, joinsNotNullableMap, client, customResultMapper } = this;
 		const hasRowsMapper = Boolean(fields || customResultMapper);
@@ -188,7 +187,9 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 		} finally {
 			stream.off('data', dataListener);
 			if (isPool(client)) {
-				conn.end();
+				// `.end()` on a pooled connection is deprecated in mysql2 (it warns and
+				// delegates to `.release()`); release it directly to avoid the warning.
+				(rawClient as PoolConnection).release();
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

`MySql2PreparedQuery.iterator()` and `SingleStoreDriverPreparedQuery.iterator()` return a pooled connection with `conn.end()` in their `finally` block. In mysql2, calling `end()` on a pooled connection is deprecated: it logs

```
Calling conn.end() to release a pooled connection is deprecated. ... Use conn.release() instead.
```

and internally delegates to `release()`. This is the deprecation warning reported in #2143.

## Fix

Keep a reference to the pooled connection returned by `getConnection()` and call `release()` on it directly in `finally`, on both the mysql2 and singlestore drivers. This returns the connection to the pool without the deprecation warning and matches the `(x as PoolConnection).release()` pattern already used elsewhere in `mysql2/session.ts`. Behaviour is otherwise unchanged, since the deprecated `end()` already delegated to `release()`.

Closes #2143.

## Notes

Simplified from an earlier revision that special-cased early iterator exit with `destroy()`. At the pinned mysql2 version `end()` on a pooled connection already delegates to `release()`, so no destroy path is needed and the minimal `release()` fix applies cleanly to both drivers.

## Verification

- `tsc --noEmit`: no new type errors (reuses the existing `(x as PoolConnection).release()` idiom; the two pre-existing `session.ts` overload errors are unchanged from `main`).
- `dprint check`: clean on both changed files.
- `vitest run` (drizzle-orm unit suite): 542 tests pass, unchanged.
