### PR TITLE
fix(pg-core,sqlite-core): apply casing to set-operation ORDER BY columns

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -480,13 +480,13 @@ export class PgDialect {
 			// which is invalid Sql syntax, Table from one of the SELECTs cannot be used in global ORDER clause
 			for (const singleOrderBy of orderBy) {
 				if (is(singleOrderBy, PgColumn)) {
-					orderByValues.push(sql.identifier(singleOrderBy.name));
+					orderByValues.push(sql.identifier(this.casing.getColumnCasing(singleOrderBy)));
 				} else if (is(singleOrderBy, SQL)) {
 					for (let i = 0; i < singleOrderBy.queryChunks.length; i++) {
 						const chunk = singleOrderBy.queryChunks[i];
 
 						if (is(chunk, PgColumn)) {
-							singleOrderBy.queryChunks[i] = sql.identifier(chunk.name);
+							singleOrderBy.queryChunks[i] = sql.identifier(this.casing.getColumnCasing(chunk));
 						}
 					}
 

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -475,7 +475,7 @@ export abstract class SQLiteDialect {
 			// which is invalid Sql syntax, Table from one of the SELECTs cannot be used in global ORDER clause
 			for (const singleOrderBy of orderBy) {
 				if (is(singleOrderBy, SQLiteColumn)) {
-					orderByValues.push(sql.identifier(singleOrderBy.name));
+					orderByValues.push(sql.identifier(this.casing.getColumnCasing(singleOrderBy)));
 				} else if (is(singleOrderBy, SQL)) {
 					for (let i = 0; i < singleOrderBy.queryChunks.length; i++) {
 						const chunk = singleOrderBy.queryChunks[i];


### PR DESCRIPTION
## Summary

`buildSetOperationQuery` emitted the raw column *property* name in the global `ORDER BY` of set operations (`union`/`intersect`/`except`) instead of the cased DB column name. Under a `casing` config (e.g. `casing: 'snake_case'`), this produced an `ORDER BY` referencing a column that does not exist in the emitted SQL.

The fix replaces `<col>.name` with `this.casing.getColumnCasing(<col>)` in the pg-core and sqlite-core dialects, matching the already-correct behavior in the mysql/singlestore dialects.

## Before / after

**pg union, bare column order:**
- Before: `... order by "firstName" ...`
- After:  `... order by "first_name" ...`

**pg union, `.asc()`:**
- Before: `... order by "firstName" asc ...`
- After:  `... order by "first_name" asc ...`

**sqlite union, bare column order:**
- Before: `... order by "firstName" ...`
- After:  `... order by "first_name" ...`

Plain (non-set-operation) selects are unaffected — their ORDER BY handling already applies casing.

Closes #5987
