### PR TITLE
fix(orm): clear nullifyMap when later field from same table is non-null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,7 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string' && (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}


### PR DESCRIPTION
Fixes #1603

/claim #1603

## Root cause

`mapResultRow` builds a `nullifyMap` to decide which nested objects should be replaced with `null` for unmatched left joins. The map is initialised for an object path on the first column: if the value is `null`, the entry is set to the table name (signalling "might be null"); if non-null, it's immediately set to `false` (keep the object).

For subsequent columns under the same path the only existing cancellation path was a column from a **different** table (line 51). A non-null value from the **same** table left the flag set, so when the nullification step ran, the entire nested object was replaced with `null` even though at least one field had data.

## Fix

One-line change in `drizzle-orm/src/utils.ts`:

```diff
-   typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+   typeof nullifyMap[objectName] === 'string' && (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
```

Adding `|| value !== null` makes the condition also cancel nullification when we encounter any non-null value from the table that originally triggered it.

## Reproduction (from issue)

```ts
// Schema: orgTable, orgBrandingTable
// Row:    logo = null,  panelBackground = "#1a8cff"

db.select({
  name: orgTable.name,
  branding: {
    logo: orgBrandingTable.logo,          // null first → triggered the bug
    panelBackground: orgBrandingTable.panelBackground,  // non-null, same table
  }
}).from(orgTable).leftJoin(...)

// Before fix → branding: null
// After fix  → branding: { logo: null, panelBackground: '#1a8cff' }
```