### PR TITLE
fix(upstash-cache): apply TTL to per-table composite-key Sets to prevent unbounded growth

### DIFF
--- a/drizzle-orm/src/cache/upstash/cache.ts
+++ b/drizzle-orm/src/cache/upstash/cache.ts
@@ -182,7 +182,13 @@ export class UpstashCache extends Cache {
 		}
 
 		for (const table of tables) {
-			pipeline.sadd(this.addTablePrefix(table), compositeKey);
+			const setKey = this.addTablePrefix(table);
+			pipeline.sadd(setKey, compositeKey);
+			// Refresh the Set key's TTL so it auto-expires when the table goes idle
+			// (e.g. read-only workloads that never trigger `onMutate`). Without this,
+			// `__CTS__<table>` accumulates a new composite-key member on every cache
+			// write and is never trimmed, leading to unbounded Redis memory growth.
+			pipeline.expire(setKey, ttlSeconds);
 		}
 
 		await pipeline.exec();


### PR DESCRIPTION
Closes #5838

In `UpstashCache.put()`, each cache write SADD's the composite key to a per-table Set (key pattern `__CTS__<table>`) so `onMutate()` can later find every composite key that needs invalidation. The Set is only cleaned up inside `onMutate` via `SUNION` + `DEL`; if no INSERT/UPDATE/DELETE ever fires on a table (e.g. a read-only workload), the Set keeps accumulating new members on every cache write and is never trimmed.

This refreshes the Set key's TTL on every `SADD` so the Set auto-expires when a table goes idle. The TTL is taken from the same per-call or instance `ttlSeconds` that already governs the hash-field expiry, keeping the lifecycle consistent.

For genuinely active workloads (writes per TTL window >> composite-key cardinality), an additional size cap would still be needed; this change addresses the dominant read-only / idling-table case the issue reports.