### PR TITLE
[Mysql] Add buffer mode to binary/varbinary columns (#1188)

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
+import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
@@ -58,19 +58,72 @@ export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> ex
 	}
 }
 
-export interface MySqlBinaryConfig {
+export type MySqlBinaryBufferBuilderInitial<TName extends string> = MySqlBinaryBufferBuilder<{
+	name: TName;
+	dataType: 'buffer';
+	columnType: 'MySqlBinaryBuffer';
+	data: Buffer;
+	driverParam: Buffer;
+	enumValues: undefined;
+}>;
+
+export class MySqlBinaryBufferBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinaryBuffer'>>
+	extends MySqlColumnBuilder<T, MySqlBinaryConfig>
+{
+	static override readonly [entityKind]: string = 'MySqlBinaryBufferBuilder';
+
+	constructor(name: T['name'], length: number | undefined) {
+		super(name, 'buffer', 'MySqlBinaryBuffer');
+		this.config.length = length;
+	}
+
+	/** @internal */
+	override build<TTableName extends string>(
+		table: AnyMySqlTable<{ name: TTableName }>,
+	): MySqlBinaryBuffer<MakeColumnConfig<T, TTableName>> {
+		return new MySqlBinaryBuffer<MakeColumnConfig<T, TTableName>>(
+			table,
+			this.config as ColumnBuilderRuntimeConfig<any, any>,
+		);
+	}
+}
+
+export class MySqlBinaryBuffer<T extends ColumnBaseConfig<'buffer', 'MySqlBinaryBuffer'>> extends MySqlColumn<
+	T,
+	MySqlBinaryConfig
+> {
+	static override readonly [entityKind]: string = 'MySqlBinaryBuffer';
+
+	length: number | undefined = this.config.length;
+
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'binary');
+		return Buffer.from(value);
+	}
+
+	getSQLType(): string {
+		return this.length === undefined ? `binary` : `binary(${this.length})`;
+	}
+}
+
+export interface MySqlBinaryConfig<TMode extends 'string' | 'buffer' = 'string' | 'buffer'> {
 	length?: number;
+	mode?: TMode;
 }
 
 export function binary(): MySqlBinaryBuilderInitial<''>;
-export function binary(
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<''>;
-export function binary<TName extends string>(
+export function binary<TMode extends 'string' | 'buffer' = 'string'>(
+	config?: MySqlBinaryConfig<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<''> : MySqlBinaryBuilderInitial<''>;
+export function binary<TName extends string, TMode extends 'string' | 'buffer' = 'string'>(
 	name: TName,
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<TName>;
+	config?: MySqlBinaryConfig<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<TName> : MySqlBinaryBuilderInitial<TName>;
 export function binary(a?: string | MySqlBinaryConfig, b: MySqlBinaryConfig = {}) {
 	const { name, config } = getColumnNameAndConfig<MySqlBinaryConfig>(a, b);
+	if (config.mode === 'buffer') {
+		return new MySqlBinaryBufferBuilder(name, config.length);
+	}
 	return new MySqlBinaryBuilder(name, config.length);
 }

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
+import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
@@ -60,18 +60,71 @@ export class MySqlVarBinary<
 	}
 }
 
-export interface MySqlVarbinaryOptions {
-	length: number;
+export type MySqlVarBinaryBufferBuilderInitial<TName extends string> = MySqlVarBinaryBufferBuilder<{
+	name: TName;
+	dataType: 'buffer';
+	columnType: 'MySqlVarBinaryBuffer';
+	data: Buffer;
+	driverParam: Buffer;
+	enumValues: undefined;
+}>;
+
+export class MySqlVarBinaryBufferBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarBinaryBuffer'>>
+	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
+{
+	static override readonly [entityKind]: string = 'MySqlVarBinaryBufferBuilder';
+
+	/** @internal */
+	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
+		super(name, 'buffer', 'MySqlVarBinaryBuffer');
+		this.config.length = config?.length;
+	}
+
+	/** @internal */
+	override build<TTableName extends string>(
+		table: AnyMySqlTable<{ name: TTableName }>,
+	): MySqlVarBinaryBuffer<MakeColumnConfig<T, TTableName>> {
+		return new MySqlVarBinaryBuffer<MakeColumnConfig<T, TTableName>>(
+			table,
+			this.config as ColumnBuilderRuntimeConfig<any, any>,
+		);
+	}
 }
 
-export function varbinary(
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<''>;
-export function varbinary<TName extends string>(
+export class MySqlVarBinaryBuffer<
+	T extends ColumnBaseConfig<'buffer', 'MySqlVarBinaryBuffer'>,
+> extends MySqlColumn<T, MySqlVarbinaryOptions> {
+	static override readonly [entityKind]: string = 'MySqlVarBinaryBuffer';
+
+	length: number | undefined = this.config.length;
+
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'binary');
+		return Buffer.from(value);
+	}
+
+	getSQLType(): string {
+		return this.length === undefined ? `varbinary` : `varbinary(${this.length})`;
+	}
+}
+
+export interface MySqlVarbinaryOptions<TMode extends 'string' | 'buffer' = 'string' | 'buffer'> {
+	length: number;
+	mode?: TMode;
+}
+
+export function varbinary<TMode extends 'string' | 'buffer' = 'string'>(
+	config: MySqlVarbinaryOptions<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<''> : MySqlVarBinaryBuilderInitial<''>;
+export function varbinary<TName extends string, TMode extends 'string' | 'buffer' = 'string'>(
 	name: TName,
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<TName>;
+	config: MySqlVarbinaryOptions<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<TName> : MySqlVarBinaryBuilderInitial<TName>;
 export function varbinary(a?: string | MySqlVarbinaryOptions, b?: MySqlVarbinaryOptions) {
 	const { name, config } = getColumnNameAndConfig<MySqlVarbinaryOptions>(a, b);
+	if (config.mode === 'buffer') {
+		return new MySqlVarBinaryBufferBuilder(name, config);
+	}
 	return new MySqlVarBinaryBuilder(name, config);
 }

--- a/drizzle-orm/tests/mysql-binary-buffer.test.ts
+++ b/drizzle-orm/tests/mysql-binary-buffer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import { binary, mysqlTable, varbinary } from '~/mysql-core/index.ts';
+
+const table = mysqlTable('binary_test', {
+	str: binary('str', { length: 4 }),
+	buf: binary('buf', { length: 4, mode: 'buffer' }),
+	vstr: varbinary('vstr', { length: 8 }),
+	vbuf: varbinary('vbuf', { length: 8, mode: 'buffer' }),
+});
+
+describe('mysql binary/varbinary buffer mode (#1188)', () => {
+	test('buffer mode maps a driver Buffer to Buffer, preserving bytes', () => {
+		const bytes = Buffer.from([0, 1, 2, 255]);
+		expect(table.buf.mapFromDriverValue(bytes)).toBeInstanceOf(Buffer);
+		expect(table.buf.mapFromDriverValue(bytes).equals(bytes)).toBe(true);
+		expect(table.vbuf.mapFromDriverValue(bytes).equals(bytes)).toBe(true);
+	});
+
+	test('string mode is unchanged (the default)', () => {
+		expect(table.str.mapFromDriverValue('abc')).toBe('abc');
+		expect(table.vstr.mapFromDriverValue('abc')).toBe('abc');
+	});
+
+	test('getSQLType is unaffected by mode', () => {
+		expect(table.buf.getSQLType()).toBe('binary(4)');
+		expect(table.vbuf.getSQLType()).toBe('varbinary(8)');
+	});
+
+	test('select types: buffer mode infers Buffer, default infers string', () => {
+		type Row = typeof table.$inferSelect;
+		expectTypeOf<Row['str']>().toEqualTypeOf<string | null>();
+		expectTypeOf<Row['buf']>().toEqualTypeOf<Buffer | null>();
+		expectTypeOf<Row['vstr']>().toEqualTypeOf<string | null>();
+		expectTypeOf<Row['vbuf']>().toEqualTypeOf<Buffer | null>();
+	});
+});


### PR DESCRIPTION
Closes #1188

## Problem

`mysql2` returns `BINARY`/`VARBINARY` columns as Node `Buffer`s, but drizzle types
`binary()` / `varbinary()` columns' selected value as `string`. So result types are
wrong, and the current `mapFromDriverValue` coerces the `Buffer` to a string
(`Buffer.toString()`), which is lossy for real binary data.

## Approach

Rather than change the default type (which would be a breaking change for everyone
currently relying on `string`), this adds an opt-in `mode` — exactly mirroring the
existing precedent for SQLite `blob({ mode: 'buffer' })` (`sqlite-core/columns/blob.ts`).

```ts
// unchanged — still string (default)
binary('col', { length: 16 })
varbinary('col', { length: 16 })

// new — typed as Buffer, returned as Buffer (no lossy conversion)
binary('col', { length: 16, mode: 'buffer' })
varbinary('col', { length: 16, mode: 'buffer' })
```

- Default behaviour is untouched → **no breaking change**.
- `mode: 'buffer'` infers `Buffer` for select results (`driverParam: Buffer` too) and
  `mapFromDriverValue` returns the `Buffer` as-is (falling back to `Buffer.from` for
  `Uint8Array`/`string`).
- The mode switch uses the same conditional-overload pattern as `blob`
  (`Equal<TMode, 'buffer'> extends true ? …BufferBuilderInitial : …BuilderInitial`).

## Tests

`drizzle-orm/tests/mysql-binary-buffer.test.ts`:
- buffer mode maps a driver `Buffer` to `Buffer`, preserving bytes;
- string mode is unchanged (default);
- `getSQLType()` is unaffected by mode (`binary(4)` / `varbinary(8)`);
- select-type inference: `mode: 'buffer'` → `Buffer | null`, default → `string | null`
  (via `expectTypeOf`).

## Notes

- Scoped to `mysql-core`, which is what #1188 reports. `singlestore-core` has the same
  `binary`/`varbinary` definitions and could get the same treatment in a follow-up if
  desired — happy to include it here if you'd prefer.
- Changing the *default* to `buffer` in a future major would be the fully-correct end
  state; this PR is the non-breaking step that unblocks correct binary handling today.
