### PR TITLE
[MsSql] Add WITH (NOLOCK) table hint support to select query builder

### DIFF
--- a/drizzle-orm/src/mssql-core/dialect.ts
+++ b/drizzle-orm/src/mssql-core/dialect.ts
@@ -396,6 +396,8 @@ export class MsSqlDialect {
 		offset,
 		distinct,
 		setOperators,
+		withNoLock,
+		allWithNoLock,
 	}: MsSqlSelectConfig): SQL {
 		const fieldsList = fieldsFlat ?? orderSelectedFields<MsSqlColumn>(fields);
 		for (const f of fieldsList) {
@@ -477,6 +479,10 @@ export class MsSqlDialect {
 			return table;
 		})();
 
+		const tableNoLockSql = (withNoLock || allWithNoLock) && is(table, MsSqlTable)
+			? sql` with (nolock)`
+			: undefined;
+
 		const joinsArray: SQL[] = [];
 
 		if (joins) {
@@ -492,10 +498,13 @@ export class MsSqlDialect {
 					const tableSchema = table[MsSqlTable.Symbol.Schema];
 					const origTableName = table[MsSqlTable.Symbol.OriginalName];
 					const alias = tableName === origTableName ? undefined : joinMeta.alias;
+					const joinNoLockSql = joinMeta.withNoLock || allWithNoLock ? sql` with (nolock)` : undefined;
 					joinsArray.push(
 						sql`${sql.raw(joinMeta.joinType)} join${lateralSql} ${
 							tableSchema ? sql`${sql.identifier(tableSchema)}.` : undefined
-						}${sql.identifier(origTableName)}${alias && sql` ${sql.identifier(alias)}`} on ${joinMeta.on}`,
+						}${sql.identifier(origTableName)}${
+							alias && sql` ${sql.identifier(alias)}`
+						}${joinNoLockSql} on ${joinMeta.on}`,
 					);
 				} else if (is(table, View)) {
 					const viewName = table[ViewBaseConfig].name;
@@ -552,7 +561,7 @@ export class MsSqlDialect {
 		}
 
 		const finalQuery =
-			sql`${withSql}select${distinctSql}${topSql} ${selection} from ${tableSql}${joinsSql}${whereSql}${groupBySql}${havingSql}${orderBySql}${offsetSql}${fetchSql}${forSQL}`;
+			sql`${withSql}select${distinctSql}${topSql} ${selection} from ${tableSql}${tableNoLockSql}${joinsSql}${whereSql}${groupBySql}${havingSql}${orderBySql}${offsetSql}${fetchSql}${forSQL}`;
 
 		if (setOperators.length > 0) {
 			return this.buildSetOperations(finalQuery, setOperators);

--- a/drizzle-orm/src/mssql-core/query-builders/select.ts
+++ b/drizzle-orm/src/mssql-core/query-builders/select.ts
@@ -3,7 +3,7 @@ import type { MsSqlColumn } from '~/mssql-core/columns/index.ts';
 import type { MsSqlDialect } from '~/mssql-core/dialect.ts';
 import type { MsSqlSession, PreparedQueryConfig, PreparedQueryHKTBase } from '~/mssql-core/session.ts';
 import type { SubqueryWithSelection } from '~/mssql-core/subquery.ts';
-import type { MsSqlTable } from '~/mssql-core/table.ts';
+import { MsSqlTable } from '~/mssql-core/table.ts';
 import { TypedQueryBuilder } from '~/query-builders/query-builder.ts';
 import type {
 	BuildSubquerySelection,
@@ -50,6 +50,10 @@ import type {
 	SetOperatorRightSelect,
 } from './select.types.ts';
 
+export type MsSqlTableHintConfig = {
+	withNoLock?: boolean;
+};
+
 // Shared base class for `from()`
 class MsSqlSelectFromBuilderBase<
 	TSelection extends SelectedFields | undefined,
@@ -86,6 +90,8 @@ class MsSqlSelectFromBuilderBase<
 
 	from<TFrom extends MsSqlTable | Subquery | MsSqlViewBase | SQL>(
 		source: TFrom,
+		tableHints?: TFrom extends MsSqlTable ? MsSqlTableHintConfig
+			: 'Table hint configuration is allowed only for MsSqlTable and not for subqueries or views',
 	): Omit<
 		CreateMsSqlSelectFromBuilderMode<
 			TBuilderMode,
@@ -116,6 +122,11 @@ class MsSqlSelectFromBuilderBase<
 			fields = getTableColumns<MsSqlTable>(source);
 		}
 
+		let withNoLock: boolean | undefined;
+		if (is(source, MsSqlTable) && tableHints && typeof tableHints !== 'string') {
+			withNoLock = tableHints.withNoLock;
+		}
+
 		return new MsSqlSelectBase({
 			table: source,
 			fields,
@@ -125,6 +136,7 @@ class MsSqlSelectFromBuilderBase<
 			withList: this.withList,
 			distinct: this.distinct,
 			topValue: this.topValue,
+			withNoLock,
 		}) as any;
 	}
 }
@@ -187,7 +199,7 @@ export abstract class MsSqlSelectQueryBuilderBase<
 	protected dialect: MsSqlDialect;
 
 	constructor(
-		{ table, fields, isPartialSelect, session, dialect, withList, distinct, topValue }: {
+		{ table, fields, isPartialSelect, session, dialect, withList, distinct, topValue, withNoLock }: {
 			table: MsSqlSelectConfig['table'];
 			fields: MsSqlSelectConfig['fields'];
 			isPartialSelect: boolean;
@@ -196,6 +208,7 @@ export abstract class MsSqlSelectQueryBuilderBase<
 			withList: Subquery[];
 			distinct: boolean | undefined;
 			topValue: number | undefined | Placeholder;
+			withNoLock?: boolean;
 		},
 	) {
 		super();
@@ -206,6 +219,7 @@ export abstract class MsSqlSelectQueryBuilderBase<
 			distinct,
 			setOperators: [],
 			top: topValue,
+			withNoLock,
 		};
 		this.isPartialSelect = isPartialSelect;
 		this.session = session;
@@ -223,6 +237,7 @@ export abstract class MsSqlSelectQueryBuilderBase<
 		return (
 			table: MsSqlTable | Subquery | MsSqlViewBase | SQL,
 			on: ((aliases: TSelection) => SQL | undefined) | SQL | undefined,
+			tableHints?: MsSqlTableHintConfig | string,
 		) => {
 			const baseTableName = this.tableName;
 			const tableName = getTableLikeName(table);
@@ -261,7 +276,12 @@ export abstract class MsSqlSelectQueryBuilderBase<
 				this.config.joins = [];
 			}
 
-			this.config.joins.push({ on, table, joinType, alias: tableName });
+			let withNoLock: boolean | undefined;
+			if (is(table, MsSqlTable) && tableHints && typeof tableHints !== 'string') {
+				withNoLock = tableHints.withNoLock;
+			}
+
+			this.config.joins.push({ on, table, joinType, alias: tableName, withNoLock });
 
 			if (typeof tableName === 'string') {
 				switch (joinType) {
@@ -409,6 +429,26 @@ export abstract class MsSqlSelectQueryBuilderBase<
 	 * ```
 	 */
 	fullJoin = this.createJoin('full');
+
+	/**
+	 * Applies the `WITH (NOLOCK)` table hint to the main table and all joined tables of the query.
+	 *
+	 * Equivalent to passing `{ withNoLock: true }` to `.from()` and to every join individually. Only tables receive the hint; subqueries, views and raw SQL sources are left untouched.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * // Select all users and their pets without taking shared locks
+	 * await db.select()
+	 *   .from(users)
+	 *   .leftJoin(pets, eq(users.id, pets.ownerId))
+	 *   .withNoLock();
+	 * ```
+	 */
+	withNoLock(): MsSqlSelectWithout<this, TDynamic, 'withNoLock'> {
+		this.config.allWithNoLock = true;
+		return this as any;
+	}
 
 	private createSetOperator(
 		type: SetOperator,

--- a/drizzle-orm/src/mssql-core/query-builders/select.types.ts
+++ b/drizzle-orm/src/mssql-core/query-builders/select.types.ts
@@ -25,7 +25,7 @@ import type { Assume, ValidateShape } from '~/utils.ts';
 import type { PreparedQueryConfig, PreparedQueryHKTBase, PreparedQueryKind } from '../session.ts';
 import type { MsSqlViewBase } from '../view-base.ts';
 import type { MsSqlView, MsSqlViewWithSelection } from '../view.ts';
-import type { MsSqlSelectBase, MsSqlSelectQueryBuilderBase } from './select.ts';
+import type { MsSqlSelectBase, MsSqlSelectQueryBuilderBase, MsSqlTableHintConfig } from './select.ts';
 
 export interface MsSqlSelectJoinConfig {
 	on: SQL | undefined;
@@ -33,6 +33,7 @@ export interface MsSqlSelectJoinConfig {
 	alias: string | undefined;
 	joinType: JoinType;
 	lateral?: boolean;
+	withNoLock?: boolean;
 }
 
 export type BuildAliasTable<TTable extends MsSqlTable | MsSqlView, TAlias extends string> = TTable extends Table<any>
@@ -76,6 +77,8 @@ export interface MsSqlSelectConfig {
 	top?: number | Placeholder;
 	offset?: number | Placeholder;
 	distinct?: boolean;
+	withNoLock?: boolean;
+	allWithNoLock?: boolean;
 	setOperators: {
 		rightSelect: TypedQueryBuilder<any, any>;
 		type: SetOperator;
@@ -127,6 +130,8 @@ export type MsSqlJoinFn<
 >(
 	table: TJoinedTable,
 	on: ((aliases: T['_']['selection']) => SQL | undefined) | SQL | undefined,
+	tableHints?: TJoinedTable extends MsSqlTable ? MsSqlTableHintConfig
+		: 'Table hint configuration is allowed only for MsSqlTable and not for subqueries or views',
 ) => MsSqlJoin<T, TDynamic, TJoinType, TJoinedTable, TJoinedName>;
 
 export type SelectedFieldsFlat = SelectedFieldsFlatBase<MsSqlColumn>;
@@ -220,7 +225,8 @@ export type MsSqlSetOperatorExcludedMethods =
 	| 'leftJoin'
 	| 'rightJoin'
 	| 'innerJoin'
-	| 'fullJoin';
+	| 'fullJoin'
+	| 'withNoLock';
 
 export type MsSqlSelectWithout<
 	T extends AnyMsSqlSelectQueryBuilder,

--- a/drizzle-orm/type-tests/mssql/select.ts
+++ b/drizzle-orm/type-tests/mssql/select.ts
@@ -614,3 +614,37 @@ await db.select().from(users);
 		}>
 	>;
 }
+
+{
+	const sq = db.select().from(users).as('sq');
+
+	await db.select().from(users, { withNoLock: true });
+
+	await db.select().from(users, {
+		// @ts-expect-error
+		unknownHint: true,
+	});
+
+	// @ts-expect-error
+	await db.select().from(newYorkers, { withNoLock: true });
+
+	// @ts-expect-error
+	await db.select().from(sq, { withNoLock: true });
+
+	await db
+		.select()
+		.from(users)
+		.leftJoin(cities, eq(users.homeCity, cities.id), { withNoLock: true });
+
+	await db
+		.select()
+		.from(users)
+		// @ts-expect-error
+		.leftJoin(db.select().from(cities).as('c'), sql`true`, { withNoLock: true });
+
+	await db
+		.select()
+		.from(users)
+		.leftJoin(cities, eq(users.homeCity, cities.id))
+		.withNoLock();
+}

--- a/integration-tests/tests/mssql/mssql.test.ts
+++ b/integration-tests/tests/mssql/mssql.test.ts
@@ -737,6 +737,60 @@ test('build query', async ({ db }) => {
 	});
 });
 
+test('Query check: select with nolock table hint', async ({ db }) => {
+	const query = db
+		.select({ id: users2Table.id, name: users2Table.name })
+		.from(users2Table, { withNoLock: true })
+		.toSQL();
+
+	expect(query).toEqual({
+		sql: 'select [id], [name] from [users2] with (nolock)',
+		params: [],
+	});
+});
+
+test('Query check: select with nolock table hint on join', async ({ db }) => {
+	const query = db
+		.select({ userName: users2Table.name, cityName: citiesTable.name })
+		.from(users2Table, { withNoLock: true })
+		.leftJoin(citiesTable, eq(users2Table.cityId, citiesTable.id), { withNoLock: true })
+		.toSQL();
+
+	expect(query).toEqual({
+		sql:
+			'select [users2].[name], [cities].[name] from [users2] with (nolock) left join [cities] with (nolock) on [users2].[city_id] = [cities].[id]',
+		params: [],
+	});
+});
+
+test('Query check: withNoLock applies nolock table hint to all tables', async ({ db }) => {
+	const query = db
+		.select({ userName: users2Table.name, cityName: citiesTable.name })
+		.from(users2Table)
+		.leftJoin(citiesTable, eq(users2Table.cityId, citiesTable.id))
+		.withNoLock()
+		.toSQL();
+
+	expect(query).toEqual({
+		sql:
+			'select [users2].[name], [cities].[name] from [users2] with (nolock) left join [cities] with (nolock) on [users2].[city_id] = [cities].[id]',
+		params: [],
+	});
+});
+
+test('select with nolock table hint', async ({ db }) => {
+	await db.insert(citiesTable).values({ id: 1, name: 'Paris' });
+	await db.insert(users2Table).values({ id: 1, name: 'John', cityId: 1 });
+
+	const result = await db
+		.select({ userName: users2Table.name, cityName: citiesTable.name })
+		.from(users2Table)
+		.leftJoin(citiesTable, eq(users2Table.cityId, citiesTable.id))
+		.withNoLock();
+
+	expect(result).toEqual([{ userName: 'John', cityName: 'Paris' }]);
+});
+
 test('Query check: Insert all defaults in 1 row', async ({ db }) => {
 	const users = mssqlTable('users', {
 		id: int('id').identity().primaryKey(),


### PR DESCRIPTION
Closes #5883

Adds `WITH (NOLOCK)` table hint support to the MSSQL select query builder, following the same pattern as the MySQL index hints (`useIndex` / `forceIndex` / `ignoreIndex`).

## API

Per-table hint config on `.from()` and all join methods:

```ts
db.select()
	.from(users, { withNoLock: true })
	.leftJoin(cities, eq(cities.id, users.cityId), { withNoLock: true });
```

Chainable `.withNoLock()` that applies the hint to the main table and every joined table (order-independent — it works regardless of whether joins are added before or after the call):

```ts
db.select()
	.from(users)
	.leftJoin(cities, eq(cities.id, users.cityId))
	.withNoLock();
```

Both produce:

```sql
select [users].[name], [cities].[name] from [users] with (nolock) left join [cities] with (nolock) on [cities].[id] = [users].[city_id]
```

## Implementation notes

- `MsSqlTableHintConfig` (`{ withNoLock?: boolean }`) is accepted only for `MsSqlTable` sources; subqueries, views and raw SQL are rejected at the type level with the same error-string-literal technique the MySQL index hints use.
- Config plumbing mirrors MySQL: stored on `MsSqlSelectConfig` (`withNoLock`, `allWithNoLock`) and `MsSqlSelectJoinConfig` (`withNoLock`), emitted in `MsSqlDialect.buildSelectQuery` right after the table identifier/alias.
- `withNoLock` is added to `MsSqlSetOperatorExcludedMethods`.
- The config type leaves room to add further table hints later (`READPAST`, `UPDLOCK`, …) without an API break.
- Scope is the select builder only (same as the MySQL index hints); RQB paths are unaffected (new config fields are optional).

## Tests

- Type tests in `type-tests/mssql/select.ts`: valid usage on tables and joins, `@ts-expect-error` for views/subqueries/unknown hint keys, `.withNoLock()` chaining — `pnpm test:types` passes.
- Integration tests in `integration-tests/tests/mssql/mssql.test.ts`: three `toSQL()` query checks (from-hint, join-hint, `.withNoLock()` all-tables) plus one execution test against a real SQL Server (azure-sql-edge) instance.
- Full `tests/mssql/mssql.test.ts` (162 passed / 1 pre-existing skip) and `tests/mssql/mssql.rels.test.ts` (88 passed) are green.
