### PR TITLE
Allow not() to compose with and()/or() (undefined-safe)

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -166,16 +166,25 @@ export function or(
 /**
  * Negate the meaning of an expression using the `not` keyword.
  *
+ * A condition that is equal to `undefined` is passed through as `undefined`,
+ * so `not` composes with `and`/`or`, which may return `undefined`.
+ *
  * ## Examples
  *
  * ```ts
  * // Select cars _not_ made by GM or Ford.
  * db.select().from(cars)
  *   .where(not(inArray(cars.make, ['GM', 'Ford'])))
+ *
+ * // Composes with `and`/`or`, which can return `undefined`.
+ * db.select().from(cars)
+ *   .where(not(and(eq(cars.make, 'GM'), eq(cars.year, 1950))))
  * ```
  */
-export function not(condition: SQLWrapper): SQL {
-	return sql`not ${condition}`;
+export function not(condition: SQLWrapper): SQL;
+export function not(condition: SQLWrapper | undefined): SQL | undefined;
+export function not(condition: SQLWrapper | undefined): SQL | undefined {
+	return condition === undefined ? undefined : sql`not ${condition}`;
 }
 
 /**

--- a/drizzle-orm/type-tests/geldb/select.ts
+++ b/drizzle-orm/type-tests/geldb/select.ts
@@ -440,6 +440,8 @@ const allOperators = await db
 			ne(users.id, 1),
 			or(eq(users.id, 1), ne(users.id, 1)),
 			not(eq(users.id, 1)),
+			not(and(eq(users.id, 1), ne(users.id, 1))),
+			not(or(eq(users.id, 1), ne(users.id, 1))),
 			gt(users.id, 1),
 			gte(users.id, 1),
 			lt(users.id, 1),

--- a/drizzle-orm/type-tests/mysql/select.ts
+++ b/drizzle-orm/type-tests/mysql/select.ts
@@ -308,6 +308,8 @@ const allOperators = await db
 		ne(users.id, 1),
 		or(eq(users.id, 1), ne(users.id, 1)),
 		not(eq(users.id, 1)),
+		not(and(eq(users.id, 1), ne(users.id, 1))),
+		not(or(eq(users.id, 1), ne(users.id, 1))),
 		gt(users.id, 1),
 		gte(users.id, 1),
 		lt(users.id, 1),

--- a/drizzle-orm/type-tests/pg/select.ts
+++ b/drizzle-orm/type-tests/pg/select.ts
@@ -439,6 +439,8 @@ const allOperators = await db
 			ne(users.id, 1),
 			or(eq(users.id, 1), ne(users.id, 1)),
 			not(eq(users.id, 1)),
+			not(and(eq(users.id, 1), ne(users.id, 1))),
+			not(or(eq(users.id, 1), ne(users.id, 1))),
 			gt(users.id, 1),
 			gte(users.id, 1),
 			lt(users.id, 1),

--- a/drizzle-orm/type-tests/singlestore/select.ts
+++ b/drizzle-orm/type-tests/singlestore/select.ts
@@ -376,6 +376,8 @@ const allOperators = await db
 		ne(users.id, 1),
 		or(eq(users.id, 1), ne(users.id, 1)),
 		not(eq(users.id, 1)),
+		not(and(eq(users.id, 1), ne(users.id, 1))),
+		not(or(eq(users.id, 1), ne(users.id, 1))),
 		gt(users.id, 1),
 		gte(users.id, 1),
 		lt(users.id, 1),

--- a/drizzle-orm/type-tests/sqlite/select.ts
+++ b/drizzle-orm/type-tests/sqlite/select.ts
@@ -387,6 +387,8 @@ const allOperators = db
 		ne(users.id, 1),
 		or(eq(users.id, 1), ne(users.id, 1)),
 		not(eq(users.id, 1)),
+		not(and(eq(users.id, 1), ne(users.id, 1))),
+		not(or(eq(users.id, 1), ne(users.id, 1))),
 		gt(users.id, 1),
 		gte(users.id, 1),
 		lt(users.id, 1),


### PR DESCRIPTION
## Summary

Fixes #1818.

`and()` and `or()` are typed to return `SQL | undefined` (they drop
`undefined` conditions and return `undefined` when nothing is left).
`not()`, however, only accepted `SQLWrapper`, so composing them:

```ts
db.query.users.findMany({
  where: not(and(ilike(users.name, '%asdf%'))),
})
```

failed to type-check with:

```
TS2345: Argument of type 'SQL | undefined' is not assignable to parameter of type 'SQLWrapper'.
  Type 'undefined' is not assignable to type 'SQLWrapper'.
```

and forced a manual `as SQLWrapper` cast on the inner expression.

## Change

Add an overload to `not()` so it also accepts `SQLWrapper | undefined`
and returns `SQL | undefined`, passing `undefined` straight through — the
same way `and()` / `or()` already ignore undefined conditions.

```ts
export function not(condition: SQLWrapper): SQL;
export function not(condition: SQLWrapper | undefined): SQL | undefined;
export function not(condition: SQLWrapper | undefined): SQL | undefined {
  return condition === undefined ? undefined : sql`not ${condition}`;
}
```

The original overload is kept, so `not(eq(...))` still returns `SQL`
(not `SQL | undefined`). No existing call site changes its inferred type,
so this is non-breaking.

## Tests

Added type-test coverage for `not(and(...))` and `not(or(...))` in the
`allOperators` block of the pg, mysql, sqlite, singlestore and geldb
`type-tests/*/select.ts` files. These lines fail to compile on `main`
(the exact TS2345 above) and compile with this change.

## Note on conventions

This is a core, dialect-agnostic operator change, so it doesn't map to a
single `[<dialect>]:` tag — the type-tests are updated for every dialect
instead.