### PR TITLE
[Kit] Preserve stack traces on unknown CLI errors

### DIFF
--- a/drizzle-kit/src/cli/index.ts
+++ b/drizzle-kit/src/cli/index.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { highlightSQL } from './highlighter';
 import { check, exportRaw, generate, migrate, pull, push, studio, up } from './schema';
 import { ormCoreVersions, QueryError } from './utils';
-import { error } from './views';
+import { unknownError } from './views';
 
 const version = async () => {
 	const { npmVersion } = await ormCoreVersions();
@@ -77,11 +77,7 @@ run([generate, migrate, pull, push, studio, up, check, exportRaw, ...legacy], {
 				return true;
 			}
 
-			if (
-				!(typeof e === 'object' && e !== null && 'message' in e && typeof e.message === 'string')
-			) return false;
-
-			console.log(error(e.message));
+			console.log(unknownError(e));
 			return true;
 		}
 

--- a/drizzle-kit/src/cli/views.ts
+++ b/drizzle-kit/src/cli/views.ts
@@ -42,6 +42,35 @@ export const error = (error: string, greyMsg: string = ''): string => {
 	return `${chalk.bgRed.bold(' Error ')} ${error} ${greyMsg ? chalk.grey(greyMsg) : ''}`.trim();
 };
 
+// Formats an otherwise-unhandled error for the CLI. Keeps the familiar
+// `Error <message>` header, but also surfaces the stack trace and the full
+// `cause` chain so schema-load crashes point at the offending file:line
+// instead of collapsing to a single message.
+export const unknownError = (e: unknown): string => {
+	const message = typeof e === 'object' && e !== null && 'message' in e && typeof e.message === 'string'
+		? e.message
+		: String(e);
+
+	let out = error(message);
+
+	const seen = new Set<unknown>();
+	let current: unknown = e;
+	let first = true;
+	while (typeof current === 'object' && current !== null && !seen.has(current)) {
+		seen.add(current);
+
+		const stack = 'stack' in current && typeof current.stack === 'string' ? current.stack : undefined;
+		if (stack) {
+			out += `\n${chalk.gray(first ? stack : `Caused by: ${stack}`)}`;
+		}
+		first = false;
+
+		current = 'cause' in current ? current.cause : undefined;
+	}
+
+	return out;
+};
+
 export const postgresSchemaWarning = (warning: PostgresSchemaWarning): string => {
 	if (warning.type === 'policy_not_linked') {
 		return withStyle.errorWarning(

--- a/drizzle-kit/tests/other/cli-unknown-error.test.ts
+++ b/drizzle-kit/tests/other/cli-unknown-error.test.ts
@@ -1,0 +1,47 @@
+import { stripVTControlCharacters } from 'node:util';
+import { unknownError } from 'src/cli/views';
+import { expect, test } from 'vitest';
+
+// Regression: the CLI's `unknown_error` theme handler used to print only
+// `e.message`, discarding the stack trace. A schema file that throws during
+// load (generate / migrate / push) then gave no file:line to debug.
+
+test('unknownError keeps the message header', () => {
+	const out = stripVTControlCharacters(unknownError(new Error('boom')));
+	expect(out).toContain('Error');
+	expect(out).toContain('boom');
+});
+
+test('unknownError surfaces the stack trace', () => {
+	const e = new Error("Cannot read properties of undefined (reading 'kind')");
+	const out = stripVTControlCharacters(unknownError(e));
+
+	// The stack must be present, not just the message line.
+	expect(out).toContain(e.stack!);
+	// This file appears in the stack frames, proving file:line is recoverable.
+	expect(out).toContain('cli-unknown-error.test.ts');
+});
+
+test('unknownError walks the cause chain', () => {
+	const root = new Error('half-initialized table from circular import');
+	const wrapped = new Error('schema load failed', { cause: root });
+
+	const out = stripVTControlCharacters(unknownError(wrapped));
+
+	expect(out).toContain('schema load failed');
+	expect(out).toContain('Caused by:');
+	expect(out).toContain('half-initialized table from circular import');
+});
+
+test('unknownError handles non-Error throwables without crashing', () => {
+	const out = stripVTControlCharacters(unknownError('plain string failure'));
+	expect(out).toContain('plain string failure');
+});
+
+test('unknownError does not loop on a self-referential cause chain', () => {
+	const e: Error & { cause?: unknown } = new Error('self ref');
+	e.cause = e;
+
+	const out = stripVTControlCharacters(unknownError(e));
+	expect(out).toContain('self ref');
+});


### PR DESCRIPTION
When a schema file throws during load, `drizzle-kit` printed only `e.message` and discarded the stack trace. This appends the stack and the full `cause` chain in the `unknown_error` handler. Adds `cli-unknown-error.test.ts` (5 cases).

Closes #5880