### PR TITLE
fix(drizzle-kit): reference authUsers for FKs into Supabase auth.users

### DIFF
--- a/drizzle-kit/src/cli/commands/introspect.ts
+++ b/drizzle-kit/src/cli/commands/introspect.ts
@@ -753,6 +753,7 @@ export const relationsToTypeScript = (
 			string,
 			{
 				schema?: string;
+				name?: string;
 				foreignKeys: Record<
 					string,
 					{
@@ -772,6 +773,14 @@ export const relationsToTypeScript = (
 	casing: Casing,
 ) => {
 	const imports: string[] = [];
+	const supabaseImports: string[] = [];
+	// Supabase's `auth.users` is managed externally and usually excluded from `pull`; when it wasn't
+	// introspected, a FK into it must reference the shipped `authUsers` from `drizzle-orm/supabase`
+	// rather than a `./schema` import that won't exist. (If the user did introspect `auth`, the normal
+	// local reference is kept.)
+	const supabaseAuthUsers = !Object.values(schema.tables).some(
+		(t) => t.schema === 'auth' && t.name === 'users',
+	);
 	const tableRelations: Record<
 		string,
 		{
@@ -789,14 +798,16 @@ export const relationsToTypeScript = (
 
 	Object.values(schema.tables).forEach((table) => {
 		Object.values(table.foreignKeys).forEach((fk) => {
+			const fkToSupabaseAuthUsers = supabaseAuthUsers && fk.schemaTo === 'auth' && fk.tableTo === 'users';
 			const tableNameFrom = paramNameFor(fk.tableFrom, table.schema);
 			const tableNameTo = paramNameFor(fk.tableTo, fk.schemaTo);
 			const tableFrom = withCasing(tableNameFrom.replace(/:+/g, ''), casing);
-			const tableTo = withCasing(tableNameTo.replace(/:+/g, ''), casing);
+			const tableTo = fkToSupabaseAuthUsers ? 'authUsers' : withCasing(tableNameTo.replace(/:+/g, ''), casing);
 			const columnFrom = withCasing(fk.columnsFrom[0], casing);
 			const columnTo = withCasing(fk.columnsTo[0], casing);
 
-			imports.push(tableTo, tableFrom);
+			imports.push(tableFrom);
+			(fkToSupabaseAuthUsers ? supabaseImports : imports).push(tableTo);
 
 			// const keyFrom = `${schemaFrom}.${tableFrom}`;
 			const keyFrom = tableFrom;
@@ -833,12 +844,17 @@ export const relationsToTypeScript = (
 	});
 
 	const uniqueImports = [...new Set(imports)];
+	const uniqueSupabaseImports = [...new Set(supabaseImports)];
 
 	const importsTs = `import { relations } from "drizzle-orm/relations";\nimport { ${
 		uniqueImports.join(
 			', ',
 		)
-	} } from "./schema";\n\n`;
+	} } from "./schema";\n${
+		uniqueSupabaseImports.length > 0
+			? `import { ${uniqueSupabaseImports.join(', ')} } from "drizzle-orm/supabase";\n`
+			: ''
+	}\n`;
 
 	const relationStatements = Object.entries(tableRelations).map(
 		([table, relations]) => {

--- a/drizzle-kit/src/introspect-pg.ts
+++ b/drizzle-kit/src/introspect-pg.ts
@@ -505,6 +505,15 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 		})
 		.join('');
 
+	// Reference Supabase's managed `auth.users` via the `authUsers` import instead of an
+	// undeclared local table, but only when the `auth.users` table itself was not introspected
+	// (e.g. the user did not include the `auth` schema in their schema filter).
+	const authUsersEmitted = Object.values(schema.tables).some(
+		(t) => t.schema === 'auth' && t.name === 'users',
+	);
+	const usesSupabaseAuthUsers = !authUsersEmitted
+		&& Object.values(schema.tables).some((t) => Object.values(t.foreignKeys).some(isSupabaseAuthUsersFk));
+
 	const tableStatements = Object.values(schema.tables).map((table) => {
 		const tableSchema = schemas[table.schema];
 		const paramName = paramNameFor(table.name, tableSchema);
@@ -539,7 +548,7 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 			statement += ', ';
 			statement += '(table) => [';
 			statement += createTableIndexes(table.name, Object.values(table.indexes), casing);
-			statement += createTableFKs(Object.values(table.foreignKeys), schemas, casing);
+			statement += createTableFKs(Object.values(table.foreignKeys), schemas, casing, usesSupabaseAuthUsers);
 			statement += createTablePKs(
 				Object.values(table.compositePrimaryKeys),
 				casing,
@@ -608,7 +617,7 @@ export const schemaToTypeScript = (schema: PgSchemaInternal, casing: Casing) => 
 			', ',
 		)
 	} } from "drizzle-orm/pg-core"
-import { sql } from "drizzle-orm"\n\n`;
+import { sql } from "drizzle-orm"\n${usesSupabaseAuthUsers ? `import { authUsers } from "drizzle-orm/supabase"\n` : ''}\n`;
 
 	let decalrations = schemaStatements;
 	decalrations += rolesStatements;
@@ -1340,15 +1349,32 @@ const createTableChecks = (
 	return statement;
 };
 
-const createTableFKs = (fks: ForeignKey[], schemas: Record<string, string>, casing: Casing): string => {
+// Supabase manages the `auth.users` table; drizzle-orm ships it as `authUsers` in the
+// `drizzle-orm/supabase` entrypoint, so a FK targeting it must reference that import rather
+// than an (undeclared) local table produced from the un-introspected `auth` schema.
+const isSupabaseAuthUsersFk = (fk: ForeignKey) => fk.schemaTo === 'auth' && fk.tableTo === 'users';
+
+const createTableFKs = (
+	fks: ForeignKey[],
+	schemas: Record<string, string>,
+	casing: Casing,
+	supabaseAuthUsers: boolean,
+): string => {
 	let statement = '';
 
 	fks.forEach((it) => {
 		const tableSchema = schemas[it.schemaTo || ''];
 		const paramName = paramNameFor(it.tableTo, tableSchema);
 
+		// A FK into Supabase's managed `auth.users` must reference the `authUsers` import even when
+		// the local (referencing) table is itself named `users` — check it before the self-FK case,
+		// which only compares table names and would otherwise mis-emit `table` (a bogus self-reference).
 		const isSelf = it.tableTo === it.tableFrom;
-		const tableTo = isSelf ? 'table' : `${withCasing(paramName, casing)}`;
+		const tableTo = supabaseAuthUsers && isSupabaseAuthUsersFk(it)
+			? 'authUsers'
+			: isSelf
+			? 'table'
+			: `${withCasing(paramName, casing)}`;
 		statement += `\n\t`;
 		statement += `foreignKey({\n`;
 		statement += `\t\t\tcolumns: [${it.columnsFrom.map((i) => `table.${withCasing(i, casing)}`).join(', ')}],\n`;

--- a/drizzle-kit/tests/introspect/pg.test.ts
+++ b/drizzle-kit/tests/introspect/pg.test.ts
@@ -36,7 +36,10 @@ import {
 	varchar,
 } from 'drizzle-orm/pg-core';
 import fs from 'fs';
-import { introspectPgToFile } from 'tests/schemaDiffer';
+import { relationsToTypeScript } from 'src/cli/commands/introspect';
+import { schemaToTypeScript } from 'src/introspect-pg';
+import { fromDatabase } from 'src/serializer/pgSerializer';
+import { applyPgDiffs, introspectPgToFile } from 'tests/schemaDiffer';
 import { expect, test } from 'vitest';
 
 if (!fs.existsSync('tests/introspect/postgres')) {
@@ -925,4 +928,96 @@ test('multiple policies with roles from schema', async () => {
 
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
+});
+
+test('introspect FK to Supabase auth.users references authUsers from drizzle-orm/supabase', async () => {
+	const client = new PGlite();
+
+	// Supabase-shaped schema: an `auth` schema with `auth.users`, and a public table with a FK
+	// into `auth.users(id)`.
+	const auth = pgSchema('auth');
+	const authUsers = auth.table('users', {
+		id: uuid('id').primaryKey().notNull(),
+	});
+	const profiles = pgTable('profiles', {
+		id: uuid('id').primaryKey().notNull(),
+		userId: uuid('user_id')
+			.notNull()
+			.references(() => authUsers.id),
+	});
+
+	// Seed the auth schema + auth.users so the FK can be created...
+	const { sqlStatements } = await applyPgDiffs({ auth, authUsers, profiles }, undefined);
+	for (const st of sqlStatements) {
+		await client.query(st);
+	}
+
+	// ...then pull ONLY the `public` schema, mirroring the real Supabase workflow where the
+	// `auth` schema is managed by Supabase and excluded from the schema filter.
+	const introspected = await fromDatabase(
+		{
+			query: async (query: string, values?: any[] | undefined) => {
+				const res = await client.query(query, values);
+				return res.rows as any[];
+			},
+		},
+		undefined,
+		['public'],
+	);
+
+	const { file } = schemaToTypeScript(introspected, 'camel');
+
+	// The FK must reference the shipped `authUsers` table, imported from drizzle-orm/supabase,
+	// instead of the undeclared local `users` reference produced from the un-introspected
+	// `auth` schema.
+	expect(file).toContain('import { authUsers } from "drizzle-orm/supabase"');
+	expect(file).toContain('foreignColumns: [authUsers.id]');
+	expect(file).not.toContain('foreignColumns: [users.id]');
+
+	// relations.ts is written by a separate emitter and must reference the same `authUsers` import,
+	// not a `usersInAuth` name from "./schema" that the fixed schema.ts no longer declares.
+	const { file: relationsFile } = relationsToTypeScript(introspected, 'camel');
+	expect(relationsFile).toContain('import { authUsers } from "drizzle-orm/supabase"');
+	expect(relationsFile).not.toContain('usersInAuth');
+});
+
+test('introspect FK to auth.users from a local table also named "users" is not treated as a self-reference', async () => {
+	const client = new PGlite();
+
+	// Common Supabase pattern: a local `public.users` mirror table whose id FKs into `auth.users`.
+	// The referencing table is itself named `users`, so a name-only self-FK check would wrongly
+	// emit `foreignColumns: [table.id]`; the FK must still resolve to the shipped `authUsers`.
+	const auth = pgSchema('auth');
+	const authUsers = auth.table('users', {
+		id: uuid('id').primaryKey().notNull(),
+	});
+	const publicUsers = pgTable('users', {
+		id: uuid('id')
+			.primaryKey()
+			.notNull()
+			.references(() => authUsers.id),
+	});
+
+	const { sqlStatements } = await applyPgDiffs({ auth, authUsers, publicUsers }, undefined);
+	for (const st of sqlStatements) {
+		await client.query(st);
+	}
+
+	const introspected = await fromDatabase(
+		{
+			query: async (query: string, values?: any[] | undefined) => {
+				const res = await client.query(query, values);
+				return res.rows as any[];
+			},
+		},
+		undefined,
+		['public'],
+	);
+
+	const { file } = schemaToTypeScript(introspected, 'camel');
+
+	expect(file).toContain('import { authUsers } from "drizzle-orm/supabase"');
+	expect(file).toContain('foreignColumns: [authUsers.id]');
+	// Must NOT collapse to a bogus self-reference just because the local table is named `users`.
+	expect(file).not.toContain('foreignColumns: [table.id]');
 });


### PR DESCRIPTION
## Summary

Fixes the primary defect in #4482: `drizzle-kit pull` against a Supabase Postgres database
generates a `schema.ts` that does not compile, because every foreign key that references
Supabase's managed `auth.users.id` is emitted as a reference to a **local table that was never
declared**.

drizzle-orm already ships the canonical `auth.users` definition as `authUsers` in the
`drizzle-orm/supabase` entrypoint. The pull emitter simply never referenced it for cross-schema
foreign keys into the `auth` schema. This PR makes the emitter render such FKs as the imported
`authUsers` and add the corresponding import.

This fixes **both** files a `pull` writes — `schema.ts` and `relations.ts` — which were broken by the
same root cause.

### Before (actual output of `drizzle-kit pull`, verified against a live Postgres)

```ts
import { pgTable, foreignKey, uuid } from "drizzle-orm/pg-core"
import { sql } from "drizzle-orm"

export const profiles = pgTable("profiles", {
	id: uuid().defaultRandom().primaryKey().notNull(),
	userId: uuid("user_id").notNull(),
}, (table) => [
	foreignKey({
		columns: [table.userId],
		foreignColumns: [users.id],   // ❌ `users` is never declared / imported → TS error
		name: "profiles_user_id_fkey"
	}),
]);
```

### After

```ts
import { pgTable, foreignKey, uuid } from "drizzle-orm/pg-core"
import { sql } from "drizzle-orm"
import { authUsers } from "drizzle-orm/supabase"

export const profiles = pgTable("profiles", {
	id: uuid().defaultRandom().primaryKey().notNull(),
	userId: uuid("user_id").notNull(),
}, (table) => [
	foreignKey({
		columns: [table.userId],
		foreignColumns: [authUsers.id],     // ✅ references the shipped table
		name: "profiles_user_id_fkey"
	}),
]);
```

## Root cause

- The FK introspection query records the target schema (`pgSerializer.ts:1275`,
  `fnsp.nspname AS foreign_table_schema`; surfaced as `schemaTo` at `pgSerializer.ts:1317`), so the FK
  correctly carries `{ tableTo: 'users', schemaTo: 'auth' }`.
- But `pull` only introspects the requested schema(s) — `public` by default (the schema filter is
  built in `fromDatabase` at `pgSerializer.ts:991`, `n.nspname = '<schema>'`), so the `auth.users`
  table is **never emitted** as a local declaration.
- The TypeScript emitter still renders the FK. In `createTableFKs` (`drizzle-kit/src/introspect-pg.ts`)
  the reference is built via `paramNameFor(it.tableTo, schemas[it.schemaTo])`. Because the `auth`
  schema was not pulled it is absent from the `schemas` map, so `schemas['auth']` is `undefined` and
  `paramNameFor('users', undefined)` returns the bare `users` (the `In<Schema>` suffix is only added
  for a defined non-public schema — `paramNameFor`, `introspect-pg.ts:304-305`). The result references
  a `users` variable that does not exist in the generated file.

`authUsers` is defined at `drizzle-orm/src/supabase/rls.ts:14` (`auth.table('users', { id: uuid()... })`)
and re-exported from the `drizzle-orm/supabase` entrypoint — exactly what a Supabase user is expected
to reference.

## Implementation

**`schema.ts` emitter (`drizzle-kit/src/introspect-pg.ts`):**

1. New predicate `isSupabaseAuthUsersFk(fk)` → `fk.schemaTo === 'auth' && fk.tableTo === 'users'`.
2. In `schemaToTypeScript`, compute `usesSupabaseAuthUsers`: true when at least one FK targets
   `auth.users` **and** `auth.users` is not itself part of the introspected tables (so users who
   explicitly include the `auth` schema in their filter keep the previous local-table behavior).
3. `createTableFKs` takes a `supabaseAuthUsers` flag; when set and the FK matches, it renders
   `authUsers` (instead of the bare, undeclared `users`). This Supabase branch is evaluated **before**
   the existing self-FK check — that check compares table names only, so a local table also named
   `users` (a common `public.users` → `auth.users` mirror) would otherwise be mis-emitted as a
   self-reference. The reorder is safe because `usesSupabaseAuthUsers` is only true when `auth.users`
   was *not* emitted, so a referencing table named `users` is necessarily `public.users`, never a
   genuine self-reference into an emitted `auth.users`.
4. The import block conditionally emits `import { authUsers } from "drizzle-orm/supabase"`.

**`relations.ts` emitter (`drizzle-kit/src/cli/commands/introspect.ts`):**

A full `pull` also writes `relations.ts` via a separate emitter with the same defect — it rendered the
FK target as `usersInAuth` imported `from "./schema"`, a name the fixed `schema.ts` no longer declares,
so `relations.ts` failed to compile too. Applying the same guarded mapping (identical `auth.users`
detection), it now renders `authUsers` and routes that single import to `drizzle-orm/supabase`, while
every other table still imports from `./schema`.

Both changes are additive and guarded, so non-Supabase schemas and schemas that explicitly pull the
`auth` schema are unaffected (byte-identical output).

**On the detection signal:** this keys on the `auth.users` schema/table-name heuristic. drizzle-kit
also exposes an explicit Supabase marker (`roles.provider === 'supabase'`, `pgSerializer.ts:940`); I
kept the name heuristic because many Supabase projects don't introspect roles, but I'm happy to gate
on/combine with the provider signal if you'd prefer. The only downside of the pure heuristic is a
non-Supabase database that has its own `auth.users` and is pulled without the `auth` schema would get
a spurious `authUsers` import — a narrow case that does **not** regress compiling output (that pull
already emitted a dangling `users`).

## Validation

- **Two introspect tests added** in `drizzle-kit/tests/introspect/pg.test.ts`:
  1. `introspect FK to Supabase auth.users references authUsers…` — seeds an `auth` schema +
     `auth.users` and a `public.profiles` table with a FK into `auth.users(id)`, introspects only the
     `public` schema (the real Supabase workflow), and asserts the generated file contains
     `import { authUsers } from "drizzle-orm/supabase"` and `foreignColumns: [authUsers.id]` and no
     longer contains the undeclared `foreignColumns: [users.id]`. It also asserts the separately-emitted
     `relations.ts` imports `authUsers` from `drizzle-orm/supabase` and no longer references `usersInAuth`.
  2. `…a local table also named "users" is not treated as a self-reference` — the `public.users` →
     `auth.users` mirror case; asserts the FK resolves to `authUsers.id` and is **not** collapsed to a
     bogus `foreignColumns: [table.id]`.
- **Reproduced live** against Postgres 16 (Docker) with the published `drizzle-kit`: `pull` emits
  `foreignColumns: [users.id]` referencing an undeclared, un-imported `users` — confirming the issue.
  Copy-pasteable SQL seed + `pull` command are in the repro notes.
- **Note on local test execution:** I could not run the suite locally — the monorepo install is
  currently blocked by an unrelated upstream issue (`drizzle-kit` dev-depends on a `drizzle-kit`
  version whose tarball 404s on npm, and drizzle-kit consumes drizzle-orm as a built `dist`). The
  change is therefore verified by code inspection plus the live reproduction above; please run CI /
  `dprint fmt` on the added tests. Happy to adjust formatting if the linter flags the reordered
  ternary.

## Adjacent issues noted (not fixed here)

The report lists two further defects that are genuinely separate emitter bugs. I root-caused them but
scoped them out; happy to open follow-ups:

- **`.default([RAY])` garbled array default (#2 in the report).** A separate emitter bug in
  array-default rendering (`buildArrayDefault`, `introspect-pg.ts:657`), which strips two characters
  from each end of curly-form array-literal defaults. The exact input that produces the reported
  `[RAY]` needs confirming against the reporter's column default before I'd propose a fix — noted for
  a follow-up, not addressed here.
- **Missing `.enableRLS()` (#3 in the report).** Introspection captures RLS state
  (`pgSerializer.ts:1663`, `isRLSEnabled: row.rls_enabled`) but the `introspect-pg.ts` emitter has no
  `enableRLS`/`isRLSEnabled` references, so the flag is dropped. Fix direction: append `.enableRLS()`
  in the table statement builder when `table.isRLSEnabled`.