### PR TITLE
fix: prevent nullifying nested objects with non-null values in left joins

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -43,13 +43,18 @@ export function mapResultRow<TResult>(
 					const rawValue = row[columnIndex]!;
 					const value = node[pathChunk] = rawValue === null ? null : decoder.mapFromDriverValue(rawValue);
 
-					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
+					if (joinsNotNullableMap && path.length >= 2) {
 						const objectName = path[0]!;
-						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
-						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
-						) {
+						if (is(field, Column)) {
+							if (!(objectName in nullifyMap)) {
+								nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
+							} else if (
+								typeof nullifyMap[objectName] === 'string'
+								&& (value !== null || nullifyMap[objectName] !== getTableName(field.table))
+							) {
+								nullifyMap[objectName] = false;
+							}
+						} else if (value !== null) {
 							nullifyMap[objectName] = false;
 						}
 					}

--- a/drizzle-orm/tests/mapResultRow.test.ts
+++ b/drizzle-orm/tests/mapResultRow.test.ts
@@ -1,0 +1,166 @@
+import { describe, test } from 'vitest';
+import { pgTable, serial, text } from '~/pg-core/index.ts';
+import { sql } from '~/sql/sql.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const orgTable = pgTable('org', {
+	id: serial('id'),
+	name: text('name'),
+});
+
+const orgBrandingTable = pgTable('org_branding', {
+	id: serial('id'),
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+describe('mapResultRow left join bug', () => {
+	test('nested object should not be nullified if any value is not null (first column is null)', ({ expect }) => {
+		const columns = [
+			{ path: ['name'], field: orgTable.name },
+			{ path: ['branding', 'logo'], field: orgBrandingTable.logo },
+			{ path: ['branding', 'panelBackground'], field: orgBrandingTable.panelBackground },
+		];
+
+		const row = ['Test org 2', null, '#1a8cff'];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			branding: {
+				logo: null,
+				panelBackground: '#1a8cff',
+			},
+		});
+	});
+
+	test('nested object should not be nullified if first column is non-null and second is null', ({ expect }) => {
+		const columns = [
+			{ path: ['name'], field: orgTable.name },
+			{ path: ['branding', 'logo'], field: orgBrandingTable.logo },
+			{ path: ['branding', 'panelBackground'], field: orgBrandingTable.panelBackground },
+		];
+
+		const row = ['Test org 2', 'logo.png', null];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			branding: {
+				logo: 'logo.png',
+				panelBackground: null,
+			},
+		});
+	});
+
+	test('nested object should be nullified if all values from nullable join table are null', ({ expect }) => {
+		const columns = [
+			{ path: ['name'], field: orgTable.name },
+			{ path: ['branding', 'logo'], field: orgBrandingTable.logo },
+			{ path: ['branding', 'panelBackground'], field: orgBrandingTable.panelBackground },
+		];
+
+		const row = ['Test org 2', null, null];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			branding: null,
+		});
+	});
+
+	test('nested object should not be nullified if non-null value comes 3rd after multiple nulls', ({ expect }) => {
+		const columns = [
+			{ path: ['name'], field: orgTable.name },
+			{ path: ['branding', 'id'], field: orgBrandingTable.id },
+			{ path: ['branding', 'logo'], field: orgBrandingTable.logo },
+			{ path: ['branding', 'panelBackground'], field: orgBrandingTable.panelBackground },
+		];
+
+		const row = ['Test org 2', null, null, '#1a8cff'];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			branding: {
+				id: null,
+				logo: null,
+				panelBackground: '#1a8cff',
+			},
+		});
+	});
+
+	test('nested object should not be nullified if table join is non-nullable (inner join)', ({ expect }) => {
+		const columns = [
+			{ path: ['name'], field: orgTable.name },
+			{ path: ['branding', 'logo'], field: orgBrandingTable.logo },
+			{ path: ['branding', 'panelBackground'], field: orgBrandingTable.panelBackground },
+		];
+
+		const row = ['Test org 2', null, null];
+		const joinsNotNullableMap = { org: true, org_branding: true };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			branding: {
+				logo: null,
+				panelBackground: null,
+			},
+		});
+	});
+
+	test('nested object should not be nullified if non-column field (SQL) is non-null even if first column is null', ({ expect }) => {
+		const sqlField = sql`1`;
+		const columns = [
+			{ path: ['name'], field: orgTable.name },
+			{ path: ['branding', 'logo'], field: orgBrandingTable.logo },
+			{ path: ['branding', 'customFlag'], field: sqlField },
+		];
+
+		const row = ['Test org 2', null, 1];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			branding: {
+				logo: null,
+				customFlag: 1,
+			},
+		});
+	});
+
+	test('deeply nested object should not be nullified if any value is non-null', ({ expect }) => {
+		const columns = [
+			{ path: ['name'], field: orgTable.name },
+			{ path: ['branding', 'theme', 'logo'], field: orgBrandingTable.logo },
+			{ path: ['branding', 'theme', 'panelBackground'], field: orgBrandingTable.panelBackground },
+		];
+
+		const row = ['Test org 2', null, '#1a8cff'];
+		const joinsNotNullableMap = { org: true, org_branding: false };
+
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			branding: {
+				theme: {
+					logo: null,
+					panelBackground: '#1a8cff',
+				},
+			},
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1603

### Description
This PR fixes a bug where a nested select object under a left join is incorrectly nullified when its first property is `null`, even if subsequent properties have non-null values.

We update the logic to set the nested object's entry in `nullifyMap` to `false` if any non-null column value is encountered for that object.

@algora-pbc /claim #1603