### PR TITLE
Ignore unsupported files when loading schema directories

### DIFF
--- a/drizzle-kit/src/serializer/index.ts
+++ b/drizzle-kit/src/serializer/index.ts
@@ -9,6 +9,12 @@ import type { PgSchemaInternal } from './pgSchema';
 import { SingleStoreSchemaInternal } from './singlestoreSchema';
 import type { SQLiteSchemaInternal } from './sqliteSchema';
 
+const schemaFileExtensions = ['.ts', '.js', '.cjs', '.mjs', '.mts', '.cts'];
+
+const isSchemaFile = (file: string) => {
+	return schemaFileExtensions.some((extension) => file.endsWith(extension));
+};
+
 export const serializeMySql = async (
 	path: string | string[],
 	casing: CasingType | undefined,
@@ -93,19 +99,7 @@ export const prepareFilenames = (path: string | string[]) => {
 
 		return result;
 	}, new Set<string>());
-	const res = [...result];
-
-	// TODO: properly handle and test
-	const errors = res.filter((it) => {
-		return !(
-			it.endsWith('.ts')
-			|| it.endsWith('.js')
-			|| it.endsWith('.cjs')
-			|| it.endsWith('.mjs')
-			|| it.endsWith('.mts')
-			|| it.endsWith('.cts')
-		);
-	});
+	const res = [...result].filter(isSchemaFile);
 
 	// when schema: "./schema" and not "./schema.ts"
 	if (res.length === 0) {

--- a/drizzle-kit/tests/prepare-filenames.test.ts
+++ b/drizzle-kit/tests/prepare-filenames.test.ts
@@ -1,0 +1,39 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, expect, test } from 'vitest';
+import { prepareFilenames } from '../src/serializer';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop()!;
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('prepareFilenames ignores TSX files when schema path is a directory', () => {
+	const schemaDir = mkdtempSync(join(tmpdir(), 'drizzle-kit-schema-'));
+	tempDirs.push(schemaDir);
+
+	writeFileSync(join(schemaDir, 'schema.ts'), 'export const users = {};\n');
+	writeFileSync(
+		join(schemaDir, 'Apple.tsx'),
+		'export const Apple = () => <svg />;\n',
+	);
+
+	const testConfigPathPrefix = process.env.TEST_CONFIG_PATH_PREFIX;
+	delete process.env.TEST_CONFIG_PATH_PREFIX;
+	try {
+		expect(prepareFilenames(schemaDir).sort()).toEqual([
+			resolve(schemaDir, 'schema.ts'),
+		]);
+	} finally {
+		if (testConfigPathPrefix === undefined) {
+			delete process.env.TEST_CONFIG_PATH_PREFIX;
+		} else {
+			process.env.TEST_CONFIG_PATH_PREFIX = testConfigPathPrefix;
+		}
+	}
+});


### PR DESCRIPTION
Fixes #5809.

## What changed
- Filter schema candidates from directories/globs to the supported module extensions already recognized by drizzle-kit (`.ts`, `.js`, `.cjs`, `.mjs`, `.mts`, `.cts`).
- Add a regression test that keeps a `.tsx` JSX component beside a schema file and verifies only the schema file is loaded.

## Verification
- `pnpm install --frozen-lockfile --ignore-scripts --store-dir /tmp/drizzle-5809-pnpm-store`
- `pnpm --dir drizzle-orm build`
- `TEST_CONFIG_PATH_PREFIX=./tests/cli/ pnpm --dir drizzle-kit exec vitest tests/cli-generate.test.ts tests/prepare-filenames.test.ts --run`
- `pnpm --dir drizzle-kit tsc`
- `pnpm exec dprint check drizzle-kit/src/serializer/index.ts drizzle-kit/tests/prepare-filenames.test.ts`
- `git diff --check`