### PR TITLE
fix: accept readonly array values in insert value types

### DIFF
--- a/drizzle-orm/src/gel-core/query-builders/insert.ts
+++ b/drizzle-orm/src/gel-core/query-builders/insert.ts
@@ -40,6 +40,7 @@ export type GelInsertValue<TTable extends GelTable<TableConfig>, OverrideT exten
 	& {
 		[Key in keyof InferInsertModel<TTable, { dbColumnNames: false; override: OverrideT }>]:
 			| InferInsertModel<TTable, { dbColumnNames: false; override: OverrideT }>[Key]
+			| Readonly<InferInsertModel<TTable, { dbColumnNames: false; override: OverrideT }>[Key]>
 			| SQL
 			| Placeholder;
 	}

--- a/drizzle-orm/src/mysql-core/query-builders/insert.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/insert.ts
@@ -38,7 +38,7 @@ export type AnyMySqlInsertConfig = MySqlInsertConfig<MySqlTable>;
 
 export type MySqlInsertValue<TTable extends MySqlTable> =
 	& {
-		[Key in keyof TTable['$inferInsert']]: TTable['$inferInsert'][Key] | SQL | Placeholder;
+		[Key in keyof TTable['$inferInsert']]: TTable['$inferInsert'][Key] | Readonly<TTable['$inferInsert'][Key]> | SQL | Placeholder;
 	}
 	& {};
 

--- a/drizzle-orm/src/pg-core/query-builders/insert.ts
+++ b/drizzle-orm/src/pg-core/query-builders/insert.ts
@@ -43,6 +43,7 @@ export type PgInsertValue<TTable extends PgTable<TableConfig>, OverrideT extends
 	& {
 		[Key in keyof InferInsertModel<TTable, { dbColumnNames: false; override: OverrideT }>]:
 			| InferInsertModel<TTable, { dbColumnNames: false; override: OverrideT }>[Key]
+			| Readonly<InferInsertModel<TTable, { dbColumnNames: false; override: OverrideT }>[Key]>
 			| SQL
 			| Placeholder;
 	}

--- a/drizzle-orm/src/singlestore-core/query-builders/insert.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/insert.ts
@@ -34,7 +34,7 @@ export type AnySingleStoreInsertConfig = SingleStoreInsertConfig<SingleStoreTabl
 
 export type SingleStoreInsertValue<TTable extends SingleStoreTable> =
 	& {
-		[Key in keyof TTable['$inferInsert']]: TTable['$inferInsert'][Key] | SQL | Placeholder;
+		[Key in keyof TTable['$inferInsert']]: TTable['$inferInsert'][Key] | Readonly<TTable['$inferInsert'][Key]> | SQL | Placeholder;
 	}
 	& {};
 

--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -29,7 +29,7 @@ export interface SQLiteInsertConfig<TTable extends SQLiteTable = SQLiteTable> {
 
 export type SQLiteInsertValue<TTable extends SQLiteTable> = Simplify<
 	{
-		[Key in keyof TTable['$inferInsert']]: TTable['$inferInsert'][Key] | SQL | Placeholder;
+		[Key in keyof TTable['$inferInsert']]: TTable['$inferInsert'][Key] | Readonly<TTable['$inferInsert'][Key]> | SQL | Placeholder;
 	}
 >;
 


### PR DESCRIPTION
## Problem

Effect Schema always produces `readonly` arrays. When you use `createInsertSchema` from `drizzle-effect` and call `.make(...)`, the inferred type contains `readonly string[]` for any array column. Passing that value to `db.insert(table).values(row)` fails with:

```
The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.
```

This happens because all five `*InsertValue` mapped types only accept the plain (mutable) form of each column's TypeScript type.

## Fix

Add `Readonly<T>` as a valid alternative alongside `T` in every `*InsertValue` mapped type:

- `PgInsertValue` (`pg-core`)
- `MySqlInsertValue` (`mysql-core`)
- `SQLiteInsertValue` (`sqlite-core`)
- `SingleStoreInsertValue` (`singlestore-core`)
- `GelInsertValue` (`gel-core`)

`Readonly<string[]>` is `readonly string[]`; `Readonly<string>` is still `string` (primitives are unchanged). The union is purely additive — no runtime impact, no narrowing change for mutable values, no breakage to existing code. Both the Effect Schema path and any other library that emits readonly-typed arrays now type-check without a cast.

Fixes #5935