### PR TITLE
[pg,gel]: forward withList to selectDistinct/selectDistinctOn in standalone QueryBuilder

### DIFF
--- a/drizzle-orm/src/gel-core/query-builders/query-builder.ts
+++ b/drizzle-orm/src/gel-core/query-builders/query-builder.ts
@@ -63,6 +63,7 @@ export class QueryBuilder {
 				fields: fields ?? undefined,
 				session: undefined,
 				dialect: self.getDialect(),
+				withList: queries,
 				distinct: true,
 			});
 		}
@@ -80,6 +81,7 @@ export class QueryBuilder {
 				fields: fields ?? undefined,
 				session: undefined,
 				dialect: self.getDialect(),
+				withList: queries,
 				distinct: { on },
 			});
 		}

--- a/drizzle-orm/src/pg-core/query-builders/query-builder.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query-builder.ts
@@ -71,6 +71,7 @@ export class QueryBuilder {
 				fields: fields ?? undefined,
 				session: undefined,
 				dialect: self.getDialect(),
+				withList: queries,
 				distinct: true,
 			});
 		}
@@ -88,6 +89,7 @@ export class QueryBuilder {
 				fields: fields ?? undefined,
 				session: undefined,
 				dialect: self.getDialect(),
+				withList: queries,
 				distinct: { on },
 			});
 		}

--- a/drizzle-orm/tests/with-select-distinct.test.ts
+++ b/drizzle-orm/tests/with-select-distinct.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { QueryBuilder as GelQueryBuilder } from '~/gel-core/index.ts';
+import { integer as gelInteger, text as gelText } from '~/gel-core/index.ts';
+import { gelTable } from '~/gel-core/table.ts';
+import { integer, pgTable, QueryBuilder, text } from '~/pg-core/index.ts';
+
+const users = pgTable('users', {
+	id: integer('id').primaryKey(),
+	name: text('name').notNull(),
+});
+
+const gelUsers = gelTable('users', {
+	id: gelInteger('id').primaryKey(),
+	name: gelText('name').notNull(),
+});
+
+// Regression tests for https://github.com/drizzle-team/drizzle-orm/issues/4095
+// The standalone QueryBuilder must forward the `with` list to selectDistinct /
+// selectDistinctOn, otherwise the generated SQL silently drops the CTE.
+describe('standalone QueryBuilder .with(...).selectDistinct keeps CTE (#4095)', () => {
+	it('[pg] select keeps the WITH clause', () => {
+		const qb = new QueryBuilder();
+		const sq = qb.$with('sq').as(qb.select({ id: users.id }).from(users));
+		const query = qb.with(sq).select({ id: sq.id }).from(sq).toSQL();
+
+		expect(query.sql).toBe('with "sq" as (select "id" from "users") select "id" from "sq"');
+	});
+
+	it('[pg] selectDistinct keeps the WITH clause', () => {
+		const qb = new QueryBuilder();
+		const sq = qb.$with('sq').as(qb.select({ id: users.id }).from(users));
+		const query = qb.with(sq).selectDistinct({ id: sq.id }).from(sq).toSQL();
+
+		expect(query.sql).toBe('with "sq" as (select "id" from "users") select distinct "id" from "sq"');
+	});
+
+	it('[pg] selectDistinctOn keeps the WITH clause', () => {
+		const qb = new QueryBuilder();
+		const sq = qb.$with('sq').as(qb.select({ id: users.id }).from(users));
+		const query = qb.with(sq).selectDistinctOn([sq.id], { id: sq.id }).from(sq).toSQL();
+
+		expect(query.sql).toBe('with "sq" as (select "id" from "users") select distinct on ("sq"."id") "id" from "sq"');
+	});
+
+	it('[gel] selectDistinct keeps the WITH clause', () => {
+		const qb = new GelQueryBuilder();
+		const sq = qb.$with('sq').as(qb.select({ id: gelUsers.id }).from(gelUsers));
+		const query = qb.with(sq).selectDistinct({ id: sq.id }).from(sq).toSQL();
+
+		expect(query.sql).toBe('with "sq" as (select "users"."id" from "users") select distinct "sq"."id" from "sq"');
+	});
+
+	it('[gel] selectDistinctOn keeps the WITH clause', () => {
+		const qb = new GelQueryBuilder();
+		const sq = qb.$with('sq').as(qb.select({ id: gelUsers.id }).from(gelUsers));
+		const query = qb.with(sq).selectDistinctOn([sq.id], { id: sq.id }).from(sq).toSQL();
+
+		expect(query.sql).toBe(
+			'with "sq" as (select "users"."id" from "users") select distinct on ("sq"."id") "sq"."id" from "sq"',
+		);
+	});
+});


### PR DESCRIPTION
### What & why

`QueryBuilder.with(...queries).selectDistinct(...)` and `.selectDistinctOn(...)` silently drop the entire `WITH` clause, producing SQL that references an undefined CTE relation (runtime `relation "…" does not exist`).

The standalone `QueryBuilder.with(...)` closure forwards `withList: queries` to the `select` builder, but `selectDistinct` and `selectDistinctOn` omit it. The sibling `select` path and all `db`-level `.with()` builders already pass `withList`, so this is a parity gap. Same copy-paste omission exists in both the Pg and Gel dialects (mysql/sqlite/singlestore query-builders are already correct; mssql has no standalone `QueryBuilder`).

Fixes #4095 (labeled `bug`, `priority`).

### Fix

Add `withList: queries,` to `selectDistinct` and `selectDistinctOn` in:
- `src/pg-core/query-builders/query-builder.ts`
- `src/gel-core/query-builders/query-builder.ts`

### Tests

New `tests/with-select-distinct.test.ts` — 5 DB-free `.toSQL()` assertions (pg + gel; plain select, selectDistinct, selectDistinctOn) confirming the `WITH` clause is emitted. `pnpm vitest run tests/with-select-distinct.test.ts` → 5 passed; full DB-free suite 571 passed, no regressions. Verified red→green (reverting the fix turns the suite red).

Closes #4095
