### PR TITLE
feat(netlify-db): support credential rotation

### DIFF
--- a/drizzle-orm/src/netlify-db/connection.ts
+++ b/drizzle-orm/src/netlify-db/connection.ts
@@ -1,0 +1,54 @@
+import { neon, type NeonQueryFunction } from '@neondatabase/serverless';
+import type { NeonHttpClient } from '~/neon-http/session.ts';
+
+/**
+ * Reads the current Netlify Database connection string from the environment.
+ *
+ * Netlify refreshes `NETLIFY_DB_URL` on every function invocation and may rotate
+ * the underlying credentials at any time, so this is read on demand (via the
+ * refreshing client below) rather than captured once.
+ */
+export function resolveNetlifyDbUrl(): string {
+	const connectionString = process.env['NETLIFY_DB_URL'];
+	if (!connectionString) {
+		throw new Error(
+			'NETLIFY_DB_URL environment variable is not set. '
+				+ 'Provide a connection string or client to drizzle().',
+		);
+	}
+	return connectionString;
+}
+
+/**
+ * Returns a Neon HTTP client that re-resolves the connection string on every
+ * query instead of capturing it once at `drizzle()` time.
+ */
+export function createRefreshingNeonHttpClient(resolve: () => string): NeonHttpClient {
+	let cachedConnectionString: string | undefined;
+	let cachedClient: NeonQueryFunction<any, any> | undefined;
+
+	const getClient = (): NeonQueryFunction<any, any> => {
+		const connectionString = resolve();
+		if (connectionString !== cachedConnectionString || cachedClient === undefined) {
+			cachedConnectionString = connectionString;
+			cachedClient = neon(connectionString);
+		}
+		return cachedClient;
+	};
+
+	// Construct eagerly so drizzle() fails fast and the client is warm.
+	getClient();
+
+	const target = function() {} as unknown as NeonHttpClient;
+	return new Proxy(target, {
+		apply(_target, _thisArg, args: any[]) {
+			return (getClient() as any)(...args);
+		},
+		get(_target, prop) {
+			const value = (getClient() as any)[prop];
+			// Re-resolve on each call so a captured method reference still uses
+			// live credentials; non-function values pass through as-is.
+			return typeof value === 'function' ? (...args: any[]) => (getClient() as any)[prop](...args) : value;
+		},
+	}) as NeonHttpClient;
+}

--- a/drizzle-orm/src/netlify-db/driver.ts
+++ b/drizzle-orm/src/netlify-db/driver.ts
@@ -12,6 +12,7 @@ import type { DrizzlePgConfig } from '~/pg-core/utils.ts';
 import type { AnyRelations, EmptyRelations } from '~/relations.ts';
 import { isConfig, jitCompatCheck } from '~/utils.ts';
 import { netlifyDbCodecs, netlifyDbTransactionCodecs } from './codecs.ts';
+import { createRefreshingNeonHttpClient, resolveNetlifyDbUrl } from './connection.ts';
 import { type NetlifyDbClient, NetlifyDbSession } from './session.ts';
 
 export interface ServerlessDrizzleClient {
@@ -210,10 +211,13 @@ export function drizzle<TRelations extends AnyRelations = EmptyRelations>(
 		const driver = process.env['NETLIFY_DB_DRIVER'];
 
 		if (driver === 'server') {
+			// Long-running server driver: the connection string is resolved once.
 			return drizzleNodePg({ connection: connectionString, ...drizzleConfig }) as any;
 		}
 
-		const httpClient = neon(connectionString);
+		// The HTTP client re-resolves NETLIFY_DB_URL per query instead of pinning
+		// it here, so rotated credentials are picked up automatically.
+		const httpClient = createRefreshingNeonHttpClient(resolveNetlifyDbUrl);
 		const pool = new Pool({ connectionString });
 		return construct(httpClient, pool, drizzleConfig) as any;
 	}

--- a/drizzle-orm/src/netlify-db/session.ts
+++ b/drizzle-orm/src/netlify-db/session.ts
@@ -81,14 +81,14 @@ export class NetlifyDbSession<TRelations extends AnyRelations>
 			if (mode === 'raw') {
 				// otherwise raw queries with .then crash due to .then not existing on raw mode queries
 				return (async () =>
-					this.httpClient(query.sql, params, {
+					this.clientQuery(query.sql, params ?? [], {
 						arrayMode: false,
 						fullResults: true,
 						authToken: this.options.authToken,
 					}))();
 			}
 
-			return this.httpClient(query.sql, params, {
+			return this.clientQuery(query.sql, params ?? [], {
 				arrayMode: mode === 'arrays',
 				fullResults: true,
 				authToken: this.options.authToken,
@@ -101,7 +101,7 @@ export class NetlifyDbSession<TRelations extends AnyRelations>
 	async batch<U extends BatchItem<'pg'>, T extends Readonly<[U, ...U[]]>>(queries: T) {
 		const preparedQueries: PgAsyncPreparedQuery<any>[] = [];
 		const builtQueries: NeonQueryPromise<any, true>[] = [];
-		const q = this.httpClient;
+		const q = this.clientQuery;
 
 		for (const query of queries) {
 			const preparedQuery = query._prepare() as PgAsyncPreparedQuery<any>;


### PR DESCRIPTION
This updates the Netlify Database adapter so that a connection obtained once via `drizzle()` keeps working after Netlify rotates the database credentials, and so that the adapter is compatible with both the v0 and v1 lines of `@neondatabase/serverless`.

## Why

Netlify can rotate a project's database credentials at any time, and it refreshes the `NETLIFY_DB_URL` environment variable on every function invocation to reflect the current values.

Until now the adapter read that variable once, when the client was constructed, and held onto it for the lifetime of the process. In long-lived or warm serverless environments that meant a rotation would leave the cached client pointing at stale credentials, and queries would start failing until the next cold start.

The goal here is for rotation to be a non-event: the same database handle should transparently pick up new credentials without any redeploy or restart.

## How

The core idea is to defer reading the connection string from "construction time" to "query time". Instead of building a Neon HTTP client once and capturing it, the adapter wraps the client so that each use re-resolves `NETLIFY_DB_URL` and rebuilds the underlying client only when the connection string has actually changed.

The wrapper preserves the client's full surface so existing call sites are unaffected; they simply get live credentials on every query. Because resolution happens lazily per call, even a reference to the client that was captured early in a function's lifetime continues to use the current credentials.

The transaction pool, which holds live authenticated connections, intentionally remains pinned to the connection string it was created with and refreshes on the next cold start, since swapping credentials underneath open connections isn't something that can be done transparently.

## `@neondatabase/serverless` v1

Separately, `@neondatabase/serverless` v1 introduced a breaking change to how its HTTP query function is called, and the adapter needs to work across both versions so consumers aren't forced onto a specific Neon release.

The adapter routes conventional `(sql, params, options)` queries through the client's `query()` method when it exists (v1 and up, where the root function is tagged-template-only) and falls back to calling the root function directly on older versions. This mirrors the approach already used in Drizzle's own `neon-http` driver, so behaviour stays consistent with the rest of the codebase.
