### PR TITLE
Introspect zero defaults on MySQL smallint, mediumint and bigint columns

### DIFF
--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -430,7 +430,7 @@ const column = (
 		const columnName = dbColumnName({ name, casing: rawCasing, withMode: isUnsigned });
 		let out = `${casing(name)}: smallint(${columnName}${isUnsigned ? '{ unsigned: true }' : ''})`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -441,7 +441,7 @@ const column = (
 		const columnName = dbColumnName({ name, casing: rawCasing, withMode: isUnsigned });
 		let out = `${casing(name)}: mediumint(${columnName}${isUnsigned ? '{ unsigned: true }' : ''})`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -453,7 +453,7 @@ const column = (
 			isUnsigned ? ', unsigned: true' : ''
 		} })`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;

--- a/drizzle-kit/tests/introspect/mysql.test.ts
+++ b/drizzle-kit/tests/introspect/mysql.test.ts
@@ -317,3 +317,25 @@ test('instrospect strings with single quotes', async () => {
 
 	await client.query(`drop table columns;`);
 });
+
+test('introspect smallint, mediumint and bigint columns with a zero default', async () => {
+	const schema = {
+		columns: mysqlTable('columns', {
+			smallintCol: smallint('smallint_col').notNull().default(0),
+			mediumintCol: mediumint('mediumint_col').notNull().default(0),
+			bigintCol: bigint('bigint_col', { mode: 'number' }).notNull().default(0),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectMySQLToFile(
+		client,
+		schema,
+		'introspect-integer-zero-default',
+		'drizzle',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+
+	await client.query(`drop table columns;`);
+});


### PR DESCRIPTION
Introspecting (`drizzle-kit pull`) a MySQL `smallint`, `mediumint` or `bigint` column whose `DEFAULT` is `0` drops the default from the generated schema.

The codegen for those three branches guards `.default()` with a plain truthy check on the default value:

```ts
out += defaultValue ? `.default(...)` : '';
```

A default of `0` is falsy, so it gets treated as "no default". The introspected snapshot stores the `0` correctly; only the generated TypeScript loses it, so a fresh pull stops matching the database. The `int` and `tinyint` branches already guard with `typeof defaultValue !== 'undefined'`, this applies the same check to `smallint`, `mediumint` and `bigint`.

This is the same class of bug as the `float`/`double`/`real` fix, in the remaining integer branches.

### Test

Added `introspect smallint, mediumint and bigint columns with a zero default` to `drizzle-kit/tests/introspect/mysql.test.ts`. It fails on `main` (the round-trip reports 3 changed columns because all three defaults are dropped) and passes with the fix. The rest of `tests/introspect/mysql.test.ts` stays green.