### PR TITLE
Match multi-line view definitions when introspecting SQLite

### DIFF
--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -850,7 +850,7 @@ export const fromDatabase = async (
 		const viewName = view['view_name'];
 		const sql = view['sql'];
 
-		const regex = new RegExp(`\\bAS\\b\\s+(SELECT.+)$`, 'i');
+		const regex = new RegExp(`\\bAS\\b\\s+(SELECT.+)$`, 'is');
 		const match = sql.match(regex);
 
 		if (!match) {

--- a/drizzle-kit/tests/introspect/sqlite.test.ts
+++ b/drizzle-kit/tests/introspect/sqlite.test.ts
@@ -2,8 +2,9 @@ import Database from 'better-sqlite3';
 import { SQL, sql } from 'drizzle-orm';
 import { check, int, sqliteTable, sqliteView, text } from 'drizzle-orm/sqlite-core';
 import * as fs from 'fs';
+import { fromDatabase } from 'src/serializer/sqliteSerializer';
 import { introspectSQLiteToFile } from 'tests/schemaDiffer';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 if (!fs.existsSync('tests/introspect/sqlite')) {
 	fs.mkdirSync('tests/introspect/sqlite');
@@ -119,4 +120,35 @@ test('view #1', async () => {
 
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
+});
+
+test('introspect view with a multi-line definition', async () => {
+	const sqlite = new Database(':memory:');
+	sqlite.exec('CREATE TABLE `users` (`id` integer, `name` text);');
+	// SQLite stores a view's SQL verbatim, so a formatted definition keeps its
+	// newlines in sqlite_master. Real schemas (e.g. Cloudflare D1) hit this.
+	sqlite.exec('CREATE VIEW `profiles` AS\nSELECT `id`, `name`\nFROM `users`;');
+
+	const db = {
+		query: async <T>(query: string, params: any[] = []) => {
+			return sqlite.prepare(query).bind(params).all() as T[];
+		},
+		run: async (query: string) => {
+			sqlite.prepare(query).run();
+		},
+	};
+
+	const exit = vi.spyOn(process, 'exit').mockImplementation(
+		((code?: number) => {
+			throw new Error(`process.exit(${code}) called`);
+		}) as never,
+	);
+
+	try {
+		const schema = await fromDatabase(db);
+		expect(Object.keys(schema.views)).toContain('profiles');
+		expect(schema.views['profiles'].definition).toContain('SELECT');
+	} finally {
+		exit.mockRestore();
+	}
 });


### PR DESCRIPTION
Fixes #5810

## What breaks

`drizzle-kit pull` against a SQLite or Cloudflare D1 database that has a view fails with:

```
[⡿] 2   views fetching
Could not process view
```

and the process exits, so no schema is generated.

## Root cause

SQLite stores a view's `CREATE` statement verbatim in `sqlite_master`, so a view written across multiple lines is read back with its newlines intact. `fromDatabase` pulls the body out of that statement with:

```ts
const regex = new RegExp(`\\bAS\\b\\s+(SELECT.+)$`, 'i');
```

There is no `s` (dotAll) flag, so `.+` stops at the first newline and `$` is never reached. The match fails, and the code hits `console.log('Could not process view'); process.exit(1)`. Single-line views (such as the ones drizzle itself generates) match fine, which is why this only shows up against real databases like D1.

## Fix

Add the `s` flag so the SELECT body is captured across newlines.

## Test

Added an introspect test in `tests/introspect/sqlite.test.ts` that creates a view with a multi-line definition and runs `fromDatabase`. It fails on `main` (the regex misses, `process.exit` is called) and passes with the flag added. The existing SQLite introspect and view suites stay green.
