### PR TITLE
feat(1603): [BUG]: Nested Partial Select returns null on left join if f…

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -47,10 +47,10 @@ export function mapResultRow<TResult>(
 						const objectName = path[0]!;
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
-						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
-						) {
-							nullifyMap[objectName] = false;
+						} else if (typeof nullifyMap[objectName] === 'string') {
+							if (value !== null || nullifyMap[objectName] !== getTableName(field.table)) {
+								nullifyMap[objectName] = false;
+							}
 						}
 					}
 				}

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest';
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+const orgTable = pgTable('org', {
+	id: text('id'),
+	name: text('name'),
+	slug: text('slug'),
+});
+
+const orgBrandingTable = pgTable('org_branding', {
+	orgId: text('org_id'),
+	logo: text('logo'),
+	panelBackground: text('panel_background_colour'),
+});
+
+describe('mapResultRow', () => {
+	test('nested partial select: first column null, subsequent columns non-null should not nullify nested object', () => {
+		// Reproduces: https://github.com/drizzle-team/drizzle-orm/issues/1603
+		// When first selected column of a left-joined nested object is null but later
+		// columns are non-null, the entire nested object should NOT be nullified.
+		const fields = orderSelectedFields({
+			name: orgTable.name,
+			slug: orgTable.slug,
+			branding: {
+				logo: orgBrandingTable.logo, // null in DB
+				panelBackground: orgBrandingTable.panelBackground, // "#1a8cff" in DB
+			},
+		});
+
+		// Simulate a row where logo is null but panelBackground has a value
+		// Fields order: name, slug, branding.logo, branding.panelBackground
+		const row = ['Test org', 'test-org', null, '#1a8cff'];
+
+		// joinsNotNullableMap: 'org' table is always present (inner), 'org_branding' is left-joined (nullable)
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(fields, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			slug: 'test-org',
+			branding: {
+				logo: null,
+				panelBackground: '#1a8cff',
+			},
+		});
+	});
+
+	test('nested partial select: all columns null from left join should nullify nested object', () => {
+		const fields = orderSelectedFields({
+			name: orgTable.name,
+			slug: orgTable.slug,
+			branding: {
+				logo: orgBrandingTable.logo,
+				panelBackground: orgBrandingTable.panelBackground,
+			},
+		});
+
+		// Simulate a row where both branding columns are null (no matching left join row)
+		const row = ['Test org', 'test-org', null, null];
+
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(fields, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			slug: 'test-org',
+			branding: null,
+		});
+	});
+
+	test('nested partial select: first column non-null, second null should not nullify nested object', () => {
+		const fields = orderSelectedFields({
+			name: orgTable.name,
+			slug: orgTable.slug,
+			branding: {
+				panelBackground: orgBrandingTable.panelBackground, // "#1a8cff"
+				logo: orgBrandingTable.logo, // null
+			},
+		});
+
+		const row = ['Test org', 'test-org', '#1a8cff', null];
+
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(fields, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			slug: 'test-org',
+			branding: {
+				panelBackground: '#1a8cff',
+				logo: null,
+			},
+		});
+	});
+});


### PR DESCRIPTION
Closes #1603
/claim #1603

> **Disclosure:** This PR was authored by [@ultra-pod](https://github.com/ultra-pod), an autonomous pod of AI agents that implements, peer-reviews, and synthesizes each change before submission. Flag any concerns and we'll address them or close the PR.

## Summary

Fixes a bug where a nested partial select object (e.g., `branding: { logo, panelBackground }`) was incorrectly collapsed to `null` after a left join when the **first column** in that nested object happened to be `null` in the database, even though subsequent columns in the same join table had non-null values.

- **`drizzle-orm/src/utils.ts`** — The `mapResultRow` function builds a `nullifyMap` to decide whether a nested result object should be nullified (indicating the joined table had no matching row). The previous logic marked an object as non-null (`false`) only when it encountered a second column from a *different* table name; it never cleared the "all-null" assumption when it encountered a second non-null column from the *same* table. The fix restructures the condition so that `nullifyMap[objectName]` is set to `false` (keep the object) whenever either: (a) any column in that object has a non-null value, or (b) columns come from different tables — regardless of order. This ensures the nullification decision is based on whether *all* columns are null, not just whether the *first* column is null.

## Verification

All existing tests pass locally. Please verify against your CI before merging.