### PR TITLE
fix: preserve enum type names during pg pull alias normalization

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1480,11 +1480,13 @@ WHERE
 							}
 						}
 
-						columnTypeMapped = columnTypeMapped
-							.replace('character varying', 'varchar')
-							.replace(' without time zone', '')
-							// .replace("timestamp without time zone", "timestamp")
-							.replace('character', 'char');
+						if (columnAdditionalDT !== 'USER-DEFINED') {
+							columnTypeMapped = columnTypeMapped
+								.replace('character varying', 'varchar')
+								.replace(' without time zone', '')
+								// .replace("timestamp without time zone", "timestamp")
+								.replace('character', 'char');
+						}
 
 						columnTypeMapped = trimChar(columnTypeMapped, '"');
 
@@ -1775,11 +1777,13 @@ WHERE
 							}
 						}
 
-						columnTypeMapped = columnTypeMapped
-							.replace('character varying', 'varchar')
-							.replace(' without time zone', '')
-							// .replace("timestamp without time zone", "timestamp")
-							.replace('character', 'char');
+						if (columnAdditionalDT !== 'USER-DEFINED') {
+							columnTypeMapped = columnTypeMapped
+								.replace('character varying', 'varchar')
+								.replace(' without time zone', '')
+								// .replace("timestamp without time zone", "timestamp")
+								.replace('character', 'char');
+						}
 
 						columnTypeMapped = trimChar(columnTypeMapped, '"');
 

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -456,6 +456,27 @@ test('introspect enum with similar name to native type', async () => {
 	expect(sqlStatements.length).toBe(0);
 });
 
+test('introspect enum whose name contains the substring "character"', async () => {
+	const client = new PGlite();
+
+	const characteristicsType = pgEnum('characteristics_type', ['a', 'b']);
+	const schema = {
+		characteristicsType,
+		things: pgTable('things', {
+			kind: characteristicsType('kind'),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectPgToFile(
+		client,
+		schema,
+		'introspect-enum-with-character-substring',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
 test('instrospect strings with single quotes', async () => {
 	const client = new PGlite();
 


### PR DESCRIPTION
When drizzle-kit pull introspects a PostgreSQL schema, it resolves the column's type against a known-enum map and assigns the result to `columnTypeMapped`. Even when an enum match is found and `enumType` is set, the subsequent alias-normalization chain (which maps `"character"` to `"char"`, among other rewrites) was applied unconditionally. This caused any enum whose name contained the substring `"character"` — such as `characteristics_type` — to be silently rewritten to `charistics_type`, producing invalid generated code.

The fix moves the normalization chain inside the branch where `enumType` is absent. When a column's type maps to a known enum, the name is taken verbatim; the alias rewrites run only for raw PostgreSQL type strings that still need normalization.

Before the fix, a column backed by an enum named `characteristics_type` would generate `characteristics_type: characteristics_typeEnum("charistics_type")`. After the fix it correctly generates `characteristics_type: characteristics_typeEnum("characteristics_type")`.

Fixes #5932