### PR TITLE
fix(drizzle-kit): preserve commas inside MySQL enum values in snapshots (#5957)

### DIFF
--- a/drizzle-kit/src/serializer/mysqlSerializer.ts
+++ b/drizzle-kit/src/serializer/mysqlSerializer.ts
@@ -34,9 +34,13 @@ export const indexName = (tableName: string, columns: string[]) => {
 };
 
 const handleEnumType = (type: string) => {
-	let str = type.split('(')[1];
-	str = str.substring(0, str.length - 1);
-	const values = str.split(',').map((v) => `'${escapeSingleQuotes(v.substring(1, v.length - 1))}'`);
+	// Values are raw strings wrapped in single quotes and joined by commas (see
+	// MySqlEnumColumn.getSQLType), so a single value may itself contain a comma.
+	// Take the content between the first '(' and last ')', strip the outer quotes,
+	// and split on the "','" delimiter between values rather than on every comma.
+	const body = type.substring(type.indexOf('(') + 1, type.lastIndexOf(')'));
+	const inner = body.substring(1, body.length - 1);
+	const values = inner.split("','").map((v) => `'${escapeSingleQuotes(v)}'`);
 	return `enum(${values.join(',')})`;
 };
 

--- a/drizzle-kit/tests/mysql.test.ts
+++ b/drizzle-kit/tests/mysql.test.ts
@@ -862,6 +862,46 @@ test('optional db aliases (camel case)', async () => {
 	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6]);
 });
 
+test('add table with enum values containing commas', async () => {
+	const to = {
+		users: mysqlTable('users', {
+			plain: mysqlEnum('plain', ['a', 'b', 'c']),
+			withComma: mysqlEnum('with_comma', ['a,b', 'c']),
+		}),
+	};
+
+	const { statements } = await diffTestSchemasMysql({}, to, []);
+
+	expect(statements.length).toBe(1);
+	expect(statements[0]).toStrictEqual({
+		type: 'create_table',
+		tableName: 'users',
+		schema: undefined,
+		columns: [{
+			autoincrement: false,
+			name: 'plain',
+			notNull: false,
+			primaryKey: false,
+			type: "enum('a','b','c')",
+		}, {
+			autoincrement: false,
+			name: 'with_comma',
+			notNull: false,
+			primaryKey: false,
+			// A comma inside a value must not be treated as a value separator.
+			type: "enum('a,b','c')",
+		}],
+		compositePKs: [],
+		internals: {
+			tables: {},
+			indexes: {},
+		},
+		uniqueConstraints: [],
+		compositePkName: '',
+		checkConstraints: [],
+	});
+});
+
 test('add table with ts enum', async () => {
 	enum Test {
 		value = 'value',


### PR DESCRIPTION
Fixes #5957.

## Problem

`handleEnumType` in `drizzle-kit/src/serializer/mysqlSerializer.ts` splits the enum body on every comma:

```ts
const values = str.split(',').map((v) => `'${escapeSingleQuotes(v.substring(1, v.length - 1))}'`);
```

`MySqlEnumColumn.getSQLType()` emits enum values as raw, single-quoted strings joined by commas, so a value that itself contains a comma gets split apart. For `mysqlEnum('col', ['a,b', 'c'])` (type `enum('a,b','c')`) the generated snapshot column type comes out corrupted as `enum('','','c')`.

## Fix

Take the content between the first `(` and last `)`, strip the outer quotes, and split on the `','` delimiter between values rather than on every comma. Plain enums round-trip unchanged.

## Test

Added `add table with enum values containing commas` in `drizzle-kit/tests/mysql.test.ts`, modeled on the existing `add table with ts enum` test (no database required). It asserts that a plain enum still produces `enum('a','b','c')` and a comma-containing enum produces `enum('a,b','c')`. The test fails on the current code (`enum('','','c')`) and passes with the fix.

## Notes

- Scoped to the comma bug. Separately, `getSQLType()` emits values unescaped, so an enum value containing a literal `'` produces malformed SQL; that looks like a pre-existing issue deserving its own PR and is not addressed here.
- I could not run the full `pnpm test` end to end locally because the workspace `drizzle-orm` dist build fails on Windows (a `tsc` path-separator issue in the build tooling, unrelated to this change). The regression test was run against the real `generateMySqlSnapshot` code path via vitest; CI should run the standard harness cleanly.
