### PR TITLE
Declare `publish_to_github` and `packages` inputs on the release dispatch form

### DIFF
--- a/.github/workflows/router.yaml
+++ b/.github/workflows/router.yaml
@@ -6,6 +6,15 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+    inputs:
+      publish_to_github:
+        description: 'Publish to GitHub Packages instead of npm'
+        type: boolean
+        default: false
+      packages:
+        description: 'Comma-separated list of packages to publish, or "all"'
+        type: string
+        default: 'all'
 
 jobs:
   switch:


### PR DESCRIPTION
Adds only the `workflow_dispatch` input declarations to the Release Router so the "Run workflow" form renders the new fields. The implementation that consumes them lives in #5999 (targeting `rc5`); the definitions here are textually identical to that PR's.

Nothing on `main` reads these inputs yet, so a dispatch on `main` with either set is silently ignored and behaves exactly as today (routes to the latest npm release flow). #5999 adds an explicit router guard for that case, which will land here when it flows to `main`.