### PR TITLE
fix(column): add tableName as a real runtime property

### DIFF
--- a/drizzle-orm/src/column.ts
+++ b/drizzle-orm/src/column.ts
@@ -8,6 +8,7 @@ import type {
 import { entityKind } from './entity.ts';
 import type { DriverValueMapper, SQL, SQLWrapper } from './sql/sql.ts';
 import type { Table } from './table.ts';
+import { TableName } from './table.utils.ts';
 import type { Update } from './utils.ts';
 
 export interface ColumnBaseConfig<
@@ -69,6 +70,7 @@ export abstract class Column<
 
 	declare readonly _: ColumnTypeConfig<T, TTypeConfig>;
 
+	readonly tableName: T['tableName'];
 	readonly name: string;
 	readonly keyAsName: boolean;
 	readonly primary: boolean;
@@ -93,6 +95,7 @@ export abstract class Column<
 		config: ColumnRuntimeConfig<T['data'], TRuntimeConfig>,
 	) {
 		this.config = config;
+		this.tableName = table[TableName] as T['tableName'];
 		this.name = config.name;
 		this.keyAsName = config.keyAsName;
 		this.notNull = config.notNull;


### PR DESCRIPTION
The `_` property on `Column` is declared with `declare readonly`, so it only exists at the type level. At runtime, `column._.tableName` is `undefined`. This worked before the backing was removed somewhere between 0.45.x and 1.0.0-rc.3.

Users who check `column._.tableName` to distinguish same-named columns across tables (for example in `check()` constraints) get a type that claims the value is there, but it is not.

The fix adds `tableName` as a real property on the `Column` base class, assigned in the constructor from `table[TableName]`. `TableName` is the `drizzle:Name` symbol already on every `Table`, so nothing new is needed. All dialect column classes extend `Column`, so they pick this up automatically.

The `declare readonly _` is left in place because internal type utilities (`GetColumnData`, `InferColumnsDataTypes`) still reference `TColumn["_"]`. Removing it would be a breaking type change. The new `tableName` property sits alongside it and provides the runtime value.

Tested with `vitest run` (15 tests, all pass). The change is 3 lines: one import, one property declaration, one constructor assignment. No dialect, driver, or query-builder code is touched.

Closes #5890
