### PR TITLE
fix(op-sqlite): await executeAsync and use .rows in all() and get()

### DIFF
--- a/drizzle-orm/src/op-sqlite/session.ts
+++ b/drizzle-orm/src/op-sqlite/session.ts
@@ -148,7 +148,7 @@ export class OPSQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuery
 			logger.logQuery(query.sql, params);
 
 			return await this.queryWithCache(query.sql, params, async () => {
-				return client.execute(query.sql, params).rows?._array || [];
+				return (await client.executeAsync(query.sql, params)).rows || [];
 			});
 		}
 
@@ -165,7 +165,7 @@ export class OPSQLitePreparedQuery<T extends PreparedQueryConfig = PreparedQuery
 		logger.logQuery(query.sql, params);
 		if (!fields && !customResultMapper) {
 			const rows = await this.queryWithCache(query.sql, params, async () => {
-				return client.execute(query.sql, params).rows?._array || [];
+				return (await client.executeAsync(query.sql, params)).rows || [];
 			});
 			return rows[0];
 		}


### PR DESCRIPTION
Fixes #5936

## Problem

`OPSQLitePreparedQuery.all()` and `.get()` both call `client.execute()` synchronously in their non-fields / non-customResultMapper fast path, then access `.rows?._array` on the result:

```ts
return client.execute(query.sql, params).rows?._array || [];
```

Two bugs here:

1. `client.execute` is an async method — the call returns a Promise, not a `QueryResult`, so `.rows` is always `undefined` and every query silently returns `[]`
2. The `QueryResult` type from `@op-engineering/op-sqlite` exposes a `.rows` array directly; there is no `._array` sub-property

The `run()` method (line 140) and `values()` (line 191) already do this correctly via `executeAsync` / `executeRawAsync`

## Fix

Await `client.executeAsync()` and access `.rows` directly, consistent with how `run()` is implemented:

```ts
return (await client.executeAsync(query.sql, params)).rows || [];
```

Applied at both call sites in `all()` and `get()`