### PR TITLE
fix(postgres-js): don't override Date serializer, only the parser (#5789)

### DIFF
--- a/drizzle-orm/src/postgres-js/driver.ts
+++ b/drizzle-orm/src/postgres-js/driver.ts
@@ -28,9 +28,14 @@ function construct<TSchema extends Record<string, unknown> = Record<string, neve
 	const transparentParser = (val: any) => val;
 
 	// Override postgres.js default date parsers: https://github.com/porsager/postgres/discussions/761
+	// Only the inbound *parsers* are neutralized here so Drizzle can parse the
+	// raw text itself. The outbound *serializers* for these OIDs must be left
+	// untouched — overriding them breaks JS `Date` params passed through raw
+	// `sql` templates, since postgres.js's Bind() step expects the serializer
+	// to produce a wire-safe string, not a `Date` instance passed straight
+	// through. See https://github.com/drizzle-team/drizzle-orm/issues/5789
 	for (const type of ['1184', '1082', '1083', '1114', '1182', '1185', '1115', '1231']) {
 		client.options.parsers[type as any] = transparentParser;
-		client.options.serializers[type as any] = transparentParser;
 	}
 	client.options.serializers['114'] = transparentParser;
 	client.options.serializers['3802'] = transparentParser;

--- a/drizzle-orm/tests/postgres-js/driver.test.ts
+++ b/drizzle-orm/tests/postgres-js/driver.test.ts
@@ -1,0 +1,59 @@
+import postgres from 'postgres';
+import { describe, expect, test } from 'vitest';
+import { drizzle } from '~/postgres-js/driver.ts';
+
+// Regression test for https://github.com/drizzle-team/drizzle-orm/issues/5789
+//
+// drizzle(client) neutralizes postgres-js's inbound *parsers* for date/timestamp
+// OIDs so Drizzle can parse the raw text itself. It must NOT also neutralize the
+// outbound *serializers* for those same OIDs — doing so causes postgres-js's
+// Bind() step to receive a raw `Date` instance instead of a wire-safe string,
+// which throws when postgres-js calls `Buffer.byteLength(date)`.
+const DATE_OIDS = ['1184', '1082', '1083', '1114', '1182', '1185', '1115', '1231'] as const;
+
+function createUnconnectedClient() {
+	// postgres-js is lazy: constructing a client does not open a socket, so this
+	// is safe to run without a live Postgres instance.
+	return postgres({ host: 'localhost', port: 5432, database: 'x', username: 'x', password: 'x' });
+}
+
+describe('postgres-js driver: date OID parser/serializer split', () => {
+	test('drizzle(client) leaves the outbound Date serializer intact (only neutralizes the inbound parser)', () => {
+		// Capture postgres-js's own default serializer before drizzle touches anything.
+		const reference = createUnconnectedClient();
+		const defaultSerializer = reference.options.serializers['1184'];
+		expect(typeof defaultSerializer).toBe('function');
+
+		const client = createUnconnectedClient();
+		drizzle(client);
+
+		const date = new Date('2026-05-20T12:00:00.000Z');
+
+		// The serializer must still behave like postgres-js's untouched default:
+		// it must convert the Date to a wire-safe string, not pass it through unchanged.
+		const serializer = client.options.serializers['1184']!;
+		const serialized: unknown = serializer(date);
+		expect(serialized).toBe(defaultSerializer!(date));
+		expect(serialized).not.toBeInstanceOf(Date);
+		expect(typeof serialized).toBe('string');
+
+		// A value produced by the outbound serializer must be safely encodable on
+		// the wire. This is exactly what postgres-js's Bind() step does internally
+		// (bytes.js `str()` -> `Buffer.byteLength()`), and is what throws
+		// `TypeError [ERR_INVALID_ARG_TYPE]` when the serializer is a passthrough.
+		expect(() => Buffer.byteLength(serialized as string)).not.toThrow();
+	});
+
+	test('drizzle(client) still neutralizes the inbound parser for date/timestamp OIDs', () => {
+		const client = createUnconnectedClient();
+		drizzle(client);
+
+		// This is the behavior the override was actually meant to provide: Drizzle
+		// wants the raw text back from Postgres so it can parse dates itself.
+		for (const oid of DATE_OIDS) {
+			const rawText = '2026-05-20 12:00:00+00';
+			const parser = client.options.parsers[oid]!;
+			expect(parser(rawText)).toBe(rawText);
+		}
+	});
+});

--- a/integration-tests/tests/pg/postgres-js.test.ts
+++ b/integration-tests/tests/pg/postgres-js.test.ts
@@ -488,3 +488,25 @@ test('insert via db.execute w/ query builder', async () => {
 	);
 	expect(Array.prototype.slice.call(result)).toEqual([{ id: 1, name: 'John' }]);
 });
+
+// Regression test for https://github.com/drizzle-team/drizzle-orm/issues/5789
+// A JS `Date` bound as a raw `sql` template parameter against a timestamptz
+// column must round-trip correctly, not throw `TypeError [ERR_INVALID_ARG_TYPE]`
+// from postgres.js's Bind() step.
+test('insert via raw sql`` with a Date param does not throw (#5789)', async () => {
+	const now = new Date();
+
+	await db.execute(
+		sql`insert into ${usersTable} (${new Name(usersTable.name.name)}, ${
+			new Name(usersTable.createdAt.name)
+		}) values (${'Jane'}, ${now})`,
+	);
+
+	const result = await db.execute<{ id: number; name: string; created_at: string }>(
+		sql`select id, name, created_at from "users" where name = ${'Jane'}`,
+	);
+	const rows = Array.prototype.slice.call(result);
+	expect(rows).toHaveLength(1);
+	expect(rows[0].name).toBe('Jane');
+	expect(new Date(rows[0].created_at).getTime()).toBe(now.getTime());
+});


### PR DESCRIPTION
## Summary

`drizzle()` for the postgres-js driver overrides postgres.js's outbound timestamp/date **serializers** alongside its inbound **parsers**, when only the parsers were meant to be overridden (see porsager/postgres#761). This breaks every `${jsDate}` parameter passed through a raw `sql` template, throwing `TypeError [ERR_INVALID_ARG_TYPE]` from postgres.js's `Bind()` step.

Closes #5789

## Root cause

`src/postgres-js/driver.ts`, in `construct()`:

```ts
for (const type of ['1184', '1082', '1083', '1114', '1182', '1185', '1115', '1231']) {
  client.options.parsers[type as any] = transparentParser;
  client.options.serializers[type as any] = transparentParser; // <- rebinds outbound serializer too
}
```

postgres.js's default serializer for OID 1184 is `x => (x instanceof Date ? x : new Date(x)).toISOString()`. After this override the passthrough returns the raw `Date` unchanged; postgres.js's `Bind()` then calls `Buffer.byteLength(date)`, which throws.

## Fix

Drop the serializer override from the date-OID loop; keep only the parser override (the documented intent per porsager/postgres#761). The unrelated json/jsonb serializer overrides (OIDs 114/3802) are untouched.

**Alternative considered and rejected:** keep a serializer override but make it "actually serialize" (`x => x instanceof Date ? x.toISOString() : x`). Rejected, it duplicates postgres.js's own default Date serializer and risks drifting from its implementation. Dropping the override and falling back to postgres.js's default is narrower.

## Tests

- `tests/postgres-js/driver.test.ts` (new): source-level unit test against the real `construct()` using an **unconnected** postgres.js client (no live DB, postgres.js only opens a socket on first query). Asserts the outbound serializer for OID 1184 still matches postgres.js's default and produces a wire-safe string, while the inbound parser stays neutralized. RED (before): 1 failed / 1 passed → GREEN (after): 2 passed.
- `integration-tests/tests/pg/postgres-js.test.ts` (new case, `insert via raw sql with a Date param does not throw (#5789)`): end-to-end reproduction against a `timestamptz` column. **This test requires a live Postgres and was not executed in my environment**, included for CI/reviewer verification.

## Verification run locally

- `vitest run` (drizzle-orm package): 568/568 passed
- `tsc -p tests/tsconfig.json --noEmit` (strict): 0 errors
- `dprint check` + `eslint` on changed files: clean

