### PR TITLE
[Mysql][SingleStore]: fix dangling event listeners in iterator()

### DIFF
--- a/drizzle-orm/src/mysql2/session.ts
+++ b/drizzle-orm/src/mysql2/session.ts
@@ -162,13 +162,28 @@ export class MySql2PreparedQuery<T extends MySqlPreparedQueryConfig> extends MyS
 
 		stream.on('data', dataListener);
 
-		try {
-			const onEnd = once(stream, 'end');
-			const onError = once(stream, 'error');
+		const ac = new AbortController();
+		const { signal } = ac;
 
+		try {
+			const onEnd = once(stream, 'end', { signal });
+			const onError = once(stream, 'error', { signal });
+
+			let dataResolve: ((value: unknown) => void) | undefined;
 			while (true) {
+				if (dataResolve) {
+					stream.off('data', dataResolve);
+					dataResolve = undefined;
+				}
 				stream.resume();
-				const row = await Promise.race([onEnd, onError, new Promise((resolve) => stream.once('data', resolve))]);
+				const row = await Promise.race([
+					onEnd,
+					onError,
+					new Promise<unknown>((resolve) => {
+						dataResolve = resolve;
+						stream.once('data', resolve);
+					}),
+				]);
 				if (row === undefined || (Array.isArray(row) && row.length === 0)) {
 					break;
 				} else if (row instanceof Error) { // eslint-disable-line no-instanceof/no-instanceof
@@ -187,6 +202,7 @@ export class MySql2PreparedQuery<T extends MySqlPreparedQueryConfig> extends MyS
 				}
 			}
 		} finally {
+			ac.abort();
 			stream.off('data', dataListener);
 			if (isPool(client)) {
 				conn.end();

--- a/drizzle-orm/src/singlestore/session.ts
+++ b/drizzle-orm/src/singlestore/session.ts
@@ -161,13 +161,28 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 
 		stream.on('data', dataListener);
 
-		try {
-			const onEnd = once(stream, 'end');
-			const onError = once(stream, 'error');
+		const ac = new AbortController();
+		const { signal } = ac;
 
+		try {
+			const onEnd = once(stream, 'end', { signal });
+			const onError = once(stream, 'error', { signal });
+
+			let dataResolve: ((value: unknown) => void) | undefined;
 			while (true) {
+				if (dataResolve) {
+					stream.off('data', dataResolve);
+					dataResolve = undefined;
+				}
 				stream.resume();
-				const row = await Promise.race([onEnd, onError, new Promise((resolve) => stream.once('data', resolve))]);
+				const row = await Promise.race([
+					onEnd,
+					onError,
+					new Promise<unknown>((resolve) => {
+						dataResolve = resolve;
+						stream.once('data', resolve);
+					}),
+				]);
 				if (row === undefined || (Array.isArray(row) && row.length === 0)) {
 					break;
 				} else if (row instanceof Error) { // eslint-disable-line no-instanceof/no-instanceof
@@ -186,6 +201,7 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 				}
 			}
 		} finally {
+			ac.abort();
 			stream.off('data', dataListener);
 			if (isPool(client)) {
 				conn.end();


### PR DESCRIPTION
### Summary

Fixes #5839

### Problem

The `iterator()` method in both `mysql2` and `singlestore` session implementations leaves dangling `once()` event listeners on the underlying stream. When the generator exits (normally or via error), `once(stream, 'end')` and `once(stream, 'error')` listeners remain attached. Per-iteration `stream.once('data', resolve)` listeners also leak when another branch of `Promise.race` wins.

In long-running applications, this causes `MaxListenersExceededWarning` and memory growth proportional to iterator call count.

### Solution

- Use `AbortController` to register `once()` listeners with a `signal`, then call `ac.abort()` in the `finally` block to remove them
- Track per-iteration `data` listener references and clean them up at the start of each loop iteration before registering a new one

Applied identically to both `drizzle-orm/src/mysql2/session.ts` and `drizzle-orm/src/singlestore/session.ts`.

### Testing

Existing iterator tests (`select iterator`, `select iterator w/ prepared statement`) cover the happy path. The fix is a resource cleanup change — no behavior change for consumed iterators, only prevents listener accumulation on stream exit.