### PR TITLE
fix(cache): await db query before cache.onMutate to close stale-repopulation race

### DIFF
--- a/drizzle-orm/src/gel-core/session.ts
+++ b/drizzle-orm/src/gel-core/session.ts
@@ -69,10 +69,8 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 			) && this.queryMetadata.tables.length > 0
 		) {
 			try {
-				const [res] = await Promise.all([
-					query(),
-					this.cache.onMutate({ tables: this.queryMetadata.tables }),
-				]);
+				const res = await query();
+				await this.cache.onMutate({ tables: this.queryMetadata.tables });
 				return res;
 			} catch (e) {
 				throw new DrizzleQueryError(queryString, params, e as Error);

--- a/drizzle-orm/src/mysql-core/session.ts
+++ b/drizzle-orm/src/mysql-core/session.ts
@@ -97,10 +97,8 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			) && this.queryMetadata.tables.length > 0
 		) {
 			try {
-				const [res] = await Promise.all([
-					query(),
-					this.cache.onMutate({ tables: this.queryMetadata.tables }),
-				]);
+				const res = await query();
+				await this.cache.onMutate({ tables: this.queryMetadata.tables });
 				return res;
 			} catch (e) {
 				throw new DrizzleQueryError(queryString, params, e as Error);

--- a/drizzle-orm/src/pg-core/session.ts
+++ b/drizzle-orm/src/pg-core/session.ts
@@ -91,10 +91,8 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			) && this.queryMetadata.tables.length > 0
 		) {
 			try {
-				const [res] = await Promise.all([
-					query(),
-					this.cache.onMutate({ tables: this.queryMetadata.tables }),
-				]);
+				const res = await query();
+				await this.cache.onMutate({ tables: this.queryMetadata.tables });
 				return res;
 			} catch (e) {
 				throw new DrizzleQueryError(queryString, params, e as Error);

--- a/drizzle-orm/src/singlestore-core/session.ts
+++ b/drizzle-orm/src/singlestore-core/session.ts
@@ -95,10 +95,8 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 			) && this.queryMetadata.tables.length > 0
 		) {
 			try {
-				const [res] = await Promise.all([
-					query(),
-					this.cache.onMutate({ tables: this.queryMetadata.tables }),
-				]);
+				const res = await query();
+				await this.cache.onMutate({ tables: this.queryMetadata.tables });
 				return res;
 			} catch (e) {
 				throw new DrizzleQueryError(queryString, params, e as Error);

--- a/drizzle-orm/src/sqlite-core/session.ts
+++ b/drizzle-orm/src/sqlite-core/session.ts
@@ -98,10 +98,8 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			) && this.queryMetadata.tables.length > 0
 		) {
 			try {
-				const [res] = await Promise.all([
-					query(),
-					this.cache.onMutate({ tables: this.queryMetadata.tables }),
-				]);
+				const res = await query();
+				await this.cache.onMutate({ tables: this.queryMetadata.tables });
 				return res;
 			} catch (e) {
 				throw new DrizzleQueryError(queryString, params, e as Error);

--- a/integration-tests/tests/pg/pg-common-cache.ts
+++ b/integration-tests/tests/pg/pg-common-cache.ts
@@ -196,6 +196,38 @@ export function tests() {
 			expect(spyInvalidate).toHaveBeenCalledTimes(1);
 		});
 
+		test('write: db query resolves before onMutate (no concurrent cache race)', async (ctx) => {
+			const { db } = ctx.cachedPg;
+
+			// Track invocation order to verify the DB write commits before cache invalidation.
+			const callOrder: string[] = [];
+
+			// @ts-expect-error
+			vi.spyOn(db.$cache, 'onMutate').mockImplementation(async () => {
+				callOrder.push('onMutate');
+			});
+
+			// Patch the underlying session.query to record when the DB write resolves.
+			const session = (db as any).session;
+			const originalQuery = session?.query?.bind(session);
+			if (originalQuery) {
+				vi.spyOn(session, 'query').mockImplementation(async (...args: any[]) => {
+					callOrder.push('query:start');
+					const result = await originalQuery(...args);
+					callOrder.push('query:end');
+					return result;
+				});
+			}
+
+			await db.insert(usersTable).values({ name: 'Jane' });
+
+			const queryEndIdx = callOrder.indexOf('query:end');
+			const onMutateIdx = callOrder.indexOf('onMutate');
+			expect(queryEndIdx).toBeGreaterThanOrEqual(0);
+			expect(onMutateIdx).toBeGreaterThanOrEqual(0);
+			expect(queryEndIdx).toBeLessThan(onMutateIdx);
+		});
+
 		test('default global config + enable cache on select + disable invalidate: get, put', async (ctx) => {
 			const { db } = ctx.cachedPg;
 


### PR DESCRIPTION
Closes #5828.

The cache invalidation in `PgPreparedQuery.queryWithCache` was firing concurrently with the DB write via `Promise.all`, contradicting the in-code comment that said the DB write should resolve first.

When `onMutate` (a single Redis Lua script call) completed before the DB write committed, a concurrent SELECT could read the pre-mutation row and repopulate the cache via `cache.put()`, serving stale data until TTL expiry. Repro: write-heavy workload with `cache.ex` larger than the DB RTT.

Change `Promise.all([query(), onMutate])` to sequential `await`. The DB write now commits before any cache keys are cleared, closing the race. Same fix applied to mysql-core, sqlite-core, gel-core, singlestore-core which shared the identical pattern.

Regression test added in pg-common-cache.ts that fails on the old ordering and passes on the new.