### PR TITLE
[All] Fix $count/extras filter columns being re-aliased to the root table in relational queries

### DIFF
--- a/drizzle-orm/src/alias.ts
+++ b/drizzle-orm/src/alias.ts
@@ -106,21 +106,46 @@ export function aliasedTableColumn<T extends AnyColumn>(column: T, tableAlias: s
 	);
 }
 
-export function mapColumnsInAliasedSQLToAlias(query: SQL.Aliased, alias: string): SQL.Aliased {
-	return new SQL.Aliased(mapColumnsInSQLToAlias(query.sql, alias), query.fieldAlias);
+export function mapColumnsInAliasedSQLToAlias(query: SQL.Aliased, alias: string, table?: Table): SQL.Aliased {
+	return new SQL.Aliased(mapColumnsInSQLToAlias(query.sql, alias, table), query.fieldAlias);
 }
 
-export function mapColumnsInSQLToAlias(query: SQL, alias: string): SQL {
+export function mapColumnsInSQLToAlias(query: SQL, alias: string, table?: Table): SQL {
 	return sql.join(query.queryChunks.map((c) => {
 		if (is(c, Column)) {
+			// Only re-alias columns that belong to `table` (the table being aliased). When a
+			// nested SQL embeds columns of *another* table — e.g. `$count(otherTable, <filter>)`
+			// used as a relational-query `extras` value — those foreign columns must keep their
+			// own table qualifier; re-aliasing them to `alias` produces a reference to a column
+			// that doesn't exist on the aliased table. When `table` is omitted the historical
+			// behaviour (re-alias every column) is preserved.
+			if (table !== undefined && !columnBelongsToTable(c, table)) {
+				return c;
+			}
 			return aliasedTableColumn(c, alias);
 		}
 		if (is(c, SQL)) {
-			return mapColumnsInSQLToAlias(c, alias);
+			return mapColumnsInSQLToAlias(c, alias, table);
 		}
 		if (is(c, SQL.Aliased)) {
-			return mapColumnsInAliasedSQLToAlias(c, alias);
+			return mapColumnsInAliasedSQLToAlias(c, alias, table);
 		}
 		return c;
 	}));
+}
+
+function columnBelongsToTable(column: Column, table: Table): boolean {
+	const columnTable = column.table;
+	// If the column isn't attributable to a concrete table (e.g. it belongs to a view or
+	// subquery selection), fall back to the historical behaviour of re-aliasing it.
+	if (!is(columnTable, Table)) {
+		return true;
+	}
+	return tableOriginalUniqueName(columnTable) === tableOriginalUniqueName(table);
+}
+
+// Identifies a table by its *original* (pre-alias) schema-qualified name, so that a column
+// referenced through an alias proxy still matches the underlying table it was defined on.
+function tableOriginalUniqueName(table: Table): string {
+	return `${table[Table.Symbol.Schema] ?? 'public'}.${table[Table.Symbol.OriginalName]}`;
 }

--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -1186,7 +1186,7 @@ export class GelDialect {
 				const whereSql = typeof config.where === 'function'
 					? config.where(aliasedColumns, getOperators())
 					: config.where;
-				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias);
+				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias, table);
 			}
 
 			const fieldsSelection: { tsKey: string; value: GelColumn | SQL.Aliased }[] = [];
@@ -1247,7 +1247,7 @@ export class GelDialect {
 				for (const [tsKey, value] of Object.entries(extras)) {
 					fieldsSelection.push({
 						tsKey,
-						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
+						value: mapColumnsInAliasedSQLToAlias(value, tableAlias, table),
 					});
 				}
 			}
@@ -1275,7 +1275,7 @@ export class GelDialect {
 				if (is(orderByValue, Column)) {
 					return aliasedTableColumn(orderByValue, tableAlias) as GelColumn;
 				}
-				return mapColumnsInSQLToAlias(orderByValue, tableAlias);
+				return mapColumnsInSQLToAlias(orderByValue, tableAlias, table);
 			});
 
 			limit = config.limit;

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -705,7 +705,7 @@ export class MySqlDialect {
 				const whereSql = typeof config.where === 'function'
 					? config.where(aliasedColumns, getOperators())
 					: config.where;
-				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias);
+				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias, table);
 			}
 
 			const fieldsSelection: {
@@ -779,7 +779,7 @@ export class MySqlDialect {
 				for (const [tsKey, value] of Object.entries(extras)) {
 					fieldsSelection.push({
 						tsKey,
-						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
+						value: mapColumnsInAliasedSQLToAlias(value, tableAlias, table),
 					});
 				}
 			}
@@ -811,7 +811,7 @@ export class MySqlDialect {
 				if (is(orderByValue, Column)) {
 					return aliasedTableColumn(orderByValue, tableAlias) as MySqlColumn;
 				}
-				return mapColumnsInSQLToAlias(orderByValue, tableAlias);
+				return mapColumnsInSQLToAlias(orderByValue, tableAlias, table);
 			});
 
 			limit = config.limit;
@@ -1049,7 +1049,7 @@ export class MySqlDialect {
 				const whereSql = typeof config.where === 'function'
 					? config.where(aliasedColumns, getOperators())
 					: config.where;
-				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias);
+				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias, table);
 			}
 
 			const fieldsSelection: {
@@ -1123,7 +1123,7 @@ export class MySqlDialect {
 				for (const [tsKey, value] of Object.entries(extras)) {
 					fieldsSelection.push({
 						tsKey,
-						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
+						value: mapColumnsInAliasedSQLToAlias(value, tableAlias, table),
 					});
 				}
 			}
@@ -1155,7 +1155,7 @@ export class MySqlDialect {
 				if (is(orderByValue, Column)) {
 					return aliasedTableColumn(orderByValue, tableAlias) as MySqlColumn;
 				}
-				return mapColumnsInSQLToAlias(orderByValue, tableAlias);
+				return mapColumnsInSQLToAlias(orderByValue, tableAlias, table);
 			});
 
 			limit = config.limit;

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -1195,7 +1195,7 @@ export class PgDialect {
 				const whereSql = typeof config.where === 'function'
 					? config.where(aliasedColumns, getOperators())
 					: config.where;
-				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias);
+				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias, table);
 			}
 
 			const fieldsSelection: { tsKey: string; value: PgColumn | SQL.Aliased }[] = [];
@@ -1256,7 +1256,7 @@ export class PgDialect {
 				for (const [tsKey, value] of Object.entries(extras)) {
 					fieldsSelection.push({
 						tsKey,
-						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
+						value: mapColumnsInAliasedSQLToAlias(value, tableAlias, table),
 					});
 				}
 			}
@@ -1284,7 +1284,7 @@ export class PgDialect {
 				if (is(orderByValue, Column)) {
 					return aliasedTableColumn(orderByValue, tableAlias) as PgColumn;
 				}
-				return mapColumnsInSQLToAlias(orderByValue, tableAlias);
+				return mapColumnsInSQLToAlias(orderByValue, tableAlias, table);
 			});
 
 			limit = config.limit;

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -652,7 +652,7 @@ export class SingleStoreDialect {
 				const whereSql = typeof config.where === 'function'
 					? config.where(aliasedColumns, getOperators())
 					: config.where;
-				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias);
+				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias, table);
 			}
 
 			const fieldsSelection: {
@@ -726,7 +726,7 @@ export class SingleStoreDialect {
 				for (const [tsKey, value] of Object.entries(extras)) {
 					fieldsSelection.push({
 						tsKey,
-						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
+						value: mapColumnsInAliasedSQLToAlias(value, tableAlias, table),
 					});
 				}
 			}
@@ -761,7 +761,7 @@ export class SingleStoreDialect {
 						tableAlias,
 					) as SingleStoreColumn;
 				}
-				return mapColumnsInSQLToAlias(orderByValue, tableAlias);
+				return mapColumnsInSQLToAlias(orderByValue, tableAlias, table);
 			});
 
 			limit = config.limit;

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -656,7 +656,7 @@ export abstract class SQLiteDialect {
 				const whereSql = typeof config.where === 'function'
 					? config.where(aliasedColumns, getOperators())
 					: config.where;
-				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias);
+				where = whereSql && mapColumnsInSQLToAlias(whereSql, tableAlias, table);
 			}
 
 			const fieldsSelection: {
@@ -730,7 +730,7 @@ export abstract class SQLiteDialect {
 				for (const [tsKey, value] of Object.entries(extras)) {
 					fieldsSelection.push({
 						tsKey,
-						value: mapColumnsInAliasedSQLToAlias(value, tableAlias),
+						value: mapColumnsInAliasedSQLToAlias(value, tableAlias, table),
 					});
 				}
 			}
@@ -762,7 +762,7 @@ export abstract class SQLiteDialect {
 				if (is(orderByValue, Column)) {
 					return aliasedTableColumn(orderByValue, tableAlias) as SQLiteColumn;
 				}
-				return mapColumnsInSQLToAlias(orderByValue, tableAlias);
+				return mapColumnsInSQLToAlias(orderByValue, tableAlias, table);
 			});
 
 			limit = config.limit;

--- a/integration-tests/tests/relational/bettersqlite.test.ts
+++ b/integration-tests/tests/relational/bettersqlite.test.ts
@@ -157,6 +157,52 @@ test('[Find Many] Get users with posts', () => {
 	});
 });
 
+// https://github.com/drizzle-team/drizzle-orm/issues/4169
+// https://github.com/drizzle-team/drizzle-orm/issues/4836
+// A `$count(otherTable, <filter>)` used as an `extras` value must keep the filter's own
+// table qualifiers. Previously every column in the nested filter — including columns of
+// other tables — was rewritten to the root query's alias, producing a reference to a
+// column that doesn't exist (`users.owner_id`) and throwing at execution time.
+test('[Find Many] $count with filter in extras keeps the foreign table qualifier', () => {
+	db.insert(usersTable).values([
+		{ id: 1, name: 'Dan' },
+		{ id: 2, name: 'Andrew' },
+		{ id: 3, name: 'Alex' },
+	]).run();
+
+	db.insert(postsTable).values([
+		{ ownerId: 1, content: 'Post1.1' },
+		{ ownerId: 1, content: 'Post1.2' },
+		{ ownerId: 2, content: 'Post2.1' },
+	]).run();
+
+	const query = db.query.usersTable.findMany({
+		columns: { id: true, name: true },
+		extras: {
+			postsCount: db.$count(postsTable, eq(postsTable.ownerId, usersTable.id)).as('posts_count'),
+		},
+	});
+
+	// The nested `$count` filter must reference `posts.owner_id`, not `users.owner_id`.
+	const { sql: generatedSql } = query.toSQL();
+	expect(generatedSql).toContain('"posts"."owner_id"');
+	expect(generatedSql).not.toContain('"users"."owner_id"');
+
+	const usersWithPostsCount = query.sync().sort((a, b) => (a.id > b.id) ? 1 : -1);
+
+	expectTypeOf(usersWithPostsCount).toEqualTypeOf<{
+		id: number;
+		name: string;
+		postsCount: number;
+	}[]>();
+
+	expect(usersWithPostsCount).toEqual([
+		{ id: 1, name: 'Dan', postsCount: 2 },
+		{ id: 2, name: 'Andrew', postsCount: 1 },
+		{ id: 3, name: 'Alex', postsCount: 0 },
+	]);
+});
+
 test('[Find Many] Get users with posts + limit posts', () => {
 	db.insert(usersTable).values([
 		{ id: 1, name: 'Dan' },


### PR DESCRIPTION
## What this fixes

Fixes #4169
Fixes #4836

When a `$count(otherTable, <filter>)` (or any nested SQL that references another table's columns) is used as an `extras` value in a relational query, the generated `count` subquery rewrites **every** column — including the *other* table's columns — to the **root** query's alias. The subquery then references a column that doesn't exist and the query throws.

### Reproduction

```ts
db.query.candidates.findMany({
  extras: {
    activeJobs: db.$count(
      jobCandidacy,
      and(
        eq(jobCandidacy.candidateId, candidates.id),
        not(inArray(jobCandidacy.status, ['rejected', 'withdrawn'])),
      ),
    ).as('activeJobs'),
  },
});
```

**Before** — `job_candidacy` columns get the root `candidates` alias:

```sql
(select count(*) from "job_candidacy"
 where ("candidates"."candidate_id" = "candidates"."id"
        and not "candidates"."status" in ($1, $2)))
-- ERROR: column candidates.candidate_id does not exist
```

**After** — only root-table columns are re-aliased:

```sql
(select count(*) from "job_candidacy"
 where ("job_candidacy"."candidate_id" = "candidates"."id"
        and not "job_candidacy"."status" in ($1, $2)))
```

## Root cause

`mapColumnsInSQLToAlias` (`drizzle-orm/src/alias.ts`) walks every chunk of the SQL and applies `aliasedTableColumn(c, alias)` to **any** `Column`, with no check that the column belongs to the table being aliased. The relational query builder calls it for the `where`, `extras` and `orderBy` values of each query, so columns of unrelated tables embedded in those SQLs (via `$count`, correlated subqueries, etc.) get the wrong qualifier.

## The change

- `mapColumnsInSQLToAlias` / `mapColumnsInAliasedSQLToAlias` take an optional `table` argument. When provided, a column is only re-aliased if it belongs to that table. Ownership is compared by the table's **original** (pre-alias) schema-qualified name, so columns referenced through an alias proxy still match the underlying table. When `table` is omitted, the previous behaviour (re-alias every column) is preserved, so existing callers are unaffected.
- Columns that can't be attributed to a concrete table (e.g. view / subquery selections) fall back to the old behaviour.
- The relational-query call sites (`where`, `extras`, `orderBy`) now pass the query's table, across **all** dialects: pg, mysql, sqlite, singlestore and gel.

## Tests

Added a regression test to `integration-tests/tests/relational/bettersqlite.test.ts` that runs a `$count(postsTable, eq(postsTable.ownerId, usersTable.id))` inside `extras`, asserts the generated SQL keeps `"posts"."owner_id"` (never `"users"."owner_id"`), and executes it against an in-memory database to confirm the correct per-row counts. The test fails on `main` (throws `no such column`) and passes with this change; the rest of the relational sqlite suite continues to pass.