### PR TITLE
Keep generatedAlwaysAsIdentity columns in select schema types (typebox/valibot/arktype)

### DIFF
--- a/drizzle-arktype/src/schema.types.internal.ts
+++ b/drizzle-arktype/src/schema.types.internal.ts
@@ -47,17 +47,19 @@ export type BuildSchema<
 > = type.instantiate<
 	Simplify<
 		{
-			readonly [K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? never : K]:
-				TColumns[K] extends infer TColumn extends Column
-					? IsRefinementDefined<TRefinements, K> extends true
-						? HandleRefinement<TType, TRefinements[K & keyof TRefinements], TColumn>
-					: HandleColumn<TType, TColumn>
-					: TColumns[K] extends infer TNested extends SelectedFieldsFlat<Column> | Table | View ? BuildSchema<
-							TType,
-							GetSelection<TNested>,
-							TRefinements extends object ? TRefinements[K & keyof TRefinements] : undefined
-						>
-					: any;
+			readonly [
+				K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? TType extends 'select' ? K : never
+					: K
+			]: TColumns[K] extends infer TColumn extends Column
+				? IsRefinementDefined<TRefinements, K> extends true
+					? HandleRefinement<TType, TRefinements[K & keyof TRefinements], TColumn>
+				: HandleColumn<TType, TColumn>
+				: TColumns[K] extends infer TNested extends SelectedFieldsFlat<Column> | Table | View ? BuildSchema<
+						TType,
+						GetSelection<TNested>,
+						TRefinements extends object ? TRefinements[K & keyof TRefinements] : undefined
+					>
+				: any;
 		}
 	>
 >;

--- a/drizzle-arktype/tests/pg.test.ts
+++ b/drizzle-arktype/tests/pg.test.ts
@@ -26,11 +26,12 @@ const textSchema = type.string;
 test('table - select', (t) => {
 	const table = pgTable('test', {
 		id: serial().primaryKey(),
+		generated: integer().generatedAlwaysAsIdentity(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = type({ id: integerSchema, name: textSchema });
+	const expected = type({ id: integerSchema, generated: integerSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });

--- a/drizzle-typebox/src/schema.types.internal.ts
+++ b/drizzle-typebox/src/schema.types.internal.ts
@@ -43,8 +43,10 @@ export type BuildSchema<
 > = t.TObject<
 	Simplify<
 		{
-			[K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? never : K]: TColumns[K] extends
-				infer TColumn extends Column
+			[
+				K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? TType extends 'select' ? K : never
+					: K
+			]: TColumns[K] extends infer TColumn extends Column
 				? IsRefinementDefined<TRefinements, K> extends true
 					? Assume<HandleRefinement<TType, TRefinements[K & keyof TRefinements], TColumn>, t.TSchema>
 				: HandleColumn<TType, TColumn>

--- a/drizzle-typebox/tests/pg.test.ts
+++ b/drizzle-typebox/tests/pg.test.ts
@@ -26,11 +26,12 @@ const textSchema = t.String();
 test('table - select', (tc) => {
 	const table = pgTable('test', {
 		id: serial().primaryKey(),
+		generated: integer().generatedAlwaysAsIdentity(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = t.Object({ id: integerSchema, name: textSchema });
+	const expected = t.Object({ id: integerSchema, generated: integerSchema, name: textSchema });
 	expectSchemaShape(tc, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });

--- a/drizzle-valibot/src/schema.types.internal.ts
+++ b/drizzle-valibot/src/schema.types.internal.ts
@@ -54,17 +54,19 @@ export type BuildSchema<
 > = v.ObjectSchema<
 	Simplify<
 		{
-			readonly [K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? never : K]:
-				TColumns[K] extends infer TColumn extends Column
-					? IsRefinementDefined<TRefinements, Assume<K, string>> extends true
-						? Assume<HandleRefinement<TType, TRefinements[K & keyof TRefinements], TColumn>, v.GenericSchema>
-					: HandleColumn<TType, TColumn>
-					: TColumns[K] extends infer TObject extends SelectedFieldsFlat<Column> | Table | View ? BuildSchema<
-							TType,
-							GetSelection<TObject>,
-							TRefinements extends object ? TRefinements[K & keyof TRefinements] : undefined
-						>
-					: v.AnySchema;
+			readonly [
+				K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? TType extends 'select' ? K : never
+					: K
+			]: TColumns[K] extends infer TColumn extends Column
+				? IsRefinementDefined<TRefinements, Assume<K, string>> extends true
+					? Assume<HandleRefinement<TType, TRefinements[K & keyof TRefinements], TColumn>, v.GenericSchema>
+				: HandleColumn<TType, TColumn>
+				: TColumns[K] extends infer TObject extends SelectedFieldsFlat<Column> | Table | View ? BuildSchema<
+						TType,
+						GetSelection<TObject>,
+						TRefinements extends object ? TRefinements[K & keyof TRefinements] : undefined
+					>
+				: v.AnySchema;
 		}
 	>,
 	undefined

--- a/drizzle-valibot/tests/pg.test.ts
+++ b/drizzle-valibot/tests/pg.test.ts
@@ -26,11 +26,12 @@ const textSchema = v.string();
 test('table - select', (t) => {
 	const table = pgTable('test', {
 		id: serial().primaryKey(),
+		generated: integer().generatedAlwaysAsIdentity(),
 		name: text().notNull(),
 	});
 
 	const result = createSelectSchema(table);
-	const expected = v.object({ id: integerSchema, name: textSchema });
+	const expected = v.object({ id: integerSchema, generated: integerSchema, name: textSchema });
 	expectSchemaShape(t, expected).from(result);
 	Expect<Equal<typeof result, typeof expected>>();
 });


### PR DESCRIPTION
Closes #4724.

`createSelectSchema` in **drizzle-typebox**, **drizzle-valibot** and **drizzle-arktype** drops columns defined with `generatedAlwaysAsIdentity()` (and any `generated: 'always'` column) from the generated **type**, even though the runtime select schema keeps them. So selecting from a table with an identity primary key gives a schema whose runtime shape and static type disagree.

## Cause

The runtime is correct — `createSelectSchema` uses `selectConditions` where `never: () => false`, so generated-always columns are kept on select (only insert/update omit them):

```ts
const selectConditions: Conditions = {
	never: () => false,
	// ...
};
```

But the type-level `BuildSchema` excludes them for **every** schema type:

```ts
[K in keyof TColumns as ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? never : K]
```

So the column exists at runtime but is missing from the type — the mismatch reported in the issue.

## Fix

`drizzle-zod` already handles this correctly by guarding the exclusion with `TType extends 'select'`:

```ts
ColumnIsGeneratedAlwaysAs<TColumns[K]> extends true ? TType extends 'select' ? K : never : K
```

This applies that exact guard to the typebox, valibot and arktype packages (the issue notes all three share the defect, and they're kept in lockstep with zod). Generated-always columns are now kept for `select` and still omitted for `insert`/`update`, matching the runtime in every package.

## Tests

Extends each package's existing `table - select` type test with a `generated: integer().generatedAlwaysAsIdentity()` column and asserts it appears in the resulting schema — mirroring the `table - select` test that already exists in `drizzle-zod`. Verified each test **fails** on the current code (`Property 'generated' is missing` / `Type 'false' does not satisfy the constraint 'true'` from the `Expect<Equal<…>>` assertion) and **passes** with this change. The full runtime suites (`vitest run`, 62 tests per package) stay green and `dprint` formatting is clean.
