### PR TITLE
[SQLite-kit] Don't select newly added columns on table recreate

### DIFF
--- a/drizzle-kit/src/jsonStatements.ts
+++ b/drizzle-kit/src/jsonStatements.ts
@@ -72,6 +72,11 @@ export interface JsonRecreateTableStatement {
 	compositePKs: string[][];
 	uniqueConstraints?: string[];
 	checkConstraints: string[];
+	// Names of the columns to copy from the old table into the recreated one.
+	// When omitted, every column in `columns` is copied. This is used to avoid
+	// selecting newly added columns (which don't exist on the old table yet)
+	// when a table is recreated and columns are added in the same migration.
+	columnsToTransfer?: string[];
 }
 
 export interface JsonRecreateSingleStoreTableStatement {

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -3769,9 +3769,10 @@ class SQLiteRecreateTableConvertor extends Convertor {
 	}
 
 	convert(statement: JsonRecreateTableStatement): string | string[] {
-		const { tableName, columns, compositePKs, referenceData, checkConstraints } = statement;
+		const { tableName, columns, compositePKs, referenceData, checkConstraints, columnsToTransfer } = statement;
 
-		const columnNames = columns.map((it) => `"${it.name}"`).join(', ');
+		const transferColumns = columnsToTransfer ?? columns.map((it) => it.name);
+		const columnNames = transferColumns.map((it) => `"${it}"`).join(', ');
 		const newTableName = `__new_${tableName}`;
 
 		const sqlStatements: string[] = [];
@@ -3836,9 +3837,10 @@ class LibSQLRecreateTableConvertor extends Convertor {
 	}
 
 	convert(statement: JsonRecreateTableStatement): string[] {
-		const { tableName, columns, compositePKs, referenceData, checkConstraints } = statement;
+		const { tableName, columns, compositePKs, referenceData, checkConstraints, columnsToTransfer } = statement;
 
-		const columnNames = columns.map((it) => `"${it.name}"`).join(', ');
+		const transferColumns = columnsToTransfer ?? columns.map((it) => it.name);
+		const columnNames = transferColumns.map((it) => `"${it}"`).join(', ');
 		const newTableName = `__new_${tableName}`;
 
 		const sqlStatements: string[] = [];

--- a/drizzle-kit/src/statementCombiner.ts
+++ b/drizzle-kit/src/statementCombiner.ts
@@ -7,6 +7,36 @@ import {
 import { SingleStoreSchemaSquashed } from './serializer/singlestoreSchema';
 import { SQLiteSchemaSquashed, SQLiteSquasher } from './serializer/sqliteSchema';
 
+// When a table is recreated (e.g. because a column type or constraint changed)
+// and new columns are added in the same migration, the added columns don't yet
+// exist on the old table. They must therefore be excluded from the
+// `INSERT ... SELECT` that copies the data into the recreated table, otherwise
+// the generated migration fails with "no such column". See issue #5822.
+const excludeAddedColumnsFromRecreate = (
+	statements: JsonStatement[],
+	newStatements: Record<string, JsonStatement[]>,
+) => {
+	const addedColumnsByTable: Record<string, Set<string>> = {};
+	for (const statement of statements) {
+		if (statement.type === 'sqlite_alter_table_add_column') {
+			(addedColumnsByTable[statement.tableName] ??= new Set()).add(statement.column.name);
+		}
+	}
+
+	for (const [tableName, tableStatements] of Object.entries(newStatements)) {
+		const addedColumns = addedColumnsByTable[tableName];
+		if (!addedColumns || addedColumns.size === 0) continue;
+
+		for (const statement of tableStatements) {
+			if (statement.type === 'recreate_table') {
+				statement.columnsToTransfer = statement.columns
+					.map((column) => column.name)
+					.filter((name) => !addedColumns.has(name));
+			}
+		}
+	}
+};
+
 export const prepareLibSQLRecreateTable = (
 	table: SQLiteSchemaSquashed['tables'][keyof SQLiteSchemaSquashed['tables']],
 	action?: 'push',
@@ -293,6 +323,8 @@ export const libSQLCombineStatements = (
 		}
 	}
 
+	excludeAddedColumnsFromRecreate(statements, newStatements);
+
 	const combinedStatements = Object.values(newStatements).flat();
 	const renamedTables = combinedStatements.filter((it) => it.type === 'rename_table');
 	const renamedColumns = combinedStatements.filter((it) => it.type === 'alter_table_rename_column');
@@ -435,6 +467,8 @@ export const sqliteCombineStatements = (
 			newStatements[tableName].push(statement);
 		}
 	}
+
+	excludeAddedColumnsFromRecreate(statements, newStatements);
 
 	const combinedStatements = Object.values(newStatements).flat();
 

--- a/drizzle-kit/tests/sqlite-recreate-add-column.test.ts
+++ b/drizzle-kit/tests/sqlite-recreate-add-column.test.ts
@@ -1,0 +1,67 @@
+import { sql } from 'drizzle-orm';
+import { check, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { expect, test } from 'vitest';
+import { diffTestSchemasLibSQL, diffTestSchemasSqlite } from './schemaDiffer';
+
+// https://github.com/drizzle-team/drizzle-orm/issues/5822
+// When a table has to be recreated and a new column is added in the same
+// migration, the generated `INSERT ... SELECT` must not select the newly added
+// column from the old table, because it doesn't exist there yet.
+
+test('sqlite recreate table does not select added columns from the old table', async () => {
+	// Dropping the NOT NULL constraint on column2 forces SQLite to recreate the
+	// table; column3 is added in the same migration.
+	const schema1 = {
+		test: sqliteTable('test', {
+			column1: text('column1').notNull(),
+			column2: text('column2').notNull(),
+		}),
+	};
+
+	const schema2 = {
+		test: sqliteTable('test', {
+			column1: text('column1').notNull(),
+			column2: text('column2'),
+			column3: text('column3'),
+		}),
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite(schema1, schema2, []);
+
+	expect(sqlStatements).toContain(
+		'INSERT INTO `__new_test`("column1", "column2") SELECT "column1", "column2" FROM `test`;',
+	);
+
+	for (const statement of sqlStatements) {
+		expect(statement).not.toContain('SELECT "column1", "column2", "column3" FROM `test`');
+	}
+});
+
+test('libsql recreate table does not select added columns from the old table', async () => {
+	// LibSQL can drop NOT NULL in place, so a constraint change is used to force a
+	// table recreate; column3 is added in the same migration.
+	const schema1 = {
+		test: sqliteTable('test', {
+			column1: text('column1').notNull(),
+			column2: text('column2').notNull(),
+		}),
+	};
+
+	const schema2 = {
+		test: sqliteTable('test', {
+			column1: text('column1').notNull(),
+			column2: text('column2').notNull(),
+			column3: text('column3'),
+		}, (t) => [check('ck', sql`${t.column1} <> ''`)]),
+	};
+
+	const { sqlStatements } = await diffTestSchemasLibSQL(schema1, schema2, []);
+
+	expect(sqlStatements).toContain(
+		'INSERT INTO `__new_test`("column1", "column2") SELECT "column1", "column2" FROM `test`;',
+	);
+
+	for (const statement of sqlStatements) {
+		expect(statement).not.toContain('SELECT "column1", "column2", "column3" FROM `test`');
+	}
+});


### PR DESCRIPTION
## What's changed

Fixes #5822.

When a SQLite/LibSQL table has to be recreated during a migration (for example a column drops its `NOT NULL` constraint, or a check/constraint change forces a rebuild) **and** a new column is added in the same migration, the generated migration was broken:

```sql
CREATE TABLE `__new_test` ( ... , `column3` text );
INSERT INTO `__new_test`("column1", "column2", "column3")
  SELECT "column1", "column2", "column3" FROM `test`;  -- ❌ column3 doesn't exist on the old table yet
```

Running it fails with `no such column: column3`.

### Fix

- `statementCombiner.ts` now collects the names of columns that are added in the same migration (`sqlite_alter_table_add_column`) and records them on the recreate statement through a new optional `columnsToTransfer` field. Applied to both `sqliteCombineStatements` and `libSQLCombineStatements`.
- `sqlgenerator.ts` (`SQLiteRecreateTableConvertor` / `LibSQLRecreateTableConvertor`) copies only `columnsToTransfer` in the `INSERT ... SELECT`. When the field is omitted it falls back to copying every column, so existing behaviour is unchanged.
- `jsonStatements.ts` adds the optional `columnsToTransfer?: string[]` field to `JsonRecreateTableStatement`.

After the fix:

```sql
INSERT INTO `__new_test`("column1", "column2") SELECT "column1", "column2" FROM `test`;
```

### Tests

Added `drizzle-kit/tests/sqlite-recreate-add-column.test.ts` covering both SQLite and LibSQL: a recreate-triggering change plus an added column, asserting the added column is excluded from the `INSERT ... SELECT`.

Verified the new tests pass and existing `sqlite-columns`, `sqlite-tables`, `sqlite-checks`, `libsql-checks` and `libsql-statements` suites still pass (71 existing tests green, no regressions).