### PR TITLE
Fix drizzle-kit pull failing on comments in view definitions

### DIFF
--- a/drizzle-kit/src/dialects/mssql/grammar.ts
+++ b/drizzle-kit/src/dialects/mssql/grammar.ts
@@ -112,8 +112,14 @@ export const parseFkAction = (type: string): OnAction => {
 	}
 };
 
-const viewAsStatementRegex =
-	/\bAS\b\s*\(?\s*(WITH[\s\S]+?SELECT[\s\S]*?|SELECT[\s\S]*?)\)?(?=\s+WITH CHECK OPTION\b|\s*;?$)/i;
+// whitespace, `-- line` comments and `/* block */` comments allowed between AS and the view body
+// https://github.com/drizzle-team/drizzle-orm/issues/5964
+const commentableGap = String.raw`(?:\s|--[^\n]*(?:\n|$)|/\*[\s\S]*?\*/)*`;
+const viewAsStatementRegex = new RegExp(
+	String
+		.raw`\bAS\b${commentableGap}\(?${commentableGap}(WITH[\s\S]+?SELECT[\s\S]*?|SELECT[\s\S]*?)\)?(?=\s+WITH CHECK OPTION\b|\s*;?$)`,
+	'i',
+);
 export const parseViewSQL = (sql: string | null): string | null => {
 	if (!sql) return ''; // this means that used is_encrypted
 

--- a/drizzle-kit/src/dialects/sqlite/grammar.ts
+++ b/drizzle-kit/src/dialects/sqlite/grammar.ts
@@ -6,7 +6,10 @@ import type { Import } from './typescript';
 
 const namedCheckPattern = /CONSTRAINT\s+["'`[]?(\w+)["'`\]]?\s+CHECK\s*\((.*)\)/gi;
 const unnamedCheckPattern = /CHECK\s+\((.*)\)/gi;
-const viewAsStatementRegex = new RegExp(`\\bAS\\b\\s+(WITH.+|SELECT.+)$`, 'is'); // 'i' for case-insensitive, 's' for dotall mode
+// whitespace, `-- line` comments and `/* block */` comments allowed between AS and the view body
+// https://github.com/drizzle-team/drizzle-orm/issues/5964
+const commentableGap = String.raw`(?:\s|--[^\n]*(?:\n|$)|/\*[\s\S]*?\*/)*`;
+const viewAsStatementRegex = new RegExp(`\\bAS\\b${commentableGap}((?:WITH|SELECT).+)$`, 'is'); // 'i' for case-insensitive, 's' for dotall mode
 
 export const nameForForeignKey = (fk: Pick<ForeignKey, 'table' | 'columns' | 'tableTo' | 'columnsTo'>) => {
 	return `fk_${fk.table}_${fk.columns.join('_')}_${fk.tableTo}_${fk.columnsTo.join('_')}_fk`;

--- a/drizzle-kit/tests/mssql/grammar.test.ts
+++ b/drizzle-kit/tests/mssql/grammar.test.ts
@@ -1,0 +1,76 @@
+import { parseViewSQL } from 'src/dialects/mssql/grammar';
+import { expect, test } from 'vitest';
+
+// https://github.com/drizzle-team/drizzle-orm/issues/5964
+test.each([
+	[
+		'plain view',
+		'CREATE VIEW dbo.vCustomer AS\nSELECT CustomerId, [Name] FROM dbo.Customer',
+		'SELECT CustomerId, [Name] FROM dbo.Customer',
+	],
+	[
+		'block comment between AS and SELECT',
+		'CREATE VIEW dbo.vCustomer WITH SCHEMABINDING AS\n/* comment */\nSELECT CustomerId,\n       [Name]\n  FROM dbo.Customer',
+		'SELECT CustomerId,\n       [Name]\n  FROM dbo.Customer',
+	],
+	[
+		'line comment between AS and SELECT',
+		'CREATE VIEW dbo.vCustomer AS\n-- comment\nSELECT CustomerId FROM dbo.Customer',
+		'SELECT CustomerId FROM dbo.Customer',
+	],
+	[
+		'mixed comments between AS and SELECT',
+		'CREATE VIEW dbo.vCustomer AS /* a */ -- b\n/* c */ SELECT CustomerId FROM dbo.Customer',
+		'SELECT CustomerId FROM dbo.Customer',
+	],
+	[
+		'parenthesized body',
+		'CREATE VIEW dbo.vCustomer AS (SELECT CustomerId FROM dbo.Customer)',
+		'SELECT CustomerId FROM dbo.Customer',
+	],
+	[
+		'comment inside parenthesized body',
+		'CREATE VIEW dbo.vCustomer AS ( /* comment */ SELECT CustomerId FROM dbo.Customer)',
+		'SELECT CustomerId FROM dbo.Customer',
+	],
+	[
+		'with check option',
+		'CREATE VIEW dbo.vCustomer AS SELECT CustomerId FROM dbo.Customer WITH CHECK OPTION',
+		'SELECT CustomerId FROM dbo.Customer',
+	],
+	[
+		'comment before body with check option',
+		'CREATE VIEW dbo.vCustomer AS /* comment */ SELECT CustomerId FROM dbo.Customer WITH CHECK OPTION',
+		'SELECT CustomerId FROM dbo.Customer',
+	],
+	[
+		'cte body',
+		'CREATE VIEW dbo.vCustomer AS WITH cte AS (SELECT 1 AS x) SELECT * FROM cte',
+		'WITH cte AS (SELECT 1 AS x) SELECT * FROM cte',
+	],
+	[
+		'comment between AS and cte body',
+		'CREATE VIEW dbo.vCustomer AS /* comment */ WITH cte AS (SELECT 1 AS x) SELECT * FROM cte',
+		'WITH cte AS (SELECT 1 AS x) SELECT * FROM cte',
+	],
+	[
+		'trailing semicolon',
+		'CREATE VIEW dbo.vCustomer AS SELECT CustomerId FROM dbo.Customer;',
+		'SELECT CustomerId FROM dbo.Customer',
+	],
+	[
+		'column alias does not anchor the match',
+		'CREATE VIEW dbo.vCustomer AS SELECT CustomerId AS id FROM dbo.Customer',
+		'SELECT CustomerId AS id FROM dbo.Customer',
+	],
+])('parseViewSQL: %s', (_, sql, expected) => {
+	expect(parseViewSQL(sql)).toBe(expected);
+});
+
+test('parseViewSQL: null definition means encrypted view', () => {
+	expect(parseViewSQL(null)).toBe('');
+});
+
+test('parseViewSQL: non-view sql returns null', () => {
+	expect(parseViewSQL('not a view definition')).toBe(null);
+});

--- a/drizzle-kit/tests/sqlite/grammar.test.ts
+++ b/drizzle-kit/tests/sqlite/grammar.test.ts
@@ -20,7 +20,33 @@ beforeEach(async () => {
 });
 
 test('view definition', () => {
-	parseViewSQL('CREATE VIEW current_cycle AS\nSELECT\n* from users;');
+	expect(parseViewSQL('CREATE VIEW current_cycle AS\nSELECT\n* from users;')).toBe('SELECT\n* from users;');
+});
+
+// https://github.com/drizzle-team/drizzle-orm/issues/5964
+test.each([
+	[
+		'block comment between AS and SELECT',
+		'CREATE VIEW current_cycle AS /* comment */ SELECT * from users',
+		'SELECT * from users',
+	],
+	[
+		'line comment between AS and SELECT',
+		'CREATE VIEW current_cycle AS\n-- comment\nSELECT * from users',
+		'SELECT * from users',
+	],
+	[
+		'column alias does not anchor the match',
+		'CREATE VIEW current_cycle AS SELECT id AS user_id from users',
+		'SELECT id AS user_id from users',
+	],
+	[
+		'cte body with comment',
+		'CREATE VIEW current_cycle AS /* comment */ WITH cte AS (SELECT 1) SELECT * FROM cte',
+		'WITH cte AS (SELECT 1) SELECT * FROM cte',
+	],
+])('view definition: %s', (_, sql, expected) => {
+	expect(parseViewSQL(sql)).toBe(expected);
 });
 
 describe('parse ddl', (t) => {


### PR DESCRIPTION
Fixes #5964

### Root cause

SQL Server (`sys.sql_modules`) and SQLite (`sqlite_master`) store view definitions **verbatim, comments included**. `parseViewSQL` in both dialects required `SELECT`/`WITH` to follow `AS` with nothing but whitespace in between, so a `/* block */` or `-- line` comment between `AS` and the view body made the regex fail, and `drizzle-kit pull` threw `Could not process view <name>` — a hard failure for any database with commented views.

### Fix

Both regexes now allow whitespace **and comments** between `AS` (and the optional opening paren) and the view body. The captured definition is unchanged for all previously-working inputs: capture still starts at `SELECT`/`WITH`, and comments inside the body still ride along verbatim — so no diff churn for existing users.

Postgres and MySQL are unaffected by design: they read `pg_get_viewdef()` / `information_schema.VIEW_DEFINITION`, which the servers regenerate in normalized, comment-free form. Other MSSQL introspection inputs (checks, defaults, computed columns, index predicates) come from normalized `sys.*` catalog text and can't contain comments.

### Tests

- `tests/mssql/grammar.test.ts` (new): the reporter's exact DDL, line/block/mixed comments, parenthesized bodies, CTEs, `WITH CHECK OPTION`, encrypted-view `null`, plus regressions for all previously-working shapes
- `tests/sqlite/grammar.test.ts`: existing smoke test now asserts its result; added comment/CTE/alias cases
- Full sqlite kit suite passes (258 tests); mssql grammar tests are pure string-level and run without a database

### Known limitation (deliberate)

T-SQL block comments can nest (`/* a /* b */ c */`); a regex can't parse nesting, so a nested comment in the gap would still fail. Handling that means a small tokenizer — happy to do it as a follow-up if you want it.
