### PR TITLE
[MsSql] Exclude generated columns from INSERT column list

### DIFF
--- a/drizzle-orm/src/mssql-core/columns/common.ts
+++ b/drizzle-orm/src/mssql-core/columns/common.ts
@@ -106,11 +106,6 @@ export abstract class MsSqlColumn<
 		super(table, config);
 		this.table = table;
 	}
-
-	/** @internal */
-	override shouldDisableInsert(): boolean {
-		return false;
-	}
 }
 
 export type AnyMsSqlColumn<TPartial extends Partial<ColumnBaseConfig<ColumnType>> = {}> = MsSqlColumn<
@@ -156,6 +151,6 @@ export abstract class MsSqlColumnWithIdentity<
 	readonly identity = this.config.identity;
 
 	override shouldDisableInsert(): boolean {
-		return !!this.identity;
+		return !!this.identity || super.shouldDisableInsert();
 	}
 }

--- a/integration-tests/tests/mssql/mssql.test.ts
+++ b/integration-tests/tests/mssql/mssql.test.ts
@@ -36,6 +36,7 @@ import {
 	mssqlTable,
 	mssqlTableCreator,
 	mssqlView,
+	nvarchar,
 	primaryKey,
 	real,
 	text,
@@ -407,6 +408,28 @@ test('insert returning sql', async ({ db }) => {
 	const result = await db.insert(usersTable).values({ name: 'John' });
 
 	expect(result.rowsAffected[0]).toEqual(1);
+});
+
+test('insert into table with generated column', async ({ db }) => {
+	const docsTable = mssqlTable('docs_with_generated', {
+		id: int().identity().primaryKey(),
+		value: nvarchar({ length: 'max' }).notNull(),
+		valueUpper: nvarchar('value_upper', { length: 450 }).generatedAlwaysAs(sql`upper([value])`),
+	});
+
+	await db.execute(sql`drop table if exists [docs_with_generated]`);
+	await db.execute(sql`
+		create table [docs_with_generated] (
+			[id] int identity primary key,
+			[value] nvarchar(max) not null,
+			[value_upper] as (upper([value]))
+		)
+	`);
+
+	await db.insert(docsTable).values({ value: 'hello' });
+	const result = await db.select().from(docsTable);
+
+	expect(result).toEqual([{ id: 1, value: 'hello', valueUpper: 'HELLO' }]);
 });
 
 test('delete returning sql', async ({ db }) => {


### PR DESCRIPTION
Fixes #5881

## Problem

The MSSQL dialect's `buildInsertQuery` emits every table column in the INSERT column list, filling missing values with the `default` keyword. `MsSqlColumn` overrides `shouldDisableInsert()` with a hardcoded `false`, so `generatedAlwaysAs()` (computed) columns are included too — and SQL Server rejects any mention of a computed column in an INSERT column list, even with `DEFAULT`:

```
Msg 271: The column "value_upper" cannot be modified because it is either a computed column or is the result of a UNION operator.
```

```ts
const docs = mssqlTable('docs', {
	id: int().identity(),
	value: nvarchar({ length: 'max' }).notNull(),
	valueUpper: nvarchar('value_upper', { length: 450 }).generatedAlwaysAs(sql`upper([value])`),
});

db.insert(docs).values({ value: 'hello' }).toSQL().sql;
// before: insert into [docs] ([value], [value_upper]) values (@par0, default)  → Msg 271
// after:  insert into [docs] ([value]) values (@par0)
```

This blocks inserting into any table with a computed column — including schemas produced by `drizzle-kit pull`, which introspects SQL Server computed columns into `generatedAlwaysAs()`.

## Fix

- Remove the `MsSqlColumn.shouldDisableInsert()` override so the base `Column` logic applies (the MSSQL `generatedAlwaysAs()` builder always sets `generated.type: 'always'`, so computed columns are excluded). No other dialect overrides this method on its base column class.
- `MsSqlColumnWithIdentity.shouldDisableInsert()` now combines its identity exclusion with the inherited check.

## Tests

- Added `insert into table with generated column` to `integration-tests/tests/mssql/mssql.test.ts`: creates a table with a computed column, inserts through the query builder, and reads the computed value back. Fails with Msg 271 before the fix, passes after.
- Full MSSQL integration suite is green locally against `mcr.microsoft.com/azure-sql-edge`: `mssql.test.ts` 159 passed / 0 failed; `mssql.custom.test.ts` + `mssql.prefixed.test.ts` + `mssql.rels.test.ts` 186 passed / 0 failed.