### PR TITLE
feat(effect-tursodatabase): Effect-native driver for the Rust Turso engine (closes #5962)

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -57,6 +57,7 @@
 		"@effect/sql-sqlite-do": ">=4.0.0-beta.83 || >=4.0.0",
 		"@effect/sql-sqlite-node": ">=4.0.0-beta.83 || >=4.0.0",
 		"@effect/sql-sqlite-wasm": ">=4.0.0-beta.83 || >=4.0.0",
+		"@effect/sql-tursodatabase": ">=4.0.0-beta.83 || >=4.0.0",
 		"@electric-sql/pglite": ">=0.2.0",
 		"@libsql/client": ">=0.10.0",
 		"@libsql/client-wasm": ">=0.10.0",
@@ -227,6 +228,9 @@
 		"@effect/sql-libsql": {
 			"optional": true
 		},
+		"@effect/sql-tursodatabase": {
+			"optional": true
+		},
 		"typebox": {
 			"optional": true
 		},
@@ -250,6 +254,7 @@
 		"@effect/sql-sqlite-do": "4.0.0-beta.83",
 		"@effect/sql-sqlite-node": "4.0.0-beta.83",
 		"@effect/sql-sqlite-wasm": "4.0.0-beta.83",
+		"@effect/sql-tursodatabase": "4.0.0-beta.83",
 		"@electric-sql/pglite": "^0.4.6",
 		"@libsql/client": "^0.10.0",
 		"@libsql/client-wasm": "^0.10.0",

--- a/drizzle-orm/src/effect-tursodatabase/driver.ts
+++ b/drizzle-orm/src/effect-tursodatabase/driver.ts
@@ -1,0 +1,86 @@
+import { TursoClient } from '@effect/sql-tursodatabase/TursoClient';
+import * as Effect from 'effect/Effect';
+import { EffectCache } from '~/cache/core/cache-effect.ts';
+import { DefaultServices } from '~/effect-core/defaults.ts';
+import { EffectLogger } from '~/effect-core/index.ts';
+import { entityKind } from '~/entity.ts';
+import type { AnyRelations, EmptyRelations } from '~/relations.ts';
+import { SQLiteDialect } from '~/sqlite-core/dialect.ts';
+import { SQLiteEffectDatabase } from '~/sqlite-core/effect/db.ts';
+import type { EffectDrizzleSQLiteConfig } from '~/sqlite-core/effect/utils.ts';
+import { jitCompatCheck } from '~/utils.ts';
+import {
+	type EffectTursoDatabaseQueryEffectHKT,
+	type EffectTursoDatabaseRunResult,
+	EffectTursoDatabaseSession,
+} from './session.ts';
+export { DefaultServices } from '~/effect-core/defaults.ts';
+
+export class EffectTursoDatabaseDatabase<TRelations extends AnyRelations = EmptyRelations>
+	extends SQLiteEffectDatabase<EffectTursoDatabaseQueryEffectHKT, EffectTursoDatabaseRunResult, TRelations>
+{
+	static override readonly [entityKind]: string = 'EffectTursoDatabaseDatabase';
+}
+
+/**
+ * Creates an EffectTursoDatabaseDatabase instance.
+ *
+ * Requires `TursoClient`, `EffectLogger`, and `EffectCache` services to be provided.
+ * Use `DefaultServices` to provide default (no-op) logger and cache implementations.
+ *
+ * @example
+ * ```ts
+ * // With default services (no logging, no caching)
+ * const db = yield* TursoDrizzle.make({ relations }).pipe(
+ *   Effect.provide(TursoDrizzle.DefaultServices),
+ * );
+ *
+ * // With Effect-based logging
+ * const db = yield* TursoDrizzle.make({ relations }).pipe(
+ *   Effect.provide(EffectLogger.layer),
+ *   Effect.provide(TursoDrizzle.DefaultServices),
+ * );
+ *
+ * // With custom Drizzle logger
+ * const db = yield* TursoDrizzle.make({ relations }).pipe(
+ *   Effect.provide(EffectLogger.layerFromDrizzle(myLogger)),
+ *   Effect.provide(TursoDrizzle.DefaultServices),
+ * );
+ * ```
+ */
+export const make = Effect.fn('TursoDrizzle.make')(
+	function*<
+		TRelations extends AnyRelations = EmptyRelations,
+	>(config: EffectDrizzleSQLiteConfig<TRelations> = {}) {
+		const client = yield* TursoClient;
+		const cache = yield* EffectCache;
+		const logger = yield* EffectLogger;
+
+		const dialect = new SQLiteDialect({
+			useJitMappers: jitCompatCheck(config.jit),
+		});
+
+		const relations = config.relations ?? {} as TRelations;
+		const session = new EffectTursoDatabaseSession(client, dialect, relations, {
+			logger,
+			cache,
+		});
+		const db = new EffectTursoDatabaseDatabase(dialect, session, relations);
+		(<any> db).$client = client;
+		(<any> db).$cache = cache;
+		if ((<any> db).$cache) {
+			(<any> db).$cache['invalidate'] = cache.onMutate;
+		}
+
+		return db as EffectTursoDatabaseDatabase<TRelations> & {
+			$client: TursoClient;
+		};
+	},
+);
+
+/**
+ * Convenience function that creates an EffectTursoDatabaseDatabase with `DefaultServices` already provided.
+ */
+export const makeWithDefaults = <
+	TRelations extends AnyRelations = EmptyRelations,
+>(config: EffectDrizzleSQLiteConfig<TRelations> = {}) => make(config).pipe(Effect.provide(DefaultServices));

--- a/drizzle-orm/src/effect-tursodatabase/index.ts
+++ b/drizzle-orm/src/effect-tursodatabase/index.ts
@@ -1,0 +1,3 @@
+export { EffectLogger } from '~/effect-core/index.ts';
+export * from './driver.ts';
+export * from './session.ts';

--- a/drizzle-orm/src/effect-tursodatabase/migrator.ts
+++ b/drizzle-orm/src/effect-tursodatabase/migrator.ts
@@ -1,0 +1,13 @@
+import type { MigrationConfig } from '~/migrator.ts';
+import { readMigrationFiles } from '~/migrator.ts';
+import type { AnyRelations } from '~/relations.ts';
+import { migrate as coreMigrate } from '~/sqlite-core/effect/session.ts';
+import type { EffectTursoDatabaseDatabase } from './driver.ts';
+
+export function migrate<TRelations extends AnyRelations>(
+	db: EffectTursoDatabaseDatabase<TRelations>,
+	config: MigrationConfig,
+) {
+	const migrations = readMigrationFiles(config);
+	return coreMigrate(migrations, db.session, config);
+}

--- a/drizzle-orm/src/effect-tursodatabase/session.ts
+++ b/drizzle-orm/src/effect-tursodatabase/session.ts
@@ -1,0 +1,120 @@
+import type { TursoClient } from '@effect/sql-tursodatabase/TursoClient';
+import * as Effect from 'effect/Effect';
+import type { SqlError } from 'effect/unstable/sql/SqlError';
+import type { EffectCacheShape } from '~/cache/core/cache-effect.ts';
+import type { WithCacheConfig } from '~/cache/core/types.ts';
+import type { EffectDrizzleQueryError } from '~/effect-core/errors.ts';
+import type { EffectLoggerShape } from '~/effect-core/logger.ts';
+import type { QueryEffectHKTBase } from '~/effect-core/query-effect.ts';
+import { entityKind } from '~/entity.ts';
+import type { AnyRelations } from '~/relations.ts';
+import type { Query } from '~/sql/sql.ts';
+import type { SQLiteDialect } from '~/sqlite-core/dialect.ts';
+import {
+	SQLiteEffectPreparedQuery,
+	type SQLiteEffectQueryExecutors,
+	SQLiteEffectSession,
+	SQLiteEffectTransaction,
+} from '~/sqlite-core/effect/session.ts';
+import type { PreparedQueryConfig, SQLiteExecuteMethod } from '~/sqlite-core/session.ts';
+
+export interface EffectTursoDatabaseQueryEffectHKT extends QueryEffectHKTBase {
+	readonly error: EffectDrizzleQueryError;
+	readonly context: never;
+}
+
+export type EffectTursoDatabaseRunResult = unknown;
+
+export interface EffectTursoDatabaseSessionOptions {
+	logger: EffectLoggerShape;
+	cache: EffectCacheShape;
+}
+
+export class EffectTursoDatabaseSession<TRelations extends AnyRelations>
+	extends SQLiteEffectSession<EffectTursoDatabaseRunResult, EffectTursoDatabaseQueryEffectHKT, TRelations>
+{
+	static override readonly [entityKind]: string = 'EffectTursoDatabaseSession';
+
+	constructor(
+		private client: TursoClient,
+		dialect: SQLiteDialect,
+		protected relations: TRelations,
+		private options: EffectTursoDatabaseSessionOptions,
+	) {
+		super(dialect);
+	}
+
+	override prepareQuery<T extends PreparedQueryConfig = PreparedQueryConfig>(
+		query: Query,
+		mode: 'arrays' | 'objects' | 'raw',
+		_prepare: boolean,
+		executeMethod?: SQLiteExecuteMethod,
+		mapper?: (rows: any[]) => any,
+		queryMetadata?: {
+			type: 'select' | 'update' | 'delete' | 'insert';
+			tables: string[];
+		},
+		cacheConfig?: WithCacheConfig,
+	): SQLiteEffectPreparedQuery<T, EffectTursoDatabaseQueryEffectHKT> {
+		const executors: SQLiteEffectQueryExecutors = {
+			all: (params) => {
+				const q = this.client.unsafe(query.sql, params);
+
+				if (mode === 'arrays') return q.values;
+				return q.withoutTransform;
+			},
+			get: (params) => {
+				const q = this.client.unsafe(query.sql, params);
+
+				if (mode === 'arrays') return q.values.pipe(Effect.map((e) => e[0]));
+				return q.withoutTransform.pipe(Effect.map((e) => e[0]));
+			},
+			values: (params) => this.client.unsafe(query.sql, params).values,
+			run: (params) => this.client.unsafe(query.sql, params).raw,
+		};
+
+		return new SQLiteEffectPreparedQuery<T, EffectTursoDatabaseQueryEffectHKT>(
+			executeMethod,
+			executors,
+			query,
+			mapper,
+			mode,
+			this.options.logger,
+			this.options.cache,
+			queryMetadata,
+			cacheConfig,
+		);
+	}
+
+	override transaction<A, E, R>(
+		transaction: (
+			tx: EffectTursoDatabaseTransaction<TRelations>,
+		) => Effect.Effect<A, E, R>,
+	): Effect.Effect<A, E | SqlError, R> {
+		const { dialect, relations } = this;
+
+		return this.client.withTransaction(Effect.gen({ self: this }, function*() {
+			const tx = new EffectTursoDatabaseTransaction<TRelations>(
+				dialect,
+				this,
+				relations,
+			);
+
+			return yield* transaction(tx);
+		}));
+	}
+}
+
+export class EffectTursoDatabaseTransaction<TRelations extends AnyRelations>
+	extends SQLiteEffectTransaction<EffectTursoDatabaseQueryEffectHKT, EffectTursoDatabaseRunResult, TRelations>
+{
+	static override readonly [entityKind]: string = 'EffectTursoDatabaseTransaction';
+
+	override transaction<A, E, R>(
+		transaction: (
+			tx: SQLiteEffectTransaction<EffectTursoDatabaseQueryEffectHKT, EffectTursoDatabaseRunResult, TRelations>,
+		) => Effect.Effect<A, E, R>,
+	): Effect.Effect<A, E | SqlError, R> {
+		return this.session.transaction(transaction);
+	}
+}


### PR DESCRIPTION
Closes #5962.

## What

Adds the **`drizzle-orm/effect-tursodatabase`** entrypoint — an Effect-native driver for the in-process **Rust Turso engine** (`@tursodatabase/database`) — at full parity with `drizzle-orm/effect-libsql`.

- queries return `Effect` instead of `Promise`
- the connection is a composable `Layer` (`TursoClient.layer` from `@effect/sql-tursodatabase`)
- typed `SqlError`
- interruption + OpenTelemetry tracing + transactions come from the shared `sqlite-core/effect` session (identical to every other `effect-*` driver)

API mirrors `effect-libsql` exactly:

```ts
import { TursoClient } from "@effect/sql-tursodatabase"
import * as TursoDrizzle from "drizzle-orm/effect-tursodatabase"
import { Effect } from "effect"

const program = Effect.gen(function*() {
  const db = yield* TursoDrizzle.makeWithDefaults({ relations })
  const rows = yield* db.select().from(tasks) // Effect, typed SqlError, interruptible
}).pipe(Effect.provide(TursoClient.layer({ url: ":memory:" })))
```

## Why

`1.0.0-rc.4` shipped the Effect v4 driver matrix but left the Rust Turso engine as the only major driver with just the regular async driver (`drizzle-orm/tursodatabase`) and no Effect-native variant. Users wanting the Rust engine specifically (MVCC / `BEGIN CONCURRENT` concurrent writes, CDC) had to choose between "real Rust Turso (no Effect-native)" and "Effect-native (libSQL / plain SQLite only)". This closes that gap.

## Dependency

This entrypoint is built on a new first-party Effect SQL client, **`@effect/sql-tursodatabase`** (`TursoClient`), submitted upstream as Effect-TS/effect-smol#2509 — the same relationship `effect-libsql` has with `@effect/sql-libsql`. The peer/dev/optional-peer wiring in `drizzle-orm/package.json` matches the existing `@effect/sql-*` entries. The lockfile is intentionally not touched here: `@effect/sql-tursodatabase` needs to be published first (coordinated with the upstream PR); regenerate the lockfile at that point, exactly as for the other `@effect/sql-*` betas.

## Test

Verified end-to-end against a real in-memory Turso engine (local build of `@effect/sql-tursodatabase` linked in): `CREATE` / `INSERT` / `SELECT` and a `db.transaction(...)` all flow correctly through `effect-tursodatabase` → `TursoClient` → the Rust engine. `tsc --noEmit`, `oxlint`, and `dprint` are clean on the new files. Follow-ups (out of scope here): Effect variants for `tursodatabase-serverless` and `tursodatabase-sync`.
