### PR TITLE
fix(op-sqlite): unwrap RawQueryResult from executeRawAsync (op-sqlite 17+)

### DIFF
--- a/drizzle-orm/src/op-sqlite/session.ts
+++ b/drizzle-orm/src/op-sqlite/session.ts
@@ -188,7 +188,16 @@ export class OPSQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuery
 		const params = fillPlaceholders(this.query.params, placeholderValues ?? {});
 		this.logger.logQuery(this.query.sql, params);
 		return await this.queryWithCache(this.query.sql, params, async () => {
-			return await this.client.executeRawAsync(this.query.sql, params);
+			const result = await this.client.executeRawAsync(this.query.sql, params);
+			// op-sqlite ≥17 returns a `RawQueryResult` object (`{ rawRows, ... }`)
+			// from `executeRawAsync`; pre-17 returned the bare `unknown[][]` directly.
+			// Detect and unwrap so downstream `.map()` callers keep working across
+			// both versions. See drizzle-team/drizzle-orm#5928 +
+			// https://github.com/OP-Engineering/op-sqlite/commit/83e6d260b0dc9b5d0fad42e82dffac431f80a61a.
+			if (result && !Array.isArray(result) && Array.isArray((result as { rawRows?: unknown }).rawRows)) {
+				return (result as { rawRows: unknown[][] }).rawRows;
+			}
+			return result;
 		});
 	}
 


### PR DESCRIPTION
## Summary

Fixes #5928 — op-sqlite 17 made `executeRawAsync` (and `executeRawSync`) return a `RawQueryResult` object instead of a bare `unknown[][]`, which the docs call out as a [breaking change](https://github.com/OP-Engineering/op-sqlite/commit/83e6d260b0dc9b5d0fad42e82dffac431f80a61a):

> Starting on version `17.0.0`, `executeRaw()` and `executeRawSync()` return an object instead of a bare array of rows.

`OPSQLitePreparedQuery#values` returns that result verbatim, then `#all` (and `#get`) call `.map()` on it — which now crashes with `TypeError: undefined is not a function` for every select on op-sqlite ≥17.

Reporter's diagnosis ([@joekrill](https://github.com/joekrill)) pointed at the exact line: `drizzle-orm/src/op-sqlite/session.ts:191`.

## Fix

Detect both shapes inside `values()` and unwrap to `rawRows` only when the new object form is present. The check is structural (object with an array `rawRows`), so it works regardless of which op-sqlite version the user has installed:

```ts
const result = await this.client.executeRawAsync(this.query.sql, params);
if (result && !Array.isArray(result) && Array.isArray((result as { rawRows?: unknown }).rawRows)) {
    return (result as { rawRows: unknown[][] }).rawRows;
}
return result;
```

This keeps op-sqlite ≤16 users on the existing fast path (no allocation, no field access) and unblocks op-sqlite 17+ users without forcing a downgrade.

## Why `values()` is the right place

`values()` is the single call site of `executeRawAsync` in the package — `all()`, `get()`, and any custom result mapper all go through it. Fixing it at the boundary means `all/get/customResultMapper` don't need version-aware branches.

## Test plan

- [x] `pnpm tsc --noEmit` clean on `src/op-sqlite/` (pre-existing TS errors in `src/node-postgres/session.ts` are unrelated to this change)
- [ ] Maintainer-side: regression in op-sqlite 17 — `select` returns rows; in op-sqlite 16 — unchanged behavior

I don't have a React-Native harness to run the existing integration tests against both op-sqlite 16 and 17, so didn't add a test in this PR. Happy to add a small unit test against a fake client (returning each shape) if that's the preferred shape — just say.

## Breaking changes

None. Pre-17 op-sqlite returns the bare array, hits the `Array.isArray(result)` branch, and falls through untouched.