### PR TITLE
fix(orm): evaluate $onUpdate lazily in buildUpdateSet across dialects

### DIFF
--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -149,7 +149,10 @@ export class GelDialect {
 		return sql.join(columnNames.flatMap((colName, i) => {
 			const col = tableColumns[colName]!;
 
-			const onUpdateFnResult = col.onUpdateFn?.();
+			// Only evaluate the $onUpdate callback when the column is absent from
+			// `set` — calling it eagerly runs its side effects even when an explicit
+			// value is provided and wins via `??` (regression, see #5780).
+			const onUpdateFnResult = set[colName] == null ? col.onUpdateFn?.() : undefined;
 			const value = set[colName] ?? (is(onUpdateFnResult, SQL) ? onUpdateFnResult : sql.param(onUpdateFnResult, col));
 			const res = sql`${sql.identifier(this.casing.getColumnCasing(col))} = ${value}`;
 

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -160,7 +160,10 @@ export class MySqlDialect {
 			columnNames.flatMap((colName, i) => {
 				const col = tableColumns[colName]!;
 
-				const onUpdateFnResult = col.onUpdateFn?.();
+				// Only evaluate the $onUpdate callback when the column is absent from
+				// `set` — calling it eagerly runs its side effects even when an explicit
+				// value is provided and wins via `??` (regression, see #5780).
+				const onUpdateFnResult = set[colName] == null ? col.onUpdateFn?.() : undefined;
 				const value = set[colName]
 					?? (is(onUpdateFnResult, SQL)
 						? onUpdateFnResult

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -160,7 +160,10 @@ export class PgDialect {
 		return sql.join(columnNames.flatMap((colName, i) => {
 			const col = tableColumns[colName]!;
 
-			const onUpdateFnResult = col.onUpdateFn?.();
+			// Only evaluate the $onUpdate callback when the column is absent from
+			// `set` — calling it eagerly runs its side effects even when an explicit
+			// value is provided and wins via `??` (regression, see #5780).
+			const onUpdateFnResult = set[colName] == null ? col.onUpdateFn?.() : undefined;
 			const value = set[colName] ?? (is(onUpdateFnResult, SQL) ? onUpdateFnResult : sql.param(onUpdateFnResult, col));
 			const res = sql`${sql.identifier(this.casing.getColumnCasing(col))} = ${value}`;
 

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -159,7 +159,10 @@ export class SingleStoreDialect {
 			columnNames.flatMap((colName, i) => {
 				const col = tableColumns[colName]!;
 
-				const onUpdateFnResult = col.onUpdateFn?.();
+				// Only evaluate the $onUpdate callback when the column is absent from
+				// `set` — calling it eagerly runs its side effects even when an explicit
+				// value is provided and wins via `??` (regression, see #5780).
+				const onUpdateFnResult = set[colName] == null ? col.onUpdateFn?.() : undefined;
 				const value = set[colName]
 					?? (is(onUpdateFnResult, SQL)
 						? onUpdateFnResult

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -117,7 +117,10 @@ export abstract class SQLiteDialect {
 			columnNames.flatMap((colName, i) => {
 				const col = tableColumns[colName]!;
 
-				const onUpdateFnResult = col.onUpdateFn?.();
+				// Only evaluate the $onUpdate callback when the column is absent from
+				// `set` — calling it eagerly runs its side effects even when an explicit
+				// value is provided and wins via `??` (regression, see #5780).
+				const onUpdateFnResult = set[colName] == null ? col.onUpdateFn?.() : undefined;
 				const value = set[colName]
 					?? (is(onUpdateFnResult, SQL)
 						? onUpdateFnResult

--- a/drizzle-orm/tests/on-update-set.test.ts
+++ b/drizzle-orm/tests/on-update-set.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { PgDialect, pgTable, text, uuid } from '~/pg-core/index.ts';
+import { sql } from '~/sql/sql.ts';
+import { mapUpdateSet } from '~/utils.ts';
+
+describe('$onUpdate lazy evaluation (#5780)', () => {
+	it('does not invoke $onUpdate when the column value is explicitly provided in set', () => {
+		const table = pgTable('example', {
+			id: uuid('id').primaryKey(),
+			name: text('name').notNull(),
+			updatedById: uuid('updated_by_id')
+				.$onUpdate(() => {
+					throw new Error('$onUpdate must not run when the column is explicitly set');
+				})
+				.notNull(),
+		});
+
+		const dialect = new PgDialect();
+
+		expect(() => dialect.buildUpdateSet(table, mapUpdateSet(table, { name: 'foo', updatedById: 'some-uuid' }))).not
+			.toThrow();
+	});
+
+	it('still invokes $onUpdate when the column is absent from set', () => {
+		let called = false;
+		const table = pgTable('example', {
+			id: uuid('id').primaryKey(),
+			name: text('name').notNull(),
+			touched: text('touched').$onUpdate(() => {
+				called = true;
+				return sql`now()`;
+			}),
+		});
+
+		new PgDialect().buildUpdateSet(table, mapUpdateSet(table, { name: 'foo' }));
+
+		expect(called).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #5780.

`buildUpdateSet` computed `col.onUpdateFn?.()` **eagerly** for every column, then only used the result when the column was absent from `set` (`set[colName] ?? …`). So any `$onUpdate` callback with side effects — `throw`, logging, reading external state — ran on **every** `UPDATE`, even when the column value was explicitly provided and would win via `??`. This is a regression from the lazy `0.44.6` behavior.

```ts
const table = pgTable('example', {
  updatedById: uuid('updated_by_id').$onUpdate(() => {
    throw new Error('should not be called when explicitly set');
  }),
  // ...
});

// 0.44.6: ok · 0.45.x: throws
await db.update(table).set({ updatedById: 'some-uuid' }).where(/* … */);
```

**Fix:** only evaluate the callback when the column is absent from `set` (`set[colName] == null`, matching the existing `??` semantics). The value line is unchanged. Applied to all five dialects that share this code path: **pg, mysql, sqlite, singlestore, gel**.

**Test:** added a DB-less unit test (`tests/on-update-set.test.ts`) — a throwing `$onUpdate` with an explicit value must not throw, and an absent column must still invoke the callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
