### PR TITLE
[Mssql] Fix empty inArray/notInArray using invalid true/false in T-SQL

### DIFF
--- a/drizzle-orm/src/mssql-core/expressions.ts
+++ b/drizzle-orm/src/mssql-core/expressions.ts
@@ -1,9 +1,97 @@
+import type { Column, GetColumnData } from '~/column.ts';
 import { bindIfParam } from '~/sql/expressions/index.ts';
 import type { Placeholder, SQL, SQLChunk, SQLWrapper } from '~/sql/sql.ts';
 import { sql } from '~/sql/sql.ts';
 import type { MsSqlColumn } from './columns/index.ts';
 
 export * from '~/sql/expressions/index.ts';
+
+/**
+ * Test whether the first parameter, a column or expression,
+ * has a value from a list passed as the second argument.
+ *
+ * T-SQL has no `true`/`false` keywords, so an empty array
+ * is rendered as the always-false predicate `1 = 0`.
+ *
+ * ## Examples
+ *
+ * ```ts
+ * // Select cars made by Ford or GM.
+ * db.select().from(cars)
+ *   .where(inArray(cars.make, ['Ford', 'GM']))
+ * ```
+ *
+ * @see notInArray for the inverse of this test
+ */
+export function inArray<T>(
+	column: SQL.Aliased<T>,
+	values: (T | Placeholder)[] | SQLWrapper,
+): SQL;
+export function inArray<TColumn extends Column>(
+	column: TColumn,
+	values: ReadonlyArray<GetColumnData<TColumn, 'raw'> | Placeholder> | SQLWrapper,
+): SQL;
+export function inArray<T extends SQLWrapper>(
+	column: Exclude<T, SQL.Aliased | Column>,
+	values: ReadonlyArray<unknown | Placeholder> | SQLWrapper,
+): SQL;
+export function inArray(
+	column: SQLWrapper,
+	values: ReadonlyArray<unknown | Placeholder> | SQLWrapper,
+): SQL {
+	if (Array.isArray(values)) {
+		if (values.length === 0) {
+			return sql`1 = 0`;
+		}
+		return sql`${column} in ${values.map((v) => bindIfParam(v, column))}`;
+	}
+
+	return sql`${column} in ${bindIfParam(values, column)}`;
+}
+
+/**
+ * Test whether the first parameter, a column or expression,
+ * has a value that is not present in a list passed as the
+ * second argument.
+ *
+ * T-SQL has no `true`/`false` keywords, so an empty array
+ * is rendered as the always-true predicate `1 = 1`.
+ *
+ * ## Examples
+ *
+ * ```ts
+ * // Select cars made by any company except Ford or GM.
+ * db.select().from(cars)
+ *   .where(notInArray(cars.make, ['Ford', 'GM']))
+ * ```
+ *
+ * @see inArray for the inverse of this test
+ */
+export function notInArray<T>(
+	column: SQL.Aliased<T>,
+	values: (T | Placeholder)[] | SQLWrapper,
+): SQL;
+export function notInArray<TColumn extends Column>(
+	column: TColumn,
+	values: (GetColumnData<TColumn, 'raw'> | Placeholder)[] | SQLWrapper,
+): SQL;
+export function notInArray<T extends SQLWrapper>(
+	column: Exclude<T, SQL.Aliased | Column>,
+	values: (unknown | Placeholder)[] | SQLWrapper,
+): SQL;
+export function notInArray(
+	column: SQLWrapper,
+	values: (unknown | Placeholder)[] | SQLWrapper,
+): SQL {
+	if (Array.isArray(values)) {
+		if (values.length === 0) {
+			return sql`1 = 1`;
+		}
+		return sql`${column} not in ${values.map((v) => bindIfParam(v, column))}`;
+	}
+
+	return sql`${column} not in ${bindIfParam(values, column)}`;
+}
 
 // type ConcatValue = string | number | Placeholder | SQLWrapper;
 //

--- a/integration-tests/tests/mssql/mssql.test.ts
+++ b/integration-tests/tests/mssql/mssql.test.ts
@@ -17,6 +17,7 @@ import {
 	max,
 	min,
 	Name,
+	notInArray,
 	sql,
 	sum,
 	sumDistinct,
@@ -1641,6 +1642,34 @@ test('with ... select', async ({ db }) => {
 			product: 'B',
 			productUnits: 9,
 			productSales: 90,
+		},
+	]);
+});
+
+test('inArray with empty array', async ({ db }) => {
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db
+		.select()
+		.from(usersTable)
+		.where(inArray(usersTable.id, []));
+
+	expect(result).toEqual([]);
+});
+
+test('notInArray with empty array', async ({ db }) => {
+	await db.insert(usersTable).values({ name: 'John' });
+	const result = await db
+		.select()
+		.from(usersTable)
+		.where(notInArray(usersTable.id, []));
+
+	expect(result).toEqual([
+		{
+			id: 1,
+			name: 'John',
+			verified: false,
+			jsonb: null,
+			createdAt: result[0]!.createdAt,
 		},
 	]);
 });


### PR DESCRIPTION
## Problem
`inArray(column, [])` and `notInArray(column, [])` render as
`sql`false`` / `sql`true`` in the shared expression code
(`sql/expressions/conditions.ts`). This is correct for Postgres,
MySQL, and SQLite, but T-SQL has no `true`/`false` keywords, so
these queries fail on the mssql driver.

## Fix
Override `inArray`/`notInArray` in `mssql-core/expressions.ts` to use
`1 = 0` (always false) and `1 = 1` (always true) for the empty-array
case, while leaving every other dialect untouched. This follows the
same per-dialect override pattern already used in this file for
`concat()` and `substring()`.

## Testing
- Added integration tests in `integration-tests/tests/mssql/mssql.test.ts`
  covering `inArray`/`notInArray` with an empty array.
- Verified `tsc --noEmit` introduces no new type errors.

Fixes drizzle-team/drizzle-orm#5632