### PR TITLE
Fix nested partial select null mapping

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -45,10 +45,12 @@ export function mapResultRow<TResult>(
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;
+						const tableName = getTableName(field.table);
 						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
+							nullifyMap[objectName] = value === null ? tableName : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== tableName || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/mapResultRow.test.ts
+++ b/drizzle-orm/tests/mapResultRow.test.ts
@@ -1,0 +1,47 @@
+import { test } from 'vitest';
+import type { AnyColumn } from '~/column.ts';
+import type { SelectedFieldsOrdered } from '~/operations.ts';
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const orgBranding = pgTable('org_branding', {
+	logo: text('logo'),
+	panelBackground: text('panel_background_colour'),
+});
+
+test('does not nullify nested object when only the first same-table joined column is null', ({ expect }) => {
+	const columns: SelectedFieldsOrdered<AnyColumn> = [
+		{ path: ['branding', 'logo'], field: orgBranding.logo },
+		{ path: ['branding', 'panelBackground'], field: orgBranding.panelBackground },
+	];
+
+	const result = mapResultRow(
+		columns,
+		[null, '#1a8cff'],
+		{ org_branding: false },
+	);
+
+	expect(result).toEqual({
+		branding: {
+			logo: null,
+			panelBackground: '#1a8cff',
+		},
+	});
+});
+
+test('nullifies nested object when all same-table joined columns are null', ({ expect }) => {
+	const columns: SelectedFieldsOrdered<AnyColumn> = [
+		{ path: ['branding', 'logo'], field: orgBranding.logo },
+		{ path: ['branding', 'panelBackground'], field: orgBranding.panelBackground },
+	];
+
+	const result = mapResultRow(
+		columns,
+		[null, null],
+		{ org_branding: false },
+	);
+
+	expect(result).toEqual({
+		branding: null,
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1603.

`mapResultRow()` tracks nullable joined nested objects so it can nullify the object when every selected column from the nullable joined table is `null`. When the first selected nested column was `null` and a later column from the same table was non-null, the mapper kept the nested object marked for nullification and returned the whole object as `null`.

This updates the nullification tracking so a same-table non-null value clears that marker, preserving the nested object.

## Tests

- `npx -y pnpm@10.6.3 --filter drizzle-orm exec vitest run tests/mapResultRow.test.ts`
- `npx -y pnpm@10.6.3 --filter drizzle-orm test`
- `npx -y pnpm@10.6.3 --filter drizzle-orm test:types`
- `npx -y pnpm@10.6.3 exec dprint check drizzle-orm/src/utils.ts drizzle-orm/tests/mapResultRow.test.ts`

/claim #1603