### PR TITLE
[Core]: Refine condition operator return types

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -101,6 +101,7 @@ export const ne: BinaryOperator = (left: SQLWrapper, right: unknown): SQL => {
  *   )
  * ```
  */
+export function and(condition: SQLWrapper, ...conditions: (SQLWrapper | undefined)[]): SQL;
 export function and(...conditions: (SQLWrapper | undefined)[]): SQL | undefined;
 export function and(
 	...unfilteredConditions: (SQLWrapper | undefined)[]
@@ -140,6 +141,7 @@ export function and(
  *   )
  * ```
  */
+export function or(condition: SQLWrapper, ...conditions: (SQLWrapper | undefined)[]): SQL;
 export function or(...conditions: (SQLWrapper | undefined)[]): SQL | undefined;
 export function or(
 	...unfilteredConditions: (SQLWrapper | undefined)[]

--- a/drizzle-orm/type-tests/pg/other.ts
+++ b/drizzle-orm/type-tests/pg/other.ts
@@ -1,6 +1,6 @@
 import type { QueryResult } from 'pg';
-import { eq, inArray } from '~/sql/expressions/index.ts';
-import { sql } from '~/sql/sql.ts';
+import { and, eq, inArray, or } from '~/sql/expressions/index.ts';
+import { type SQL, sql } from '~/sql/sql.ts';
 
 import type { Equal } from 'type-tests/utils.ts';
 import { Expect } from 'type-tests/utils.ts';
@@ -14,3 +14,16 @@ const rawQuery = await db.execute(
 );
 
 Expect<Equal<QueryResult<Record<string, unknown>>, typeof rawQuery>>;
+
+const mandatoryAnd = and(eq(users.id, 1), eq(users.class, 'A'));
+const mandatoryOr = or(eq(users.id, 1), eq(users.class, 'A'));
+const optionalCondition: SQL | undefined = Math.random() > 0.5 ? eq(users.id, 1) : undefined;
+const mixedOptionalAnd = and(eq(users.id, 1), optionalCondition);
+const mixedOptionalOr = or(eq(users.id, 1), optionalCondition);
+const optionalOr = or(optionalCondition);
+
+Expect<Equal<SQL, typeof mandatoryAnd>>;
+Expect<Equal<SQL, typeof mandatoryOr>>;
+Expect<Equal<SQL, typeof mixedOptionalAnd>>;
+Expect<Equal<SQL, typeof mixedOptionalOr>>;
+Expect<Equal<SQL | undefined, typeof optionalOr>>;


### PR DESCRIPTION
## What changed

- Added overloads for `and()` and `or()` when the first condition is known to be present.
- Preserved the existing `SQL | undefined` return type for optional-only condition lists.
- Added type assertions covering fixed non-empty calls, required-first/optional-rest calls, and optional-only calls.

## Why

`and()` and `or()` only return `undefined` when every supplied condition is filtered out. If the first argument is a definite `SQLWrapper`, the result cannot be empty at runtime, so the return type can safely be `SQL`.

This avoids forcing non-null assertions for calls like:

```ts
or(eq(table.source, 'builtin'), isNotNull(table.tarballUrl))
```

## Verification

- `git diff --check`
- `pnpm dlx dprint@0.46.2 check --list-different drizzle-orm/src/sql/expressions/conditions.ts drizzle-orm/type-tests/pg/other.ts`

I could not complete the full type-test run locally because the workspace install currently fails while fetching `drizzle-kit-0.25.0-b1faa33.tgz` from npm with a 404. Running `pnpm --dir drizzle-orm test:types` after a standalone package install is also blocked by unrelated dependency type mismatches in existing driver files.
