### PR TITLE
Add manual-dispatch options to publish to GitHub Packages and to filter published packages

### DIFF
--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -2,6 +2,11 @@ name: Release (feature branch)
 
 on:
   workflow_call:
+    inputs:
+      publish_to_github:
+        description: 'Publish to GitHub Packages instead of npm'
+        type: boolean
+        default: false
     secrets:
       PLANETSCALE_CONNECTION_STRING:
         required: true
@@ -376,7 +381,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    permissions: { contents: read, id-token: write }
+    permissions: { contents: read, id-token: write, packages: write }
     
     # force empty so npm can use OIDC
     env:
@@ -399,6 +404,9 @@ jobs:
       # >= 11.5.1 for trusted publishing
       - name: Update NPM
         run: npm install -g npm@latest
+      - name: Configure GitHub Packages auth
+        if: inputs.publish_to_github
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
       - name: Download package tarball
         uses: actions/download-artifact@v4
         with:
@@ -409,7 +417,19 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          
+
+          if [[ "${{ inputs.publish_to_github }}" == "true" ]]; then
+            # GitHub Packages only accepts packages scoped to the repo owner, and the
+            # repository field must point at this repo for GITHUB_TOKEN publishes
+            pkg_name="@${{ github.repository_owner }}/${{ matrix.package }}"
+            repo_url="git+https://github.com/${{ github.repository }}.git"
+            registry_args=(--registry=https://npm.pkg.github.com)
+          else
+            pkg_name="${{ matrix.package }}"
+            repo_url=""
+            registry_args=()
+          fi
+
           _version="$(tar -xOf ./artifacts/${{ matrix.package }}/package.tgz package/package.json | jq -r .version)"
           branch="${{ github.ref_name }}"
           if [[ "$branch" == "beta" ]]; then
@@ -423,16 +443,18 @@ jobs:
           tmpdir="$(mktemp -d)"
           tar -xzf ./artifacts/${{ matrix.package }}/package.tgz -C "$tmpdir"
 
-          jq --arg v "$version" '.version = $v' \
+          jq --arg v "$version" --arg n "$pkg_name" --arg r "$repo_url" \
+            '.version = $v | .name = $n | if $r != "" then .repository = { type: "git", url: $r } else . end' \
             "$tmpdir/package/package.json" > "$tmpdir/package/package.json.tmp"
             mv "$tmpdir/package/package.json.tmp" "$tmpdir/package/package.json"
 
           tar -czf ./artifacts/${{ matrix.package }}/package.tgz -C "$tmpdir" package
           rm -rf "$tmpdir"
 
-          is_published="$(npm view ${{ matrix.package }} versions --json | jq -r '.[] | select(. == "'$version'") | . == "'$version'"')"
+          # tolerate 404 (never published) and a single-version string response
+          is_published="$(npm view "$pkg_name" versions --json "${registry_args[@]}" 2>/dev/null | jq -r --arg v "$version" '[.] | flatten | any(. == $v)' || echo false)"
           if [[ "$is_published" == "true" ]]; then
-            echo "\`${{ matrix.package }}@$version\` already published, tagging \`$tag\`" >> $GITHUB_STEP_SUMMARY
+            echo "\`$pkg_name@$version\` already published, tagging \`$tag\`" >> $GITHUB_STEP_SUMMARY
           else
             { echo "version=$version"; echo "tag=$tag"; echo "has_new_release=true"; } >> $GITHUB_OUTPUT
           fi
@@ -441,5 +463,11 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          npm publish ./artifacts/${{ matrix.package }}/package.tgz --tag "${{ steps.checks.outputs.tag }}"
-          echo "npm: \`${{ matrix.package }}@${{ steps.checks.outputs.tag }} | ${{ steps.checks.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ inputs.publish_to_github }}" == "true" ]]; then
+            # provenance is npmjs-only
+            npm publish ./artifacts/${{ matrix.package }}/package.tgz --tag "${{ steps.checks.outputs.tag }}" --registry=https://npm.pkg.github.com --no-provenance
+            echo "GitHub Packages: \`@${{ github.repository_owner }}/${{ matrix.package }}@${{ steps.checks.outputs.tag }} | ${{ steps.checks.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          else
+            npm publish ./artifacts/${{ matrix.package }}/package.tgz --tag "${{ steps.checks.outputs.tag }}"
+            echo "npm: \`${{ matrix.package }}@${{ steps.checks.outputs.tag }} | ${{ steps.checks.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -7,6 +7,10 @@ on:
         description: 'Publish to GitHub Packages instead of npm'
         type: boolean
         default: false
+      packages:
+        description: 'Comma-separated list of packages to publish, or "all"'
+        type: string
+        default: 'all'
     secrets:
       PLANETSCALE_CONNECTION_STRING:
         required: true
@@ -45,10 +49,35 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04
     timeout-minutes: 25
+    outputs:
+      publish_matrix: ${{ steps.publish-matrix.outputs.packages }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: 'team_KbvYUtAn1Tqytsj8HbNcYDqV'
     steps:
+      - name: Compute publish matrix
+        id: publish-matrix
+        shell: bash
+        env:
+          PACKAGES_FILTER: ${{ inputs.packages }}
+        run: |
+          set -euo pipefail
+          all='["drizzle-orm","drizzle-kit","drizzle-seed","eslint-plugin-drizzle"]'
+          if [[ -z "$PACKAGES_FILTER" || "$PACKAGES_FILTER" == "all" ]]; then
+            selected="$all"
+          else
+            selected="$(jq -cn --arg f "$PACKAGES_FILTER" '$f | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(. != ""))')"
+            unknown="$(jq -cn --argjson all "$all" --argjson sel "$selected" '$sel - $all')"
+            if [[ "$unknown" != "[]" ]]; then
+              echo "::error::Unknown package(s) in filter: $unknown"
+              exit 1
+            fi
+            if [[ "$selected" == "[]" ]]; then
+              echo "::error::Empty package filter"
+              exit 1
+            fi
+          fi
+          echo "packages=$selected" >> "$GITHUB_OUTPUT"
       - uses: oven-sh/setup-bun@v2
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
@@ -389,7 +418,7 @@ jobs:
       NPM_TOKEN: ""
     strategy:
       matrix:
-        package: [drizzle-orm, drizzle-kit, drizzle-seed, eslint-plugin-drizzle]
+        package: ${{ fromJson(needs.prepare.outputs.publish_matrix) }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/router.yaml
+++ b/.github/workflows/router.yaml
@@ -8,6 +8,10 @@ on:
         description: 'Publish to GitHub Packages instead of npm'
         type: boolean
         default: false
+      packages:
+        description: 'Comma-separated list of packages to publish, or "all"'
+        type: string
+        default: 'all'
 
 jobs:
   switch:
@@ -25,6 +29,10 @@ jobs:
               echo "::error::Publishing to GitHub Packages is only supported for feature-branch dispatches, not main"
               exit 1
             fi
+            if [[ -n "${{ inputs.packages }}" && "${{ inputs.packages }}" != "all" ]]; then
+              echo "::error::Package filtering is only supported for feature-branch dispatches, not main"
+              exit 1
+            fi
             echo "target=latest" >> $GITHUB_OUTPUT
           else
             # workflow_dispatch on a non-main ref and any pull request (same-repo or
@@ -40,6 +48,7 @@ jobs:
     uses: ./.github/workflows/release-feature-branch.yaml
     with:
       publish_to_github: ${{ inputs.publish_to_github == true }}
+      packages: ${{ inputs.packages || 'all' }}
     secrets:
       PLANETSCALE_CONNECTION_STRING: ${{ secrets.PLANETSCALE_CONNECTION_STRING }}
       NEON_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}

--- a/.github/workflows/router.yaml
+++ b/.github/workflows/router.yaml
@@ -3,6 +3,11 @@ name: Release Router
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      publish_to_github:
+        description: 'Publish to GitHub Packages instead of npm'
+        type: boolean
+        default: false
 
 jobs:
   switch:
@@ -16,6 +21,10 @@ jobs:
         run: |
           HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "${GITHUB_REF##*/}" == "main" ]]; then
+            if [[ "${{ inputs.publish_to_github }}" == "true" ]]; then
+              echo "::error::Publishing to GitHub Packages is only supported for feature-branch dispatches, not main"
+              exit 1
+            fi
             echo "target=latest" >> $GITHUB_OUTPUT
           else
             # workflow_dispatch on a non-main ref and any pull request (same-repo or
@@ -29,6 +38,8 @@ jobs:
     needs: switch
     if: needs.switch.outputs.target == 'feature'
     uses: ./.github/workflows/release-feature-branch.yaml
+    with:
+      publish_to_github: ${{ inputs.publish_to_github == true }}
     secrets:
       PLANETSCALE_CONNECTION_STRING: ${{ secrets.PLANETSCALE_CONNECTION_STRING }}
       NEON_CONNECTION_STRING: ${{ secrets.NEON_CONNECTION_STRING }}


### PR DESCRIPTION
Adds two inputs to the Release Router's `workflow_dispatch` form, threaded into the feature-branch release pipeline:

- **`publish_to_github`** (checkbox, default off) — the release job publishes to `npm.pkg.github.com` instead of npm, authenticated with `GITHUB_TOKEN` (`packages: write`). GitHub Packages only accepts owner-scoped names, so the existing tarball rewrite also sets the name to `@drizzle-team/<pkg>` and normalizes the `repository` field; provenance is disabled for this path (npmjs-only). The npm path is unchanged, including OIDC trusted publishing.
- **`packages`** (text, default `all`) — comma-separated list of packages to publish (e.g. `drizzle-orm` or `drizzle-orm, drizzle-kit`). Validated as the first step of `prepare` so a typo fails the run immediately; the validated list drives the `release` job matrix via `fromJson`, so filtered-out packages don't spawn jobs.

The already-published check now queries whichever registry is targeted and tolerates a 404 (first publish) and npm's single-version string response.

Both options are feature-branch-only: a dispatch on `main` with either set fails the router with an explicit error instead of being silently ignored — the latest flow's precondition/changelog logic is tied to npmjs state and is untouched.