### PR TITLE
fix(drizzle-kit): add trailing LF to snapshots and remove indentations

### DIFF
--- a/drizzle-kit/src/cli/commands/generate-common.ts
+++ b/drizzle-kit/src/cli/commands/generate-common.ts
@@ -51,7 +51,7 @@ export const writeResult = (config: {
 	fs.mkdirSync(join(outFolder, tag));
 	fs.writeFileSync(
 		join(outFolder, `${tag}/snapshot.json`),
-		JSON.stringify(JSON.parse(JSON.stringify(snapshot)), null, 2),
+		`${JSON.stringify(JSON.parse(JSON.stringify(snapshot)))}\n`,
 	);
 
 	const sqlDelimiter = breakpoints ? BREAKPOINT : '\n';


### PR DESCRIPTION
The snapshot is not supposed to be modified by human, so it can be one line.