### PR TITLE
chore: fix README logo displaying

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
-  <img src="./misc/readme/logo-github-sq-dark.svg#gh-dark-mode-only" />
-  <img src="./misc/readme/logo-github-sq-light.svg#gh-light-mode-only" />
-</div>
-
-<br/>
-<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./misc/readme/logo-github-sq-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="./misc/readme/logo-github-sq-light.svg">
+    <img alt="Drizzle ORM" src="./misc/readme/logo-github-sq-light.svg">
+  </picture>
+  <br/>
   <h3>Headless ORM for NodeJS, TypeScript and JavaScript 🚀</h3>
   <a href="https://orm.drizzle.team">Website</a> •
   <a href="https://orm.drizzle.team/docs/overview">Documentation</a> •

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="./misc/readme/logo-github-sq-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset="./misc/readme/logo-github-sq-light.svg">
     <img alt="Drizzle ORM" src="./misc/readme/logo-github-sq-light.svg">
   </picture>
   <br/>


### PR DESCRIPTION
The old syntax is [deprecated and removed in docs](https://github.com/yusukebe/gh-markdown-preview/issues/36#issuecomment-1295810189). NPM does not support it either:

<img width="1544" height="480" alt="image" src="https://github.com/user-attachments/assets/d3a427d7-4e40-494a-81ea-bd899c5d7f6c" />
