### PR TITLE
[Kit] Fix exponential generate hang on branched/merged migration history

### DIFF
--- a/drizzle-kit/src/commutativity/engine.ts
+++ b/drizzle-kit/src/commutativity/engine.ts
@@ -382,8 +382,17 @@ export abstract class AbstractCommutativity<
 			}
 		}
 
+		// Track visited nodes so each node is processed once. Without this,
+		// a branched/merged migration DAG (a node reachable through multiple
+		// paths) is re-traversed for every path, which is exponential on real
+		// histories with merge migrations. `buildChain` already guards the same
+		// way.
+		const visited = new Set<string>();
+
 		while (stack.length) {
 			const id = stack.pop()!;
+			if (visited.has(id)) continue;
+			visited.add(id);
 			const children = prevToChildren[id] ?? [];
 			if (children.length === 0) {
 				leaves.push(id);

--- a/drizzle-kit/tests/postgres/commutativity-collect-leaves.test.ts
+++ b/drizzle-kit/tests/postgres/commutativity-collect-leaves.test.ts
@@ -1,0 +1,159 @@
+import { AbstractCommutativity, type CommutativityStatementDefinitions } from 'src/commutativity/engine';
+import type { PostgresSnapshot } from 'src/dialects/postgres/snapshot';
+import { describe, expect, test } from 'vitest';
+
+/**
+ * Regression coverage for `AbstractCommutativity.collectLeaves`.
+ *
+ * `collectLeaves` walks the migration-snapshot DAG (parent -> children) with a
+ * stack-based DFS to find every reachable leaf below a starting node. Before the
+ * fix it had NO visited set, so any node reachable through more than one path was
+ * re-expanded once per path. On a branched/merged history (diamonds that
+ * reconverge, e.g. real repos with merge migrations) this is exponential in the
+ * number of merge points: a chain of N diamonds produces ~2^N stack expansions,
+ * which makes `drizzle-kit generate`'s pre-step commutativity check hang for
+ * minutes (CPU-bound) before any schema work happens.
+ *
+ * The sibling `buildChain` in the same class already guards with a visited Set;
+ * `collectLeaves` now does the same. These tests assert both correctness
+ * (deduplicated leaves) and bounded runtime on a diamond-heavy DAG.
+ *
+ * `collectLeaves` is private, so a tiny test-only subclass exposes it. The graph
+ * it consumes is keyed by snapshot id with `{ id, prevIds }` nodes, matching what
+ * `buildSnapshotGraph` produces.
+ */
+
+type GraphNode = {
+	id: string;
+	prevIds: string[];
+	path: string;
+	folderPath: string;
+	raw: PostgresSnapshot;
+};
+
+class TestCommutativity extends AbstractCommutativity<
+	{ type: string },
+	PostgresSnapshot,
+	unknown
+> {
+	protected getStatementDefinitions(): CommutativityStatementDefinitions<
+		{ type: string },
+		unknown
+	> {
+		return {} as CommutativityStatementDefinitions<{ type: string }, unknown>;
+	}
+
+	protected formatFootprintTarget(): string {
+		return '';
+	}
+
+	protected describeStatement(): string {
+		return '';
+	}
+
+	protected getDrySnapshot(): PostgresSnapshot {
+		return {} as PostgresSnapshot;
+	}
+
+	protected async diffSnapshots(): Promise<{ statements: { type: string }[] }> {
+		return { statements: [] };
+	}
+
+	// Expose the private DFS for focused regression testing.
+	public collectLeavesForTest(
+		graph: Record<string, GraphNode>,
+		startId: string,
+	): string[] {
+		// @ts-expect-error accessing private member for regression coverage
+		return this.collectLeaves(graph, startId);
+	}
+}
+
+function node(id: string, prevIds: string[]): GraphNode {
+	return {
+		id,
+		prevIds,
+		path: `${id}/snapshot.json`,
+		folderPath: id,
+		raw: { id, prevIds } as unknown as PostgresSnapshot,
+	};
+}
+
+function graphFromNodes(nodes: GraphNode[]): Record<string, GraphNode> {
+	const byId: Record<string, GraphNode> = {};
+	for (const n of nodes) byId[n.id] = n;
+	return byId;
+}
+
+describe('AbstractCommutativity.collectLeaves', () => {
+	const engine = new TestCommutativity();
+
+	test('linear chain returns the single leaf', () => {
+		const graph = graphFromNodes([
+			node('a', []),
+			node('b', ['a']),
+			node('c', ['b']),
+		]);
+
+		expect(engine.collectLeavesForTest(graph, 'a')).toEqual(['c']);
+	});
+
+	test('diamond (reconverging branch) returns the shared leaf exactly once', () => {
+		// a -> b, a -> c, then b -> d and c -> d (d has two parents).
+		const graph = graphFromNodes([
+			node('a', []),
+			node('b', ['a']),
+			node('c', ['a']),
+			node('d', ['b', 'c']),
+		]);
+
+		const leaves = engine.collectLeavesForTest(graph, 'a');
+
+		// Without a visited set the merged leaf `d` would be reported twice.
+		expect(leaves).toEqual(['d']);
+	});
+
+	test('multiple distinct leaves under a branch point are all returned', () => {
+		const graph = graphFromNodes([
+			node('a', []),
+			node('b', ['a']),
+			node('c', ['a']),
+			node('leafB', ['b']),
+			node('leafC', ['c']),
+		]);
+
+		expect(engine.collectLeavesForTest(graph, 'a').sort()).toEqual([
+			'leafB',
+			'leafC',
+		]);
+	});
+
+	test('chain of many reconverging diamonds completes in bounded time', () => {
+		// Build N stacked diamonds: each "merge" node mK has two parents
+		// (the previous merge's two children) and fans out again. Without the
+		// visited-set fix this is ~2^N stack expansions; 60 diamonds would hang
+		// for an extremely long time. With the fix it is O(nodes).
+		const N = 60;
+		const nodes: GraphNode[] = [node('m0', [])];
+		for (let k = 0; k < N; k++) {
+			const parent = `m${k}`;
+			const left = `l${k}`;
+			const right = `r${k}`;
+			const merge = `m${k + 1}`;
+			nodes.push(node(left, [parent]));
+			nodes.push(node(right, [parent]));
+			nodes.push(node(merge, [left, right]));
+		}
+		const graph = graphFromNodes(nodes);
+
+		const start = performance.now();
+		const leaves = engine.collectLeavesForTest(graph, 'm0');
+		const elapsedMs = performance.now() - start;
+
+		// Single final merge node is the only leaf, reported once.
+		expect(leaves).toEqual([`m${N}`]);
+		// Generous bound: the fixed traversal is sub-millisecond; the buggy
+		// exponential version cannot finish anywhere near this.
+		expect(elapsedMs).toBeLessThan(2000);
+	});
+});


### PR DESCRIPTION
## Summary

`drizzle-kit generate` can hang for tens of minutes (CPU-bound, at "Reading config file") on a repo whose migration history has **merge migrations** (a branched/merged snapshot DAG). The cause is a missing visited set in the commutativity pre-check's DAG traversal.

## The bug

`AbstractCommutativity.collectLeaves` (`drizzle-kit/src/commutativity/engine.ts`) does a stack-based DFS over the migration-snapshot DAG (`parent -> children`, built from each snapshot's `prevIds`) to find every reachable leaf below a node:

```ts
while (stack.length) {
  const id = stack.pop()!;
  const children = prevToChildren[id] ?? [];
  if (children.length === 0) {
    leaves.push(id);
  } else {
    for (const child of children) stack.push(child);
  }
}
```

There is **no visited set**, so any node reachable through more than one path is re-expanded once per path. On a branched/merged history — diamonds that reconverge, which is exactly what merge migrations produce — this is exponential in the number of merge points. A chain of `N` reconverging diamonds yields `~2^N` stack expansions and `~2^N` duplicated leaves.

On a real-world repo with ~143 snapshots, 2 heads and ~38 branch points this works out to roughly **81M stack pops**, and `generate` hangs for tens of minutes before doing any schema work. It also reports the same leaf multiple times.

### Root-cause evidence

Simulating the current algorithm on a chain of `N` reconverging diamonds:

| N  | stack pops | leaves returned |
|----|-----------:|----------------:|
| 10 |      4,093 |           1,024 |
| 20 |  4,194,301 |       1,048,576 |
| 25 | 50,000,000+ | (aborted)      |

A single diamond (`a→b, a→c, b→d, c→d`) already returns `["d", "d"]` — the merged leaf is duplicated.

The sibling method `buildChain` in the **same class** already guards its traversal with `const visited = new Set<string>()`, so the omission in `collectLeaves` is a clear, isolated bug rather than intended behavior.

## The fix

Add a visited set to `collectLeaves` so each node id is processed exactly once, mirroring `buildChain`:

```ts
const visited = new Set<string>();

while (stack.length) {
  const id = stack.pop()!;
  if (visited.has(id)) continue;
  visited.add(id);
  ...
}
```

The walk is now `O(nodes + edges)` and leaves are deduplicated. Dedup is the intended semantics: downstream in `detectNonCommutative`, leaf statements are keyed by leaf id (`leafStatements[leafId]`) and branches are compared via set overlap, so a leaf appearing once vs. many times does not change correctness — only cost.

## Test

Adds `drizzle-kit/tests/postgres/commutativity-collect-leaves.test.ts`, a focused unit test (no DB needed) covering:

- linear chain → single leaf
- diamond (reconverging branch) → shared leaf returned exactly once
- multiple distinct leaves under a branch point → all returned
- a chain of 60 reconverging diamonds → correct single deduplicated leaf in bounded time

The private `collectLeaves` is exercised through a tiny test-only subclass of `AbstractCommutativity`.

Verified the test **fails on the unpatched source** (the diamond case reports a duplicate leaf; the 60-diamond case blows up with `RangeError: Invalid array length`) and **passes with the fix** (4/4, ~5ms). The repo's lint-staged pre-commit hook (`format:check` + `lint:check`) passes on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)