### PR TITLE
Pin the release npm self-update to major 11

### DIFF
--- a/.github/workflows/release-feature-branch-beelink.yaml
+++ b/.github/workflows/release-feature-branch-beelink.yaml
@@ -376,7 +376,7 @@ jobs:
     
       # >= 11.5.1 for trusted publishing
       - name: Update NPM
-        run: npm install -g npm@latest
+        run: npm install -g npm@11 # npm 12.0.0 ships without sigstore in its bundled tree and breaks `npm publish`
       
       # Restore packages from local filesystem
       - name: Restore packages locally

--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -455,7 +455,7 @@ jobs:
     
       # >= 11.5.1 for trusted publishing
       - name: Update NPM
-        run: npm install -g npm@latest
+        run: npm install -g npm@11 # npm 12.0.0 ships without sigstore in its bundled tree and breaks `npm publish`
       - name: Configure GitHub Packages auth
         if: inputs.publish_to_github
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"


### PR DESCRIPTION
The rc5 dispatch failed in `run-feature / release (drizzle-orm)` with `Cannot find module 'sigstore'` from `libnpmpublish/lib/provenance.js` (https://github.com/drizzle-team/drizzle-orm/actions/runs/29099638299).

Root cause: npm 12.0.0 was just published as `latest`, and its tarball is missing `sigstore` from the flattened `node_modules` tree (it only exists under `workspaces/libnpmpublish/node_modules/`, which isn't on the require path). Since `provenance.js` is loaded unconditionally, every `npm publish` fails — `--no-provenance` doesn't help. Verified by inspecting the tarballs: `npm-12.0.0.tgz` has zero `package/node_modules/sigstore/` entries, `npm-11.18.0.tgz` has them.

Fix: pin the `Update NPM` step to `npm@11` (currently 11.18.0) in both feature-branch release workflows. The `>= 11.5.1` trusted-publishing requirement still holds; the pin can move to 12 once upstream ships a fixed tarball.