### PR TITLE
feat(drizzle-kit): add unsecure studio mode

### DIFF
--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -673,7 +673,7 @@ export const prepareStudioConfig = async (options: Record<string, unknown>) => {
 		console.log(outputs.studio.noCredentials());
 		process.exit(1);
 	}
-	const { host, port } = params;
+	const { host, port, unsecure } = params;
 	const { dialect, schema, casing } = result.data;
 	const flattened = flattenDatabaseCredentials(config);
 
@@ -689,6 +689,7 @@ export const prepareStudioConfig = async (options: Record<string, unknown>) => {
 			schema,
 			host,
 			port,
+			unsecure,
 			credentials,
 			casing,
 		};
@@ -706,6 +707,7 @@ export const prepareStudioConfig = async (options: Record<string, unknown>) => {
 			schema,
 			host,
 			port,
+			unsecure,
 			credentials,
 			casing,
 		};
@@ -723,6 +725,7 @@ export const prepareStudioConfig = async (options: Record<string, unknown>) => {
 			schema,
 			host,
 			port,
+			unsecure,
 			credentials,
 			casing,
 		};
@@ -740,6 +743,7 @@ export const prepareStudioConfig = async (options: Record<string, unknown>) => {
 			schema,
 			host,
 			port,
+			unsecure,
 			credentials,
 			casing,
 		};
@@ -757,6 +761,7 @@ export const prepareStudioConfig = async (options: Record<string, unknown>) => {
 			schema,
 			host,
 			port,
+			unsecure,
 			credentials,
 			casing,
 		};

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -655,6 +655,7 @@ export const studio = command({
 		config: optionConfig,
 		port: number().desc('Custom port for drizzle studio [default=4983]'),
 		host: string().desc('Custom host for drizzle studio [default=0.0.0.0]'),
+		unsecure: boolean().desc('Serve drizzle studio over HTTP instead of HTTPS [default=false]'),
 		verbose: boolean()
 			.default(false)
 			.desc('Print all stataments that are executed by Studio'),
@@ -670,6 +671,7 @@ export const studio = command({
 			schema: schemaPath,
 			port,
 			host,
+			unsecure,
 			credentials,
 			casing,
 		} = await prepareStudioConfig(opts);
@@ -762,7 +764,7 @@ export const studio = command({
 				),
 			);
 
-			const { key, cert } = (await certs()) || {};
+			const { key, cert } = (!unsecure && (await certs())) || {};
 			server.start({
 				host,
 				port,
@@ -790,7 +792,9 @@ export const studio = command({
 						console.log(
 							`\nDrizzle Studio is up and running on ${
 								chalk.blue(
-									`https://local.drizzle.studio${queryString ? `?${queryString}` : ''}`,
+									unsecure
+										? `http://localhost:${port}`
+										: `https://local.drizzle.studio${queryString ? `?${queryString}` : ''}`,
 								)
 							}`,
 						);

--- a/drizzle-kit/src/cli/validations/studio.ts
+++ b/drizzle-kit/src/cli/validations/studio.ts
@@ -16,6 +16,7 @@ export type Credentials = TypeOf<typeof credentials>;
 export const studioCliParams = object({
 	port: coerce.number().optional().default(4983),
 	host: string().optional().default('127.0.0.1'),
+	unsecure: coerce.boolean().optional().default(false),
 	config: string().optional(),
 });
 


### PR DESCRIPTION
## Summary
Add a new `--unsecure` flag for `drizzle-kit studio` so Studio can skip TLS certificate generation and serve over HTTP. This is intended for proxy setups like portless, where the outer proxy owns HTTPS termination.

## Changes
- Add `--unsecure` to the Studio CLI
- Skip `certs()` generation when unsecure mode is enabled
- Start Studio over HTTP in unsecure mode
- Keep HTTPS as the default behavior

May fix: #3464