### PR TITLE
fix(orm): parenthesize isNull/isNotNull so they are safe as operands

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -350,7 +350,7 @@ export function notInArray(
  * @see isNotNull for the inverse of this test
  */
 export function isNull(value: SQLWrapper): SQL {
-	return sql`${value} is null`;
+	return sql`(${value} is null)`;
 }
 
 /**
@@ -370,7 +370,7 @@ export function isNull(value: SQLWrapper): SQL {
  * @see isNull for the inverse of this test
  */
 export function isNotNull(value: SQLWrapper): SQL {
-	return sql`${value} is not null`;
+	return sql`(${value} is not null)`;
 }
 
 /**

--- a/drizzle-orm/tests/conditions-null-parens.test.ts
+++ b/drizzle-orm/tests/conditions-null-parens.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { PgDialect } from '~/pg-core/dialect';
+import { eq, isNotNull, isNull } from '~/sql/expressions/conditions';
+import { type SQL, sql } from '~/sql/sql';
+
+describe('isNull / isNotNull parenthesization (#6010)', () => {
+	const dialect = new PgDialect();
+	const render = (query: SQL) => dialect.sqlToQuery(query).sql;
+
+	it('wraps the expression so it is safe as an operand', () => {
+		expect(render(isNull(sql`"a"`))).toBe('("a" is null)');
+		expect(render(isNotNull(sql`"a"`))).toBe('("a" is not null)');
+	});
+
+	it('keeps operator precedence when compared via eq', () => {
+		expect(render(eq(isNotNull(sql`"a"`), isNotNull(sql`"b"`)))).toBe(
+			'("a" is not null) = ("b" is not null)',
+		);
+		expect(render(eq(isNull(sql`"a"`), isNull(sql`"b"`)))).toBe(
+			'("a" is null) = ("b" is null)',
+		);
+	});
+});


### PR DESCRIPTION
Fixes #6010

### Problem
`isNull` / `isNotNull` emit `<expr> is null` / `<expr> is not null` without parentheses. When one is used as an operand of another operator — e.g. comparing two of them with `eq` inside a `check()` constraint — the generated SQL loses precedence:

```ts
check('a_and_b_same_nullability', eq(isNotNull(table.a), isNotNull(table.b)))
```
```sql
-- before
CHECK ("example"."a" is not null = "example"."b" is not null)
-- after
CHECK (("example"."a" is not null) = ("example"."b" is not null))
```

### Fix
Wrap the expression in parentheses, matching how `and`/`or` already wrap their output. This makes `isNull`/`isNotNull` safe to nest as operands.

### Tests
Added `drizzle-orm/tests/conditions-null-parens.test.ts`, rendering the expressions via `PgDialect`. The assertions fail on `main` (`"a" is not null = "b" is not null`) and pass with this change. `dprint check` is clean.

Note: this also adds parentheses around top-level uses (e.g. `where(isNull(x))` → `WHERE (x is null)`), which is semantically identical and consistent with `and`/`or`.
