### PR TITLE
Add single-flight dedup to $withCache

### DIFF
--- a/drizzle-orm/src/cache/core/cache.ts
+++ b/drizzle-orm/src/cache/core/cache.ts
@@ -5,6 +5,9 @@ import type { CacheConfig } from './types.ts';
 export abstract class Cache {
 	static readonly [entityKind]: string = 'Cache';
 
+	/** @internal */
+	inFlightQueries: Map<string, Promise<unknown>> = new Map();
+
 	abstract strategy(): 'explicit' | 'all';
 
 	/**

--- a/drizzle-orm/src/gel-core/session.ts
+++ b/drizzle-orm/src/gel-core/session.ts
@@ -89,31 +89,42 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 		}
 
 		if (this.queryMetadata.type === 'select') {
-			const fromCache = await this.cache.get(
-				this.cacheConfig.tag ?? await hashQuery(queryString, params),
+			const cache = this.cache;
+			const cacheConfig = this.cacheConfig;
+			const isTag = cacheConfig.tag !== undefined;
+			const cacheKey = cacheConfig.tag ?? await hashQuery(queryString, params);
+			const fromCache = await cache.get(
+				cacheKey,
 				this.queryMetadata.tables,
-				this.cacheConfig.tag !== undefined,
-				this.cacheConfig.autoInvalidate,
+				isTag,
+				cacheConfig.autoInvalidate,
 			);
 			if (fromCache === undefined) {
-				let result;
-				try {
-					result = await query();
-				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+				const inflight = cache.inFlightQueries.get(cacheKey);
+				if (inflight !== undefined) {
+					return inflight as Promise<T>;
 				}
-
-				// put actual key
-				await this.cache.put(
-					this.cacheConfig.tag ?? await hashQuery(queryString, params),
-					result,
-					// make sure we send tables that were used in a query only if user wants to invalidate it on each write
-					this.cacheConfig.autoInvalidate ? this.queryMetadata.tables : [],
-					this.cacheConfig.tag !== undefined,
-					this.cacheConfig.config,
-				);
-				// put flag if we should invalidate or not
-				return result;
+				const tablesForInvalidation = cacheConfig.autoInvalidate ? this.queryMetadata.tables : [];
+				const promise = (async () => {
+					let result: T;
+					try {
+						result = await query();
+					} catch (e) {
+						throw new DrizzleQueryError(queryString, params, e as Error);
+					}
+					await cache.put(
+						cacheKey,
+						result,
+						tablesForInvalidation,
+						isTag,
+						cacheConfig.config,
+					);
+					return result;
+				})().finally(() => {
+					cache.inFlightQueries.delete(cacheKey);
+				});
+				cache.inFlightQueries.set(cacheKey, promise);
+				return promise;
 			}
 
 			return fromCache as unknown as T;

--- a/drizzle-orm/src/mysql-core/session.ts
+++ b/drizzle-orm/src/mysql-core/session.ts
@@ -117,31 +117,42 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 		}
 
 		if (this.queryMetadata.type === 'select') {
-			const fromCache = await this.cache.get(
-				this.cacheConfig.tag ?? await hashQuery(queryString, params),
+			const cache = this.cache;
+			const cacheConfig = this.cacheConfig;
+			const isTag = cacheConfig.tag !== undefined;
+			const cacheKey = cacheConfig.tag ?? await hashQuery(queryString, params);
+			const fromCache = await cache.get(
+				cacheKey,
 				this.queryMetadata.tables,
-				this.cacheConfig.tag !== undefined,
-				this.cacheConfig.autoInvalidate,
+				isTag,
+				cacheConfig.autoInvalidate,
 			);
 			if (fromCache === undefined) {
-				let result;
-				try {
-					result = await query();
-				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+				const inflight = cache.inFlightQueries.get(cacheKey);
+				if (inflight !== undefined) {
+					return inflight as Promise<T>;
 				}
-
-				// put actual key
-				await this.cache.put(
-					this.cacheConfig.tag ?? await hashQuery(queryString, params),
-					result,
-					// make sure we send tables that were used in a query only if user wants to invalidate it on each write
-					this.cacheConfig.autoInvalidate ? this.queryMetadata.tables : [],
-					this.cacheConfig.tag !== undefined,
-					this.cacheConfig.config,
-				);
-				// put flag if we should invalidate or not
-				return result;
+				const tablesForInvalidation = cacheConfig.autoInvalidate ? this.queryMetadata.tables : [];
+				const promise = (async () => {
+					let result: T;
+					try {
+						result = await query();
+					} catch (e) {
+						throw new DrizzleQueryError(queryString, params, e as Error);
+					}
+					await cache.put(
+						cacheKey,
+						result,
+						tablesForInvalidation,
+						isTag,
+						cacheConfig.config,
+					);
+					return result;
+				})().finally(() => {
+					cache.inFlightQueries.delete(cacheKey);
+				});
+				cache.inFlightQueries.set(cacheKey, promise);
+				return promise;
 			}
 
 			return fromCache as unknown as T;

--- a/drizzle-orm/src/pg-core/session.ts
+++ b/drizzle-orm/src/pg-core/session.ts
@@ -111,30 +111,42 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 		}
 
 		if (this.queryMetadata.type === 'select') {
-			const fromCache = await this.cache.get(
-				this.cacheConfig.tag ?? await hashQuery(queryString, params),
+			const cache = this.cache;
+			const cacheConfig = this.cacheConfig;
+			const isTag = cacheConfig.tag !== undefined;
+			const cacheKey = cacheConfig.tag ?? await hashQuery(queryString, params);
+			const fromCache = await cache.get(
+				cacheKey,
 				this.queryMetadata.tables,
-				this.cacheConfig.tag !== undefined,
-				this.cacheConfig.autoInvalidate,
+				isTag,
+				cacheConfig.autoInvalidate,
 			);
 			if (fromCache === undefined) {
-				let result;
-				try {
-					result = await query();
-				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+				const inflight = cache.inFlightQueries.get(cacheKey);
+				if (inflight !== undefined) {
+					return inflight as Promise<T>;
 				}
-				// put actual key
-				await this.cache.put(
-					this.cacheConfig.tag ?? await hashQuery(queryString, params),
-					result,
-					// make sure we send tables that were used in a query only if user wants to invalidate it on each write
-					this.cacheConfig.autoInvalidate ? this.queryMetadata.tables : [],
-					this.cacheConfig.tag !== undefined,
-					this.cacheConfig.config,
-				);
-				// put flag if we should invalidate or not
-				return result;
+				const tablesForInvalidation = cacheConfig.autoInvalidate ? this.queryMetadata.tables : [];
+				const promise = (async () => {
+					let result: T;
+					try {
+						result = await query();
+					} catch (e) {
+						throw new DrizzleQueryError(queryString, params, e as Error);
+					}
+					await cache.put(
+						cacheKey,
+						result,
+						tablesForInvalidation,
+						isTag,
+						cacheConfig.config,
+					);
+					return result;
+				})().finally(() => {
+					cache.inFlightQueries.delete(cacheKey);
+				});
+				cache.inFlightQueries.set(cacheKey, promise);
+				return promise;
 			}
 
 			return fromCache as unknown as T;

--- a/drizzle-orm/src/singlestore-core/session.ts
+++ b/drizzle-orm/src/singlestore-core/session.ts
@@ -115,31 +115,42 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 		}
 
 		if (this.queryMetadata.type === 'select') {
-			const fromCache = await this.cache.get(
-				this.cacheConfig.tag ?? await hashQuery(queryString, params),
+			const cache = this.cache;
+			const cacheConfig = this.cacheConfig;
+			const isTag = cacheConfig.tag !== undefined;
+			const cacheKey = cacheConfig.tag ?? await hashQuery(queryString, params);
+			const fromCache = await cache.get(
+				cacheKey,
 				this.queryMetadata.tables,
-				this.cacheConfig.tag !== undefined,
-				this.cacheConfig.autoInvalidate,
+				isTag,
+				cacheConfig.autoInvalidate,
 			);
 			if (fromCache === undefined) {
-				let result;
-				try {
-					result = await query();
-				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+				const inflight = cache.inFlightQueries.get(cacheKey);
+				if (inflight !== undefined) {
+					return inflight as Promise<T>;
 				}
-
-				// put actual key
-				await this.cache.put(
-					this.cacheConfig.tag ?? await hashQuery(queryString, params),
-					result,
-					// make sure we send tables that were used in a query only if user wants to invalidate it on each write
-					this.cacheConfig.autoInvalidate ? this.queryMetadata.tables : [],
-					this.cacheConfig.tag !== undefined,
-					this.cacheConfig.config,
-				);
-				// put flag if we should invalidate or not
-				return result;
+				const tablesForInvalidation = cacheConfig.autoInvalidate ? this.queryMetadata.tables : [];
+				const promise = (async () => {
+					let result: T;
+					try {
+						result = await query();
+					} catch (e) {
+						throw new DrizzleQueryError(queryString, params, e as Error);
+					}
+					await cache.put(
+						cacheKey,
+						result,
+						tablesForInvalidation,
+						isTag,
+						cacheConfig.config,
+					);
+					return result;
+				})().finally(() => {
+					cache.inFlightQueries.delete(cacheKey);
+				});
+				cache.inFlightQueries.set(cacheKey, promise);
+				return promise;
 			}
 
 			return fromCache as unknown as T;

--- a/drizzle-orm/src/sqlite-core/session.ts
+++ b/drizzle-orm/src/sqlite-core/session.ts
@@ -118,31 +118,42 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 		}
 
 		if (this.queryMetadata.type === 'select') {
-			const fromCache = await this.cache.get(
-				this.cacheConfig.tag ?? await hashQuery(queryString, params),
+			const cache = this.cache;
+			const cacheConfig = this.cacheConfig;
+			const isTag = cacheConfig.tag !== undefined;
+			const cacheKey = cacheConfig.tag ?? await hashQuery(queryString, params);
+			const fromCache = await cache.get(
+				cacheKey,
 				this.queryMetadata.tables,
-				this.cacheConfig.tag !== undefined,
-				this.cacheConfig.autoInvalidate,
+				isTag,
+				cacheConfig.autoInvalidate,
 			);
 			if (fromCache === undefined) {
-				let result;
-				try {
-					result = await query();
-				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+				const inflight = cache.inFlightQueries.get(cacheKey);
+				if (inflight !== undefined) {
+					return inflight as Promise<T>;
 				}
-
-				// put actual key
-				await this.cache.put(
-					this.cacheConfig.tag ?? await hashQuery(queryString, params),
-					result,
-					// make sure we send tables that were used in a query only if user wants to invalidate it on each write
-					this.cacheConfig.autoInvalidate ? this.queryMetadata.tables : [],
-					this.cacheConfig.tag !== undefined,
-					this.cacheConfig.config,
-				);
-				// put flag if we should invalidate or not
-				return result;
+				const tablesForInvalidation = cacheConfig.autoInvalidate ? this.queryMetadata.tables : [];
+				const promise = (async () => {
+					let result: T;
+					try {
+						result = await query();
+					} catch (e) {
+						throw new DrizzleQueryError(queryString, params, e as Error);
+					}
+					await cache.put(
+						cacheKey,
+						result,
+						tablesForInvalidation,
+						isTag,
+						cacheConfig.config,
+					);
+					return result;
+				})().finally(() => {
+					cache.inFlightQueries.delete(cacheKey);
+				});
+				cache.inFlightQueries.set(cacheKey, promise);
+				return promise;
 			}
 
 			return fromCache as unknown as T;

--- a/integration-tests/tests/gel/gel.test.ts
+++ b/integration-tests/tests/gel/gel.test.ts
@@ -5360,4 +5360,23 @@ describe('some', async () => {
 		// @ts-expect-error
 		expect(db.select().from(sq).getUsedTables()).toStrictEqual(['users']);
 	});
+
+	test('concurrent $withCache on cold cache fires a single DB query (single-flight)', async (ctx) => {
+		const { db } = ctx.cachedGel;
+
+		await db.insert(usersTable).values({ id1: 1, name: 'John' });
+
+		// @ts-expect-error
+		const spyPut = vi.spyOn(db.$cache, 'put');
+		// @ts-expect-error
+		const spyGet = vi.spyOn(db.$cache, 'get');
+
+		const results = await Promise.all(
+			Array.from({ length: 20 }, () => db.select().from(usersTable).$withCache()),
+		);
+
+		expect(spyGet).toHaveBeenCalledTimes(20);
+		expect(spyPut).toHaveBeenCalledTimes(1);
+		expect(results.length).toBe(20);
+	});
 });

--- a/integration-tests/tests/gel/gel.test.ts
+++ b/integration-tests/tests/gel/gel.test.ts
@@ -5379,4 +5379,24 @@ describe('some', async () => {
 		expect(spyPut).toHaveBeenCalledTimes(1);
 		expect(results.length).toBe(20);
 	});
+
+	test('concurrent $withCache propagates put errors to all waiters', async (ctx) => {
+		const { db } = ctx.cachedGel;
+
+		await db.insert(usersTable).values({ id1: 1, name: 'John' });
+
+		const putError = new Error('put failed');
+		// @ts-expect-error
+		vi.spyOn(db.$cache, 'put').mockRejectedValueOnce(putError);
+
+		const promises = Array.from({ length: 5 }, () =>
+			db.select().from(usersTable).$withCache().catch((e) => e)
+		);
+
+		const results = await Promise.all(promises);
+
+		results.forEach((result) => {
+			expect(result).toBe(putError);
+		});
+	});
 });

--- a/integration-tests/tests/mysql/mysql-common-cache.ts
+++ b/integration-tests/tests/mysql/mysql-common-cache.ts
@@ -394,5 +394,25 @@ export function tests() {
 			expect(spyPut).toHaveBeenCalledTimes(1);
 			expect(results.length).toBe(20);
 		});
+
+		test('concurrent $withCache propagates put errors to all waiters', async (ctx) => {
+			const { db } = ctx.cachedMySQL;
+
+			await db.insert(usersTable).values({ name: 'John' });
+
+			const putError = new Error('put failed');
+			// @ts-expect-error
+			vi.spyOn(db.$cache, 'put').mockRejectedValueOnce(putError);
+
+			const promises = Array.from({ length: 5 }, () =>
+				db.select().from(usersTable).$withCache().catch((e) => e)
+			);
+
+			const results = await Promise.all(promises);
+
+			results.forEach((result) => {
+				expect(result).toBe(putError);
+			});
+		});
 	});
 }

--- a/integration-tests/tests/mysql/mysql-common-cache.ts
+++ b/integration-tests/tests/mysql/mysql-common-cache.ts
@@ -375,5 +375,24 @@ export function tests() {
 			// @ts-expect-error
 			expect(db.select().from(sq).getUsedTables()).toStrictEqual(['users']);
 		});
+
+		test('concurrent $withCache on cold cache fires a single DB query (single-flight)', async (ctx) => {
+			const { db } = ctx.cachedMySQL;
+
+			await db.insert(usersTable).values({ name: 'John' });
+
+			// @ts-expect-error
+			const spyPut = vi.spyOn(db.$cache, 'put');
+			// @ts-expect-error
+			const spyGet = vi.spyOn(db.$cache, 'get');
+
+			const results = await Promise.all(
+				Array.from({ length: 20 }, () => db.select().from(usersTable).$withCache()),
+			);
+
+			expect(spyGet).toHaveBeenCalledTimes(20);
+			expect(spyPut).toHaveBeenCalledTimes(1);
+			expect(results.length).toBe(20);
+		});
 	});
 }

--- a/integration-tests/tests/pg/pg-common-cache.ts
+++ b/integration-tests/tests/pg/pg-common-cache.ts
@@ -396,5 +396,24 @@ export function tests() {
 			// @ts-expect-error
 			expect(db.select().from(sq).getUsedTables()).toStrictEqual(['users']);
 		});
+
+		test('concurrent $withCache on cold cache fires a single DB query (single-flight)', async (ctx) => {
+			const { db } = ctx.cachedPg;
+
+			await db.insert(usersTable).values({ name: 'John' });
+
+			// @ts-expect-error
+			const spyPut = vi.spyOn(db.$cache, 'put');
+			// @ts-expect-error
+			const spyGet = vi.spyOn(db.$cache, 'get');
+
+			const results = await Promise.all(
+				Array.from({ length: 20 }, () => db.select().from(usersTable).$withCache()),
+			);
+
+			expect(spyGet).toHaveBeenCalledTimes(20);
+			expect(spyPut).toHaveBeenCalledTimes(1);
+			expect(results.length).toBe(20);
+		});
 	});
 }

--- a/integration-tests/tests/pg/pg-common-cache.ts
+++ b/integration-tests/tests/pg/pg-common-cache.ts
@@ -415,5 +415,25 @@ export function tests() {
 			expect(spyPut).toHaveBeenCalledTimes(1);
 			expect(results.length).toBe(20);
 		});
+
+		test('concurrent $withCache propagates put errors to all waiters', async (ctx) => {
+			const { db } = ctx.cachedPg;
+
+			await db.insert(usersTable).values({ name: 'John' });
+
+			const putError = new Error('put failed');
+			// @ts-expect-error
+			vi.spyOn(db.$cache, 'put').mockRejectedValueOnce(putError);
+
+			const promises = Array.from({ length: 5 }, () =>
+				db.select().from(usersTable).$withCache().catch((e) => e)
+			);
+
+			const results = await Promise.all(promises);
+
+			results.forEach((result) => {
+				expect(result).toBe(putError);
+			});
+		});
 	});
 }

--- a/integration-tests/tests/singlestore/singlestore-cache.ts
+++ b/integration-tests/tests/singlestore/singlestore-cache.ts
@@ -405,5 +405,25 @@ export function tests() {
 			expect(spyPut).toHaveBeenCalledTimes(1);
 			expect(results.length).toBe(20);
 		});
+
+		test('concurrent $withCache propagates put errors to all waiters', async (ctx) => {
+			const { db } = ctx.cachedSingleStore;
+
+			await db.insert(usersTable).values({ name: 'John' });
+
+			const putError = new Error('put failed');
+			// @ts-expect-error
+			vi.spyOn(db.$cache, 'put').mockRejectedValueOnce(putError);
+
+			const promises = Array.from({ length: 5 }, () =>
+				db.select().from(usersTable).$withCache().catch((e) => e)
+			);
+
+			const results = await Promise.all(promises);
+
+			results.forEach((result) => {
+				expect(result).toBe(putError);
+			});
+		});
 	});
 }

--- a/integration-tests/tests/singlestore/singlestore-cache.ts
+++ b/integration-tests/tests/singlestore/singlestore-cache.ts
@@ -386,5 +386,24 @@ export function tests() {
 			// @ts-expect-error
 			expect(db.select().from(sq).getUsedTables()).toStrictEqual(['users']);
 		});
+
+		test('concurrent $withCache on cold cache fires a single DB query (single-flight)', async (ctx) => {
+			const { db } = ctx.cachedSingleStore;
+
+			await db.insert(usersTable).values({ name: 'John' });
+
+			// @ts-expect-error
+			const spyPut = vi.spyOn(db.$cache, 'put');
+			// @ts-expect-error
+			const spyGet = vi.spyOn(db.$cache, 'get');
+
+			const results = await Promise.all(
+				Array.from({ length: 20 }, () => db.select().from(usersTable).$withCache()),
+			);
+
+			expect(spyGet).toHaveBeenCalledTimes(20);
+			expect(spyPut).toHaveBeenCalledTimes(1);
+			expect(results.length).toBe(20);
+		});
 	});
 }

--- a/integration-tests/tests/sqlite/sqlite-common-cache.ts
+++ b/integration-tests/tests/sqlite/sqlite-common-cache.ts
@@ -395,5 +395,25 @@ export function tests() {
 			expect(spyPut).toHaveBeenCalledTimes(1);
 			expect(results.length).toBe(20);
 		});
+
+		test('concurrent $withCache propagates put errors to all waiters', async (ctx) => {
+			const { db } = ctx.cachedSqlite;
+
+			await db.insert(usersTable).values({ name: 'John' });
+
+			const putError = new Error('put failed');
+			// @ts-expect-error
+			vi.spyOn(db.$cache, 'put').mockRejectedValueOnce(putError);
+
+			const promises = Array.from({ length: 5 }, () =>
+				db.select().from(usersTable).$withCache().catch((e) => e)
+			);
+
+			const results = await Promise.all(promises);
+
+			results.forEach((result) => {
+				expect(result).toBe(putError);
+			});
+		});
 	});
 }

--- a/integration-tests/tests/sqlite/sqlite-common-cache.ts
+++ b/integration-tests/tests/sqlite/sqlite-common-cache.ts
@@ -376,5 +376,24 @@ export function tests() {
 			// @ts-expect-error
 			expect(db.select().from(sq).getUsedTables()).toStrictEqual(['users']);
 		});
+
+		test('concurrent $withCache on cold cache fires a single DB query (single-flight)', async (ctx) => {
+			const { db } = ctx.cachedSqlite;
+
+			await db.insert(usersTable).values({ name: 'John' });
+
+			// @ts-expect-error
+			const spyPut = vi.spyOn(db.$cache, 'put');
+			// @ts-expect-error
+			const spyGet = vi.spyOn(db.$cache, 'get');
+
+			const results = await Promise.all(
+				Array.from({ length: 20 }, () => db.select().from(usersTable).$withCache()),
+			);
+
+			expect(spyGet).toHaveBeenCalledTimes(20);
+			expect(spyPut).toHaveBeenCalledTimes(1);
+			expect(results.length).toBe(20);
+		});
 	});
 }


### PR DESCRIPTION
On a cold cache, concurrent SELECTs sharing the same key all miss and each fire their own DB query. The number of queries scales with concurrency, not cache misses. Most cache backends used with $withCache do not promise single-flight, so the dedup has to live in the ORM.

Fix: add an inFlightQueries map on the Cache instance. On miss, the first caller runs query() and put() inside a shared promise; concurrent callers for the same key return that same promise. The entry is removed on settle, so a later call after the cache is populated behaves as before. put() stays inside the in-flight chain so every caller observes the cached value once it is written.

Scope: same change applied to pg-core, mysql-core, sqlite-core, singlestore-core, gel-core.

Test: a concurrent stampede test added to each dialect cache suite. 20 parallel $withCache calls on a cold cache assert exactly one put() and 20 get()s.

Fixes #5841