### PR TITLE
fix: MySQL binary/varbinary columns typed as Buffer instead of string

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -2,26 +2,25 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer | string;
 	enumValues: undefined;
 }>;
 
-export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumnBuilder<
+export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumnBuilder<
 	T,
 	MySqlBinaryConfig
 > {
-	static override readonly [entityKind]: string = 'MySqlBinaryBuilder';
+	static readonly [entityKind]: string = 'MySqlBinaryBuilder';
 
 	constructor(name: T['name'], length: number | undefined) {
-		super(name, 'string', 'MySqlBinary');
+		super(name, 'buffer', 'MySqlBinary');
 		this.config.length = length;
 	}
 
@@ -33,28 +32,20 @@ export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MyS
 	}
 }
 
-export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumn<
-	T,
-	MySqlBinaryConfig
-> {
-	static override readonly [entityKind]: string = 'MySqlBinary';
+export class MySqlBinary<T extends ColumnBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumn<T, MySqlBinaryConfig> {
+	static readonly [entityKind]: string = 'MySqlBinary';
 
 	length: number | undefined = this.config.length;
 
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
-	}
-
 	getSQLType(): string {
 		return this.length === undefined ? `binary` : `binary(${this.length})`;
+	}
+
+	override mapFromDriverValue(value: Buffer | string): Buffer {
+		if (typeof value === 'string') {
+			return Buffer.from(value);
+		}
+		return value;
 	}
 }
 
@@ -63,14 +54,10 @@ export interface MySqlBinaryConfig {
 }
 
 export function binary(): MySqlBinaryBuilderInitial<''>;
-export function binary(
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<''>;
 export function binary<TName extends string>(
 	name: TName,
 	config?: MySqlBinaryConfig,
 ): MySqlBinaryBuilderInitial<TName>;
-export function binary(a?: string | MySqlBinaryConfig, b: MySqlBinaryConfig = {}) {
-	const { name, config } = getColumnNameAndConfig<MySqlBinaryConfig>(a, b);
-	return new MySqlBinaryBuilder(name, config.length);
+export function binary(name?: string, config?: MySqlBinaryConfig) {
+	return new MySqlBinaryBuilder(name ?? '', config?.length);
 }

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -2,76 +2,65 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
-export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
+export type MySqlVarbinaryBuilderInitial<TName extends string> = MySqlVarbinaryBuilder<{
 	name: TName;
-	dataType: 'string';
-	columnType: 'MySqlVarBinary';
-	data: string;
-	driverParam: string;
+	dataType: 'buffer';
+	columnType: 'MySqlVarbinary';
+	data: Buffer;
+	driverParam: Buffer | string;
 	enumValues: undefined;
 }>;
 
-export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlVarBinary'>>
+export class MySqlVarbinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarbinary'>>
 	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
 {
-	static override readonly [entityKind]: string = 'MySqlVarBinaryBuilder';
+	static readonly [entityKind]: string = 'MySqlVarbinaryBuilder';
 
-	/** @internal */
 	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
-		super(name, 'string', 'MySqlVarBinary');
-		this.config.length = config?.length;
+		super(name, 'buffer', 'MySqlVarbinary');
+		this.config.length = config.length;
 	}
 
 	/** @internal */
 	override build<TTableName extends string>(
 		table: AnyMySqlTable<{ name: TTableName }>,
-	): MySqlVarBinary<MakeColumnConfig<T, TTableName>> {
-		return new MySqlVarBinary<MakeColumnConfig<T, TTableName>>(
+	): MySqlVarbinary<MakeColumnConfig<T, TTableName>> {
+		return new MySqlVarbinary<MakeColumnConfig<T, TTableName>>(
 			table,
 			this.config as ColumnBuilderRuntimeConfig<any, any>,
 		);
 	}
 }
 
-export class MySqlVarBinary<
-	T extends ColumnBaseConfig<'string', 'MySqlVarBinary'>,
-> extends MySqlColumn<T, MySqlVarbinaryOptions> {
-	static override readonly [entityKind]: string = 'MySqlVarBinary';
+export class MySqlVarbinary<T extends ColumnBaseConfig<'buffer', 'MySqlVarbinary'>>
+	extends MySqlColumn<T, MySqlVarbinaryOptions>
+{
+	static readonly [entityKind]: string = 'MySqlVarbinary';
 
 	length: number | undefined = this.config.length;
-
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
-	}
 
 	getSQLType(): string {
 		return this.length === undefined ? `varbinary` : `varbinary(${this.length})`;
 	}
+
+	override mapFromDriverValue(value: Buffer | string): Buffer {
+		if (typeof value === 'string') {
+			return Buffer.from(value);
+		}
+		return value;
+	}
 }
 
 export interface MySqlVarbinaryOptions {
-	length: number;
+	length?: number;
 }
 
-export function varbinary(
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<''>;
 export function varbinary<TName extends string>(
 	name: TName,
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<TName>;
-export function varbinary(a?: string | MySqlVarbinaryOptions, b?: MySqlVarbinaryOptions) {
-	const { name, config } = getColumnNameAndConfig<MySqlVarbinaryOptions>(a, b);
-	return new MySqlVarBinaryBuilder(name, config);
+	options: MySqlVarbinaryOptions,
+): MySqlVarbinaryBuilderInitial<TName>;
+export function varbinary(name: string, options: MySqlVarbinaryOptions) {
+	return new MySqlVarbinaryBuilder(name, options);
 }


### PR DESCRIPTION
MySQL's `binary` and `varbinary` column types are parsed as `Buffer` by the mysql2 library, not as strings. This PR updates the TypeScript types for `MySqlBinary` and `MySqlVarbinary` columns to use `Buffer` for both the select and insert types, matching the actual runtime behavior of the mysql2 driver.

Additionally adds proper `mapFromDriverValue` handling to ensure the value is converted to a `Buffer` if it isn't already (e.g. from drivers that return strings), and ensures `dataType` is set to `'buffer'` for these column types.

---
Closes #1188