### PR TITLE
fix: only invoke $onUpdate callback when column is not being set

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -160,7 +160,7 @@ export class PgDialect {
 		return sql.join(columnNames.flatMap((colName, i) => {
 			const col = tableColumns[colName]!;
 
-			const onUpdateFnResult = col.onUpdateFn?.();
+			const onUpdateFnResult = set[colName] !== undefined ? undefined : col.onUpdateFn?.();
 			const value = set[colName] ?? (is(onUpdateFnResult, SQL) ? onUpdateFnResult : sql.param(onUpdateFnResult, col));
 			const res = sql`${sql.identifier(this.casing.getColumnCasing(col))} = ${value}`;
 


### PR DESCRIPTION
Fixes issue #5780 — $onUpdate callback invoked eagerly even when column is not being updated.

In drizzle-orm/src/pg-core/dialect.ts, the onUpdateFn was being called unconditionally. Changed to only invoke when column is not being explicitly set in the update.

**Before:**
```ts
const onUpdateFnResult = col.onUpdateFn?.();
```

**After:**
```ts
const onUpdateFnResult = set[colName] !== undefined ? undefined : col.onUpdateFn?.();
```