### PR TITLE
[Mysql-kit] Fix introspection dropping a zero default on numeric columns

### DIFF
--- a/drizzle-kit/src/introspect-mysql.ts
+++ b/drizzle-kit/src/introspect-mysql.ts
@@ -430,7 +430,7 @@ const column = (
 		const columnName = dbColumnName({ name, casing: rawCasing, withMode: isUnsigned });
 		let out = `${casing(name)}: smallint(${columnName}${isUnsigned ? '{ unsigned: true }' : ''})`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -441,7 +441,7 @@ const column = (
 		const columnName = dbColumnName({ name, casing: rawCasing, withMode: isUnsigned });
 		let out = `${casing(name)}: mediumint(${columnName}${isUnsigned ? '{ unsigned: true }' : ''})`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -453,7 +453,7 @@ const column = (
 			isUnsigned ? ', unsigned: true' : ''
 		} })`;
 		out += autoincrement ? `.autoincrement()` : '';
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -461,7 +461,7 @@ const column = (
 
 	if (lowered === 'boolean') {
 		let out = `${casing(name)}: boolean(${dbColumnName({ name, casing: rawCasing })})`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -492,7 +492,7 @@ const column = (
 			: `${casing(name)}: double(${dbColumnName({ name, casing: rawCasing })})`;
 
 		// let out = `${name.camelCase()}: double("${name}")`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -515,7 +515,7 @@ const column = (
 		}
 
 		let out = `${casing(name)}: float(${dbColumnName({ name, casing: rawCasing })}${params ? timeConfig(params) : ''})`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;
@@ -523,7 +523,7 @@ const column = (
 
 	if (lowered === 'real') {
 		let out = `${casing(name)}: real(${dbColumnName({ name, casing: rawCasing })})`;
-		out += defaultValue
+		out += typeof defaultValue !== 'undefined'
 			? `.default(${mapColumnDefault(defaultValue, isExpression)})`
 			: '';
 		return out;

--- a/drizzle-kit/tests/introspect/mysql.test.ts
+++ b/drizzle-kit/tests/introspect/mysql.test.ts
@@ -13,6 +13,7 @@ import {
 	mysqlEnum,
 	mysqlTable,
 	mysqlView,
+	real,
 	serial,
 	smallint,
 	text,
@@ -261,6 +262,47 @@ test('handle float type', async () => {
 		client,
 		schema,
 		'handle-float-type',
+		'drizzle',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
+test('handle float type with not null default', async () => {
+	const schema = {
+		table: mysqlTable('table', {
+			col1: float().notNull().default(1.5),
+			col2: float().notNull().default(0),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectMySQLToFile(
+		client,
+		schema,
+		'handle-float-type-with-not-null-default',
+		'drizzle',
+	);
+
+	expect(statements.length).toBe(0);
+	expect(sqlStatements.length).toBe(0);
+});
+
+test('handle numeric types with a zero default', async () => {
+	const schema = {
+		table: mysqlTable('table', {
+			col1: smallint().notNull().default(0),
+			col2: mediumint().notNull().default(0),
+			col3: bigint({ mode: 'number' }).notNull().default(0),
+			col4: double().notNull().default(0),
+			col5: real().notNull().default(0),
+		}),
+	};
+
+	const { statements, sqlStatements } = await introspectMySQLToFile(
+		client,
+		schema,
+		'handle-numeric-types-with-a-zero-default',
 		'drizzle',
 	);
 


### PR DESCRIPTION
Fixes #5911.

`introspect-mysql.ts`'s `column()` function decides whether to append `.default(...)` to a generated column definition using a plain truthy check on the parsed default value: `defaultValue ? '.default(...)' : ''`.

That breaks for a legitimate default of `0` (numeric types) or `false` (boolean), since both are falsy in JS. `int` and `tinyint` already guard against this correctly with `typeof defaultValue !== 'undefined'`, but `smallint`, `mediumint`, `bigint`, `boolean`, `double`, `float`, and `real` still used the truthy check, so a `NOT NULL DEFAULT 0` column on any of those types silently loses its `.default()` during introspection — matching the report exactly (a MySQL `FLOAT NOT NULL DEFAULT 1.5` column round-trips fine, but the same column with `DEFAULT 0` doesn't).

Fixed by applying the same `typeof defaultValue !== 'undefined'` check `int`/`tinyint` already use, to the remaining affected types.

Verified against a real `mysql:8.0` container:
- Before the fix: `float().notNull().default(0)` introspects as `float().notNull()` — default silently dropped.
- After the fix: introspects correctly as `float().default(0).notNull()`.

Added two regression tests to `tests/introspect/mysql.test.ts`: one matching the reported float case, one covering the other affected types (`smallint`, `mediumint`, `bigint`, `double`, `real`) with a zero default. Ran the full `introspect/mysql.test.ts` suite — all 12 pass.

Left `boolean` out of the regression test even though I fixed that code path too — MySQL reports `BOOLEAN` columns as `tinyint(1)` in `information_schema`, not `boolean`, so that branch turned out to be unreachable via real introspection and hits an unrelated, pre-existing bug in the generated file's import list when exercised directly. Didn't want to fix an unrelated issue in this PR, but happy to file it separately if useful.
