### PR TITLE
fix(cache): disambiguate undefined array elements in hashQuery cache key

### DIFF
--- a/drizzle-orm/src/cache/core/cache.ts
+++ b/drizzle-orm/src/cache/core/cache.ts
@@ -67,7 +67,9 @@ export class NoopCache extends Cache {
 export type MutationOption = { tags?: string | string[]; tables?: Table<any> | Table<any>[] | string | string[] };
 
 export async function hashQuery(sql: string, params?: any[]) {
-	const dataToHash = `${sql}-${JSON.stringify(params)}`;
+	const dataToHash = `${sql}-${
+		JSON.stringify(params, (_, v) => (v === undefined ? '__undefined__' : v))
+	}`;
 	const encoder = new TextEncoder();
 	const data = encoder.encode(dataToHash);
 	const hashBuffer = await crypto.subtle.digest('SHA-256', data);

--- a/drizzle-orm/tests/cache-hash.test.ts
+++ b/drizzle-orm/tests/cache-hash.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import { hashQuery } from '~/cache/core/cache.ts';
+
+// @see https://github.com/drizzle-team/drizzle-orm/issues/5842
+// `JSON.stringify` silently coerces `undefined` array elements to `null`.
+// Without the replacer in `hashQuery`, `[null]` and `[undefined]` would
+// serialise to the identical string `"[null]"` and produce the same SHA-256
+// hash, so two structurally different parameter arrays would collide on the
+// same cache key and return the cached result of the other query.
+describe('hashQuery', () => {
+	test('produces different hashes for [null] and [undefined] params', async () => {
+		const sql = 'SELECT * FROM users WHERE id = ?';
+		const hashNull = await hashQuery(sql, [null]);
+		const hashUndefined = await hashQuery(sql, [undefined]);
+		expect(hashNull).not.toBe(hashUndefined);
+	});
+
+	test('produces different hashes for [] and [undefined] params', async () => {
+		const sql = 'SELECT * FROM users WHERE id IN ?';
+		const hashEmpty = await hashQuery(sql, []);
+		const hashUndefined = await hashQuery(sql, [undefined]);
+		expect(hashEmpty).not.toBe(hashUndefined);
+	});
+
+	test('produces stable hashes for repeated calls (regression guard)', async () => {
+		const sql = 'SELECT * FROM users WHERE id = ?';
+		const a = await hashQuery(sql, [42]);
+		const b = await hashQuery(sql, [42]);
+		expect(a).toBe(b);
+	});
+});


### PR DESCRIPTION
## Summary

`hashQuery` in `src/cache/core/cache.ts` builds the cache key via `JSON.stringify(params)`. JavaScript's `JSON.stringify` silently coerces every `undefined` array element to `null`, so `[null]` and `[undefined]` serialise to the identical string `"[null]"` and produce the same SHA-256 hash. Two structurally different parameter arrays then collide on the same cache slot and a cached result from a prior query is returned for the new one.

## Fix

Pass a replacer to `JSON.stringify` that maps `undefined` to the sentinel string `"__undefined__"`, making it distinguishable from `null` in the serialised form. The hash itself is unchanged for inputs that do not contain `undefined`, so this is a strict bug fix with no behaviour change for the common case.

## Test

Adds `drizzle-orm/tests/cache-hash.test.ts` with three regression cases:
- `[null]` and `[undefined]` params produce different hashes
- `[]` and `[undefined]` params produce different hashes
- repeated calls with the same input produce the same hash (stability guard)

The fix was also verified with a standalone Node script: the original `JSON.stringify(params)` produces the same SHA-256 for `[null]` and `[undefined]`, the fixed replacer produces two distinct hashes, and same-input determinism is preserved.

## Closes

Closes #5842