### PR TITLE
fix(drizzle-orm): parenthesize isNull/isNotNull on main, matching beta (#6010)

### DIFF
--- a/drizzle-orm/src/sql/expressions/conditions.ts
+++ b/drizzle-orm/src/sql/expressions/conditions.ts
@@ -350,7 +350,7 @@ export function notInArray(
  * @see isNotNull for the inverse of this test
  */
 export function isNull(value: SQLWrapper): SQL {
-	return sql`${value} is null`;
+	return sql`(${value} is null)`;
 }
 
 /**
@@ -370,7 +370,7 @@ export function isNull(value: SQLWrapper): SQL {
  * @see isNull for the inverse of this test
  */
 export function isNotNull(value: SQLWrapper): SQL {
-	return sql`${value} is not null`;
+	return sql`(${value} is not null)`;
 }
 
 /**

--- a/drizzle-orm/tests/conditions.test.ts
+++ b/drizzle-orm/tests/conditions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+
+import { PgDialect, pgTable, timestamp, varchar } from '~/pg-core';
+import { and, eq, isNotNull, isNull, or } from '~/sql/expressions/conditions';
+import type { SQL } from '~/sql/sql';
+
+const users = pgTable('users', {
+	name: varchar('name'),
+	deletedAt: timestamp('deleted_at'),
+});
+
+const render = (condition: SQL): string => new PgDialect().sqlToQuery(condition).sql;
+
+describe('isNull / isNotNull parenthesization', () => {
+	// https://github.com/drizzle-team/drizzle-orm/issues/6010
+	test('composes inside a binary operator without producing invalid SQL', () => {
+		// Unparenthesized this renders `"users"."name" is not null = "users"."deleted_at" is not null`.
+		// Postgres rejects it: `=` binds tighter than `IS NOT NULL`, so the server reads it as
+		// `"users"."name" is not (null = "users"."deleted_at") is not null`.
+		expect(render(eq(isNotNull(users.name), isNotNull(users.deletedAt)))).toBe(
+			'("users"."name" is not null) = ("users"."deleted_at" is not null)',
+		);
+	});
+
+	test('parenthesizes isNull the same way', () => {
+		expect(render(eq(isNull(users.name), isNull(users.deletedAt)))).toBe(
+			'("users"."name" is null) = ("users"."deleted_at" is null)',
+		);
+	});
+
+	test('composes with and/or, which already parenthesize themselves', () => {
+		expect(render(and(isNull(users.deletedAt), or(isNotNull(users.name), eq(users.name, 'a')))!)).toBe(
+			'(("users"."deleted_at" is null) and (("users"."name" is not null) or "users"."name" = $1))',
+		);
+	});
+});


### PR DESCRIPTION
### What changed?

Wrapped `isNull` and `isNotNull` in parentheses in `drizzle-orm/src/sql/expressions/conditions.ts`, and added `drizzle-orm/tests/conditions.test.ts` to cover it.

### Why?

Composing either one inside a binary operator — `eq(isNotNull(table.a), isNotNull(table.b))`, typically in a `check()` constraint — renders:

```sql
CHECK ("example"."a" is not null = "example"."b" is not null)
```

Postgres rejects that. `=` binds tighter than `IS NOT NULL`, so the server reads it as `"a" is not (null = "b") is not null`. With the parentheses it renders `("a" is not null) = ("b" is not null)`, which is what the schema author wrote. That is [#6010](https://github.com/drizzle-team/drizzle-orm/issues/6010).

### This is a backport, not a new proposal

**`beta` already has exactly this change**, shipped in `drizzle-orm@1.0.0-rc.4` — the two lines here are byte-identical to the ones on that branch, and there is a `conditions-wrap` dist-tag from that work. #6010 was closed as fixed on that basis, which is correct for v1.

`main` never got it, and `main` is what publishes as **`npm latest` → `0.45.2`**. So the bug is still live for every stable user, including #6010's reporter, and the closed issue makes it look otherwise. This PR only pulls `main` level with `beta`.

### Consistency

`and()` and `or()` in this same module already wrap their output in `StringChunk('(')` / `StringChunk(')')`. `isNull` / `isNotNull` were the outliers, so this follows the file's existing convention rather than introducing one.

### Tests

`beta` has no test for this; this PR adds three. They render the condition through `new PgDialect().sqlToQuery(cond).sql` and assert the string, rather than asserting the expression is merely defined:

- `eq(isNotNull, isNotNull)` — the #6010 case
- `eq(isNull, isNull)` — the same for the negated form
- nested inside `and`/`or`, pinning the interaction with the two operators that already self-parenthesize, so any future change there fails loudly instead of silently altering everyone's queries

**All three fail against the unparenthesized version** — verified by reverting the two lines and re-running, not assumed.

I left `conditions.ts` alone as far as `dprint` goes: it does not pass `dprint check` on `main` as it stands, so reformatting it here would bury a two-line fix in unrelated churn. The new test file is `dprint`-clean.
