### PR TITLE
fix: sequential cache invalidation in session.ts (#5828)

### DIFF
--- a/drizzle-orm/src/pg-core/session.ts
+++ b/drizzle-orm/src/pg-core/session.ts
@@ -91,10 +91,9 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			) && this.queryMetadata.tables.length > 0
 		) {
 			try {
-				const [res] = await Promise.all([
-					query(),
-					this.cache.onMutate({ tables: this.queryMetadata.tables }),
-				]);
+				// Sequential: query first, then invalidate cache
+				const res = await query();
+				await this.cache.onMutate({ tables: this.queryMetadata.tables });
 				return res;
 			} catch (e) {
 				throw new DrizzleQueryError(queryString, params, e as Error);


### PR DESCRIPTION
Fixes race condition in cache invalidation. Changed Promise.all to sequential await to ensure query completes before cache invalidation.

Closes #5828