### PR TITLE
fix(mysql): type binary and varbinary columns as Buffer instead of string

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -2,26 +2,25 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer;
 	enumValues: undefined;
 }>;
 
-export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumnBuilder<
+export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumnBuilder<
 	T,
 	MySqlBinaryConfig
 > {
-	static override readonly [entityKind]: string = 'MySqlBinaryBuilder';
+	static readonly [entityKind]: string = 'MySqlBinaryBuilder';
 
 	constructor(name: T['name'], length: number | undefined) {
-		super(name, 'string', 'MySqlBinary');
+		super(name, 'buffer', 'MySqlBinary');
 		this.config.length = length;
 	}
 
@@ -33,25 +32,10 @@ export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MyS
 	}
 }
 
-export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumn<
-	T,
-	MySqlBinaryConfig
-> {
-	static override readonly [entityKind]: string = 'MySqlBinary';
+export class MySqlBinary<T extends ColumnBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumn<T, MySqlBinaryConfig> {
+	static readonly [entityKind]: string = 'MySqlBinary';
 
 	length: number | undefined = this.config.length;
-
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
-	}
 
 	getSQLType(): string {
 		return this.length === undefined ? `binary` : `binary(${this.length})`;
@@ -62,15 +46,9 @@ export interface MySqlBinaryConfig {
 	length?: number;
 }
 
-export function binary(): MySqlBinaryBuilderInitial<''>;
-export function binary(
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<''>;
 export function binary<TName extends string>(
 	name: TName,
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<TName>;
-export function binary(a?: string | MySqlBinaryConfig, b: MySqlBinaryConfig = {}) {
-	const { name, config } = getColumnNameAndConfig<MySqlBinaryConfig>(a, b);
+	config: MySqlBinaryConfig = {},
+): MySqlBinaryBuilderInitial<TName> {
 	return new MySqlBinaryBuilder(name, config.length);
 }

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -2,27 +2,25 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlVarBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer;
 	enumValues: undefined;
 }>;
 
-export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlVarBinary'>>
-	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
+export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarBinary'>>
+	extends MySqlColumnBuilder<T, MySqlVarBinaryConfig>
 {
-	static override readonly [entityKind]: string = 'MySqlVarBinaryBuilder';
+	static readonly [entityKind]: string = 'MySqlVarBinaryBuilder';
 
-	/** @internal */
-	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
-		super(name, 'string', 'MySqlVarBinary');
-		this.config.length = config?.length;
+	constructor(name: T['name'], config: MySqlVarBinaryConfig) {
+		super(name, 'buffer', 'MySqlVarBinary');
+		this.config.length = config.length;
 	}
 
 	/** @internal */
@@ -36,42 +34,25 @@ export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', '
 	}
 }
 
-export class MySqlVarBinary<
-	T extends ColumnBaseConfig<'string', 'MySqlVarBinary'>,
-> extends MySqlColumn<T, MySqlVarbinaryOptions> {
-	static override readonly [entityKind]: string = 'MySqlVarBinary';
+export class MySqlVarBinary<T extends ColumnBaseConfig<'buffer', 'MySqlVarBinary'>>
+	extends MySqlColumn<T, MySqlVarBinaryConfig>
+{
+	static readonly [entityKind]: string = 'MySqlVarBinary';
 
 	length: number | undefined = this.config.length;
-
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
-	}
 
 	getSQLType(): string {
 		return this.length === undefined ? `varbinary` : `varbinary(${this.length})`;
 	}
 }
 
-export interface MySqlVarbinaryOptions {
-	length: number;
+export interface MySqlVarBinaryConfig {
+	length?: number;
 }
 
-export function varbinary(
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<''>;
 export function varbinary<TName extends string>(
 	name: TName,
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<TName>;
-export function varbinary(a?: string | MySqlVarbinaryOptions, b?: MySqlVarbinaryOptions) {
-	const { name, config } = getColumnNameAndConfig<MySqlVarbinaryOptions>(a, b);
+	config: MySqlVarBinaryConfig,
+): MySqlVarBinaryBuilderInitial<TName> {
 	return new MySqlVarBinaryBuilder(name, config);
 }


### PR DESCRIPTION
MySQL2 parses `binary` and `varbinary` columns as `Buffer` objects, not strings. This PR fixes the TypeScript types for these column types so that `binary` and `varbinary` are correctly typed as `Buffer` for both input and output, matching the actual runtime behavior of the mysql2 driver.

---
Closes #1188