### PR TITLE
feat(pg-core): add .forceRLS() to pgTable builder

### DIFF
--- a/drizzle-kit/src/cli/commands/pgUp.ts
+++ b/drizzle-kit/src/cli/commands/pgUp.ts
@@ -93,7 +93,14 @@ export const updateUpToV7 = (json: Record<string, any>): PgSchema => {
 					return [idx[0], { columns: mappedColumns, with: {}, ...rest }];
 				}),
 			);
-			return [it[0], { ...table, indexes: mappedIndexes, policies: {}, isRLSEnabled: false, checkConstraints: {} }];
+			return [it[0], {
+				...table,
+				indexes: mappedIndexes,
+				policies: {},
+				isRLSEnabled: false,
+				isForceRLSEnabled: false,
+				checkConstraints: {},
+			}];
 		}),
 	);
 

--- a/drizzle-kit/src/jsonStatements.ts
+++ b/drizzle-kit/src/jsonStatements.ts
@@ -54,6 +54,7 @@ export interface JsonCreateTableStatement {
 	checkConstraints?: string[];
 	internals?: MySqlKitInternals | SingleStoreKitInternals;
 	isRLSEnabled?: boolean;
+	isForceRLSEnabled?: boolean;
 }
 
 export interface JsonRecreateTableStatement {
@@ -293,6 +294,18 @@ export interface JsonEnableRLSStatement {
 
 export interface JsonDisableRLSStatement {
 	type: 'disable_rls';
+	tableName: string;
+	schema: string;
+}
+
+export interface JsonForceRLSStatement {
+	type: 'force_rls';
+	tableName: string;
+	schema: string;
+}
+
+export interface JsonNoForceRLSStatement {
+	type: 'no_force_rls';
 	tableName: string;
 	schema: string;
 }
@@ -865,6 +878,8 @@ export type JsonStatement =
 	| JsonRenamePolicyStatement
 	| JsonEnableRLSStatement
 	| JsonDisableRLSStatement
+	| JsonForceRLSStatement
+	| JsonNoForceRLSStatement
 	| JsonRenameRoleStatement
 	| JsonCreateRoleStatement
 	| JsonDropRoleStatement
@@ -891,8 +906,17 @@ export const preparePgCreateTableJson = (
 	// TODO: remove?
 	json2: PgSchema,
 ): JsonCreateTableStatement => {
-	const { name, schema, columns, compositePrimaryKeys, uniqueConstraints, checkConstraints, policies, isRLSEnabled } =
-		table;
+	const {
+		name,
+		schema,
+		columns,
+		compositePrimaryKeys,
+		uniqueConstraints,
+		checkConstraints,
+		policies,
+		isRLSEnabled,
+		isForceRLSEnabled,
+	} = table;
 	const tableKey = `${schema || 'public'}.${name}`;
 
 	// TODO: @AndriiSherman. We need this, will add test cases
@@ -913,6 +937,7 @@ export const preparePgCreateTableJson = (
 		policies: Object.values(policies),
 		checkConstraints: Object.values(checkConstraints),
 		isRLSEnabled: isRLSEnabled ?? false,
+		isForceRLSEnabled: isForceRLSEnabled ?? false,
 	};
 };
 

--- a/drizzle-kit/src/serializer/pgSchema.ts
+++ b/drizzle-kit/src/serializer/pgSchema.ts
@@ -338,6 +338,7 @@ const table = object({
 	policies: record(string(), policy).default({}),
 	checkConstraints: record(string(), checkConstraint).default({}),
 	isRLSEnabled: boolean().default(false),
+	isForceRLSEnabled: boolean().default(false),
 }).strict();
 
 const schemaHash = object({
@@ -463,6 +464,7 @@ const tableSquashed = object({
 	policies: record(string(), string()),
 	checkConstraints: record(string(), string()),
 	isRLSEnabled: boolean().default(false),
+	isForceRLSEnabled: boolean().default(false),
 }).strict();
 
 const tableSquashedV4 = object({
@@ -822,6 +824,7 @@ export const squashPgScheme = (
 					policies: squashedPolicies,
 					checkConstraints: squashedChecksContraints,
 					isRLSEnabled: it[1].isRLSEnabled ?? false,
+					isForceRLSEnabled: it[1].isForceRLSEnabled ?? false,
 				},
 			];
 		}),

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -139,6 +139,7 @@ export const generatePgSnapshot = (
 			uniqueConstraints,
 			policies,
 			enableRLS,
+			enableForceRLS,
 		} = getTableConfig(table);
 
 		if (schemaFilter && !schemaFilter.includes(schema ?? 'public')) {
@@ -584,6 +585,7 @@ export const generatePgSnapshot = (
 			policies: policiesObject,
 			checkConstraints: checksObject,
 			isRLSEnabled: enableRLS,
+			isForceRLSEnabled: enableForceRLS,
 		};
 	}
 
@@ -990,17 +992,20 @@ export const fromDatabase = async (
 
 	const where = schemaFilters.map((t) => `n.nspname = '${t}'`).join(' or ');
 
-	const allTables = await db.query<{ table_schema: string; table_name: string; type: string; rls_enabled: boolean }>(
-		`SELECT 
-    n.nspname AS table_schema, 
-    c.relname AS table_name, 
-    CASE 
+	const allTables = await db.query<
+		{ table_schema: string; table_name: string; type: string; rls_enabled: boolean; rls_force_enabled: boolean }
+	>(
+		`SELECT
+    n.nspname AS table_schema,
+    c.relname AS table_name,
+    CASE
         WHEN c.relkind = 'r' THEN 'table'
         WHEN c.relkind = 'v' THEN 'view'
         WHEN c.relkind = 'm' THEN 'materialized_view'
     END AS type,
-	c.relrowsecurity AS rls_enabled
-FROM 
+	c.relrowsecurity AS rls_enabled,
+	c.relforcerowsecurity AS rls_force_enabled
+FROM
     pg_catalog.pg_class c
 JOIN 
     pg_catalog.pg_namespace n ON n.oid = c.relnamespace
@@ -1661,6 +1666,7 @@ WHERE
 						checkConstraints: checkConstraints,
 						policies: policiesByTable[`${tableSchema}.${tableName}`] ?? {},
 						isRLSEnabled: row.rls_enabled,
+						isForceRLSEnabled: row.rls_force_enabled,
 					};
 				} catch (e) {
 					rej(e);

--- a/drizzle-kit/src/snapshotsDiffer.ts
+++ b/drizzle-kit/src/snapshotsDiffer.ts
@@ -45,7 +45,9 @@ import {
 	JsonDropPolicyStatement,
 	JsonDropViewStatement,
 	JsonEnableRLSStatement,
+	JsonForceRLSStatement,
 	JsonIndRenamePolicyStatement,
+	JsonNoForceRLSStatement,
 	JsonReferenceStatement,
 	JsonRenameColumnStatement,
 	JsonRenamePolicyStatement,
@@ -269,6 +271,7 @@ const tableScheme = object({
 	policies: record(string(), string()).default({}),
 	checkConstraints: record(string(), string()).default({}),
 	isRLSEnabled: boolean().default(false),
+	isForceRLSEnabled: boolean().default(false),
 }).strict();
 
 export const alteredTableScheme = object({
@@ -1413,6 +1416,9 @@ export const applyPgSnapshotsDiff = async (
 	const jsonEnableRLSStatements: JsonEnableRLSStatement[] = [];
 	const jsonDisableRLSStatements: JsonDisableRLSStatement[] = [];
 
+	const jsonForceRLSStatements: JsonForceRLSStatement[] = [];
+	const jsonNoForceRLSStatements: JsonNoForceRLSStatement[] = [];
+
 	for (let it of indPolicyRenames) {
 		jsonRenameIndPoliciesStatements.push(
 			...prepareRenameIndPolicyJsons([it]),
@@ -1604,6 +1610,16 @@ export const applyPgSnapshotsDiff = async (
 				) {
 					// was force disabled
 					jsonDisableRLSStatements.push({ type: 'disable_rls', tableName: table.name, schema: table.schema });
+				}
+			}
+
+			// handle table.isForceRLSEnabled
+			const wasForceRlsEnabled = tableInPreviousState ? tableInPreviousState.isForceRLSEnabled : false;
+			if (table.isForceRLSEnabled !== wasForceRlsEnabled) {
+				if (table.isForceRLSEnabled) {
+					jsonForceRLSStatements.push({ type: 'force_rls', tableName: table.name, schema: table.schema });
+				} else {
+					jsonNoForceRLSStatements.push({ type: 'no_force_rls', tableName: table.name, schema: table.schema });
 				}
 			}
 		}
@@ -1966,6 +1982,8 @@ export const applyPgSnapshotsDiff = async (
 
 	jsonStatements.push(...jsonEnableRLSStatements);
 	jsonStatements.push(...jsonDisableRLSStatements);
+	jsonStatements.push(...jsonForceRLSStatements);
+	jsonStatements.push(...jsonNoForceRLSStatements);
 	jsonStatements.push(...dropViews);
 	jsonStatements.push(...renameViews);
 	jsonStatements.push(...alterViews);

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -66,9 +66,11 @@ import {
 	JsonDropValueFromEnumStatement,
 	JsonDropViewStatement,
 	JsonEnableRLSStatement,
+	JsonForceRLSStatement,
 	JsonIndRenamePolicyStatement,
 	JsonMoveEnumStatement,
 	JsonMoveSequenceStatement,
+	JsonNoForceRLSStatement,
 	JsonPgCreateIndexStatement,
 	JsonRecreateSingleStoreTableStatement,
 	JsonRecreateTableStatement,
@@ -382,14 +384,49 @@ class PgDisableRlsConvertor extends Convertor {
 	}
 }
 
+class PgForceRlsConvertor extends Convertor {
+	override can(statement: JsonStatement, dialect: Dialect): boolean {
+		return statement.type === 'force_rls' && dialect === 'postgresql';
+	}
+	override convert(statement: JsonForceRLSStatement): string {
+		const tableNameWithSchema = statement.schema
+			? `"${statement.schema}"."${statement.tableName}"`
+			: `"${statement.tableName}"`;
+
+		return `ALTER TABLE ${tableNameWithSchema} FORCE ROW LEVEL SECURITY;`;
+	}
+}
+
+class PgNoForceRlsConvertor extends Convertor {
+	override can(statement: JsonStatement, dialect: Dialect): boolean {
+		return statement.type === 'no_force_rls' && dialect === 'postgresql';
+	}
+	override convert(statement: JsonNoForceRLSStatement): string {
+		const tableNameWithSchema = statement.schema
+			? `"${statement.schema}"."${statement.tableName}"`
+			: `"${statement.tableName}"`;
+
+		return `ALTER TABLE ${tableNameWithSchema} NO FORCE ROW LEVEL SECURITY;`;
+	}
+}
+
 class PgCreateTableConvertor extends Convertor {
 	can(statement: JsonStatement, dialect: Dialect): boolean {
 		return statement.type === 'create_table' && dialect === 'postgresql';
 	}
 
 	convert(st: JsonCreateTableStatement) {
-		const { tableName, schema, columns, compositePKs, uniqueConstraints, checkConstraints, policies, isRLSEnabled } =
-			st;
+		const {
+			tableName,
+			schema,
+			columns,
+			compositePKs,
+			uniqueConstraints,
+			checkConstraints,
+			policies,
+			isRLSEnabled,
+			isForceRLSEnabled,
+		} = st;
 
 		let statement = '';
 		const name = schema ? `"${schema}"."${tableName}"` : `"${tableName}"`;
@@ -490,7 +527,17 @@ class PgCreateTableConvertor extends Convertor {
 			schema,
 		});
 
-		return [statement, ...(policies && policies.length > 0 || isRLSEnabled ? [enableRls] : [])];
+		const forceRls = new PgForceRlsConvertor().convert({
+			type: 'force_rls',
+			tableName,
+			schema,
+		});
+
+		return [
+			statement,
+			...(policies && policies.length > 0 || isRLSEnabled ? [enableRls] : []),
+			...(isRLSEnabled && isForceRLSEnabled ? [forceRls] : []),
+		];
 	}
 }
 
@@ -4059,6 +4106,8 @@ convertors.push(new PgRenameIndPolicyConvertor());
 
 convertors.push(new PgEnableRlsConvertor());
 convertors.push(new PgDisableRlsConvertor());
+convertors.push(new PgForceRlsConvertor());
+convertors.push(new PgNoForceRlsConvertor());
 
 convertors.push(new PgDropRoleConvertor());
 convertors.push(new PgAlterRoleConvertor());

--- a/drizzle-kit/tests/rls/pg-policy.test.ts
+++ b/drizzle-kit/tests/rls/pg-policy.test.ts
@@ -1654,3 +1654,122 @@ test('alter policy in the table: using', async (t) => {
 		},
 	]);
 });
+
+test('create table with force rls enabled', async (t) => {
+	const schema1 = {};
+
+	const schema2 = {
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+		}).forceRLS(),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemas(schema1, schema2, []);
+
+	expect(sqlStatements).toStrictEqual([
+		`CREATE TABLE "users" (\n\t"id" integer PRIMARY KEY NOT NULL\n);
+`,
+		'ALTER TABLE "users" ENABLE ROW LEVEL SECURITY;',
+		'ALTER TABLE "users" FORCE ROW LEVEL SECURITY;',
+	]);
+});
+
+test('force rls on existing table', async (t) => {
+	const schema1 = {
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+		}).enableRLS(),
+	};
+
+	const schema2 = {
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+		}).forceRLS(),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemas(schema1, schema2, []);
+
+	expect(sqlStatements).toStrictEqual(['ALTER TABLE "users" FORCE ROW LEVEL SECURITY;']);
+	expect(statements).toStrictEqual([
+		{
+			schema: '',
+			tableName: 'users',
+			type: 'force_rls',
+		},
+	]);
+});
+
+test('no force rls on existing table', async (t) => {
+	const schema1 = {
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+		}).forceRLS(),
+	};
+
+	const schema2 = {
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+		}).enableRLS(),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemas(schema1, schema2, []);
+
+	expect(sqlStatements).toStrictEqual(['ALTER TABLE "users" NO FORCE ROW LEVEL SECURITY;']);
+	expect(statements).toStrictEqual([
+		{
+			schema: '',
+			tableName: 'users',
+			type: 'no_force_rls',
+		},
+	]);
+});
+
+test('add policy + force rls', async (t) => {
+	const schema1 = {
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+		}),
+	};
+
+	const schema2 = {
+		users: pgTable('users', {
+			id: integer('id').primaryKey(),
+		}, () => ({
+			rls: pgPolicy('test', { as: 'permissive' }),
+		})).forceRLS(),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemas(schema1, schema2, []);
+
+	expect(sqlStatements).toStrictEqual([
+		'ALTER TABLE "users" ENABLE ROW LEVEL SECURITY;',
+		'ALTER TABLE "users" FORCE ROW LEVEL SECURITY;',
+		'CREATE POLICY "test" ON "users" AS PERMISSIVE FOR ALL TO public;',
+	]);
+	expect(statements).toStrictEqual([
+		{
+			schema: '',
+			tableName: 'users',
+			type: 'enable_rls',
+		},
+		{
+			schema: '',
+			tableName: 'users',
+			type: 'force_rls',
+		},
+		{
+			data: {
+				as: 'PERMISSIVE',
+				for: 'ALL',
+				name: 'test',
+				to: ['public'],
+				on: undefined,
+				using: undefined,
+				withCheck: undefined,
+			},
+			schema: '',
+			tableName: 'users',
+			type: 'create_policy',
+		},
+	]);
+});

--- a/drizzle-orm/src/pg-core/table.ts
+++ b/drizzle-orm/src/pg-core/table.ts
@@ -29,6 +29,8 @@ export type TableConfig = TableConfigBase<PgColumn>;
 export const InlineForeignKeys = Symbol.for('drizzle:PgInlineForeignKeys');
 /** @internal */
 export const EnableRLS = Symbol.for('drizzle:EnableRLS');
+/** @internal */
+export const EnableForceRLS = Symbol.for('drizzle:EnableForceRLS');
 
 export class PgTable<T extends TableConfig = TableConfig> extends Table<T> {
 	static override readonly [entityKind]: string = 'PgTable';
@@ -37,6 +39,7 @@ export class PgTable<T extends TableConfig = TableConfig> extends Table<T> {
 	static override readonly Symbol = Object.assign({}, Table.Symbol, {
 		InlineForeignKeys: InlineForeignKeys as typeof InlineForeignKeys,
 		EnableRLS: EnableRLS as typeof EnableRLS,
+		EnableForceRLS: EnableForceRLS as typeof EnableForceRLS,
 	});
 
 	/**@internal */
@@ -44,6 +47,9 @@ export class PgTable<T extends TableConfig = TableConfig> extends Table<T> {
 
 	/** @internal */
 	[EnableRLS]: boolean = false;
+
+	/** @internal */
+	[EnableForceRLS]: boolean = false;
 
 	/** @internal */
 	override [Table.Symbol.ExtraConfigBuilder]: ((self: Record<string, PgColumn>) => PgTableExtraConfig) | undefined =
@@ -64,6 +70,10 @@ export type PgTableWithColumns<T extends TableConfig> =
 		enableRLS: () => Omit<
 			PgTableWithColumns<T>,
 			'enableRLS'
+		>;
+		forceRLS: () => Omit<
+			PgTableWithColumns<T>,
+			'forceRLS'
 		>;
 	};
 
@@ -126,6 +136,17 @@ export function pgTableWithSchema<
 	return Object.assign(table, {
 		enableRLS: () => {
 			table[PgTable.Symbol.EnableRLS] = true;
+			return table as PgTableWithColumns<{
+				name: TTableName;
+				schema: TSchemaName;
+				columns: BuildColumns<TTableName, TColumnsMap, 'pg'>;
+				dialect: 'pg';
+			}>;
+		},
+		forceRLS: () => {
+			// FORCE ROW LEVEL SECURITY is a no-op unless RLS is also enabled, so enabling it implies enableRLS.
+			table[PgTable.Symbol.EnableRLS] = true;
+			table[PgTable.Symbol.EnableForceRLS] = true;
 			return table as PgTableWithColumns<{
 				name: TTableName;
 				schema: TSchemaName;

--- a/drizzle-orm/src/pg-core/utils.ts
+++ b/drizzle-orm/src/pg-core/utils.ts
@@ -27,6 +27,7 @@ export function getTableConfig<TTable extends PgTable>(table: TTable) {
 	const schema = table[Table.Symbol.Schema];
 	const policies: PgPolicy[] = [];
 	const enableRLS: boolean = table[PgTable.Symbol.EnableRLS];
+	const enableForceRLS: boolean = table[PgTable.Symbol.EnableForceRLS];
 
 	const extraConfigBuilder = table[PgTable.Symbol.ExtraConfigBuilder];
 
@@ -61,6 +62,7 @@ export function getTableConfig<TTable extends PgTable>(table: TTable) {
 		schema,
 		policies,
 		enableRLS,
+		enableForceRLS,
 	};
 }
 


### PR DESCRIPTION
Adds a `.forceRLS()` modifier on the pgTable builder, a companion to the existing `.enableRLS()`. It emits `ALTER TABLE ... FORCE ROW LEVEL SECURITY` in the generated migration so that the table owner role is also subject to RLS policies. `.forceRLS()` implies `.enableRLS()`, since FORCE is a no-op unless RLS is enabled.

drizzle-orm:
- new `EnableForceRLS` symbol + `[EnableForceRLS]` flag on PgTable
- `.forceRLS()` modifier and `forceRLS` on the PgTableWithColumns type
- `getTableConfig` now returns `enableForceRLS`

drizzle-kit:
- thread `isForceRLSEnabled` through the pg snapshot (serializer, schema, squash) and the V6->V7 snapshot upgrade
- diff the force toggle -> `force_rls` / `no_force_rls` json statements
- `PgForceRlsConvertor` / `PgNoForceRlsConvertor` emit FORCE / NO FORCE
- create-table appends FORCE after ENABLE when forceRLS is set
- introspection reads `relforcerowsecurity` so pull round-trips the flag

Tests: add forceRLS cases to drizzle-kit/tests/rls/pg-policy.test.ts covering create-table, toggling force on/off, and add-policy + force.

Closes #5819