### PR TITLE
fix(utils): nested partial select null on left join when first column is null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/mapResultRow.test.ts
+++ b/drizzle-orm/tests/mapResultRow.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'vitest';
+import { eq } from '~/expressions.ts';
+import { integer, pgTable, text, serial } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+const orgTable = pgTable('org', {
+	id: serial('id').primaryKey(),
+	name: text('name').notNull(),
+	slug: text('slug').notNull(),
+});
+
+const orgBrandingTable = pgTable('org_branding', {
+	id: serial('id').primaryKey(),
+	orgId: integer('org_id').notNull(),
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+describe('mapResultRow', () => {
+	test('nested partial select with left join should not nullify object when first column is null', () => {
+		const fields = {
+			name: orgTable.name,
+			slug: orgTable.slug,
+			branding: {
+				logo: orgBrandingTable.logo,
+				panelBackground: orgBrandingTable.panelBackground,
+			},
+		};
+
+		const columns = orderSelectedFields(fields);
+
+		// Simulate row: name='Test org', slug='test-org', logo=null, panelBackground='#1a8cff'
+		const row = ['Test org', 'test-org', null, '#1a8cff'];
+
+		// org_branding is a left join (nullable)
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			slug: 'test-org',
+			branding: {
+				logo: null,
+				panelBackground: '#1a8cff',
+			},
+		});
+	});
+
+	test('nested partial select with left join should nullify when ALL columns are null', () => {
+		const fields = {
+			name: orgTable.name,
+			slug: orgTable.slug,
+			branding: {
+				logo: orgBrandingTable.logo,
+				panelBackground: orgBrandingTable.panelBackground,
+			},
+		};
+
+		const columns = orderSelectedFields(fields);
+
+		// Simulate row: name='Test org', slug='test-org', logo=null, panelBackground=null
+		const row = ['Test org', 'test-org', null, null];
+
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			slug: 'test-org',
+			branding: null,
+		});
+	});
+
+	test('nested partial select with left join and swapped column order should work', () => {
+		const fields = {
+			name: orgTable.name,
+			slug: orgTable.slug,
+			branding: {
+				panelBackground: orgBrandingTable.panelBackground,
+				logo: orgBrandingTable.logo,
+			},
+		};
+
+		const columns = orderSelectedFields(fields);
+
+		// panelBackground='#1a8cff', logo=null
+		const row = ['Test org', 'test-org', '#1a8cff', null];
+
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			slug: 'test-org',
+			branding: {
+				panelBackground: '#1a8cff',
+				logo: null,
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1603

- **Bug**: When using `.select()` with nested objects and `.leftJoin()`, if the first column in a nested object was `null`, the entire nested object was incorrectly set to `null` — even when other columns had non-null values. Swapping column order was a workaround.
- **Root cause**: In `mapResultRow()`, once `nullifyMap[objectName]` was set to a table name (first field null), subsequent non-null fields from the same table never cleared it back to `false`.
- **Fix**: Added `|| value !== null` to the existing table-name-mismatch condition (1 line, `drizzle-orm/src/utils.ts:51`), so any non-null value from the same joined table clears the nullify flag.

## Reproducer (from the issue)

```ts
const org = await db
  .select({
    name: orgTable.name,
    slug: orgTable.slug,
    branding: {
      logo: orgBrandingTable.logo,           // null in DB
      panelBackground: orgBrandingTable.panelBackground, // "#1a8cff" in DB
    }
  })
  .from(orgTable)
  .leftJoin(orgBrandingTable, eq(orgTable.id, orgBrandingTable.orgId))

// Before fix: { name: 'Test org 2', slug: 'test-org-2', branding: null }
// After fix:  { name: 'Test org 2', slug: 'test-org-2', branding: { logo: null, panelBackground: '#1a8cff' } }
```

## Test plan

- [x] Added `drizzle-orm/tests/mapResultRow.test.ts` with 3 test cases:
  1. First column null, second non-null → nested object preserved (the bug)
  2. All columns null → nested object correctly nullified (left join no-match)
  3. Swapped column order → works (regression guard)
- [x] Verified test fails without fix, passes with fix
- [x] All 569 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)