### PR TITLE
[Cache]: Fix hashQuery null/undefined cache key collision

### DIFF
--- a/drizzle-orm/src/cache/core/cache.ts
+++ b/drizzle-orm/src/cache/core/cache.ts
@@ -103,7 +103,13 @@ export const strategyFor = async (
 export type MutationOption = { tags?: string | string[]; tables?: Table<any> | Table<any>[] | string | string[] };
 
 export async function hashQuery(sql: string, params?: any[]) {
-	const dataToHash = `${sql}-${JSON.stringify(params, (_, v) => typeof v === 'bigint' ? `${v}n` : v)}`;
+	const dataToHash = `${sql}-${
+		JSON.stringify(params, (_, v) => {
+			if (typeof v === 'bigint') return `${v}n`;
+			if (v === undefined) return '__undefined__';
+			return v;
+		})
+	}`;
 	const encoder = new TextEncoder();
 	const data = encoder.encode(dataToHash);
 	const hashBuffer = await crypto.subtle.digest('SHA-256', data);

--- a/drizzle-orm/tests/cache.test.ts
+++ b/drizzle-orm/tests/cache.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { hashQuery } from '~/cache/core/cache.ts';
+
+// @see https://github.com/drizzle-team/drizzle-orm/issues/5842
+describe('hashQuery', () => {
+	test('null and undefined params produce different cache keys', async () => {
+		const query = 'select * from users where id = $1';
+		const hashNull = await hashQuery(query, [null]);
+		const hashUndefined = await hashQuery(query, [undefined]);
+		expect(hashNull).not.toBe(hashUndefined);
+	});
+
+	test('same sql with no params and undefined params produce different cache keys', async () => {
+		const query = 'select * from users where id = $1';
+		const hashNoParams = await hashQuery(query, []);
+		const hashUndefined = await hashQuery(query, [undefined]);
+		expect(hashNoParams).not.toBe(hashUndefined);
+	});
+
+	test('bigint and number params produce different cache keys', async () => {
+		const query = 'select * from users where id = $1';
+		const hashBigint = await hashQuery(query, [1n]);
+		const hashNumber = await hashQuery(query, [1]);
+		expect(hashBigint).not.toBe(hashNumber);
+	});
+});


### PR DESCRIPTION
## Summary

`hashQuery` uses `JSON.stringify` to serialise query params into the cache key. JavaScript's `JSON.stringify` converts `undefined` array elements to `null`, so `[undefined]` and `[null]` both produce `"[null]"` — causing two distinct queries to share the same cache key and return stale/wrong cached results.

Fix: extend the existing `JSON.stringify` replacer to map `undefined` to the sentinel string `'__undefined__'`, making it distinguishable from `null`.

Closes #5842

## Test plan

Added `drizzle-orm/tests/cache.test.ts` with three cases:

- `[null]` vs `[undefined]` params produce different hashes ← was failing before fix
- `[]` vs `[undefined]` params produce different hashes
- `[1n]` (bigint) vs `[1]` (number) produce different hashes (regression guard for existing behaviour)

All 962 unit tests pass (`pnpm --filter drizzle-orm test`).