### PR TITLE
Pin the release npm self-update to major 11

### DIFF
--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -366,7 +366,7 @@ jobs:
     
       # >= 11.5.1 for trusted publishing
       - name: Update NPM
-        run: npm install -g npm@latest
+        run: npm install -g npm@11 # npm 12.0.0 ships without sigstore in its bundled tree and breaks `npm publish`
 
       # nuke, so npm can use OIDC
       - name: Remove temp npmrc

--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -398,7 +398,7 @@ jobs:
     
       # >= 11.5.1 for trusted publishing
       - name: Update NPM
-        run: npm install -g npm@latest
+        run: npm install -g npm@11 # npm 12.0.0 ships without sigstore in its bundled tree and breaks `npm publish`
 
       # nuke, so npm can use OIDC
       - name: Remove temp npmrc


### PR DESCRIPTION
Same fix as #6003, applied to `main`'s copies (`release-feature-branch.yaml` and `release-latest.yaml` — the latter is the npm-latest publish flow and would fail identically on the next `main` dispatch).

npm 12.0.0 was just published as `latest` with a broken tarball: `sigstore` is missing from the flattened `node_modules` tree, so `libnpmpublish/lib/provenance.js` fails at require time and every `npm publish` errors with `Cannot find module 'sigstore'` (seen in https://github.com/drizzle-team/drizzle-orm/actions/runs/29099638299). Pinning the `Update NPM` step to `npm@11` (currently 11.18.0) keeps the `>= 11.5.1` trusted-publishing requirement while avoiding the broken major.