### PR TITLE
Introspect zero defaults on MySQL float, double and real columns

### DIFF
--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -492,7 +492,7 @@ const column = (
 			: `${casing(name)}: double(${dbColumnName({ name, casing: rawCasing })})`;
 
 		// let out = `${name.camelCase()}: double("${name}")`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -515,7 +515,7 @@ const column = (
 		}
 
 		let out = `${casing(name)}: float(${dbColumnName({ name, casing: rawCasing })}${params ? timeConfig(params) : ''})`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -523,7 +523,7 @@ const column = (
 
 	if (lowered === 'real') {
 		let out = `${casing(name)}: real(${dbColumnName({ name, casing: rawCasing })})`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;

--- a/drizzle-kit/tests/introspect/mysql.test.ts
+++ b/drizzle-kit/tests/introspect/mysql.test.ts
@@ -317,3 +317,24 @@ test('instrospect strings with single quotes', async () => {
 
 	await client.query(`drop table columns;`);
 });
+
+test('introspect float and double columns with a zero default', async () => {
+	const schema = {
+		columns: mysqlTable('columns', {
+			floatCol: float('float_col').notNull().default(0),
+			doubleCol: double('double_col').notNull().default(0),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectMySQLToFile(
+		client,
+		schema,
+		'introspect-float-double-zero-default',
+		'drizzle',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+
+	await client.query(`drop table columns;`);
+});


### PR DESCRIPTION
Fixes #5911

Introspecting (`drizzle-kit pull`) a MySQL `float`, `double` or `real` column whose `DEFAULT` is `0` drops the default from the generated schema.

The codegen for those three branches guards `.default()` with a plain truthy check on the default value:

```ts
out += defaultValue ? `.default(...)` : '';
```

A default of `0` is falsy, so it gets treated as "no default". The introspected snapshot stores the `0` correctly; only the generated TypeScript loses it, so a fresh pull stops matching the database. The `int` and `tinyint` branches already guard with `typeof defaultValue !== 'undefined'`, this applies the same check to `float`, `double` and `real`.

### Test

Added `introspect float and double columns with a zero default` to `drizzle-kit/tests/introspect/mysql.test.ts`. It fails on `main` (the round-trip reports 2 changed columns because both defaults are dropped) and passes with the fix. The rest of `tests/introspect/mysql.test.ts` stays green.