### PR TITLE
[Kit] Remove 'pride' from migration name word list

### DIFF
--- a/drizzle-kit/src/utils/words.ts
+++ b/drizzle-kit/src/utils/words.ts
@@ -969,7 +969,6 @@ export const heroes = [
 	'praxagora',
 	'preak',
 	'pretty_boy',
-	'pride',
 	'prima',
 	'princess_powerful',
 	'prism',


### PR DESCRIPTION
## Summary
In rare instances, `pride` can create some less-than-desirable filenames that should not end up in git history.