### PR TITLE
Link the published GitHub package version from the workflow step summary

### DIFF
--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -531,9 +531,14 @@ jobs:
           if [[ "${{ inputs.publish_to_github }}" == "true" ]]; then
             # provenance is npmjs-only
             npm publish ./artifacts/${{ matrix.package }}/package.tgz --tag "${{ steps.checks.outputs.tag }}" --registry=https://npm.pkg.github.com --no-provenance
-            pkg_url="$(curl -fsSL -H "Authorization: Bearer $GH_PACKAGES_TOKEN" \
-              "https://api.github.com/orgs/${{ github.repository_owner }}/packages/npm/${{ matrix.package }}/versions?per_page=100" \
-              | jq -r --arg v "${{ steps.checks.outputs.version }}" 'first(.[] | select(.name == $v) | .html_url) // empty' || true)"
+            pkg_url=""
+            SECONDS=0
+            until [[ -n "$pkg_url" ]] || (( SECONDS >= 10 )); do
+              pkg_url="$(curl -fsSL -H "Authorization: Bearer $GH_PACKAGES_TOKEN" \
+                "https://api.github.com/orgs/${{ github.repository_owner }}/packages/npm/${{ matrix.package }}/versions?per_page=100" \
+                | jq -r --arg v "${{ steps.checks.outputs.version }}" 'first(.[] | select(.name == $v) | .html_url) // empty' || true)"
+              [[ -n "$pkg_url" ]] || sleep 2
+            done
             pkg_url="${pkg_url:-https://github.com/orgs/${{ github.repository_owner }}/packages/npm/package/${{ matrix.package }}}"
             echo "GitHub Packages: [\`@${{ github.repository_owner }}/${{ matrix.package }}@${{ steps.checks.outputs.tag }} | ${{ steps.checks.outputs.version }}\`]($pkg_url)" >> $GITHUB_STEP_SUMMARY
           else

--- a/.github/workflows/release-feature-branch.yaml
+++ b/.github/workflows/release-feature-branch.yaml
@@ -524,12 +524,18 @@ jobs:
       - name: Publish (from tarball)
         if: steps.checks.outputs.has_new_release == 'true'
         shell: bash
+        env:
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
         run: |
           set -euxo pipefail
           if [[ "${{ inputs.publish_to_github }}" == "true" ]]; then
             # provenance is npmjs-only
             npm publish ./artifacts/${{ matrix.package }}/package.tgz --tag "${{ steps.checks.outputs.tag }}" --registry=https://npm.pkg.github.com --no-provenance
-            echo "GitHub Packages: \`@${{ github.repository_owner }}/${{ matrix.package }}@${{ steps.checks.outputs.tag }} | ${{ steps.checks.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+            pkg_url="$(curl -fsSL -H "Authorization: Bearer $GH_PACKAGES_TOKEN" \
+              "https://api.github.com/orgs/${{ github.repository_owner }}/packages/npm/${{ matrix.package }}/versions?per_page=100" \
+              | jq -r --arg v "${{ steps.checks.outputs.version }}" 'first(.[] | select(.name == $v) | .html_url) // empty' || true)"
+            pkg_url="${pkg_url:-https://github.com/orgs/${{ github.repository_owner }}/packages/npm/package/${{ matrix.package }}}"
+            echo "GitHub Packages: [\`@${{ github.repository_owner }}/${{ matrix.package }}@${{ steps.checks.outputs.tag }} | ${{ steps.checks.outputs.version }}\`]($pkg_url)" >> $GITHUB_STEP_SUMMARY
           else
             npm publish ./artifacts/${{ matrix.package }}/package.tgz --tag "${{ steps.checks.outputs.tag }}"
             echo "npm: \`${{ matrix.package }}@${{ steps.checks.outputs.tag }} | ${{ steps.checks.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
After a GitHub Packages publish, the step summary line is now a markdown link pointing directly at the published version's page (e.g. `https://github.com/orgs/drizzle-team/packages/npm/drizzle-orm/<version-id>`). The version id is resolved by listing the package's versions via the REST API with the same `GH_PACKAGES_TOKEN` used for publishing and matching the just-published version's `html_url`; if the lookup fails for any reason the link falls back to the package overview page instead of failing the job. The npm path's summary is unchanged.