### PR TITLE
effect-schema: thread customType schema through createSelectSchema (and friends)

### DIFF
--- a/drizzle-orm/src/cockroach-core/columns/custom.ts
+++ b/drizzle-orm/src/cockroach-core/columns/custom.ts
@@ -11,6 +11,7 @@ export type ConvertCustomConfig<T extends Partial<CustomTypeValues>> =
 		dataType: 'custom';
 		data: T['data'];
 		driverParam: T['driverData'];
+		customTypeSchemas: T['schemas'];
 	}
 	& (T['notNull'] extends true ? { notNull: true } : {})
 	& (T['default'] extends true ? { hasDefault: true } : {});
@@ -59,6 +60,7 @@ export class CockroachCustomColumn<T extends ColumnBaseConfig<'custom'>> extends
 	private mapFrom?: (value: T['driverParam']) => T['data'];
 	private mapJson?: (value: unknown) => T['data'];
 	private forJsonSelect?: (identifier: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
+	readonly customTypeSchemas?: { effect?: unknown };
 
 	constructor(
 		table: CockroachTable<any>,
@@ -70,6 +72,7 @@ export class CockroachCustomColumn<T extends ColumnBaseConfig<'custom'>> extends
 		this.mapFrom = config.customTypeParams.fromDriver;
 		this.mapJson = config.customTypeParams.fromJson;
 		this.forJsonSelect = config.customTypeParams.forJsonSelect;
+		this.customTypeSchemas = config.customTypeParams.schemas;
 	}
 
 	getSQLType(): string {
@@ -176,6 +179,16 @@ export type CustomTypeValues = {
 	 * });
 	 */
 	default?: boolean;
+
+	/**
+	 * Optional type-level marker for adapter-package schemas. Declare here to make
+	 * the customType column's TypeScript type carry the schema, so schema generators
+	 * (e.g. `drizzle-orm/effect-schema`) can thread it into their output instead of
+	 * collapsing the column to `Schema.Any` / `z.any()` / etc.
+	 *
+	 * Provide the actual schema *values* via {@link CustomTypeParams.schemas}.
+	 */
+	schemas?: { effect?: unknown };
 };
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
@@ -332,6 +345,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	forJsonSelect?: (identifier: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
+
+	/**
+	 * Optional per-adapter schema overrides. When a key is present, the matching
+	 * schema-generator adapter uses it in place of its default fallback.
+	 *
+	 * Currently honored:
+	 * - `effect` — read by `drizzle-orm/effect-schema`.
+	 *
+	 * For type-level threading, also declare the slot in the `customType` generic
+	 * via {@link CustomTypeValues.schemas}.
+	 */
+	schemas?: T['schemas'] extends undefined ? { effect?: unknown } : T['schemas'];
 }
 
 /**

--- a/drizzle-orm/src/effect-schema/column.ts
+++ b/drizzle-orm/src/effect-schema/column.ts
@@ -66,7 +66,8 @@ export function columnToSchema(
 			break;
 		}
 		case 'custom': {
-			schema = S.Any;
+			const customSchema = (<{ customTypeSchemas?: { effect?: unknown } }> column).customTypeSchemas?.effect;
+			schema = S.isSchema(customSchema) ? (customSchema as SchemaTop) : S.Any;
 			break;
 		}
 		default: {

--- a/drizzle-orm/src/effect-schema/column.types.ts
+++ b/drizzle-orm/src/effect-schema/column.types.ts
@@ -52,7 +52,9 @@ type GetBaseEffectSchemaType<
 			? Struct<{ readonly a: typeof s.Number; readonly b: typeof s.Number; readonly c: typeof s.Number }>
 		: TType['constraint'] extends 'json' ? typeof jsonSchema
 		: typeof s.ObjectKeyword
-	: TType['type'] extends 'custom' ? typeof s.Any
+	: TType['type'] extends 'custom' ? TColumn['_'] extends { customTypeSchemas: { effect: infer TEffect } }
+			? TEffect extends SchemaTop ? TEffect : typeof s.Any
+		: typeof s.Any
 	: TType['type'] extends 'number'
 		? (TType['constraint'] extends
 			'int8' | 'int16' | 'int24' | 'int32' | 'int53' | 'uint8' | 'uint16' | 'uint24' | 'uint32' | 'uint53' | 'year'

--- a/drizzle-orm/src/mssql-core/columns/custom.ts
+++ b/drizzle-orm/src/mssql-core/columns/custom.ts
@@ -11,6 +11,7 @@ export type ConvertCustomConfig<T extends Partial<CustomTypeValues>> =
 		dataType: 'custom';
 		data: T['data'];
 		driverParam: T['driverData'];
+		customTypeSchemas: T['schemas'];
 	}
 	& (T['notNull'] extends true ? { notNull: true } : {})
 	& (T['default'] extends true ? { hasDefault: true } : {});
@@ -57,6 +58,7 @@ export class MsSqlCustomColumn<T extends ColumnBaseConfig<'custom'>> extends MsS
 	private mapFrom?: (value: T['driverParam']) => T['data'];
 	private mapJson?: (value: unknown) => T['data'];
 	private forJsonSelect?: (name: SQL, sql: SQLGenerator) => SQL;
+	readonly customTypeSchemas?: { effect?: unknown };
 
 	constructor(
 		table: MsSqlTable<any>,
@@ -68,6 +70,7 @@ export class MsSqlCustomColumn<T extends ColumnBaseConfig<'custom'>> extends MsS
 		this.mapFrom = config.customTypeParams.fromDriver;
 		this.mapJson = config.customTypeParams.fromJson;
 		this.forJsonSelect = config.customTypeParams.forJsonSelect;
+		this.customTypeSchemas = config.customTypeParams.schemas;
 	}
 
 	getSQLType(): string {
@@ -176,6 +179,16 @@ export type CustomTypeValues = {
 	 * });
 	 */
 	default?: boolean;
+
+	/**
+	 * Optional type-level marker for adapter-package schemas. Declare here to make
+	 * the customType column's TypeScript type carry the schema, so schema generators
+	 * (e.g. `drizzle-orm/effect-schema`) can thread it into their output instead of
+	 * collapsing the column to `Schema.Any` / `z.any()` / etc.
+	 *
+	 * Provide the actual schema *values* via {@link CustomTypeParams.schemas}.
+	 */
+	schemas?: { effect?: unknown };
 };
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
@@ -332,6 +345,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	forJsonSelect?: (identifier: SQL, sql: SQLGenerator) => SQL;
+
+	/**
+	 * Optional per-adapter schema overrides. When a key is present, the matching
+	 * schema-generator adapter uses it in place of its default fallback.
+	 *
+	 * Currently honored:
+	 * - `effect` — read by `drizzle-orm/effect-schema`.
+	 *
+	 * For type-level threading, also declare the slot in the `customType` generic
+	 * via {@link CustomTypeValues.schemas}.
+	 */
+	schemas?: T['schemas'] extends undefined ? { effect?: unknown } : T['schemas'];
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -11,6 +11,7 @@ export type ConvertCustomConfig<T extends Partial<CustomTypeValues>> =
 		dataType: 'custom';
 		data: T['data'];
 		driverParam: T['driverData'];
+		customTypeSchemas: T['schemas'];
 	}
 	& (T['notNull'] extends true ? { notNull: true } : {})
 	& (T['default'] extends true ? { hasDefault: true } : {});
@@ -55,6 +56,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom'>> extends MyS
 	private mapFrom?: (value: T['driverParam']) => T['data'];
 	private mapJson?: (value: unknown) => T['data'];
 	private forJsonSelect?: (name: SQL, sql: SQLGenerator) => SQL;
+	readonly customTypeSchemas?: { effect?: unknown };
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -66,6 +68,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom'>> extends MyS
 		this.mapFrom = config.customTypeParams.fromDriver;
 		this.mapJson = config.customTypeParams.fromJson;
 		this.forJsonSelect = config.customTypeParams.forJsonSelect;
+		this.customTypeSchemas = config.customTypeParams.schemas;
 	}
 
 	getSQLType(): string {
@@ -175,6 +178,16 @@ export interface CustomTypeValues {
 	 * });
 	 */
 	default?: boolean;
+
+	/**
+	 * Optional type-level marker for adapter-package schemas. Declare here to make
+	 * the customType column's TypeScript type carry the schema, so schema generators
+	 * (e.g. `drizzle-orm/effect-schema`) can thread it into their output instead of
+	 * collapsing the column to `Schema.Any` / `z.any()` / etc.
+	 *
+	 * Provide the actual schema *values* via {@link CustomTypeParams.schemas}.
+	 */
+	schemas?: { effect?: unknown };
 }
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
@@ -331,6 +344,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	forJsonSelect?: (identifier: SQL, sql: SQLGenerator) => SQL;
+
+	/**
+	 * Optional per-adapter schema overrides. When a key is present, the matching
+	 * schema-generator adapter uses it in place of its default fallback.
+	 *
+	 * Currently honored:
+	 * - `effect` — read by `drizzle-orm/effect-schema`.
+	 *
+	 * For type-level threading, also declare the slot in the `customType` generic
+	 * via {@link CustomTypeValues.schemas}.
+	 */
+	schemas?: T['schemas'] extends undefined ? { effect?: unknown } : T['schemas'];
 }
 
 /**

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -12,6 +12,7 @@ export type ConvertCustomConfig<T extends Partial<CustomTypeValues>> =
 		dataType: 'custom';
 		data: T['data'];
 		driverParam: T['driverData'];
+		customTypeSchemas: T['schemas'];
 	}
 	& (T['notNull'] extends true ? { notNull: true } : {})
 	& (T['default'] extends true ? { hasDefault: true } : {});
@@ -57,6 +58,7 @@ export class PgCustomColumn<T extends ColumnBuilderBaseConfig<'custom'>> extends
 	private sqlName: string;
 	readonly mapFromJsonValue?: (value: unknown) => T['data'];
 	readonly jsonSelectIdentifier?: (identifier: SQL, sql: SQLGenerator, arrayDimensions?: number) => SQL;
+	readonly customTypeSchemas?: { effect?: unknown };
 
 	constructor(
 		table: PgTable<any>,
@@ -68,6 +70,7 @@ export class PgCustomColumn<T extends ColumnBuilderBaseConfig<'custom'>> extends
 		this.mapFromDriverValue = config.customTypeParams.fromDriver ?? this.mapFromDriverValue;
 		this.mapFromJsonValue = config.customTypeParams.fromJson;
 		this.jsonSelectIdentifier = config.customTypeParams.forJsonSelect;
+		this.customTypeSchemas = config.customTypeParams.schemas;
 		const cfgCodec =
 			typeof config.customTypeParams.codec === 'string' || typeof config.customTypeParams.codec === 'undefined'
 				? config.customTypeParams.codec
@@ -167,6 +170,23 @@ export interface CustomTypeValues {
 	 * });
 	 */
 	default?: boolean;
+
+	/**
+	 * Optional type-level marker for adapter-package schemas. Declare here to make
+	 * the customType column's TypeScript type carry the schema, so schema generators
+	 * (e.g. `drizzle-orm/effect-schema`) can thread it into their output instead of
+	 * collapsing the column to `Schema.Any` / `z.any()` / etc.
+	 *
+	 * Provide the actual schema *values* via {@link CustomTypeParams.schemas}.
+	 *
+	 * @example
+	 * const instantType = customType<{
+	 *   data: Temporal.Instant;
+	 *   driverData: string;
+	 *   schemas: { effect: typeof InstantSchema };
+	 * }>({ ..., schemas: { effect: InstantSchema } });
+	 */
+	schemas?: { effect?: unknown };
 }
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
@@ -337,6 +357,41 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 		| ((
 			config: T['config'] | (Equal<T['configRequired'], true> extends true ? never : undefined),
 		) => PostgresColumnType | undefined);
+
+	/**
+	 * Optional per-adapter schema overrides. When a key is present, the matching
+	 * schema-generator adapter uses it in place of its default fallback (which is
+	 * `Schema.Any` / `z.any()` / etc. for customType columns).
+	 *
+	 * Currently honored:
+	 * - `effect` — read by `drizzle-orm/effect-schema`'s `createSelectSchema`,
+	 *   `createInsertSchema`, and `createUpdateSchema`.
+	 *
+	 * For type-level threading through `column['_']`, also declare the slot in
+	 * the `customType` generic via {@link CustomTypeValues.schemas}.
+	 *
+	 * @example
+	 * import { Schema } from 'effect';
+	 * import { Temporal } from '@js-temporal/polyfill';
+	 *
+	 * const InstantSchema = Schema.transform(
+	 *   Schema.String,
+	 *   Schema.declare<Temporal.Instant>((v): v is Temporal.Instant => v instanceof Temporal.Instant),
+	 *   { decode: (s) => Temporal.Instant.from(s), encode: (i) => i.toString() },
+	 * );
+	 *
+	 * const instantType = customType<{
+	 *   data: Temporal.Instant;
+	 *   driverData: string;
+	 *   schemas: { effect: typeof InstantSchema };
+	 * }>({
+	 *   dataType: () => 'timestamptz',
+	 *   toDriver: (v) => v.toString(),
+	 *   fromDriver: (s) => Temporal.Instant.from(s),
+	 *   schemas: { effect: InstantSchema },
+	 * });
+	 */
+	schemas?: T['schemas'] extends undefined ? { effect?: unknown } : T['schemas'];
 }
 
 /**

--- a/drizzle-orm/src/singlestore-core/columns/custom.ts
+++ b/drizzle-orm/src/singlestore-core/columns/custom.ts
@@ -11,6 +11,7 @@ export type ConvertCustomConfig<T extends Partial<CustomTypeValues>> =
 		dataType: 'custom';
 		data: T['data'];
 		driverParam: T['driverData'];
+		customTypeSchemas: T['schemas'];
 	}
 	& (T['notNull'] extends true ? { notNull: true } : {})
 	& (T['default'] extends true ? { hasDefault: true } : {});
@@ -57,6 +58,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom'>> exten
 	private mapFrom?: (value: T['driverParam']) => T['data'];
 	private mapJson?: (value: unknown) => T['data'];
 	private forJsonSelect?: (name: SQL, sql: SQLGenerator) => SQL;
+	readonly customTypeSchemas?: { effect?: unknown };
 
 	constructor(
 		table: AnySingleStoreTable<{ name: T['tableName'] }>,
@@ -68,6 +70,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom'>> exten
 		this.mapFrom = config.customTypeParams.fromDriver;
 		this.mapJson = config.customTypeParams.fromJson;
 		this.forJsonSelect = config.customTypeParams.forJsonSelect;
+		this.customTypeSchemas = config.customTypeParams.schemas;
 	}
 
 	getSQLType(): string {
@@ -175,6 +178,16 @@ export interface CustomTypeValues {
 	 * });
 	 */
 	default?: boolean;
+
+	/**
+	 * Optional type-level marker for adapter-package schemas. Declare here to make
+	 * the customType column's TypeScript type carry the schema, so schema generators
+	 * (e.g. `drizzle-orm/effect-schema`) can thread it into their output instead of
+	 * collapsing the column to `Schema.Any` / `z.any()` / etc.
+	 *
+	 * Provide the actual schema *values* via {@link CustomTypeParams.schemas}.
+	 */
+	schemas?: { effect?: unknown };
 }
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
@@ -331,6 +344,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	forJsonSelect?: (identifier: SQL, sql: SQLGenerator) => SQL;
+
+	/**
+	 * Optional per-adapter schema overrides. When a key is present, the matching
+	 * schema-generator adapter uses it in place of its default fallback.
+	 *
+	 * Currently honored:
+	 * - `effect` — read by `drizzle-orm/effect-schema`.
+	 *
+	 * For type-level threading, also declare the slot in the `customType` generic
+	 * via {@link CustomTypeValues.schemas}.
+	 */
+	schemas?: T['schemas'] extends undefined ? { effect?: unknown } : T['schemas'];
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -11,6 +11,7 @@ export type ConvertCustomConfig<T extends Partial<CustomTypeValues>> =
 		dataType: 'custom';
 		data: T['data'];
 		driverParam: T['driverData'];
+		customTypeSchemas: T['schemas'];
 	}
 	& (T['notNull'] extends true ? { notNull: true } : {})
 	& (T['default'] extends true ? { hasDefault: true } : {});
@@ -55,6 +56,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom'>> extends SQ
 	private mapFrom?: (value: T['driverParam']) => T['data'];
 	private mapJson?: (value: unknown) => T['data'];
 	private forJsonSelect?: (name: SQL, sql: SQLGenerator) => SQL;
+	readonly customTypeSchemas?: { effect?: unknown };
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -66,6 +68,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom'>> extends SQ
 		this.mapFrom = config.customTypeParams.fromDriver;
 		this.mapJson = config.customTypeParams.fromJson;
 		this.forJsonSelect = config.customTypeParams.forJsonSelect;
+		this.customTypeSchemas = config.customTypeParams.schemas;
 	}
 
 	getSQLType(): string {
@@ -172,6 +175,16 @@ export interface CustomTypeValues {
 	 * });
 	 */
 	default?: boolean;
+
+	/**
+	 * Optional type-level marker for adapter-package schemas. Declare here to make
+	 * the customType column's TypeScript type carry the schema, so schema generators
+	 * (e.g. `drizzle-orm/effect-schema`) can thread it into their output instead of
+	 * collapsing the column to `Schema.Any` / `z.any()` / etc.
+	 *
+	 * Provide the actual schema *values* via {@link CustomTypeParams.schemas}.
+	 */
+	schemas?: { effect?: unknown };
 }
 
 export interface CustomTypeParams<T extends CustomTypeValues> {
@@ -328,6 +341,18 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	forJsonSelect?: (identifier: SQL, sql: SQLGenerator) => SQL;
+
+	/**
+	 * Optional per-adapter schema overrides. When a key is present, the matching
+	 * schema-generator adapter uses it in place of its default fallback.
+	 *
+	 * Currently honored:
+	 * - `effect` — read by `drizzle-orm/effect-schema`.
+	 *
+	 * For type-level threading, also declare the slot in the `customType` generic
+	 * via {@link CustomTypeValues.schemas}.
+	 */
+	schemas?: T['schemas'] extends undefined ? { effect?: unknown } : T['schemas'];
 }
 
 /**

--- a/drizzle-orm/tests/effect-schema-custom-type.test.ts
+++ b/drizzle-orm/tests/effect-schema-custom-type.test.ts
@@ -1,0 +1,61 @@
+import { Schema as s } from 'effect';
+import { describe, expect, test } from 'vitest';
+import { createSelectSchema } from '~/effect-schema/index.ts';
+import { customType, integer, pgTable } from '~/pg-core/index.ts';
+
+class FakeInstant {
+	constructor(readonly iso: string) {}
+	toString() {
+		return this.iso;
+	}
+}
+const InstantSchema = s.declare<FakeInstant>((v: unknown): v is FakeInstant => v instanceof FakeInstant);
+
+describe('effect-schema customType.schemas.effect', () => {
+	test('honors per-customType effect schema at runtime', () => {
+		const instantType = customType<{
+			data: FakeInstant;
+			driverData: string;
+			schemas: { effect: typeof InstantSchema };
+		}>({
+			codec: undefined,
+			dataType: () => 'timestamptz',
+			toDriver: (v) => v.toString(),
+			fromDriver: (str) => new FakeInstant(str),
+			schemas: { effect: InstantSchema },
+		});
+
+		const audit = pgTable('audit', {
+			id: integer().notNull(),
+			createdAt: instantType('created_at').notNull(),
+		});
+
+		const Row = createSelectSchema(audit);
+
+		const now = new FakeInstant('2026-01-01T00:00:00Z');
+		const decoded = s.decodeUnknownSync(Row)({ id: 1, createdAt: now });
+		expect(decoded.createdAt).toBeInstanceOf(FakeInstant);
+		expect(decoded.createdAt.iso).toBe('2026-01-01T00:00:00Z');
+
+		// raw string should be rejected — the schema is no longer Schema.Any
+		expect(() => s.decodeUnknownSync(Row)({ id: 1, createdAt: '2026-01-01T00:00:00Z' })).toThrow();
+	});
+
+	test('falls back to Schema.Any when schemas.effect is not provided', () => {
+		const opaqueType = customType<{ data: { foo: string }; driverData: string }>({
+			codec: undefined,
+			dataType: () => 'text',
+			toDriver: (v) => JSON.stringify(v),
+			fromDriver: (str) => JSON.parse(str) as { foo: string },
+		});
+
+		const table = pgTable('opaque', {
+			blob: opaqueType('blob').notNull(),
+		});
+		const Row = createSelectSchema(table);
+
+		// without an effect schema, decode is permissive — any value passes
+		expect(s.decodeUnknownSync(Row)({ blob: 'anything' })).toEqual({ blob: 'anything' });
+		expect(s.decodeUnknownSync(Row)({ blob: { foo: 'bar' } })).toEqual({ blob: { foo: 'bar' } });
+	});
+});

--- a/integration-tests/tests/validators/effect-schema/pg.test.ts
+++ b/integration-tests/tests/validators/effect-schema/pg.test.ts
@@ -610,6 +610,61 @@ test('all data types', (t) => {
 	Expect<Equal<typeof result, typeof expected>>();
 }
 
+test('customType - schemas.effect is honored by createSelectSchema (runtime + type)', (t) => {
+	class FakeInstant {
+		constructor(readonly iso: string) {}
+		toString() {
+			return this.iso;
+		}
+	}
+	const InstantSchema = s.declare<FakeInstant>((v: unknown): v is FakeInstant => v instanceof FakeInstant);
+
+	const instantType = customType<{
+		data: FakeInstant;
+		driverData: string;
+		schemas: { effect: typeof InstantSchema };
+	}>({
+		codec: undefined,
+		dataType: () => 'timestamptz',
+		toDriver: (v) => v.toString(),
+		fromDriver: (str) => new FakeInstant(str),
+		schemas: { effect: InstantSchema },
+	});
+
+	const table = pgTable('audit', {
+		id: integer().notNull(),
+		createdAt: instantType('created_at').notNull(),
+	});
+
+	const result = createSelectSchema(table);
+	const expected = s.Struct({
+		id: integerSchema,
+		createdAt: InstantSchema,
+	});
+
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
+test('customType - missing schemas.effect falls back to Schema.Any', (t) => {
+	const opaqueType = customType<{ data: { foo: string }; driverData: string }>({
+		codec: undefined,
+		dataType: () => 'text',
+		toDriver: (v) => JSON.stringify(v),
+		fromDriver: (s) => JSON.parse(s),
+	});
+
+	const table = pgTable('opaque', {
+		blob: opaqueType('blob').notNull(),
+	});
+	const result = createSelectSchema(table);
+	const expected = s.Struct({
+		blob: anySchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
 /* Disallow unknown keys in table refinement - select */ {
 	const table = pgTable('test', { id: integer() });
 	// @ts-expect-error


### PR DESCRIPTION
## Summary

Adds an opt-in `schemas.effect` slot to `customType()` params so that `drizzle-orm/effect-schema`'s `createSelectSchema` / `createInsertSchema` / `createUpdateSchema` no longer collapse customType columns to `Schema.Any`.

When set, the supplied Effect Schema is honored at **both** runtime and the type level. When omitted, behavior is unchanged (falls back to `Schema.Any`).

This is a first crack at the issue described internally — the smallest concrete change that unblocks codebases using `customType` for domain types (Temporal classes, branded IDs, structural enums, etc.) without forcing per-column-per-router `refine` overrides.

## Example

```ts
import { customType } from 'drizzle-orm/pg-core';
import { createSelectSchema } from 'drizzle-orm/effect-schema';
import { Schema } from 'effect';
import { Temporal } from '@js-temporal/polyfill';

const InstantSchema = Schema.transform(
  Schema.String,
  Schema.declare<Temporal.Instant>((v): v is Temporal.Instant => v instanceof Temporal.Instant),
  { decode: (s) => Temporal.Instant.from(s), encode: (i) => i.toString() },
);

const instantType = customType<{
  data: Temporal.Instant;
  driverData: string;
  schemas: { effect: typeof InstantSchema };
}>({
  dataType: () => 'timestamptz',
  toDriver: (v) => v.toString(),
  fromDriver: (s) => Temporal.Instant.from(s),
  schemas: { effect: InstantSchema },
});

const audit = pgTable('audit', {
  id: uuid().defaultRandom().primaryKey(),
  createdAt: instantType('created_at').notNull(),
});

const Row = createSelectSchema(audit);
type RowOut = Schema.Schema.Type<typeof Row>;
//   ^? { id: string; createdAt: Temporal.Instant }   (previously: createdAt was `any`)
```

## What's in the change

- Added `schemas?: { effect?: unknown }` to `CustomTypeValues` (type-level marker) and `CustomTypeParams` (runtime value) across all six dialect `custom.ts` files: pg, mysql, sqlite, mssql, singlestore, cockroach.
- Threaded `customTypeSchemas: T['schemas']` through `ConvertCustomConfig<T>` so the schema type lives on `column['_']`.
- Exposed `customTypeSchemas` as a readonly field on each `*CustomColumn` class, set from `customTypeParams.schemas` in the constructor.
- `drizzle-orm/src/effect-schema/column.ts` — `case 'custom'` reads `column.customTypeSchemas?.effect` and uses it (gated on `S.isSchema`), else `S.Any`.
- `drizzle-orm/src/effect-schema/column.types.ts` — `GetBaseEffectSchemaType`'s `'custom'` branch infers `_['customTypeSchemas']['effect']` if it extends `SchemaTop`, else `typeof s.Any`.

The slot is named `schemas` (plural, keyed by adapter name) intentionally — leaves room for zod / valibot / arktype / typebox to honor the same hook later without breaking changes. Currently only `effect` is wired through.

## Tests

- `drizzle-orm/tests/effect-schema-custom-type.test.ts` — runtime: schema is honored; a raw string is rejected where it would have silently passed through `Schema.Any` before. Both fall-back paths covered.
- `integration-tests/tests/validators/effect-schema/pg.test.ts` — type-level + schema-shape coverage.

## Test plan

- [ ] CI typecheck passes (`drizzle-orm` and `type-tests`)
- [ ] CI runs the new `effect-schema-custom-type.test.ts`
- [ ] Existing effect-schema tests still pass (no behavior change when `schemas.effect` is absent)

## Open questions for maintainers

1. **Type-level inference of the schema type**: today the user has to declare `schemas: { effect: typeof X }` in the `customType<T>` generic for the type to thread through `_`. A follow-up could add a second generic to `customType()` for auto-inference from the passed value. Want that in this PR, or a separate one?
2. **Other adapters (zod / valibot / arktype / typebox)**: same pattern can be applied — read `column.customTypeSchemas?.<key>` in each `column.ts` `'custom'` branch. Happy to extend in this PR if you'd prefer one bundled change.
3. **Synthesizing `toDriver`/`fromDriver` from the schema**: tempting, but conflates the wire boundary with the DB-driver boundary (which sometimes have different acceptable types). Better as a separate opt-in helper in `drizzle-orm/effect-schema` later, if at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)