### PR TITLE
fix(drizzle-seed): stop rejecting shared columns across composite unique constraints

### DIFF
--- a/drizzle-seed/src/SeedService.ts
+++ b/drizzle-seed/src/SeedService.ts
@@ -355,9 +355,15 @@ export class SeedService {
 				}
 
 				compositeKeyColumnNames = table.uniqueConstraints.filter((colNames) => colNames.includes(col.name));
-				if (compositeKeyColumnNames.length > 1) {
-					throw new Error('Currently, multiple composite unique keys that share the same column are not supported.');
-				}
+				// When the current column participates in more than one composite
+				// unique constraint (e.g. multi-tenant patterns like
+				// `unique(orgId, id)` + `unique(orgId, name)`), we don't bind it
+				// to any single composite generator — the column keeps its base
+				// generator, and the *other* column in each composite carries the
+				// uniqueness guarantee for that pair. That degrades to a valid
+				// superset of what PostgreSQL accepts (the non-shared columns end
+				// up globally unique rather than unique-within-tenant) but stops
+				// `drizzle-seed` from rejecting otherwise-legal schemas.
 
 				// to handle composite unique key generation, I will need a unique generator for each column in the composite key
 				if (compositeKeyColumnNames.length === 1) {

--- a/drizzle-seed/tests/pg/compositeUniqueKey/pg.test.ts
+++ b/drizzle-seed/tests/pg/compositeUniqueKey/pg.test.ts
@@ -164,4 +164,46 @@ test('composite unique includes a fk column', async ({ db, push }) => {
 
 	expect(composite.length).toBe(1000);
 });
+/**
+ * @see https://github.com/drizzle-team/drizzle-orm/issues/5919
+ */
+test('shared column in two composite unique constraints (#5919)', async ({ db, push }) => {
+	const currSchema = { sharedColumnInTwoComposites: schema.sharedColumnInTwoComposites };
+	await push(currSchema);
+
+	// Default generators — no .refine(). Used to throw "Currently, multiple
+	// composite unique keys that share the same column are not supported."
+	await seed(db, currSchema, { count: 16 });
+	let rows = await db.select().from(schema.sharedColumnInTwoComposites);
+	expect(rows.length).toBe(16);
+
+	// Both composite uniques must hold: PostgreSQL would have rejected the
+	// INSERTs otherwise. Sanity-check on the seed output too.
+	const orgIdAndId = new Set(rows.map((r) => `${r.orgId}|${r.id}`));
+	const orgIdAndName = new Set(rows.map((r) => `${r.orgId}|${r.name}`));
+	expect(orgIdAndId.size).toBe(16);
+	expect(orgIdAndName.size).toBe(16);
+	await reset(db, currSchema);
+
+	// Mixed-cardinality refine: small set of org IDs reused across many rows,
+	// distinct id / name per row. This is the multi-tenant shape the reporter
+	// filed against, and the throw used to fire before .refine() was applied.
+	await seed(db, currSchema, { count: 12 }).refine((funcs) => ({
+		sharedColumnInTwoComposites: {
+			columns: {
+				orgId: funcs.valuesFromArray({ values: [1, 2, 3] }),
+				id: funcs.valuesFromArray({ values: [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21] }),
+				name: funcs.valuesFromArray({
+					values: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'],
+				}),
+			},
+		},
+	}));
+	rows = await db.select().from(schema.sharedColumnInTwoComposites);
+	expect(rows.length).toBe(12);
+	expect(new Set(rows.map((r) => `${r.orgId}|${r.id}`)).size).toBe(12);
+	expect(new Set(rows.map((r) => `${r.orgId}|${r.name}`)).size).toBe(12);
+	await reset(db, currSchema);
+});
+
 // TODO add test with composite foreign key

--- a/drizzle-seed/tests/pg/compositeUniqueKey/pgSchema.ts
+++ b/drizzle-seed/tests/pg/compositeUniqueKey/pgSchema.ts
@@ -38,3 +38,17 @@ export const uniqueColumnInCompositeOfThree1 = pgTable('unique_column_in_composi
 	unique('custom_name3').on(t.id, t.name, t.slug),
 	unique('custom_name3_id').on(t.id),
 ]);
+
+// Regression schema for https://github.com/drizzle-team/drizzle-orm/issues/5919:
+// a column (`org_id`) shared across two composite unique constraints. This is
+// the multi-tenant pattern (composite-FK target + per-tenant business key) and
+// PostgreSQL accepts it; drizzle-seed used to throw "Currently, multiple
+// composite unique keys that share the same column are not supported."
+export const sharedColumnInTwoComposites = pgTable('shared_column_in_two_composites', {
+	id: integer('id').notNull(),
+	orgId: integer('org_id').notNull(),
+	name: text('name').notNull(),
+}, (t) => [
+	unique('shared_org_id_unique').on(t.orgId, t.id),
+	unique('shared_org_name_unique').on(t.orgId, t.name),
+]);


### PR DESCRIPTION
Fixes #5919.

## What

`drizzle-seed`'s `SeedService.generatePossibleGenerators` (`drizzle-seed/src/SeedService.ts:359` on the `beta` branch) threw

> Currently, multiple composite unique keys that share the same column are not supported.

as soon as the same column appeared in more than one composite unique constraint. The reporter @aress31 hit this with the standard multi-tenant pattern:

```ts
unique('products_org_id_unique').on(t.orgId, t.id),   // composite-FK target
unique('products_org_name_unique').on(t.orgId, t.name), // per-tenant business key
```

— both constraints are independently valid in PostgreSQL, but `seed()` rejects the schema structurally before any `.refine()` overrides run.

## Fix

The throw isn't actually load-bearing. Walking the existing logic for `orgId`:

- `compositeKeyColumnNames` for `orgId` contains `[['orgId','id'], ['orgId','name']]`.
- The length-1 special-cases (lines 336 + 342) don't fire, so `orgId.isUnique` stays `false` and no constraints get removed.
- Without the throw, the `if (compositeKeyColumnNames.length === 1)` blocks below all skip. `orgId` keeps its base generator and is **not** wrapped in any `GenerateCompositeUniqueKey`.
- When `id` is iterated, its `compositeKeyColumnNames` is `[['orgId','id']]`. It goes through the single-composite path → `id` gets `params.isUnique = true` and becomes the anchor of a `GenerateCompositeUniqueKey` keyed `'orgId_id'`. The composite group has only `id` registered, so the generator just emits unique `id` values.
- Same for `name` against `'orgId_name'`.

Result: each row has a random `orgId` and globally-unique `id` / `name`. Both `(orgId, id)` and `(orgId, name)` are unique because their anchor column alone is unique — a valid (slightly over-restrictive) superset of what PostgreSQL would accept. `.refine()` works as expected on top.

## Tests

Added `drizzle-seed/tests/pg/compositeUniqueKey/` regression coverage:

- `pgSchema.ts` — `sharedColumnInTwoComposites` table mirroring the reporter's schema verbatim.
- `pg.test.ts` — `shared column in two composite unique constraints (#5919)`:
  - Default-generator seed of 16 rows: asserts the row count and that both `(orgId|id)` and `(orgId|name)` tuple-sets have 16 distinct values.
  - `.refine()`-driven mixed-cardinality seed: 12 rows, `orgId` from a 3-value pool, `id` and `name` from 12-value pools. Asserts row count and both tuple uniquenesses — this is the multi-tenant shape the reporter cared about, and it's the scenario where the throw previously fired before `.refine()` was applied.

Verified the test **fails** on the unpatched code (the throw fires) and **passes** after the fix. All 5 tests in `drizzle-seed/tests/pg/compositeUniqueKey/pg.test.ts` are green.

## Notes for maintainers

- The "valid superset" trade-off is documented in the new in-source comment: PostgreSQL would have allowed `id` to repeat across different `orgId`s, but the fixed code generates globally-unique `id` values. Functionally correct, just stricter than necessary. A future refinement could let the shared column genuinely repeat by teaching `GenerateCompositeUniqueKey` to share an anchor generator across multiple composites — outside the scope of this fix.
- Targeting `beta` (the 1.0.0-beta.x line) because the throw lives there; `main` (the 0.x stable line) has a different `SeedService` layout where this branch doesn't exist.