### PR TITLE
fix(drizzle-kit): declare `entities` on `configCommonSchema` so the config-file loader stops dropping it (closes #5896)

### DIFF
--- a/drizzle-kit/src/cli/validations/cli.ts
+++ b/drizzle-kit/src/cli/validations/cli.ts
@@ -1,6 +1,6 @@
 import { array, boolean, intersection, literal, object, string, TypeOf, union } from 'zod';
 import { dialect } from '../../schemaValidator';
-import { casing, casingType, prefix } from './common';
+import { casing, casingType, entitiesSchema, prefix } from './common';
 
 export const cliConfigGenerate = object({
 	dialect: dialect.optional(),
@@ -26,13 +26,7 @@ export const pushParams = object({
 	extensionsFilters: literal('postgis').array().optional(),
 	verbose: boolean().optional(),
 	strict: boolean().optional(),
-	entities: object({
-		roles: boolean().or(object({
-			provider: string().optional(),
-			include: string().array().optional(),
-			exclude: string().array().optional(),
-		})).optional().default(false),
-	}).optional(),
+	entities: entitiesSchema.optional(),
 }).passthrough();
 
 export type PushParams = TypeOf<typeof pushParams>;
@@ -51,13 +45,7 @@ export const pullParams = object({
 	migrations: object({
 		prefix: prefix.optional().default('index'),
 	}).optional(),
-	entities: object({
-		roles: boolean().or(object({
-			provider: string().optional(),
-			include: string().array().optional(),
-			exclude: string().array().optional(),
-		})).optional().default(false),
-	}).optional(),
+	entities: entitiesSchema.optional(),
 }).passthrough();
 
 export type Entities = TypeOf<typeof pullParams>['entities'];

--- a/drizzle-kit/src/cli/validations/common.ts
+++ b/drizzle-kit/src/cli/validations/common.ts
@@ -100,6 +100,22 @@ export const configMigrations = object({
 	prefix: prefix.optional().default('index'),
 }).optional();
 
+// `entitiesSchema` is the wire shape of the `entities` block in `drizzle.config.ts`.
+// It's declared on `configCommonSchema` (rather than only on the downstream push/pull
+// param schemas) so the config-file loader's Zod pass doesn't drop the field on its
+// way through. `.passthrough()` would normally carry unknown keys, but
+// `loadModule()` returns an object whose only *enumerable* own key is `default`
+// (the actual config properties are read via non-enumerable interop getters), so
+// `.passthrough()` never sees a field unless Zod knows about it explicitly. See
+// https://github.com/drizzle-team/drizzle-orm/issues/5896.
+export const entitiesSchema = object({
+	roles: boolean().or(object({
+		provider: string().optional(),
+		include: string().array().optional(),
+		exclude: string().array().optional(),
+	})).optional().default(false),
+});
+
 export const configCommonSchema = object({
 	dialect: dialect,
 	schema: union([string(), string().array()]).optional(),
@@ -112,6 +128,7 @@ export const configCommonSchema = object({
 	migrations: configMigrations,
 	dbCredentials: any().optional(),
 	casing: casingType.optional(),
+	entities: entitiesSchema.optional(),
 	sql: boolean().default(true),
 }).passthrough();
 

--- a/drizzle-kit/tests/config-entities.test.ts
+++ b/drizzle-kit/tests/config-entities.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from 'vitest';
+import { configCommonSchema } from '../src/cli/validations/common';
+
+// Regression for https://github.com/drizzle-team/drizzle-orm/issues/5896.
+//
+// `entities` is parsed by `drizzleConfigFromFile()` via `configCommonSchema`.
+// Before the fix, the field wasn't declared on `configCommonSchema` and was
+// supposed to be carried by `.passthrough()`. The actual `require()`-based
+// config loader, however, returns an object whose only enumerable own key is
+// `default` (the rest are non-enumerable interop getters), so `.passthrough()`
+// silently dropped `entities` and downstream push/pull saw `undefined`. The
+// fix declares `entities` explicitly so Zod walks the field by direct
+// property access (which DOES see non-enumerable keys) and surfaces it on
+// `safeParse().data`.
+test('configCommonSchema surfaces entities.roles (boolean form)', () => {
+	const result = configCommonSchema.safeParse({
+		dialect: 'postgresql',
+		entities: { roles: true },
+	});
+	expect(result.success).toBe(true);
+	if (!result.success) return;
+	expect(result.data.entities).toStrictEqual({ roles: true });
+});
+
+test('configCommonSchema surfaces entities.roles (object form with provider/include/exclude)', () => {
+	const result = configCommonSchema.safeParse({
+		dialect: 'postgresql',
+		entities: {
+			roles: {
+				provider: 'supabase',
+				include: ['app_role', 'service_role'],
+				exclude: ['legacy_role'],
+			},
+		},
+	});
+	expect(result.success).toBe(true);
+	if (!result.success) return;
+	expect(result.data.entities).toStrictEqual({
+		roles: {
+			provider: 'supabase',
+			include: ['app_role', 'service_role'],
+			exclude: ['legacy_role'],
+		},
+	});
+});
+
+test('configCommonSchema treats omitted entities as undefined', () => {
+	const result = configCommonSchema.safeParse({
+		dialect: 'postgresql',
+	});
+	expect(result.success).toBe(true);
+	if (!result.success) return;
+	expect(result.data.entities).toBeUndefined();
+});
+
+test('configCommonSchema defaults entities.roles to false when entities present without roles', () => {
+	const result = configCommonSchema.safeParse({
+		dialect: 'postgresql',
+		entities: {},
+	});
+	expect(result.success).toBe(true);
+	if (!result.success) return;
+	expect(result.data.entities).toStrictEqual({ roles: false });
+});


### PR DESCRIPTION
## Why

Closes #5896.

\`entities\` set in \`drizzle.config.ts\` is silently stripped by \`drizzleConfigFromFile()\`. That makes \`entities.roles\` a no-op from the CLI — roles defined in the schema are emitted as \`CREATE ROLE\` on every run because existing roles never get introspected, and the second \`drizzle-kit push\` fails with \`role \"<name>\" already exists\`. The programmatic API (\`pushSchema\` from \`drizzle-kit/api\`, which receives \`entities\` as a function argument and bypasses the config-file loader) is unaffected.

The reporter (@TODO their handle goes here once they comment) did the full forensic root-cause — credit there.

## Root cause

A Zod / Node interop interaction:

1. \`drizzleConfigFromFile()\` validates the loaded config with \`configCommonSchema\`.
2. \`configCommonSchema\` used to NOT declare \`entities\`.
3. \`.passthrough()\` was meant to carry the unknown key through to the downstream \`pushParams\` / \`pullParams\` schemas (which DO declare \`entities\`).
4. But the \`safeRegister\` / \`require()\`-based loader returns a module object whose only **enumerable** own key is \`default\` — the actual config properties are exposed via non-enumerable interop getters.
5. Zod's \`.passthrough()\` copies enumerable own keys only, so the field is dropped before the downstream params ever see it.

Direct evidence from the loader (\`drizzle-kit/src/cli/commands/utils.ts:927\`):

\`\`\`ts
return safeRegister(async () => {
    const required = require(\`\${path}\`);
    const content = required.default ?? required;
    const res = configCommonSchema.safeParse(content);  // ← entities dropped here
    ...
    return res.data;
});
\`\`\`

By the time \`pushParams\` / \`pullParams\` run, \`entities\` is already gone from \`res.data\`.

## Fix

Declare \`entities\` explicitly on \`configCommonSchema\`. Zod walks declared fields by direct property access (which DOES see non-enumerable interop keys), so the field now survives the loader. The \`entities\` schema was already duplicated inline in \`pushParams\` and \`pullParams\`; extracted to a shared \`entitiesSchema\` constant so all three reference one definition.

\`\`\`diff
+ export const entitiesSchema = object({
+   roles: boolean().or(object({
+     provider: string().optional(),
+     include: string().array().optional(),
+     exclude: string().array().optional(),
+   })).optional().default(false),
+ });
+
  export const configCommonSchema = object({
    dialect: dialect,
    ...
    casing: casingType.optional(),
+   entities: entitiesSchema.optional(),
    sql: boolean().default(true),
  }).passthrough();
\`\`\`

And in \`cli.ts\`, the inline declarations on \`pushParams\` / \`pullParams\` collapse to:

\`\`\`diff
- entities: object({
-   roles: boolean().or(object({...})).optional().default(false),
- }).optional(),
+ entities: entitiesSchema.optional(),
\`\`\`

## Tests

Added \`drizzle-kit/tests/config-entities.test.ts\`:
- \`configCommonSchema surfaces entities.roles (boolean form)\` — input \`{ roles: true }\` survives parse
- \`configCommonSchema surfaces entities.roles (object form with provider/include/exclude)\` — full nested shape survives
- \`configCommonSchema treats omitted entities as undefined\` — backwards-compat
- \`configCommonSchema defaults entities.roles to false when entities present without roles\` — this one **fails on unpatched source** with \`Expected { \"roles\": false } / Received {}\` because Zod can only apply the inner \`.default(false)\` when it knows about the field. The other three pin schema behavior so future refactors that drop \`entities\` from \`configCommonSchema\` get caught.

Note on the test scope: the reporter's original symptom requires the \`require()\` interop path specifically (non-enumerable own keys from \`safeRegister\`). The unit tests here can't easily mock that loader behavior, but they directly test the schema layer where the fix lives. The defaults-not-applied test catches the schema-level regression that produces the same downstream symptom.

\`tsc\` clean on touched files. Full \`vitest run tests/config-entities.test.ts\` passes (4/4). \`vitest run tests/cli-push.test.ts\` still passes (6/6, no regressions to the existing CLI parse tests).