### PR TITLE
Publish to GitHub Packages with a PAT and no repo linkage so packages stay private

### DIFF
--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -36,10 +36,12 @@ on:
         required: true
       SQLITE_MANY_CLOUD_CONNECTION_STRING:
         required: true
-      TURBO_TOKEN: 
+      TURBO_TOKEN:
         required: true
-      NETLIFY_DB_URL: 
+      NETLIFY_DB_URL:
         required: true
+      GH_PACKAGES_TOKEN:
+        required: false
 
 concurrency:
   group: feature-${{ github.workflow }}-${{ github.ref }}
@@ -433,7 +435,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    permissions: { contents: read, id-token: write, packages: write }
+    permissions: { contents: read, id-token: write }
     
     # force empty so npm can use OIDC
     env:
@@ -458,7 +460,16 @@ jobs:
         run: npm install -g npm@11 # npm 12.0.0 ships without sigstore in its bundled tree and breaks `npm publish`
       - name: Configure GitHub Packages auth
         if: inputs.publish_to_github
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+        env:
+          # a PAT instead of GITHUB_TOKEN: workflow-token publishes link the package to this
+          # public repo and inherit its visibility; PAT publishes default to private
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+        run: |
+          if [[ -z "$GH_PACKAGES_TOKEN" ]]; then
+            echo "::error::Set the GH_PACKAGES_TOKEN secret (classic PAT with write:packages) to publish to GitHub Packages"
+            exit 1
+          fi
+          echo "//npm.pkg.github.com/:_authToken=$GH_PACKAGES_TOKEN" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
       - name: Download package tarball
         uses: actions/download-artifact@v4
         with:
@@ -471,14 +482,14 @@ jobs:
           set -euxo pipefail
 
           if [[ "${{ inputs.publish_to_github }}" == "true" ]]; then
-            # GitHub Packages only accepts packages scoped to the repo owner, and the
-            # repository field must point at this repo for GITHUB_TOKEN publishes
+            # GitHub Packages only accepts packages scoped to the repo owner; the repository
+            # field is stripped so the package isn't linked to this public repo and stays private
             pkg_name="@${{ github.repository_owner }}/${{ matrix.package }}"
-            repo_url="git+https://github.com/${{ github.repository }}.git"
+            strip_repo="true"
             registry_args=(--registry=https://npm.pkg.github.com)
           else
             pkg_name="${{ matrix.package }}"
-            repo_url=""
+            strip_repo="false"
             registry_args=()
           fi
 
@@ -495,8 +506,8 @@ jobs:
           tmpdir="$(mktemp -d)"
           tar -xzf ./artifacts/${{ matrix.package }}/package.tgz -C "$tmpdir"
 
-          jq --arg v "$version" --arg n "$pkg_name" --arg r "$repo_url" \
-            '.version = $v | .name = $n | if $r != "" then .repository = { type: "git", url: $r } else . end' \
+          jq --arg v "$version" --arg n "$pkg_name" --argjson strip_repo "$strip_repo" \
+            '.version = $v | .name = $n | if $strip_repo then del(.repository) else . end' \
             "$tmpdir/package/package.json" > "$tmpdir/package/package.json.tmp"
             mv "$tmpdir/package/package.json.tmp" "$tmpdir/package/package.json"
 

--- a/.github/workflows/router.yaml
+++ b/.github/workflows/router.yaml
@@ -64,6 +64,7 @@ jobs:
       SQLITE_MANY_CLOUD_CONNECTION_STRING: ${{ secrets.SQLITE_MANY_CLOUD_CONNECTION_STRING }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       NETLIFY_DB_URL: ${{ secrets.NETLIFY_DB_URL }}
+      GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
   run-latest:
     needs: switch


### PR DESCRIPTION
Recreates the previously closed #6002 — now with empirical proof it's required: the first GitHub Packages dispatch published `@drizzle-team/drizzle-orm` as **public** (https://github.com/drizzle-team/drizzle-orm/pkgs/npm/drizzle-orm), because packages published via `GITHUB_TOKEN` are auto-connected to the workflow's repository and take its visibility. The "first publish defaults to private" doc language does not apply to that path.

- Auth switches from `GITHUB_TOKEN` to a **`GH_PACKAGES_TOKEN`** secret (classic PAT with `write:packages`; fine-grained PATs don't work with GitHub Packages). PAT publishes create org-scoped packages with the default private visibility. The step fails fast with a clear error if the secret isn't set, and the release job drops `packages: write`.
- The tarball rewrite strips the `repository` field on the GitHub path so there's no repo linkage to inherit visibility from. The npm path stays byte-for-byte unchanged.

Before the next GitHub Packages dispatch:
1. **Delete the existing public `drizzle-orm` package** (package settings → Danger Zone). Visibility is a one-way door — "Once you make a package public, you cannot make it private again" — so republishing onto the existing package would keep it public forever.
2. Create the `GH_PACKAGES_TOKEN` secret.

Optional belt-and-braces: org Settings → Packages → Package Creation → uncheck "Public".