### PR TITLE
docs(joins): replace deprecated InferModel with InferSelectModel

### DIFF
--- a/docs/joins.md
+++ b/docs/joins.md
@@ -218,10 +218,10 @@ That's the neat part - you can do that however you'd like! No hand-holding here.
 For example, one of the ways to do that would be `Array.reduce()`:
 
 ```typescript
-import { InferModel } from 'drizzle-orm';
+import { InferSelectModel } from 'drizzle-orm';
 
-type User = InferModel<typeof users>;
-type City = InferModel<typeof cities>;
+type User = InferSelectModel<typeof users>;
+type City = InferSelectModel<typeof cities>;
 
 const rows = await db
   .select({


### PR DESCRIPTION
`docs/joins.md` uses the deprecated `InferModel` type in its aggregation example:

```typescript
import { InferModel } from 'drizzle-orm';

type User = InferModel<typeof users>;
type City = InferModel<typeof cities>;
```

`InferModel` is marked `@deprecated` in the source ([`drizzle-orm/src/table.ts`](https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-orm/src/table.ts)):

> `/** @deprecated Use one of the alternatives: {@link InferSelectModel} / {@link InferInsertModel}, or `table.\` / `table.\` */`

The example derives row types from `select()` results, so the correct non-deprecated replacement is `InferSelectModel`. This avoids steering readers toward a deprecated API (and the TypeScript deprecation warning it triggers).

Docs-only change.
