### PR TITLE
fix(drizzle-kit): tolerate missing information_schema.check_constraints view on MySQL 5.7

### DIFF
--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -561,6 +561,31 @@ function clearDefaults(defaultValue: any, collate: string) {
 	}
 }
 
+/**
+ * Returns `true` when `error` is the "information_schema.check_constraints
+ * is not a known table" error a pre-8.0.16 MySQL server (5.7, 8.0.0–8.0.15)
+ * raises during introspection. Used by the `fromDatabase` pull path to
+ * downgrade that specific failure to "no check constraints" instead of
+ * exiting `drizzle-kit pull` with an unsurfaced error (issue #5921).
+ *
+ * Exported for unit testing; not part of the public surface.
+ */
+export const isMissingCheckConstraintsView = (error: unknown): boolean => {
+	if (!error || typeof error !== 'object') return false;
+	const code = String((error as { code?: unknown }).code ?? '');
+	const message = String((error as { message?: unknown }).message ?? '');
+	// MySQL 5.7 raises ER_NO_SUCH_TABLE; "Unknown table 'check_constraints'
+	// in information_schema". Other dialects / drivers may stringify the
+	// error differently, so also fall back to a message-level match that
+	// pins both halves: the missing-table phrasing AND the specific table
+	// name. That keeps unrelated SQL failures from being silently swallowed.
+	if (code === 'ER_NO_SUCH_TABLE' && /check_constraints/i.test(message)) return true;
+	return (
+		/check_constraints/i.test(message)
+		&& /(?:unknown table|doesn't exist|does not exist)/i.test(message)
+	);
+};
+
 export const fromDatabase = async (
 	db: DB,
 	inputSchema: string,
@@ -947,21 +972,36 @@ export const fromDatabase = async (
 		progressCallback('views', viewsCount, 'done');
 	}
 
-	const checkConstraints = await db.query(
-		`SELECT 
-    tc.table_name, 
-    tc.constraint_name, 
+	// information_schema.check_constraints only exists on MySQL 8.0.16+
+	// and MariaDB 10.2+. On MySQL 5.7 the introspection query errors with
+	// ER_NO_SUCH_TABLE / "Unknown table 'check_constraints'"; before this
+	// guard the whole `drizzle-kit pull` would exit 1 with no surfaced
+	// error, looking like a silent failure (issue #5921). Treat it as
+	// "this server does not support CHECK constraints" — every other
+	// failure (auth, connectivity, unrelated SQL) still throws so the
+	// real diagnostic surfaces instead of being swallowed.
+	let checkConstraints: any[] = [];
+	try {
+		checkConstraints = await db.query(
+			`SELECT
+    tc.table_name,
+    tc.constraint_name,
     cc.check_clause
-FROM 
+FROM
     information_schema.table_constraints tc
-JOIN 
-    information_schema.check_constraints cc 
+JOIN
+    information_schema.check_constraints cc
     ON tc.constraint_name = cc.constraint_name
-WHERE 
+WHERE
     tc.constraint_schema = '${inputSchema}'
-AND 
+AND
     tc.constraint_type = 'CHECK';`,
-	);
+		);
+	} catch (e) {
+		if (!isMissingCheckConstraintsView(e)) {
+			throw e;
+		}
+	}
 
 	checksCount += checkConstraints.length;
 	if (progressCallback) {

--- a/drizzle-kit/tests/mysql-introspect-check-constraints.test.ts
+++ b/drizzle-kit/tests/mysql-introspect-check-constraints.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression coverage for issue #5921.
+ *
+ * `drizzle-kit pull` against MySQL 5.7 used to exit `1` with no surfaced
+ * error because the introspection query against
+ * `information_schema.check_constraints` (which 5.7 does not have) blew
+ * up the entire `fromDatabase` call. The fix downgrades exactly that
+ * failure to "no check constraints" while keeping every other error
+ * (auth, connectivity, unrelated SQL) propagating.
+ */
+import { expect, test } from 'vitest';
+import { isMissingCheckConstraintsView } from '../src/serializer/mysqlSerializer';
+
+test('isMissingCheckConstraintsView: ER_NO_SUCH_TABLE on check_constraints (mysql2 shape)', () => {
+	const err = Object.assign(new Error("Unknown table 'check_constraints' in information_schema"), {
+		code: 'ER_NO_SUCH_TABLE',
+		errno: 1109,
+	});
+	expect(isMissingCheckConstraintsView(err)).toBe(true);
+});
+
+test('isMissingCheckConstraintsView: MariaDB-style message-only match', () => {
+	// Some drivers do not populate `code`; we still want to recognize the
+	// failure mode from the message alone.
+	const err = new Error("Unknown table 'check_constraints' in information_schema");
+	expect(isMissingCheckConstraintsView(err)).toBe(true);
+});
+
+test("isMissingCheckConstraintsView: 'doesn't exist' phrasing", () => {
+	const err = new Error("Table 'information_schema.check_constraints' doesn't exist");
+	expect(isMissingCheckConstraintsView(err)).toBe(true);
+});
+
+test('isMissingCheckConstraintsView: rejects unrelated SQL error', () => {
+	const err = Object.assign(new Error('Access denied for user'), {
+		code: 'ER_ACCESS_DENIED_ERROR',
+	});
+	expect(isMissingCheckConstraintsView(err)).toBe(false);
+});
+
+test('isMissingCheckConstraintsView: rejects ER_NO_SUCH_TABLE on a different table', () => {
+	// A real "table not found" on a user table must NOT be swallowed by
+	// the check-constraints guard.
+	const err = Object.assign(new Error("Unknown table 'foo_bar' in test_schema"), {
+		code: 'ER_NO_SUCH_TABLE',
+	});
+	expect(isMissingCheckConstraintsView(err)).toBe(false);
+});
+
+test('isMissingCheckConstraintsView: rejects null / undefined / non-object', () => {
+	expect(isMissingCheckConstraintsView(null)).toBe(false);
+	expect(isMissingCheckConstraintsView(undefined)).toBe(false);
+	expect(isMissingCheckConstraintsView('check_constraints')).toBe(false);
+	expect(isMissingCheckConstraintsView(42)).toBe(false);
+});
+
+test('isMissingCheckConstraintsView: rejects a check_constraints mention without missing-table phrasing', () => {
+	// A SELECT permission error on the check_constraints view should NOT
+	// be downgraded to "no check constraints"; the operator needs to see it.
+	const err = Object.assign(
+		new Error("SELECT command denied to user for table 'check_constraints'"),
+		{ code: 'ER_TABLEACCESS_DENIED_ERROR' },
+	);
+	expect(isMissingCheckConstraintsView(err)).toBe(false);
+});


### PR DESCRIPTION
Closes #5921.

`drizzle-kit pull` against MySQL 5.7 exits `1` with no surfaced error because the introspection query against `information_schema.check_constraints` (added in MySQL 8.0.16 and MariaDB 10.2) blows up the entire `fromDatabase` call. Operators see a silent failure even though the connection, schema, and per-table introspection are all healthy.

Wrap that specific query in a `try`/`catch` and downgrade exactly the "`check_constraints` view does not exist" error to "this server does not support CHECK constraints" (empty list). The decision lives in a small `isMissingCheckConstraintsView(error)` predicate that matches both the `mysql2` `code === 'ER_NO_SUCH_TABLE'` shape and the driver-agnostic "Unknown table / doesn't exist / does not exist" message phrasing, gated on the message also mentioning `check_constraints` so an `ER_NO_SUCH_TABLE` on a real user table is NOT swallowed.

Every other failure (auth, connectivity, unrelated SQL, permission denied on the view) re-raises so the real diagnostic surfaces — which fixes the secondary "silent failure" the report also called out.

### Tests

`drizzle-kit/tests/mysql-introspect-check-constraints.test.ts` adds 7 cases for the predicate:

- mysql2-shape `ER_NO_SUCH_TABLE` on `check_constraints`
- driver-agnostic message-only match (`"Unknown table 'check_constraints' in information_schema"`)
- alternate `"doesn't exist"` phrasing
- unrelated SQL error (e.g. `ER_ACCESS_DENIED_ERROR`) — NOT downgraded
- `ER_NO_SUCH_TABLE` on a different user table — NOT downgraded
- `null` / `undefined` / non-object input — NOT downgraded
- permission denied (`ER_TABLEACCESS_DENIED_ERROR`) on the view itself — NOT downgraded

All 7 pass under `pnpm vitest run tests/mysql-introspect-check-constraints.test.ts`. The broader introspect / pull test suite already exercises the happy path on MySQL 8 (Docker), so the unit-level predicate test is the new piece this PR needs.