### PR TITLE
Fix nested partial select returning null when the first joined column is null (#1603)

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,8 +48,13 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (value !== null || nullifyMap[objectName] !== getTableName(field.table))
 						) {
+							// A nested object is only nullified when ALL of its columns are null.
+							// Flip to `false` as soon as any column has a value (fixes #1603, where a
+							// non-null column after a leading null column was incorrectly nullified),
+							// or when a column comes from a different table.
 							nullifyMap[objectName] = false;
 						}
 					}

--- a/drizzle-orm/tests/mapResultRow.test.ts
+++ b/drizzle-orm/tests/mapResultRow.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'vitest';
+
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+const org = pgTable('org', {
+	name: text('name'),
+	slug: text('slug'),
+});
+
+const orgBranding = pgTable('org_branding', {
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+// org is the base table (not nullable), org_branding is left-joined (nullable).
+const joinsNotNullableMap = { org: true, org_branding: false };
+
+test('nested partial select keeps a left-joined object whose first column is null (#1603)', () => {
+	const columns = orderSelectedFields({
+		name: org.name,
+		slug: org.slug,
+		branding: {
+			logo: orgBranding.logo, // null in the row
+			panelBackground: orgBranding.panelBackground, // has a value
+		},
+	});
+	const row = ['Test org 2', 'test-org-2', null, '#1a8cff'];
+
+	expect(mapResultRow(columns, row, joinsNotNullableMap)).toStrictEqual({
+		name: 'Test org 2',
+		slug: 'test-org-2',
+		branding: { logo: null, panelBackground: '#1a8cff' },
+	});
+});
+
+test('column order does not affect a partially-null left-joined object (#1603)', () => {
+	// Same data, columns swapped so the non-null column comes first.
+	const columns = orderSelectedFields({
+		name: org.name,
+		slug: org.slug,
+		branding: {
+			panelBackground: orgBranding.panelBackground, // has a value
+			logo: orgBranding.logo, // null
+		},
+	});
+	const row = ['Test org 2', 'test-org-2', '#1a8cff', null];
+
+	expect(mapResultRow(columns, row, joinsNotNullableMap)).toStrictEqual({
+		name: 'Test org 2',
+		slug: 'test-org-2',
+		branding: { panelBackground: '#1a8cff', logo: null },
+	});
+});
+
+test('a left-joined object is still nullified when ALL of its columns are null', () => {
+	const columns = orderSelectedFields({
+		name: org.name,
+		slug: org.slug,
+		branding: {
+			logo: orgBranding.logo,
+			panelBackground: orgBranding.panelBackground,
+		},
+	});
+	const row = ['Test org 2', 'test-org-2', null, null];
+
+	expect(mapResultRow(columns, row, joinsNotNullableMap)).toStrictEqual({
+		name: 'Test org 2',
+		slug: 'test-org-2',
+		branding: null,
+	});
+});


### PR DESCRIPTION
## What & why

A nested-object partial select with a `leftJoin` returns the **whole nested object as `null`** when its **first** column happens to be `null`, even though later columns have values — and the result flips depending on column order (reported in #1603):

```ts
// in the DB: logo IS NULL, panel_background = '#1a8cff'
const org = await db.select({
  name: orgTable.name,
  slug: orgTable.slug,
  branding: { logo: orgBranding.logo, panelBackground: orgBranding.panelBackground },
}).from(orgTable).leftJoin(orgBranding, eq(orgTable.id, orgBranding.orgId));

// got:      { name, slug, branding: null }
// expected: { name, slug, branding: { logo: null, panelBackground: '#1a8cff' } }
// …and swapping the two branding columns made it work — a tell that ordering, not data, drove the result.
```

## Root cause

`mapResultRow` (`drizzle-orm/src/utils.ts`) builds a `nullifyMap` to decide which left-joined nested objects become `null`. Its own comment states the value should be the table name **“if all fields in the nested object are from the same table”** and null — i.e. the object is nullified only when **every** column is null. But the update step only flips an object back to “keep” (`false`) when a column comes from a **different table**:

```ts
} else if (
  typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
) {
  nullifyMap[objectName] = false;
}
```

So once the **first** column sets `nullifyMap[objectName] = <tableName>` (because that column was `null`), a later **non-null** column from the **same** table cannot undo it, and the object is wrongly nullified. Reordering “fixes” it only because a non-null column is then seen first.

## Fix

Flip the object to “keep” as soon as **any** of its columns has a value (one added clause; the cross-table behavior is unchanged):

```diff
  } else if (
-   typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+   typeof nullifyMap[objectName] === 'string'
+   && (value !== null || nullifyMap[objectName] !== getTableName(field.table))
  ) {
    nullifyMap[objectName] = false;
  }
```

A nested object is now nullified **only when all of its columns are null**, matching the documented intent and making the result independent of column order.

## Tests

Added `drizzle-orm/tests/mapResultRow.test.ts` covering three cases:

1. **#1603 repro** — a leading `null` column no longer nullifies an object that has other non-null columns.
2. **Order-independence** — the swapped-column variant from the issue.
3. **Regression guard** — an object **is** still nullified when **all** its columns are null.

I confirmed case 1 **fails on `main`** (returns `branding: null`) and passes with this change. The full `drizzle-orm` unit suite (**569 tests**) passes and `dprint check` reports no formatting differences.

Closes #1603

/claim #1603
