### PR TITLE
fix(drizzle-zod): default TCoerce to undefined in createSchemaFactory

### DIFF
--- a/drizzle-zod/src/schema.ts
+++ b/drizzle-zod/src/schema.ts
@@ -119,7 +119,7 @@ export const createUpdateSchema: CreateUpdateSchema<undefined> = (
 };
 
 export function createSchemaFactory<
-	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
+	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined = undefined,
 >(options?: CreateSchemaFactoryOptions<TCoerce>) {
 	const createSelectSchema: CreateSelectSchema<TCoerce> = (
 		entity: Table | View | PgEnum<[string, ...string[]]>,


### PR DESCRIPTION
Fixes #5968

## Root cause

`createSchemaFactory` has a generic `TCoerce` with no default:

```ts
export function createSchemaFactory<
  TCoerce extends Partial<Record<...>> | true | undefined,
>(options?: CreateSchemaFactoryOptions<TCoerce>)
```

When the caller omits the `coerce` option (e.g. `createSchemaFactory({ zodInstance: z })`), TypeScript cannot infer `TCoerce` from the argument and falls back to the full constraint bound: `Partial<Record<...>> | true | undefined`.

This union propagates into `GetZodType`, where `CanCoerce<TCoerce, 'string'>` distributes over the union and returns `boolean`. The conditional type then produces `z.ZodCoercedString | z.ZodString` for string columns.

`BuildRefineField` is distributive over its input, so it produces two function overloads with incompatible parameter types:

```
((schema: z.ZodCoercedString) => z.ZodType) | ((schema: z.ZodString) => z.ZodType) | z.ZodType
```

TypeScript cannot contextually type a callback against a union of function types with different parameter types, so `schema` widens to `any` (ts 7006).

The top-level `createInsertSchema` / `createSelectSchema` / `createUpdateSchema` exports explicitly use `CreateInsertSchema<undefined>`, which is why they work correctly.

## Fix

Add `= undefined` as the default type parameter for `TCoerce` in `createSchemaFactory`. When no `coerce` option is provided, `TCoerce` now defaults to `undefined` instead of widening to the full constraint bound — matching the behaviour of the top-level exports.