### PR TITLE
fix(gel-core): patch escapeName per GHSA-gpj5-g38j-94v9 (incomplete fix in 0.45.2)

### DIFF
--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -101,7 +101,7 @@ export class GelDialect {
 	// }
 
 	escapeName(name: string): string {
-		return `"${name}"`;
+		return `"${name.replace(/"/g, '""')}"`;
 	}
 
 	escapeParam(num: number): string {


### PR DESCRIPTION
## Summary

The 0.45.2 security release (GHSA-gpj5-g38j-94v9) advertised SQL-identifier-escape fixes for the PostgreSQL, MySQL, SQLite, SingleStore, **and Gel** dialects. The actual patch commit ([`273c780`](https://github.com/drizzle-team/drizzle-orm/commit/273c78071d4841b497f5144734b38294df7ec64b)) only touched the first four. The Gel dialect `escapeName` is still

```ts
escapeName(name: string): string {
  return `"${name}"`;
}
```

which is the pre-CVE shape that allows the same identifier-delimiter SQL injection the parent advisory documents. This PR brings the Gel dialect in line with the other four — one line, the same `replace(/"/g, )` pattern.

## Repro

Confirmed against `drizzle-orm@0.45.2` published tarball (`package/gel-core/dialect.cjs` still ships the unpatched version):

```js
function gelEscapeName(name) { return `"${name}"`; }
function pgEscapeName(name)  { return `"${name.replace(/"/g, "''")}"`; }

const attackerInput = `id"; DROP TABLE users; --`;
gelEscapeName(attackerInput); // → "id"; DROP TABLE users; --"
pgEscapeName(attackerInput);  // → "id""; DROP TABLE users; --"
```

Same shape as the advisory: any application that pipes an attacker-controlled value through `sql.identifier()` or `.as()` (dynamic sort fields, dynamic alias names, CTE naming from request params) can break out of the quoted identifier on the Gel dialect even after upgrading to 0.45.2.

## Disclosure note

Reported privately to `security@drizzle.team` first; happy to coordinate timing on the public merge / release. Filing as a draft-style PR with the one-line fix to make it easy to land alongside whatever Gel-specific test you would prefer. If a security-track release is the preferred path I can close this PR and move it to the Security Advisories flow.

## Patch

```diff
- escapeName(name: string): string {
-   return `"${name}"`;
- }
+ escapeName(name: string): string {
+   return `"${name.replace(/"/g, )}"`;
+ }
```

## Suggested regression test

If the existing escape test for `pg-core` covers the basic shape, the same fixture against the `GelDialect` would catch a future regression. Happy to add it in a follow-up commit.