### PR TITLE
Avoid passing name: undefined to underlying pg infrastructure

### DIFF
--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -42,7 +42,7 @@ export class NodePgPreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 	) {
 		super({ sql: queryString, params }, cache, queryMetadata, cacheConfig);
 		this.rawQueryConfig = {
-			name,
+			...(name === undefined ? {} : { name }),
 			text: queryString,
 			types: {
 				// @ts-ignore
@@ -85,7 +85,7 @@ export class NodePgPreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 			},
 		};
 		this.queryConfig = {
-			name,
+			...(name === undefined ? {} : { name }),
 			text: queryString,
 			rowMode: 'array',
 			types: {


### PR DESCRIPTION
First off, thanks for Drizzle!

I've been struggling for a bit trying to remove some boilerplate working around what seems to be a strange interplay between drizzle and `@opentelemetry/instrumentation-pg`, as if the `name` parameter is set [the instrumentation-pg library presumes the query is a prepared statement](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/2353bd7fbb75ae682c8dde42f32caa10a82bc315/packages/instrumentation-pg/src/instrumentation.ts#L393-L396), so instrumentation is not applied.

Existing discussion around this in `instrumentation-pg`, https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1705