### PR TITLE
Introspect zero defaults on SingleStore numeric columns

### DIFF
--- a/drizzle-kit/src/introspect-singlestore.ts
+++ b/drizzle-kit/src/introspect-singlestore.ts
@@ -404,7 +404,7 @@ const column = (
 		const columnName = dbColumnName({ name, casing: rawCasing, withMode: isUnsigned });
 		let out = `${casing(name)}: smallint(${columnName}${isUnsigned ? '{ unsigned: true }' : ''})`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -415,7 +415,7 @@ const column = (
 		const columnName = dbColumnName({ name, casing: rawCasing, withMode: isUnsigned });
 		let out = `${casing(name)}: mediumint(${columnName}${isUnsigned ? '{ unsigned: true }' : ''})`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -427,7 +427,7 @@ const column = (
 			isUnsigned ? ', unsigned: true' : ''
 		} })`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -466,7 +466,7 @@ const column = (
 			: `${casing(name)}: double(${dbColumnName({ name, casing: rawCasing })})`;
 
 		// let out = `${name.camelCase()}: double("${name}")`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -489,7 +489,7 @@ const column = (
 		}
 
 		let out = `${casing(name)}: float(${dbColumnName({ name, casing: rawCasing })}${params ? timeConfig(params) : ''})`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -497,7 +497,7 @@ const column = (
 
 	if (lowered === 'real') {
 		let out = `${casing(name)}: real(${dbColumnName({ name, casing: rawCasing })})`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;


### PR DESCRIPTION
Introspecting (`drizzle-kit pull`) a SingleStore `smallint`, `mediumint`, `bigint`, `float`, `double` or `real` column whose `DEFAULT` is `0` drops the default from the generated schema.

Each of those branches in `introspect-singlestore.ts` guards `.default()` with a plain truthy check on the default value:

```ts
out += defaultValue
  ? `.default(${mapColumnDefault(defaultValue, isExpression)})`
  : '';
```

`0` is falsy, so it is treated as "no default" and the generated TypeScript loses it, even though the introspected snapshot stores the `0` correctly. A fresh pull then stops matching the database. The `int` and `tinyint` branches in the same file already guard with `typeof defaultValue !== 'undefined'`; this applies the same check to the remaining numeric branches.

This is the SingleStore counterpart of #5917 (MySQL float/double/real) and #5918 (MySQL smallint/mediumint/bigint) — the SingleStore introspector has the same branches with the same truthy guard.

I scoped the change to the numeric types covered by those two PRs and left `boolean` untouched. I didn't add a test because the introspect suite starts a SingleStore container, which I couldn't run locally; happy to mirror the tests from #5917/#5918 if you'd prefer one here.
