### PR TITLE
[Pg] Fix nested partial select nulling object on left join by column order (#1603)

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (value !== null || nullifyMap[objectName] !== getTableName(field.table))
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/map-result-row.test.ts
+++ b/drizzle-orm/tests/map-result-row.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest';
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+const org = pgTable('org', {
+	id: text('id'),
+	name: text('name'),
+});
+
+const orgBranding = pgTable('orgBranding', {
+	orgId: text('org_id'),
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+// `org` is the base table, `orgBranding` is LEFT JOINed (nullable).
+const joinsNotNullableMap = { org: true, orgBranding: false };
+
+describe('mapResultRow — nested partial select over a left join (#1603)', () => {
+	test('keeps the nested object when a non-null column follows a null column of the same table', () => {
+		const fields = orderSelectedFields({
+			name: org.name,
+			branding: {
+				logo: orgBranding.logo, // null in the row
+				panelBackground: orgBranding.panelBackground, // present in the row
+			},
+		});
+
+		const result = mapResultRow(fields, ['Test org', null, '#1a8cff'], joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { logo: null, panelBackground: '#1a8cff' },
+		});
+	});
+
+	test('is independent of column order (non-null column first)', () => {
+		const fields = orderSelectedFields({
+			name: org.name,
+			branding: {
+				panelBackground: orgBranding.panelBackground, // present in the row
+				logo: orgBranding.logo, // null in the row
+			},
+		});
+
+		const result = mapResultRow(fields, ['Test org', '#1a8cff', null], joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { panelBackground: '#1a8cff', logo: null },
+		});
+	});
+
+	test('still nullifies the nested object when the left join did not match (all columns null)', () => {
+		const fields = orderSelectedFields({
+			name: org.name,
+			branding: {
+				logo: orgBranding.logo,
+				panelBackground: orgBranding.panelBackground,
+			},
+		});
+
+		const result = mapResultRow(fields, ['Test org', null, null], joinsNotNullableMap);
+
+		expect(result).toEqual({ name: 'Test org', branding: null });
+	});
+});


### PR DESCRIPTION
Closes #1603

## Problem

When a nested partial select reads several columns from the **same left-joined
(nullable) table**, the whole nested object could be wrongly collapsed to `null`
depending on the **order** of the selected columns.

```ts
const org = await db
  .select({
    name: orgTable.name,
    branding: {
      logo: orgBrandingTable.logo,            // null in the DB
      panelBackground: orgBrandingTable.panelBackground, // "#1a8cff" in the DB
    },
  })
  .from(orgTable)
  .leftJoin(orgBrandingTable, eq(orgTable.id, orgBrandingTable.orgId))
  .where(eq(orgTable.id, session.orgId));

// actual:   { name: '…', branding: null }
// expected: { name: '…', branding: { logo: null, panelBackground: '#1a8cff' } }
```

Swapping the order of `logo` and `panelBackground` makes it work, which is the
tell-tale sign of an order-dependent bug.

## Root cause

`mapResultRow` (`drizzle-orm/src/utils.ts`) builds a `nullifyMap` to collapse a
nested object to `null` when it comes entirely from a left-joined table that did
not match (i.e. **all** of its columns are `null`).

The candidate for an object is seeded from the **first** column it sees:

```ts
nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
```

…but it was only ever invalidated when a **later column came from a different
table**:

```ts
} else if (
  typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
) {
  nullifyMap[objectName] = false;
}
```

So if the first column is `null`, the object is marked as a nullify candidate,
and a subsequent **non-null value from the same table never clears it** — the
object is nullified even though the join actually matched.

## Fix

Also invalidate the nullify candidate when any contributing column has a
non-null value (a non-null value means the row matched the join, so the object
must be kept):

```ts
} else if (
  typeof nullifyMap[objectName] === 'string'
  && (value !== null || nullifyMap[objectName] !== getTableName(field.table))
) {
  nullifyMap[objectName] = false;
}
```

An object is now nullified only when **every** contributing column is `null`
*and* they all come from the same nullable table — which is the intended
semantics. The change only ever keeps objects that used to be dropped; objects
that were correctly nullified (a genuine no-match, all columns `null`) are
unaffected.

## Tests

Added `drizzle-orm/tests/map-result-row.test.ts` covering:

1. null column **before** a non-null column of the same table → object is kept
   (the reported bug; fails before this change).
2. the reversed column order → same result (order independence).
3. a genuine no-match (all columns `null`) → object is still nullified (guards
   against regressing the original feature).
