### PR TITLE
[SingleStore-kit]: Fix introspect silently dropping DEFAULT 0 on smallint, mediumint, bigint, double, float

### DIFF
--- a/drizzle-kit/src/introspect-singlestore.ts
+++ b/drizzle-kit/src/introspect-singlestore.ts
@@ -404,7 +404,7 @@ const column = (
 		const columnName = dbColumnName({ name, casing: rawCasing, withMode: isUnsigned });
 		let out = `${casing(name)}: smallint(${columnName}${isUnsigned ? '{ unsigned: true }' : ''})`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -415,7 +415,7 @@ const column = (
 		const columnName = dbColumnName({ name, casing: rawCasing, withMode: isUnsigned });
 		let out = `${casing(name)}: mediumint(${columnName}${isUnsigned ? '{ unsigned: true }' : ''})`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -427,7 +427,7 @@ const column = (
 			isUnsigned ? ', unsigned: true' : ''
 		} })`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -466,7 +466,7 @@ const column = (
 			: `${casing(name)}: double(${dbColumnName({ name, casing: rawCasing })})`;
 
 		// let out = `${name.camelCase()}: double("${name}")`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -489,7 +489,7 @@ const column = (
 		}
 
 		let out = `${casing(name)}: float(${dbColumnName({ name, casing: rawCasing })}${params ? timeConfig(params) : ''})`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;

--- a/drizzle-kit/tests/introspect/singlestore.test.ts
+++ b/drizzle-kit/tests/introspect/singlestore.test.ts
@@ -273,3 +273,25 @@ test('handle unsigned numerical types', async () => {
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
 });
+
+test('introspect smallint, mediumint, bigint, double and float columns with a zero default', async () => {
+	const schema = {
+		table: singlestoreTable('table', {
+			col1: smallint('col1').default(0),
+			col2: mediumint('col2').default(0),
+			col3: bigint('col3', { mode: 'number' }).default(0),
+			col4: double('col4').default(0),
+			col5: float('col5').default(0),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectSingleStoreToFile(
+		client,
+		schema,
+		'introspect-zero-default-numeric-columns',
+		'drizzle',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});


### PR DESCRIPTION
Introspecting (`drizzle-kit pull`) a SingleStore `smallint`, `mediumint`, `bigint`, `double`, or `float` column whose `DEFAULT` is `0` drops the default from the generated schema.

The codegen for those five branches guards `.default()` with a plain truthy check on the default value:

```ts
out += defaultValue ? `.default(...)` : '';
```

A default of `0` (or `0.0`) is falsy, so it gets treated as "no default". The introspected snapshot stores `0` correctly; only the generated TypeScript loses it, so a fresh pull stops matching the database.

The `int` and `tinyint` branches in the same file already use the correct guard:

```ts
out += typeof defaultValue !== 'undefined' ? `.default(...)` : '';
```

This PR applies the same fix to the remaining five numeric branches.

### Relation to MySQL twin PRs

The identical class of bug was independently found and fixed for MySQL:
- PR #5917 — `float`, `double`, `real`
- PR #5918 — `smallint`, `mediumint`, `bigint`

Both are open in-flight; this PR covers the SingleStore dialect.

### Test

Added `introspect smallint, mediumint, bigint, double and float columns with a zero default` to `drizzle-kit/tests/introspect/singlestore.test.ts`. The round-trip reports 0 changed statements with the fix applied. On `main` without the fix, all five columns lose their `.default(0)` and the snapshot diff reports 5 altered columns.