### PR TITLE
Fix: normalize nullsNotDistinct to false in pgSerializer to stop spurious truncate prompts

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -317,7 +317,7 @@ export const generatePgSnapshot = (
 
 			uniqueConstraintObject[name] = {
 				name: unq.name!,
-				nullsNotDistinct: unq.nullsNotDistinct,
+				nullsNotDistinct: unq.nullsNotDistinct ?? false,
 				columns: columnNames,
 			};
 		});


### PR DESCRIPTION
Fixes #5955

## Problem

`drizzle:push` repeatedly prompts to truncate a table for a `unique()` constraint that already exists in the database and hasn't changed.

**Root cause:** `nullsNotDistinct` mismatch between the two snapshot sources fed into the differ:

- **TypeScript schema serialization** (`pgSerializer.ts` line 320): stores `unq.nullsNotDistinct` verbatim. A plain `unique()` without `.nullsNotDistinct()` leaves this field as `undefined`.
- **DB introspection** (`pgSerializer.ts` line 1357): always stores `false` for existing `UNIQUE` constraints.

`PgSquasher.squashUnique` serializes the field directly — `undefined` and `false` stringify differently, so the differ sees the constraint as altered on every run. The diff engine turns an altered unique constraint into drop + re-add, which requires a truncate.

## Fix

One line in `drizzle-kit/src/serializer/pgSerializer.ts`:

```diff
- nullsNotDistinct: unq.nullsNotDistinct,
+ nullsNotDistinct: unq.nullsNotDistinct ?? false,
```

This aligns the schema-side snapshot with what the DB introspector produces for the same constraint, so the differ sees no change.