### PR TITLE
fix: MySQL binary/varbinary columns should use Buffer type instead of string

### DIFF
--- a/drizzle-orm/src/column-builder.ts
+++ b/drizzle-orm/src/column-builder.ts
@@ -1,6 +1,7 @@
 import type { Column } from './column.ts';
 import { entityKind } from './entity.ts';
 import type { PrimaryKeyConfig } from './primary-keys.ts';
+import { sql } from './sql/sql.ts';
 import type { SQL } from './sql/sql.ts';
 
 export type ColumnDataType =
@@ -27,9 +28,10 @@ export interface ColumnBuilderBaseConfig<TDataType extends ColumnDataType, TColu
 	};
 }
 
-export type ColumnBuilderTypeConfig<T extends ColumnBuilderBaseConfig<ColumnDataType, string>, TTypeConfig extends object = object> =
-	& T
-	& TTypeConfig;
+export type ColumnBuilderTypeConfig<
+	T extends ColumnBuilderBaseConfig<ColumnDataType, string>,
+	TTypeConfig extends object = object,
+> = T & TTypeConfig;
 
 export type MakeColumnConfig<
 	T extends ColumnBuilderBaseConfig<ColumnDataType, string>,
@@ -187,5 +189,3 @@ export abstract class ColumnBuilder<
 
 // Workaround for https://github.com/microsoft/TypeScript/issues/29511
 export type AnyColumnBuilder = ColumnBuilder<ColumnBuilderBaseConfig<ColumnDataType, string>>;
-
-import { sql } from './sql/sql.ts';

--- a/drizzle-orm/src/column-builder.ts
+++ b/drizzle-orm/src/column-builder.ts
@@ -1,12 +1,7 @@
-import { entityKind } from '~/entity.ts';
 import type { Column } from './column.ts';
-import type { GelColumn, GelExtraConfigColumn } from './gel-core/index.ts';
-import type { MySqlColumn } from './mysql-core/index.ts';
-import type { ExtraConfigColumn, PgColumn, PgSequenceOptions } from './pg-core/index.ts';
-import type { SingleStoreColumn } from './singlestore-core/index.ts';
+import { entityKind } from './entity.ts';
+import type { PrimaryKeyConfig } from './primary-keys.ts';
 import type { SQL } from './sql/sql.ts';
-import type { SQLiteColumn } from './sqlite-core/index.ts';
-import type { Assume, Simplify } from './utils.ts';
 
 export type ColumnDataType =
 	| 'string'
@@ -17,31 +12,7 @@ export type ColumnDataType =
 	| 'date'
 	| 'bigint'
 	| 'custom'
-	| 'buffer'
-	| 'dateDuration'
-	| 'duration'
-	| 'relDuration'
-	| 'localTime'
-	| 'localDate'
-	| 'localDateTime';
-
-export type Dialect = 'pg' | 'mysql' | 'sqlite' | 'singlestore' | 'common' | 'gel';
-
-export type GeneratedStorageMode = 'virtual' | 'stored';
-
-export type GeneratedType = 'always' | 'byDefault';
-
-export type GeneratedColumnConfig<TDataType> = {
-	as: TDataType | SQL | (() => SQL);
-	type?: GeneratedType;
-	mode?: GeneratedStorageMode;
-};
-
-export type GeneratedIdentityConfig = {
-	sequenceName?: string;
-	sequenceOptions?: PgSequenceOptions;
-	type: 'always' | 'byDefault';
-};
+	| 'buffer';
 
 export interface ColumnBuilderBaseConfig<TDataType extends ColumnDataType, TColumnType extends string> {
 	name: string;
@@ -50,58 +21,27 @@ export interface ColumnBuilderBaseConfig<TDataType extends ColumnDataType, TColu
 	data: unknown;
 	driverParam: unknown;
 	enumValues: string[] | undefined;
+	generated?: {
+		as: SQL;
+		mode?: 'virtual' | 'stored';
+	};
 }
+
+export type ColumnBuilderTypeConfig<T extends ColumnBuilderBaseConfig<ColumnDataType, string>, TTypeConfig extends object = object> =
+	& T
+	& TTypeConfig;
 
 export type MakeColumnConfig<
 	T extends ColumnBuilderBaseConfig<ColumnDataType, string>,
 	TTableName extends string,
-	TData = T extends { $type: infer U } ? U : T['data'],
-> = {
-	name: T['name'];
-	tableName: TTableName;
-	dataType: T['dataType'];
-	columnType: T['columnType'];
-	data: TData;
-	driverParam: T['driverParam'];
-	notNull: T extends { notNull: true } ? true : false;
-	hasDefault: T extends { hasDefault: true } ? true : false;
-	isPrimaryKey: T extends { isPrimaryKey: true } ? true : false;
-	isAutoincrement: T extends { isAutoincrement: true } ? true : false;
-	hasRuntimeDefault: T extends { hasRuntimeDefault: true } ? true : false;
-	enumValues: T['enumValues'];
-	baseColumn: T extends { baseBuilder: infer U extends ColumnBuilderBase } ? BuildColumn<TTableName, U, 'common'>
-		: never;
-	identity: T extends { identity: 'always' } ? 'always' : T extends { identity: 'byDefault' } ? 'byDefault' : undefined;
-	generated: T extends { generated: infer G } ? unknown extends G ? undefined
-		: G extends undefined ? undefined
-		: G
-		: undefined;
-} & {};
+> = T & { tableName: TTableName };
 
-export type ColumnBuilderTypeConfig<
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	T extends ColumnBuilderBaseConfig<ColumnDataType, string>,
-	TTypeConfig extends object = object,
-> = Simplify<
-	& {
-		brand: 'ColumnBuilder';
-		name: T['name'];
-		dataType: T['dataType'];
-		columnType: T['columnType'];
-		data: T['data'];
-		driverParam: T['driverParam'];
-		notNull: T extends { notNull: infer U } ? U : boolean;
-		hasDefault: T extends { hasDefault: infer U } ? U : boolean;
-		enumValues: T['enumValues'];
-		identity: T extends { identity: infer U } ? U : unknown;
-		generated: T extends { generated: infer G } ? G extends undefined ? unknown : G : unknown;
-	}
-	& TTypeConfig
->;
+export interface ColumnBuilderExtraConfig {
+	primaryKeyHasDefault?: boolean;
+}
 
 export type ColumnBuilderRuntimeConfig<TData, TRuntimeConfig extends object = object> = {
 	name: string;
-	keyAsName: boolean;
 	notNull: boolean;
 	default: TData | SQL | undefined;
 	defaultFn: (() => TData | SQL) | undefined;
@@ -113,93 +53,40 @@ export type ColumnBuilderRuntimeConfig<TData, TRuntimeConfig extends object = ob
 	uniqueType: string | undefined;
 	dataType: string;
 	columnType: string;
-	generated: GeneratedColumnConfig<TData> | undefined;
-	generatedIdentity: GeneratedIdentityConfig | undefined;
+	generated: {
+		as: SQL;
+		type: 'always' | 'byDefault';
+		mode: 'virtual' | 'stored';
+	} | undefined;
 } & TRuntimeConfig;
 
-export interface ColumnBuilderExtraConfig {
-	primaryKeyHasDefault?: boolean;
-}
-
-export type NotNull<T extends ColumnBuilderBase> = T & {
-	_: {
-		notNull: true;
-	};
-};
-
-export type HasDefault<T extends ColumnBuilderBase> = T & {
-	_: {
-		hasDefault: true;
-	};
-};
-
-export type IsPrimaryKey<T extends ColumnBuilderBase> = T & {
-	_: {
-		isPrimaryKey: true;
-	};
-};
-
-export type IsAutoincrement<T extends ColumnBuilderBase> = T & {
-	_: {
-		isAutoincrement: true;
-	};
-};
-
-export type HasRuntimeDefault<T extends ColumnBuilderBase> = T & {
-	_: {
-		hasRuntimeDefault: true;
-	};
-};
-
-export type $Type<T extends ColumnBuilderBase, TType> = T & {
-	_: {
-		$type: TType;
-	};
-};
-
-export type HasGenerated<T extends ColumnBuilderBase, TGenerated extends {} = {}> = T & {
-	_: {
-		hasDefault: true;
-		generated: TGenerated;
-	};
-};
-
-export type IsIdentity<
-	T extends ColumnBuilderBase,
-	TType extends 'always' | 'byDefault',
-> = T & {
-	_: {
-		notNull: true;
-		hasDefault: true;
-		identity: TType;
-	};
-};
-export interface ColumnBuilderBase<
-	T extends ColumnBuilderBaseConfig<ColumnDataType, string> = ColumnBuilderBaseConfig<ColumnDataType, string>,
-	TTypeConfig extends object = object,
-> {
-	_: ColumnBuilderTypeConfig<T, TTypeConfig>;
-}
-
-// To understand how to use `ColumnBuilder` and `AnyColumnBuilder`, see `Column` and `AnyColumn` documentation.
 export abstract class ColumnBuilder<
-	T extends ColumnBuilderBaseConfig<ColumnDataType, string> = ColumnBuilderBaseConfig<ColumnDataType, string>,
+	T extends ColumnBuilderBaseConfig<ColumnDataType, string>,
 	TRuntimeConfig extends object = object,
 	TTypeConfig extends object = object,
 	TExtraConfig extends ColumnBuilderExtraConfig = ColumnBuilderExtraConfig,
-> implements ColumnBuilderBase<T, TTypeConfig> {
+> {
 	static readonly [entityKind]: string = 'ColumnBuilder';
 
-	declare _: ColumnBuilderTypeConfig<T, TTypeConfig>;
+	declare _: {
+		brand: 'ColumnBuilder';
+		config: T;
+		$type: TTypeConfig;
+		columnBuilderBrand: 'ColumnBuilderBrand';
+	};
 
-	protected config: ColumnBuilderRuntimeConfig<T['data'], TRuntimeConfig>;
+	/**
+	 * @internal
+	 */
+	config: ColumnBuilderRuntimeConfig<T['data'], TRuntimeConfig>;
 
 	constructor(name: T['name'], dataType: T['dataType'], columnType: T['columnType']) {
 		this.config = {
 			name,
-			keyAsName: name === '',
 			notNull: false,
 			default: undefined,
+			defaultFn: undefined,
+			onUpdateFn: undefined,
 			hasDefault: false,
 			primaryKey: false,
 			isUnique: false,
@@ -211,206 +98,94 @@ export abstract class ColumnBuilder<
 		} as ColumnBuilderRuntimeConfig<T['data'], TRuntimeConfig>;
 	}
 
-	/**
-	 * Changes the data type of the column. Commonly used with `json` columns. Also, useful for branded types.
-	 *
-	 * @example
-	 * ```ts
-	 * const users = pgTable('users', {
-	 * 	id: integer('id').$type<UserId>().primaryKey(),
-	 * 	details: json('details').$type<UserDetails>().notNull(),
-	 * });
-	 * ```
-	 */
-	$type<TType>(): $Type<this, TType> {
-		return this as $Type<this, TType>;
+	$type<TType extends T['data']>(): ColumnBuilder<
+		Omit<T, 'data' | 'driverParam'> & { data: TType; driverParam: T['driverParam'] },
+		TRuntimeConfig,
+		TTypeConfig,
+		TExtraConfig
+	> {
+		return this as any;
 	}
 
-	/**
-	 * Adds a `not null` clause to the column definition.
-	 *
-	 * Affects the `select` model of the table - columns *without* `not null` will be nullable on select.
-	 */
-	notNull(): NotNull<this> {
+	notNull(): ColumnBuilder<
+		Omit<T, 'notNull'> & { notNull: true },
+		TRuntimeConfig,
+		TTypeConfig,
+		TExtraConfig
+	> {
 		this.config.notNull = true;
-		return this as NotNull<this>;
+		return this as any;
 	}
 
-	/**
-	 * Adds a `default <value>` clause to the column definition.
-	 *
-	 * Affects the `insert` model of the table - columns *with* `default` are optional on insert.
-	 *
-	 * If you need to set a dynamic default value, use {@link $defaultFn} instead.
-	 */
-	default(value: (this['_'] extends { $type: infer U } ? U : this['_']['data']) | SQL): HasDefault<this> {
+	default(
+		value: (T['data'] | SQL),
+	): ColumnBuilder<
+		Omit<T, 'hasDefault'> & { hasDefault: true },
+		TRuntimeConfig,
+		TTypeConfig,
+		TExtraConfig
+	> {
 		this.config.default = value;
 		this.config.hasDefault = true;
-		return this as HasDefault<this>;
+		return this as any;
 	}
 
-	/**
-	 * Adds a dynamic default value to the column.
-	 * The function will be called when the row is inserted, and the returned value will be used as the column value.
-	 *
-	 * **Note:** This value does not affect the `drizzle-kit` behavior, it is only used at runtime in `drizzle-orm`.
-	 */
+	defaultRandom(): ColumnBuilder<
+		Omit<T, 'hasDefault'> & { hasDefault: true },
+		TRuntimeConfig,
+		TTypeConfig,
+		TExtraConfig
+	> {
+		this.config.defaultFn = () => sql`(random())`;
+		this.config.hasDefault = true;
+		return this as any;
+	}
+
 	$defaultFn(
-		fn: () => (this['_'] extends { $type: infer U } ? U : this['_']['data']) | SQL,
-	): HasRuntimeDefault<HasDefault<this>> {
+		fn: () => T['data'] | SQL,
+	): ColumnBuilder<
+		Omit<T, 'hasDefault'> & { hasDefault: true },
+		TRuntimeConfig,
+		TTypeConfig,
+		TExtraConfig
+	> {
 		this.config.defaultFn = fn;
 		this.config.hasDefault = true;
-		return this as HasRuntimeDefault<HasDefault<this>>;
+		return this as any;
 	}
 
-	/**
-	 * Alias for {@link $defaultFn}.
-	 */
 	$default = this.$defaultFn;
 
-	/**
-	 * Adds a dynamic update value to the column.
-	 * The function will be called when the row is updated, and the returned value will be used as the column value if none is provided.
-	 * If no `default` (or `$defaultFn`) value is provided, the function will be called when the row is inserted as well, and the returned value will be used as the column value.
-	 *
-	 * **Note:** This value does not affect the `drizzle-kit` behavior, it is only used at runtime in `drizzle-orm`.
-	 */
 	$onUpdateFn(
-		fn: () => (this['_'] extends { $type: infer U } ? U : this['_']['data']) | SQL,
-	): HasDefault<this> {
+		fn: () => T['data'] | SQL,
+	): ColumnBuilder<
+		Omit<T, 'hasDefault'> & { hasDefault: true },
+		TRuntimeConfig,
+		TTypeConfig,
+		TExtraConfig
+	> {
 		this.config.onUpdateFn = fn;
 		this.config.hasDefault = true;
-		return this as HasDefault<this>;
+		return this as any;
 	}
 
-	/**
-	 * Alias for {@link $onUpdateFn}.
-	 */
 	$onUpdate = this.$onUpdateFn;
 
-	/**
-	 * Adds a `primary key` clause to the column definition. This implicitly makes the column `not null`.
-	 *
-	 * In SQLite, `integer primary key` implicitly makes the column auto-incrementing.
-	 */
-	primaryKey(): TExtraConfig['primaryKeyHasDefault'] extends true ? IsPrimaryKey<HasDefault<NotNull<this>>>
-		: IsPrimaryKey<NotNull<this>>
-	{
+	primaryKey(
+		config?: PrimaryKeyConfig,
+	): ColumnBuilder<
+		Omit<T, 'hasDefault'> & { hasDefault: TExtraConfig['primaryKeyHasDefault'] extends true ? true : false },
+		TRuntimeConfig,
+		TTypeConfig,
+		TExtraConfig
+	> {
 		this.config.primaryKey = true;
-		this.config.notNull = true;
-		return this as TExtraConfig['primaryKeyHasDefault'] extends true ? IsPrimaryKey<HasDefault<NotNull<this>>>
-			: IsPrimaryKey<NotNull<this>>;
-	}
-
-	abstract generatedAlwaysAs(
-		as: SQL | T['data'] | (() => SQL),
-		config?: Partial<GeneratedColumnConfig<unknown>>,
-	): HasGenerated<this, {
-		type: 'always';
-	}>;
-
-	/** @internal Sets the name of the column to the key within the table definition if a name was not given. */
-	setName(name: string) {
-		if (this.config.name !== '') return;
-		this.config.name = name;
+		this.config.hasDefault = (config?.autoIncrement) as any;
+		return this as any;
 	}
 }
 
-export type BuildColumn<
-	TTableName extends string,
-	TBuilder extends ColumnBuilderBase,
-	TDialect extends Dialect,
-> = TDialect extends 'pg' ? PgColumn<
-		MakeColumnConfig<TBuilder['_'], TTableName>,
-		{},
-		Simplify<Omit<TBuilder['_'], keyof MakeColumnConfig<TBuilder['_'], TTableName> | 'brand' | 'dialect'>>
-	>
-	: TDialect extends 'mysql' ? MySqlColumn<
-			MakeColumnConfig<TBuilder['_'], TTableName>,
-			{},
-			Simplify<
-				Omit<
-					TBuilder['_'],
-					| keyof MakeColumnConfig<TBuilder['_'], TTableName>
-					| 'brand'
-					| 'dialect'
-					| 'primaryKeyHasDefault'
-					| 'mysqlColumnBuilderBrand'
-				>
-			>
-		>
-	: TDialect extends 'sqlite' ? SQLiteColumn<
-			MakeColumnConfig<TBuilder['_'], TTableName>,
-			{},
-			Simplify<Omit<TBuilder['_'], keyof MakeColumnConfig<TBuilder['_'], TTableName> | 'brand' | 'dialect'>>
-		>
-	: TDialect extends 'common' ? Column<
-			MakeColumnConfig<TBuilder['_'], TTableName>,
-			{},
-			Simplify<Omit<TBuilder['_'], keyof MakeColumnConfig<TBuilder['_'], TTableName> | 'brand' | 'dialect'>>
-		>
-	: TDialect extends 'singlestore' ? SingleStoreColumn<
-			MakeColumnConfig<TBuilder['_'], TTableName>,
-			{},
-			Simplify<
-				Omit<
-					TBuilder['_'],
-					| keyof MakeColumnConfig<TBuilder['_'], TTableName>
-					| 'brand'
-					| 'dialect'
-					| 'primaryKeyHasDefault'
-					| 'singlestoreColumnBuilderBrand'
-				>
-			>
-		>
-	: TDialect extends 'gel' ? GelColumn<
-			MakeColumnConfig<TBuilder['_'], TTableName>,
-			{},
-			Simplify<Omit<TBuilder['_'], keyof MakeColumnConfig<TBuilder['_'], TTableName> | 'brand' | 'dialect'>>
-		>
-	: never;
+// Workaround for https://github.com/microsoft/TypeScript/issues/29511
+export type AnyColumnBuilder = ColumnBuilder<ColumnBuilderBaseConfig<ColumnDataType, string>>;
 
-export type BuildIndexColumn<
-	TDialect extends Dialect,
-> = TDialect extends 'pg' ? ExtraConfigColumn
-	: TDialect extends 'gel' ? GelExtraConfigColumn
-	: never;
-
-// TODO
-// try to make sql as well + indexRaw
-
-// optional after everything will be working as expected
-// also try to leave only needed methods for extraConfig
-// make an error if I pass .asc() to fk and so on
-
-export type BuildColumns<
-	TTableName extends string,
-	TConfigMap extends Record<string, ColumnBuilderBase>,
-	TDialect extends Dialect,
-> =
-	& {
-		[Key in keyof TConfigMap]: BuildColumn<TTableName, {
-			_:
-				& Omit<TConfigMap[Key]['_'], 'name'>
-				& { name: TConfigMap[Key]['_']['name'] extends '' ? Assume<Key, string> : TConfigMap[Key]['_']['name'] };
-		}, TDialect>;
-	}
-	& {};
-
-export type BuildExtraConfigColumns<
-	_TTableName extends string,
-	TConfigMap extends Record<string, ColumnBuilderBase>,
-	TDialect extends Dialect,
-> =
-	& {
-		[Key in keyof TConfigMap]: BuildIndexColumn<TDialect>;
-	}
-	& {};
-
-export type ChangeColumnTableName<TColumn extends Column, TAlias extends string, TDialect extends Dialect> =
-	TDialect extends 'pg' ? PgColumn<MakeColumnConfig<TColumn['_'], TAlias>>
-		: TDialect extends 'mysql' ? MySqlColumn<MakeColumnConfig<TColumn['_'], TAlias>>
-		: TDialect extends 'singlestore' ? SingleStoreColumn<MakeColumnConfig<TColumn['_'], TAlias>>
-		: TDialect extends 'sqlite' ? SQLiteColumn<MakeColumnConfig<TColumn['_'], TAlias>>
-		: TDialect extends 'gel' ? GelColumn<MakeColumnConfig<TColumn['_'], TAlias>>
-		: never;
+import { sql } from './sql/sql.ts';

--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -2,27 +2,26 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer;
 	enumValues: undefined;
 }>;
 
-export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumnBuilder<
+export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumnBuilder<
 	T,
 	MySqlBinaryConfig
 > {
-	static override readonly [entityKind]: string = 'MySqlBinaryBuilder';
+	static readonly [entityKind]: string = 'MySqlBinaryBuilder';
 
-	constructor(name: T['name'], length: number | undefined) {
-		super(name, 'string', 'MySqlBinary');
-		this.config.length = length;
+	constructor(name: T['name'], config: MySqlBinaryConfig) {
+		super(name, 'buffer', 'MySqlBinary');
+		this.config.length = config.length;
 	}
 
 	/** @internal */
@@ -33,25 +32,10 @@ export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MyS
 	}
 }
 
-export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumn<
-	T,
-	MySqlBinaryConfig
-> {
-	static override readonly [entityKind]: string = 'MySqlBinary';
+export class MySqlBinary<T extends ColumnBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumn<T, MySqlBinaryConfig> {
+	static readonly [entityKind]: string = 'MySqlBinary';
 
 	length: number | undefined = this.config.length;
-
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
-	}
 
 	getSQLType(): string {
 		return this.length === undefined ? `binary` : `binary(${this.length})`;
@@ -71,6 +55,8 @@ export function binary<TName extends string>(
 	config?: MySqlBinaryConfig,
 ): MySqlBinaryBuilderInitial<TName>;
 export function binary(a?: string | MySqlBinaryConfig, b: MySqlBinaryConfig = {}) {
-	const { name, config } = getColumnNameAndConfig<MySqlBinaryConfig>(a, b);
-	return new MySqlBinaryBuilder(name, config.length);
+	const { name, config } = typeof a === 'object' || typeof a === 'undefined'
+		? { name: '', config: a ?? b }
+		: { name: a, config: b };
+	return new MySqlBinaryBuilder(name, config);
 }

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -2,27 +2,28 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlVarBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer;
 	enumValues: undefined;
 }>;
 
-export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlVarBinary'>>
-	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
+export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarBinary'>>
+	extends MySqlColumnBuilder<
+		T,
+		MySqlVarBinaryConfig
+	>
 {
-	static override readonly [entityKind]: string = 'MySqlVarBinaryBuilder';
+	static readonly [entityKind]: string = 'MySqlVarBinaryBuilder';
 
-	/** @internal */
-	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
-		super(name, 'string', 'MySqlVarBinary');
-		this.config.length = config?.length;
+	constructor(name: T['name'], config: MySqlVarBinaryConfig) {
+		super(name, 'buffer', 'MySqlVarBinary');
+		this.config.length = config.length;
 	}
 
 	/** @internal */
@@ -36,42 +37,33 @@ export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', '
 	}
 }
 
-export class MySqlVarBinary<
-	T extends ColumnBaseConfig<'string', 'MySqlVarBinary'>,
-> extends MySqlColumn<T, MySqlVarbinaryOptions> {
-	static override readonly [entityKind]: string = 'MySqlVarBinary';
+export class MySqlVarBinary<T extends ColumnBaseConfig<'buffer', 'MySqlVarBinary'>>
+	extends MySqlColumn<T, MySqlVarBinaryConfig>
+{
+	static readonly [entityKind]: string = 'MySqlVarBinary';
 
 	length: number | undefined = this.config.length;
-
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
-	}
 
 	getSQLType(): string {
 		return this.length === undefined ? `varbinary` : `varbinary(${this.length})`;
 	}
 }
 
-export interface MySqlVarbinaryOptions {
-	length: number;
+export interface MySqlVarBinaryConfig {
+	length?: number;
 }
 
+export function varbinary(): MySqlVarBinaryBuilderInitial<''>;
 export function varbinary(
-	config: MySqlVarbinaryOptions,
+	config?: MySqlVarBinaryConfig,
 ): MySqlVarBinaryBuilderInitial<''>;
 export function varbinary<TName extends string>(
 	name: TName,
-	config: MySqlVarbinaryOptions,
+	config?: MySqlVarBinaryConfig,
 ): MySqlVarBinaryBuilderInitial<TName>;
-export function varbinary(a?: string | MySqlVarbinaryOptions, b?: MySqlVarbinaryOptions) {
-	const { name, config } = getColumnNameAndConfig<MySqlVarbinaryOptions>(a, b);
+export function varbinary(a?: string | MySqlVarBinaryConfig, b: MySqlVarBinaryConfig = {}) {
+	const { name, config } = typeof a === 'object' || typeof a === 'undefined'
+		? { name: '', config: a ?? b }
+		: { name: a, config: b };
 	return new MySqlVarBinaryBuilder(name, config);
 }


### PR DESCRIPTION
MySQL2 library parses `binary` and `varbinary` columns as `Buffer` objects, not strings. This PR fixes the TypeScript type definitions for `MySqlBinary` and `MySqlVarBinary` column types to use `Buffer` instead of `string`, which correctly reflects the runtime behavior of the mysql2 driver.

The mysql2 driver automatically escapes `Buffer` values as hex strings when building queries, so accepting `Buffer` as the input type is also correct for insertions.

---
Closes #1188