### PR TITLE
fix(mysql2,singlestore): cleanup all event listeners in iterator()

### DIFF
--- a/drizzle-orm/src/mysql2/session.ts
+++ b/drizzle-orm/src/mysql2/session.ts
@@ -162,13 +162,29 @@ export class MySql2PreparedQuery<T extends MySqlPreparedQueryConfig> extends MyS
 
 		stream.on('data', dataListener);
 
+		const ac = new AbortController();
+		const { signal } = ac;
+
+		let dataResolve: ((value: unknown) => void) | undefined;
+
 		try {
-			const onEnd = once(stream, 'end');
-			const onError = once(stream, 'error');
+			const onEnd = once(stream, 'end', { signal });
+			const onError = once(stream, 'error', { signal });
 
 			while (true) {
+				if (dataResolve) {
+					stream.off('data', dataResolve);
+					dataResolve = undefined;
+				}
 				stream.resume();
-				const row = await Promise.race([onEnd, onError, new Promise((resolve) => stream.once('data', resolve))]);
+				const row = await Promise.race([
+					onEnd,
+					onError,
+					new Promise<unknown>((resolve) => {
+						dataResolve = resolve;
+						stream.once('data', resolve);
+					}),
+				]);
 				if (row === undefined || (Array.isArray(row) && row.length === 0)) {
 					break;
 				} else if (row instanceof Error) { // eslint-disable-line no-instanceof/no-instanceof
@@ -187,7 +203,11 @@ export class MySql2PreparedQuery<T extends MySqlPreparedQueryConfig> extends MyS
 				}
 			}
 		} finally {
+			ac.abort();
 			stream.off('data', dataListener);
+			if (dataResolve) {
+				stream.off('data', dataResolve);
+			}
 			if (isPool(client)) {
 				conn.end();
 			}

--- a/drizzle-orm/src/singlestore/session.ts
+++ b/drizzle-orm/src/singlestore/session.ts
@@ -161,13 +161,29 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 
 		stream.on('data', dataListener);
 
+		const ac = new AbortController();
+		const { signal } = ac;
+
+		let dataResolve: ((value: unknown) => void) | undefined;
+
 		try {
-			const onEnd = once(stream, 'end');
-			const onError = once(stream, 'error');
+			const onEnd = once(stream, 'end', { signal });
+			const onError = once(stream, 'error', { signal });
 
 			while (true) {
+				if (dataResolve) {
+					stream.off('data', dataResolve);
+					dataResolve = undefined;
+				}
 				stream.resume();
-				const row = await Promise.race([onEnd, onError, new Promise((resolve) => stream.once('data', resolve))]);
+				const row = await Promise.race([
+					onEnd,
+					onError,
+					new Promise<unknown>((resolve) => {
+						dataResolve = resolve;
+						stream.once('data', resolve);
+					}),
+				]);
 				if (row === undefined || (Array.isArray(row) && row.length === 0)) {
 					break;
 				} else if (row instanceof Error) { // eslint-disable-line no-instanceof/no-instanceof
@@ -186,7 +202,11 @@ export class SingleStoreDriverPreparedQuery<T extends SingleStorePreparedQueryCo
 				}
 			}
 		} finally {
+			ac.abort();
 			stream.off('data', dataListener);
+			if (dataResolve) {
+				stream.off('data', dataResolve);
+			}
 			if (isPool(client)) {
 				conn.end();
 			}

--- a/drizzle-orm/tests/iterator-listener-cleanup.test.ts
+++ b/drizzle-orm/tests/iterator-listener-cleanup.test.ts
@@ -1,0 +1,277 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { NoopCache } from '~/cache/core/index.ts';
+import { NoopLogger } from '~/logger.ts';
+import { MySql2PreparedQuery } from '~/mysql2/session.ts';
+import { SingleStoreDriverPreparedQuery } from '~/singlestore/session.ts';
+
+/**
+ * Build a fake mysql2 stream that we can drive event-by-event and inspect
+ * listener counts on. The fake intentionally only implements the surface
+ * the iterator() function actually uses (`pause`, `resume`, `on`, `once`,
+ * `off`, `emit`), so any new listener registration on the production path
+ * shows up in `listenerCount`.
+ */
+function buildFakeStream(): EventEmitter & { pause: () => void; resume: () => void } {
+	const stream = new EventEmitter() as EventEmitter & { pause: () => void; resume: () => void };
+	stream.pause = () => {};
+	stream.resume = () => {};
+	return stream;
+}
+
+/**
+ * Build a fake mysql2 client that:
+ *   - Is NOT a Pool (no `getConnection`), so `isPool(client)` is false and
+ *     `conn.end()` in the finally block is skipped.
+ *   - Exposes `.connection.query(...)` which returns an object with a
+ *     `.stream()` method that yields the supplied EventEmitter.
+ */
+function buildFakeClient(stream: EventEmitter) {
+	const driverQuery = { stream: () => stream };
+	const connection = { query: () => driverQuery } as any;
+	return { connection } as any;
+}
+
+/**
+ * Drive a fake stream through three data rows then 'end', mirroring the
+ * row emission pattern of the real mysql2 driver. We schedule each emit
+ * on its own microtask so the consumer's Promise.race has a chance to
+ * settle before the next event fires.
+ */
+async function driveThreeRowsThenEnd(stream: EventEmitter): Promise<void> {
+	const rows = [['1'], ['2'], ['3']];
+	for (const row of rows) {
+		await new Promise<void>((r) => setImmediate(r));
+		stream.emit('data', row);
+	}
+	await new Promise<void>((r) => setImmediate(r));
+	stream.emit('end');
+}
+
+describe('mysql2 iterator() listener cleanup (regression for #5839)', () => {
+	beforeEach(() => {
+		// Trip the warning into an error so an accumulating leak across
+		// repeated calls would be impossible to silently miss.
+		EventEmitter.defaultMaxListeners = 10;
+	});
+
+	afterEach(() => {
+		EventEmitter.defaultMaxListeners = 10;
+	});
+
+	test('a fully-consumed iterator leaves zero listeners on the stream', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const prepared = new MySql2PreparedQuery(
+			client,
+			'select 1',
+			[],
+			new NoopLogger(),
+			new NoopCache(),
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		const consumed: unknown[] = [];
+		const consumer = (async () => {
+			for await (const row of prepared.iterator()) {
+				consumed.push(row);
+			}
+		})();
+
+		await driveThreeRowsThenEnd(stream);
+		await consumer;
+
+		expect(consumed).toHaveLength(3);
+		expect(stream.listenerCount('data'), 'data listener leaked').toBe(0);
+		expect(stream.listenerCount('end'), 'end listener leaked').toBe(0);
+		expect(stream.listenerCount('error'), 'error listener leaked').toBe(0);
+	});
+
+	test('repeated iterator() calls on a shared stream do not accumulate listeners', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const warnings: string[] = [];
+		const onWarning = (w: Error) => {
+			if (w.name === 'MaxListenersExceededWarning') {
+				warnings.push(w.message);
+			}
+		};
+		process.on('warning', onWarning);
+
+		try {
+			for (let i = 0; i < 20; i++) {
+				const prepared = new MySql2PreparedQuery(
+					client,
+					'select 1',
+					[],
+					new NoopLogger(),
+					new NoopCache(),
+					undefined,
+					undefined,
+					undefined,
+				);
+
+				const consumer = (async () => {
+					for await (const _ of prepared.iterator()) {
+						/* drain */
+					}
+				})();
+
+				await driveThreeRowsThenEnd(stream);
+				await consumer;
+			}
+		} finally {
+			process.off('warning', onWarning);
+		}
+
+		expect(warnings, 'iterator() leaked listeners on the shared stream').toEqual([]);
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+
+	test('iterator() that throws via an error event still cleans listeners', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const prepared = new MySql2PreparedQuery(
+			client,
+			'select 1',
+			[],
+			new NoopLogger(),
+			new NoopCache(),
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		const consumer = (async () => {
+			try {
+				for await (const _ of prepared.iterator()) {
+					/* drain */
+				}
+			} catch {
+				/* swallow */
+			}
+		})();
+
+		await new Promise<void>((r) => setImmediate(r));
+		stream.emit('error', new Error('boom'));
+		await consumer;
+
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+
+	test('iterator() that exits via consumer break still cleans listeners', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const prepared = new MySql2PreparedQuery(
+			client,
+			'select 1',
+			[],
+			new NoopLogger(),
+			new NoopCache(),
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		const consumer = (async () => {
+			for await (const _ of prepared.iterator()) {
+				break; // exit on first row
+			}
+		})();
+
+		await new Promise<void>((r) => setImmediate(r));
+		stream.emit('data', ['1']);
+		await consumer;
+
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+});
+
+describe('singlestore iterator() listener cleanup (regression for #5839)', () => {
+	test('a fully-consumed iterator leaves zero listeners on the stream', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const prepared = new SingleStoreDriverPreparedQuery(
+			client,
+			'select 1',
+			[],
+			new NoopLogger(),
+			new NoopCache(),
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		const consumed: unknown[] = [];
+		const consumer = (async () => {
+			for await (const row of prepared.iterator()) {
+				consumed.push(row);
+			}
+		})();
+
+		await driveThreeRowsThenEnd(stream);
+		await consumer;
+
+		expect(consumed).toHaveLength(3);
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+
+	test('repeated iterator() calls on a shared stream do not accumulate listeners', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const warnings: string[] = [];
+		const onWarning = (w: Error) => {
+			if (w.name === 'MaxListenersExceededWarning') {
+				warnings.push(w.message);
+			}
+		};
+		process.on('warning', onWarning);
+
+		try {
+			for (let i = 0; i < 20; i++) {
+				const prepared = new SingleStoreDriverPreparedQuery(
+					client,
+					'select 1',
+					[],
+					new NoopLogger(),
+					new NoopCache(),
+					undefined,
+					undefined,
+					undefined,
+				);
+
+				const consumer = (async () => {
+					for await (const _ of prepared.iterator()) {
+						/* drain */
+					}
+				})();
+
+				await driveThreeRowsThenEnd(stream);
+				await consumer;
+			}
+		} finally {
+			process.off('warning', onWarning);
+		}
+
+		expect(warnings).toEqual([]);
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+});

--- a/drizzle-orm/tests/iterator-listener-cleanup.test.ts
+++ b/drizzle-orm/tests/iterator-listener-cleanup.test.ts
@@ -1,0 +1,277 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { NoopCache } from '~/cache/core/index.ts';
+import { NoopLogger } from '~/logger.ts';
+import { MySql2PreparedQuery } from '~/mysql2/session.ts';
+import { SingleStoreDriverPreparedQuery } from '~/singlestore/session.ts';
+
+/**
+ * Build a fake mysql2 stream that we can drive event-by-event and inspect
+ * listener counts on. The fake intentionally only implements the surface
+ * the iterator() function actually uses (`pause`, `resume`, `on`, `once`,
+ * `off`, `emit`), so any new listener registration on the production path
+ * shows up in `listenerCount`.
+ */
+function buildFakeStream(): EventEmitter & { pause: () => void; resume: () => void } {
+	const stream = new EventEmitter() as EventEmitter & { pause: () => void; resume: () => void };
+	stream.pause = () => {};
+	stream.resume = () => {};
+	return stream;
+}
+
+/**
+ * Build a fake mysql2 client that:
+ *   - Is NOT a Pool (no `getConnection`), so `isPool(client)` is false and
+ *     `conn.end()` in the finally block is skipped.
+ *   - Exposes `.connection.query(...)` which returns an object with a
+ *     `.stream()` method that yields the supplied EventEmitter.
+ */
+function buildFakeClient(stream: EventEmitter) {
+	const driverQuery = { stream: () => stream };
+	const connection = { query: () => driverQuery } as any;
+	return { connection } as any;
+}
+
+/**
+ * Drive a fake stream through three data rows then 'end', mirroring the
+ * row emission pattern of the real mysql2 driver. We schedule each emit
+ * on its own microtask so the consumer's Promise.race has a chance to
+ * settle before the next event fires.
+ */
+async function driveThreeRowsThenEnd(stream: EventEmitter): Promise<void> {
+	const rows = [['1'], ['2'], ['3']];
+	for (const row of rows) {
+		await new Promise<void>((r) => setImmediate(r));
+		stream.emit('data', row);
+	}
+	await new Promise<void>((r) => setImmediate(r));
+	stream.emit('end');
+}
+
+describe('mysql2 iterator() listener cleanup (regression for #5839)', () => {
+	beforeEach(() => {
+		// Trip the warning into an error so an accumulating leak across
+		// repeated calls would be impossible to silently miss.
+		EventEmitter.defaultMaxListeners = 10;
+	});
+
+	afterEach(() => {
+		EventEmitter.defaultMaxListeners = 10;
+	});
+
+	test('a fully-consumed iterator leaves zero listeners on the stream', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const prepared = new MySql2PreparedQuery(
+			client,
+			'select 1',
+			[],
+			new NoopLogger(),
+			new NoopCache(),
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		const consumed: unknown[] = [];
+		const consumer = (async () => {
+			for await (const row of prepared.iterator()) {
+				consumed.push(row);
+			}
+		})();
+
+		await driveThreeRowsThenEnd(stream);
+		await consumer;
+
+		expect(consumed).toHaveLength(3);
+		expect(stream.listenerCount('data'), 'data listener leaked').toBe(0);
+		expect(stream.listenerCount('end'), 'end listener leaked').toBe(0);
+		expect(stream.listenerCount('error'), 'error listener leaked').toBe(0);
+	});
+
+	test('repeated iterator() calls on a shared stream do not accumulate listeners', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const warnings: string[] = [];
+		const onWarning = (w: Error) => {
+			if (w.name === 'MaxListenersExceededWarning') {
+				warnings.push(w.message);
+			}
+		};
+		process.on('warning', onWarning);
+
+		try {
+			for (let i = 0; i < 20; i++) {
+				const prepared = new MySql2PreparedQuery(
+					client,
+					'select 1',
+					[],
+					new NoopLogger(),
+					new NoopCache(),
+					undefined,
+					undefined,
+					undefined,
+				);
+
+				const consumer = (async () => {
+					for await (const _ of prepared.iterator()) {
+						/* drain */
+					}
+				})();
+
+				await driveThreeRowsThenEnd(stream);
+				await consumer;
+			}
+		} finally {
+			process.off('warning', onWarning);
+		}
+
+		expect(warnings, 'iterator() leaked listeners on the shared stream').toEqual([]);
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+
+	test('iterator() that throws via an error event still cleans listeners', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const prepared = new MySql2PreparedQuery(
+			client,
+			'select 1',
+			[],
+			new NoopLogger(),
+			new NoopCache(),
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		const consumer = (async () => {
+			try {
+				for await (const _ of prepared.iterator()) {
+					/* drain */
+				}
+			} catch {
+				/* swallow */
+			}
+		})();
+
+		await new Promise<void>((r) => setImmediate(r));
+		stream.emit('error', new Error('boom'));
+		await consumer;
+
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+
+	test('iterator() that exits via consumer break still cleans listeners', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const prepared = new MySql2PreparedQuery(
+			client,
+			'select 1',
+			[],
+			new NoopLogger(),
+			new NoopCache(),
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		const consumer = (async () => {
+			for await (const _ of prepared.iterator()) {
+				break; // exit on first row
+			}
+		})();
+
+		await new Promise<void>((r) => setImmediate(r));
+		stream.emit('data', ['1']);
+		await consumer;
+
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+});
+
+describe('singlestore iterator() listener cleanup (regression for #5839)', () => {
+	test('a fully-consumed iterator leaves zero listeners on the stream', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const prepared = new SingleStoreDriverPreparedQuery(
+			client,
+			'select 1',
+			[],
+			new NoopLogger(),
+			new NoopCache(),
+			undefined,
+			undefined,
+			undefined,
+		);
+
+		const consumed: unknown[] = [];
+		const consumer = (async () => {
+			for await (const row of prepared.iterator()) {
+				consumed.push(row);
+			}
+		})();
+
+		await driveThreeRowsThenEnd(stream);
+		await consumer;
+
+		expect(consumed).toHaveLength(3);
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+
+	test('repeated iterator() calls on a shared stream do not accumulate listeners', async () => {
+		const stream = buildFakeStream();
+		const client = buildFakeClient(stream);
+
+		const warnings: string[] = [];
+		const onWarning = (w: Error) => {
+			if (w.name === 'MaxListenersExceededWarning') {
+				warnings.push(w.message);
+			}
+		};
+		process.on('warning', onWarning);
+
+		try {
+			for (let i = 0; i < 20; i++) {
+				const prepared = new SingleStoreDriverPreparedQuery(
+					client,
+					'select 1',
+					[],
+					new NoopLogger(),
+					new NoopCache(),
+					undefined,
+					undefined,
+					undefined,
+				);
+
+				const consumer = (async () => {
+					for await (const _ of prepared.iterator()) {
+						/* drain */
+					}
+				})();
+
+				await driveThreeRowsThenEnd(stream);
+				await consumer;
+			}
+		} finally {
+			process.off('warning', onWarning);
+		}
+
+		expect(warnings).toEqual([]);
+		expect(stream.listenerCount('data')).toBe(0);
+		expect(stream.listenerCount('end')).toBe(0);
+		expect(stream.listenerCount('error')).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #5839. The `AbortController` + signal pattern (for `onEnd`/`onError`) and the per-iteration `dataResolve` tracking were both spelled out in the suggested-fix section of the issue. PR #5856 lands those two pieces but leaves the final-iteration `dataResolve` listener attached and ships without a regression test. This PR adds the missing cleanup line and the tests.

## What was still missing after #5856

`#5856` introduces `AbortController` + `signal` on `once(stream, 'end' | 'error')` and tracks `dataResolve` per iteration so the previous iteration's data listener can be cleaned at the top of the next loop pass - both directly from the issue's suggested fix. The remaining gap:

- When the loop exits via `break` (`onEnd` wins the last `Promise.race`) or via `throw` (a stream `error` rejects the `once(stream, 'end')` promise, so the race throws), execution jumps straight to `finally` without re-entering the loop top. `dataResolve` still holds the `stream.once('data', resolve)` registered for that last iteration.
- `ac.abort()` only affects listeners registered via `node:events.once(..., { signal })`. The plain `stream.once('data', resolve)` call is unaffected.
- Net result: exactly one `'data'` listener leaks per `iterator()` call, which the listener-count assertions below catch. The pre-fix `MaxListenersExceededWarning` comes from the accumulating `error`/`end` listeners (see below), not from this single leaked `data` listener.

This PR adds the missing `stream.off('data', dataResolve)` to both `finally` blocks:

```ts
} finally {
    ac.abort();
    stream.off('data', dataListener);
    if (dataResolve) {
        stream.off('data', dataResolve);
    }
    if (isPool(client)) {
        conn.end();
    }
}
```

Same change applied to both `drizzle-orm/src/mysql2/session.ts` and `drizzle-orm/src/singlestore/session.ts`.

## Test plan

A new unit test file at `drizzle-orm/tests/iterator-listener-cleanup.test.ts` mocks the mysql2 client surface over a plain `EventEmitter` and asserts `stream.listenerCount('data' | 'end' | 'error')` returns to `0` after every exit path:

- `mysql2`: fully-consumed iterator
- `mysql2`: 20 sequential calls on a shared stream (asserts `process` never emits `MaxListenersExceededWarning`)
- `mysql2`: error-event termination
- `mysql2`: consumer `break`
- `singlestore`: fully-consumed
- `singlestore`: 20 calls on a shared stream

Empirical delta on this exact test file:

| Source                          | Result |
|---------------------------------|--------|
| Pre-fix current `main`          | 6 failed \| 0 passed (6) |
| `#5856` partial fix             | 5 failed \| 1 passed (6) |
| This PR (complete fix)          | 0 failed \| 6 passed (6) |

The pre-fix run produces `Possible EventEmitter memory leak detected. 11 error listeners added to [EventEmitter]. MaxListeners is 10.` on the shared-stream test, confirming the path from issue #5839.

## Compliance

- `pnpm test` (drizzle-orm vitest): the unit suite passes with no new failures from this PR, which adds 6 tests.
- `dprint check` on the 3 modified files: clean.
- `pnpm test:types`: the pre-existing `src/prisma/*/driver.ts` errors against `@prisma/client` reproduce unchanged on `main`; no new type errors from this PR.

