### PR TITLE
[eslint-plugin-drizzle] adding rule 'enforce-alias-in-subquery'

### DIFF
--- a/eslint-plugin-drizzle/readme.md
+++ b/eslint-plugin-drizzle/readme.md
@@ -169,3 +169,51 @@ const db = drizzle(...)
 // ---> Will be triggered by ESLint Rule
 db.update()
 ```
+
+**enforce-alias-in-subquery**: Enforce an explicit `.as('alias')` on a raw `` sql`...` `` field whose name drizzle reads from a subquery, CTE, or set operation.
+
+A plain column carries its own SQL name, but a raw `` sql`...` `` template does not. Whenever drizzle needs that field's name — to build a set operation, or to read the field back out of a subquery/CTE — an unaliased raw field throws **when the query is built** (not at compile time). drizzle calls all of these a "subquery" in the error:
+
+```
+Error: You tried to reference "role" field from a subquery, which is a raw SQL field,
+but it doesn't have an alias declared. Please add an alias to the field using ".as('alias')" method.
+```
+
+This rule turns that runtime crash into a lint error. The **subquery/CTE** case is auto-fixed — there the alias must equal the referenced key, so the fix is unambiguous. The **set-operation** case offers a manual _suggestion_ instead: the correct alias is the one used for that field in the _other_ branch, which the rule cannot infer, so it never rewrites your code automatically.
+
+**Set operations** (`union`, `unionAll`, `except`, `exceptAll`, `intersect`, `intersectAll`) line up their branches by position and take the output column names from the **leading** branch. An unaliased raw field in a _trailing_ branch throws when the query is built; a leading one is silently re-inlined, but breaks the moment the branches are reordered or the set operation is wrapped in a subquery. So every branch's unaliased raw field is flagged — inline or via a variable — with a suggestion to add `.as(...)` (use the same alias as the matching field in the other branch):
+
+```ts
+// ---> Will be triggered ("role" has no alias), inline or via a variable
+const everyone = await union(
+  db.select({ role: sql<string>`'coach'`, id: users.id }).from(users),
+  db.select({ role: sql<string>`'athlete'`, id: users.id }).from(athletes),
+);
+
+// ---> Will NOT be triggered: every raw `sql` field is aliased
+const ok = await union(
+  db.select({ role: sql<string>`'coach'`.as('role'), id: users.id }).from(users),
+  db.select({ role: sql<string>`'athlete'`.as('role'), id: users.id }).from(athletes),
+);
+```
+
+**Subqueries and CTEs** (a subquery is `` <select>.as('name') ``, a CTE is `db.$with('name').as(<select>)`) only read a field when it is *used*, so the rule flags a raw field when it is read — through an explicit `subquery.field` reference, or by selecting all columns (`db.select().from(subquery)`, which reads every field). Fields that are never read are left alone:
+
+```ts
+const withCount = db
+  .select({ total: sql<number>`count(*)`, day: activities.day })
+  .from(activities)
+  .groupBy(activities.day)
+  .as('with_count');
+
+// ---> Will be triggered ("total" is read as with_count.total)
+const a = db.select({ total: withCount.total }).from(withCount);
+
+// ---> Will be triggered (select-all reads every field of the subquery)
+const b = db.select().from(withCount);
+
+// ---> Will NOT be triggered: only the plain column `day` is read
+const c = db.select({ day: withCount.day }).from(withCount);
+```
+
+Notes: fields pulled into a `.select()` through a spread from another module (`...sharedSelect`) are not traced across files, so alias the raw `sql` fields inside such shared select objects directly. The subquery/CTE check tracks values assigned to a variable; inline subqueries and aliases reassigned to another variable are best-effort.

--- a/eslint-plugin-drizzle/src/configs/all.ts
+++ b/eslint-plugin-drizzle/src/configs/all.ts
@@ -10,5 +10,6 @@ export default {
 	rules: {
 		'drizzle/enforce-delete-with-where': 'error',
 		'drizzle/enforce-update-with-where': 'error',
+		'drizzle/enforce-alias-in-subquery': 'error',
 	},
 };

--- a/eslint-plugin-drizzle/src/configs/recommended.ts
+++ b/eslint-plugin-drizzle/src/configs/recommended.ts
@@ -10,5 +10,6 @@ export default {
 	rules: {
 		'drizzle/enforce-delete-with-where': 'error',
 		'drizzle/enforce-update-with-where': 'error',
+		'drizzle/enforce-alias-in-subquery': 'error',
 	},
 };

--- a/eslint-plugin-drizzle/src/enforce-alias-in-subquery.ts
+++ b/eslint-plugin-drizzle/src/enforce-alias-in-subquery.ts
@@ -1,0 +1,449 @@
+import { ASTUtils, ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(() => 'https://github.com/drizzle-team/eslint-plugin-drizzle');
+
+type MessageIds = 'enforceAliasInSetOperation' | 'addSetOperationAlias' | 'enforceAliasInSubquery';
+type Options = [];
+
+const SET_OPERATIONS = new Set(['union', 'unionAll', 'except', 'exceptAll', 'intersect', 'intersectAll']);
+// Methods that take a table-like source whose fields get enumerated on a select-all.
+const FROM_METHODS = new Set(['from', 'leftJoin', 'rightJoin', 'innerJoin', 'fullJoin', 'crossJoin']);
+// Select builders. `selectDistinctOn(on, selection)` takes the field object as its SECOND argument.
+const SELECT_METHODS = new Set(['select', 'selectDistinct', 'selectDistinctOn']);
+const selectionArgIndex = (methodName: string): number => (methodName === 'selectDistinctOn' ? 1 : 0);
+
+// -- Raw-sql field helpers ---------------------------------------------------
+
+// Does this expression bottom out in a `sql`...`` tagged template?
+const rootsInSqlTemplate = (node: TSESTree.Node | undefined): boolean => {
+	let current = node;
+	while (current) {
+		switch (current.type) {
+			case 'TaggedTemplateExpression':
+				return current.tag.type === 'Identifier' && current.tag.name === 'sql';
+			case 'CallExpression':
+				current = current.callee;
+				break;
+			case 'MemberExpression':
+				current = current.object;
+				break;
+			case 'TSNonNullExpression':
+			case 'TSAsExpression':
+			case 'TSInstantiationExpression':
+				current = current.expression;
+				break;
+			default:
+				return false;
+		}
+	}
+	return false;
+};
+
+// Does the chain include an `.as(...)` call?
+const hasAsCall = (node: TSESTree.Node | undefined): boolean => {
+	let current = node;
+	while (current) {
+		if (current.type === 'CallExpression') {
+			const { callee } = current;
+			if (
+				callee.type === 'MemberExpression' && callee.property.type === 'Identifier' && callee.property.name === 'as'
+			) {
+				return true;
+			}
+			current = callee;
+		} else if (current.type === 'MemberExpression') {
+			current = current.object;
+		} else if (
+			current.type === 'TSNonNullExpression'
+			|| current.type === 'TSAsExpression'
+			|| current.type === 'TSInstantiationExpression'
+		) {
+			current = current.expression;
+		} else {
+			return false;
+		}
+	}
+	return false;
+};
+
+// Collect raw-sql property values that lack an alias (descending into ternary arms).
+const collectUnaliasedSql = (value: TSESTree.Node | undefined, acc: TSESTree.Node[]): TSESTree.Node[] => {
+	if (!value) {
+		return acc;
+	}
+	if (value.type === 'ConditionalExpression') {
+		collectUnaliasedSql(value.consequent, acc);
+		collectUnaliasedSql(value.alternate, acc);
+		return acc;
+	}
+	if (rootsInSqlTemplate(value) && !hasAsCall(value)) {
+		acc.push(value);
+	}
+	return acc;
+};
+
+const propertyKeyName = (key: TSESTree.Node): string | null => {
+	if (key.type === 'Identifier') {
+		return key.name;
+	}
+	if (key.type === 'Literal' && typeof key.value === 'string') {
+		return key.value;
+	}
+	return null;
+};
+
+// Map each field of a `.select({...})` object to its unaliased raw sql node(s), if any.
+const unaliasedRawFields = (fieldObject: TSESTree.ObjectExpression): Map<string, TSESTree.Node[]> => {
+	const fields = new Map<string, TSESTree.Node[]>();
+	for (const property of fieldObject.properties) {
+		if (property.type !== 'Property') {
+			continue;
+		}
+		const name = propertyKeyName(property.key);
+		if (name === null) {
+			continue;
+		}
+		const nodes = collectUnaliasedSql(property.value, []);
+		if (nodes.length > 0) {
+			fields.set(name, nodes);
+		}
+	}
+	return fields;
+};
+
+// Walk down a fluent chain (or unwrap an arrow body) to the object passed to `.select({...})`.
+// Returns null for a select with no field object (e.g. select-all `db.select()`).
+const findSelectFieldObject = (node: TSESTree.Node | undefined): TSESTree.ObjectExpression | null => {
+	let current = node;
+	while (current) {
+		if (current.type === 'ArrowFunctionExpression' || current.type === 'FunctionExpression') {
+			if (current.body.type === 'BlockStatement') {
+				const returned = current.body.body.find((statement) => statement.type === 'ReturnStatement');
+				current = returned && returned.type === 'ReturnStatement' ? returned.argument ?? undefined : undefined;
+			} else {
+				current = current.body;
+			}
+			continue;
+		}
+		if (current.type === 'CallExpression') {
+			if (
+				current.callee.type === 'MemberExpression'
+				&& current.callee.property.type === 'Identifier'
+				&& SELECT_METHODS.has(current.callee.property.name)
+			) {
+				const argument = current.arguments[selectionArgIndex(current.callee.property.name)];
+				return argument && argument.type === 'ObjectExpression' ? argument : null;
+			}
+			current = current.callee;
+			continue;
+		}
+		if (current.type === 'MemberExpression') {
+			current = current.object;
+			continue;
+		}
+		return null;
+	}
+	return null;
+};
+
+// -- Set-operation detection -------------------------------------------------
+
+// If `node` is a direct argument to a set-operation call, return that operation's name.
+const setOperationArgumentName = (node: TSESTree.Node): string | null => {
+	const parent = node.parent;
+	if (!parent || parent.type !== 'CallExpression' || !parent.arguments.some((arg) => arg === node)) {
+		return null;
+	}
+	const { callee } = parent;
+	if (callee.type === 'Identifier' && SET_OPERATIONS.has(callee.name)) {
+		return callee.name;
+	}
+	if (
+		callee.type === 'MemberExpression' && callee.property.type === 'Identifier'
+		&& SET_OPERATIONS.has(callee.property.name)
+	) {
+		return callee.property.name;
+	}
+	return null;
+};
+
+// -- Subquery / CTE detection ------------------------------------------------
+
+const unwrapType = (node: TSESTree.Node | undefined): TSESTree.Node | undefined => {
+	let current = node;
+	while (
+		current
+		&& (current.type === 'TSAsExpression'
+			|| current.type === 'TSNonNullExpression'
+			|| current.type === 'TSInstantiationExpression')
+	) {
+		current = current.expression;
+	}
+	return current;
+};
+
+const isWithCall = (node: TSESTree.Node): boolean =>
+	node.type === 'CallExpression'
+	&& node.callee.type === 'MemberExpression'
+	&& node.callee.property.type === 'Identifier'
+	&& node.callee.property.name === '$with';
+
+// If `init` creates a subquery (`<select>.as('x')`) or a CTE (`db.$with('x').as(<select>)`),
+// return the object passed to its inner `.select({...})`.
+const subqueryFieldSource = (init: TSESTree.Node | undefined): TSESTree.ObjectExpression | null => {
+	const node = unwrapType(init);
+	if (!node || node.type !== 'CallExpression' || node.callee.type !== 'MemberExpression') {
+		return null;
+	}
+	const { callee } = node;
+	if (callee.property.type !== 'Identifier' || callee.property.name !== 'as') {
+		return null;
+	}
+	// Subquery: `<select chain>.as('name')`
+	const fromSelectChain = findSelectFieldObject(callee.object);
+	if (fromSelectChain) {
+		return fromSelectChain;
+	}
+	// CTE: `X.$with(...).as(<select | (qb) => select>)`
+	if (isWithCall(callee.object)) {
+		return findSelectFieldObject(node.arguments[0]);
+	}
+	return null;
+};
+
+// Is the `.select()` paired with this `.from()`/join in the same chain a select-all (no field object)?
+const enclosingSelectIsEmpty = (node: TSESTree.Node): boolean => {
+	let current: TSESTree.Node | undefined = node;
+	while (current) {
+		if (current.type === 'CallExpression') {
+			if (
+				current.callee.type === 'MemberExpression'
+				&& current.callee.property.type === 'Identifier'
+				&& SELECT_METHODS.has(current.callee.property.name)
+			) {
+				// Select-all: no field object was passed (`.select()` / `.selectDistinctOn([...])`).
+				return current.arguments.length <= selectionArgIndex(current.callee.property.name);
+			}
+			current = current.callee;
+			continue;
+		}
+		if (current.type === 'MemberExpression') {
+			current = current.object;
+			continue;
+		}
+		return false;
+	}
+	return false;
+};
+
+// Is `id` a subquery source of a select-all query (`db.select().from(id)` / `.leftJoin(id, ...)`)?
+const isSelectAllReference = (id: TSESTree.Node): boolean => {
+	const parent = id.parent;
+	if (!parent || parent.type !== 'CallExpression' || parent.callee.type !== 'MemberExpression') {
+		return false;
+	}
+	const { callee } = parent;
+	if (callee.property.type !== 'Identifier' || !FROM_METHODS.has(callee.property.name)) {
+		return false;
+	}
+	if (!parent.arguments.some((argument) => argument === id)) {
+		return false;
+	}
+	return enclosingSelectIsEmpty(callee.object);
+};
+
+const rule = createRule<Options, MessageIds>({
+	name: 'enforce-alias-in-subquery',
+	defaultOptions: [],
+	meta: {
+		type: 'problem',
+		// Only the subquery/CTE case is auto-fixed: there the alias must equal the referenced key,
+		// so it is provably correct. The set-operation alias is contextual (it should match the same
+		// field in the other branch), so that case is offered as a manual suggestion instead.
+		fixable: 'code',
+		hasSuggestions: true,
+		docs: {
+			description:
+				'Enforce an explicit `.as()` alias on raw `sql` fields that drizzle reads by name from a subquery, CTE, or set operation, which otherwise throws when the query is built.',
+		},
+		messages: {
+			enforceAliasInSetOperation:
+				"Raw `sql` field '{{ name }}' in a `{{ operation }}` set operation has no alias. Add `.as(...)` using the same alias as this field in the other branch(es) — drizzle throws for an unaliased raw `sql` field read from a trailing branch.",
+			addSetOperationAlias: "Add `.as('{{ name }}')` (check the alias matches this field in the other branch(es)).",
+			enforceAliasInSubquery:
+				"Raw `sql` field '{{ name }}' is read from a subquery/CTE but has no alias. Add `.as('{{ name }}')` — drizzle throws when a raw `sql` field is referenced from a subquery.",
+		},
+		schema: [],
+	},
+	create(context) {
+		// ESLint 9 removed `context.getScope()`; `SourceCode#getScope(node)` is the replacement
+		// (available since ESLint 8.37), and `context.sourceCode` since 8.40. Fall back through
+		// `getSourceCode()` and the old `context.getScope()` so the rule works on ESLint 8.0+.
+		const scopeFor = (node: TSESTree.Node) => {
+			const sourceCode = context.sourceCode ?? context.getSourceCode();
+			return sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+		};
+		// Returns the enclosing set-operation name if this `.select({...})` flows into one.
+		// Covers the function form `union(a, b)` (inline or via a variable) and the method form
+		// `a.union(b)` on either side.
+		const setOperationFor = (selectCall: TSESTree.Node): string | null => {
+			let current = selectCall;
+			for (;;) {
+				const parent = current.parent;
+				if (!parent) {
+					return null;
+				}
+				// Walk up the fluent chain (`.from().where()...`).
+				if (parent.type === 'MemberExpression' && parent.object === current) {
+					// Method form with our select on the receiver side: `<select>.union(...)`.
+					const grandParent = parent.parent;
+					if (
+						parent.property.type === 'Identifier'
+						&& SET_OPERATIONS.has(parent.property.name)
+						&& grandParent !== undefined
+						&& grandParent.type === 'CallExpression'
+						&& grandParent.callee === parent
+					) {
+						return parent.property.name;
+					}
+					current = parent;
+					continue;
+				}
+				if (parent.type === 'CallExpression' && parent.callee === current) {
+					current = parent;
+					continue;
+				}
+				// End of the chain: `union(current, ...)` or `x.union(current)`.
+				const direct = setOperationArgumentName(current);
+				if (direct) {
+					return direct;
+				}
+				// Assigned to a variable that is later passed to a set operation.
+				if (parent.type === 'VariableDeclarator' && parent.init === current && parent.id.type === 'Identifier') {
+					const variable = ASTUtils.findVariable(scopeFor(parent.id), parent.id.name);
+					if (variable) {
+						for (const reference of variable.references) {
+							if (reference.identifier !== parent.id) {
+								const name = setOperationArgumentName(reference.identifier);
+								if (name) {
+									return name;
+								}
+							}
+						}
+					}
+				}
+				return null;
+			}
+		};
+
+		return {
+			// Set operations: every unaliased raw `sql` field of a union/except/intersect branch throws.
+			CallExpression(node) {
+				const { callee } = node;
+				if (
+					callee.type !== 'MemberExpression' || callee.property.type !== 'Identifier'
+					|| !SELECT_METHODS.has(callee.property.name)
+				) {
+					return;
+				}
+				const fieldObject = node.arguments[selectionArgIndex(callee.property.name)];
+				if (!fieldObject || fieldObject.type !== 'ObjectExpression') {
+					return;
+				}
+				const operation = setOperationFor(node);
+				if (!operation) {
+					return;
+				}
+				for (const property of fieldObject.properties) {
+					if (property.type !== 'Property') {
+						continue;
+					}
+					const name = propertyKeyName(property.key);
+					for (const sqlNode of collectUnaliasedSql(property.value, [])) {
+						const data = { name: name ?? 'field', operation };
+						if (name) {
+							context.report({
+								node: sqlNode,
+								messageId: 'enforceAliasInSetOperation',
+								data,
+								// A manual suggestion, not an auto-fix: the correct alias is the one used for
+								// this field in the other branch(es), which the rule cannot know — the key is
+								// only a starting point the developer should confirm.
+								suggest: [{
+									messageId: 'addSetOperationAlias',
+									data: { name },
+									fix: (fixer) => fixer.insertTextAfter(sqlNode, `.as('${name}')`),
+								}],
+							});
+						} else {
+							context.report({ node: sqlNode, messageId: 'enforceAliasInSetOperation', data });
+						}
+					}
+				}
+			},
+
+			// Subqueries / CTEs: an unaliased raw `sql` field throws only when it is read
+			// (via `sub.field` or a select-all `db.select().from(sub)`).
+			VariableDeclarator(node) {
+				if (node.id.type !== 'Identifier') {
+					return;
+				}
+				const fieldObject = subqueryFieldSource(node.init ?? undefined);
+				if (!fieldObject) {
+					return;
+				}
+				const rawFields = unaliasedRawFields(fieldObject);
+				if (rawFields.size === 0) {
+					return;
+				}
+				const variable = ASTUtils.findVariable(scopeFor(node), node.id.name);
+				if (!variable) {
+					return;
+				}
+				// If the variable is reassigned, a read may resolve to a different subquery than the one
+				// declared here, so we cannot know which handle it hits — bail rather than risk a false positive.
+				if (variable.references.some((reference) => reference.isWrite() && reference.identifier !== node.id)) {
+					return;
+				}
+
+				const referencedFields = new Set<string>();
+				let selectAll = false;
+				for (const reference of variable.references) {
+					const id = reference.identifier;
+					if (id === node.id) {
+						continue;
+					}
+					const parent = id.parent;
+					if (parent && parent.type === 'MemberExpression' && parent.object === id) {
+						// `sub.field` or `sub['field']`
+						if (parent.property.type === 'Identifier' && !parent.computed) {
+							referencedFields.add(parent.property.name);
+						} else if (
+							parent.computed && parent.property.type === 'Literal' && typeof parent.property.value === 'string'
+						) {
+							referencedFields.add(parent.property.value);
+						}
+					} else if (isSelectAllReference(id)) {
+						selectAll = true;
+					}
+				}
+
+				for (const [fieldName, sqlNodes] of rawFields) {
+					if (!selectAll && !referencedFields.has(fieldName)) {
+						continue;
+					}
+					for (const sqlNode of sqlNodes) {
+						context.report({
+							node: sqlNode,
+							messageId: 'enforceAliasInSubquery',
+							data: { name: fieldName },
+							fix: (fixer) => fixer.insertTextAfter(sqlNode, `.as('${fieldName}')`),
+						});
+					}
+				}
+			},
+		};
+	},
+});
+
+export default rule;

--- a/eslint-plugin-drizzle/src/index.ts
+++ b/eslint-plugin-drizzle/src/index.ts
@@ -2,6 +2,7 @@ import type { TSESLint } from '@typescript-eslint/utils';
 import { name, version } from '../package.json';
 import all from './configs/all';
 import recommended from './configs/recommended';
+import enforceAliasInSubquery from './enforce-alias-in-subquery';
 import deleteRule from './enforce-delete-with-where';
 import updateRule from './enforce-update-with-where';
 import type { Options } from './utils/options';
@@ -9,7 +10,8 @@ import type { Options } from './utils/options';
 export const rules = {
 	'enforce-delete-with-where': deleteRule,
 	'enforce-update-with-where': updateRule,
-} satisfies Record<string, TSESLint.RuleModule<string, Options>>;
+	'enforce-alias-in-subquery': enforceAliasInSubquery,
+} satisfies Record<string, TSESLint.RuleModule<string, Options | []>>;
 
 export const configs = { all, recommended };
 

--- a/eslint-plugin-drizzle/tests/enforce-alias-in-subquery.test.ts
+++ b/eslint-plugin-drizzle/tests/enforce-alias-in-subquery.test.ts
@@ -1,0 +1,423 @@
+// @ts-ignore
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import myRule from '../src/enforce-alias-in-subquery';
+
+const parserResolver = require.resolve('@typescript-eslint/parser');
+
+const ruleTester = new RuleTester({
+	parser: parserResolver,
+});
+
+ruleTester.run('enforce alias in subquery (set operations)', myRule, {
+	valid: [
+		// every raw sql field is aliased
+		`union(
+			db.select({ role: sql\`'coach'\`.as('role'), id: users.id }).from(users),
+			db.select({ role: sql\`'athlete'\`.as('role'), id: users.id }).from(athletes),
+		)`,
+		// only plain columns, no raw sql
+		`union(
+			db.select({ id: users.id, name: users.name }).from(users),
+			db.select({ id: athletes.id, name: athletes.name }).from(athletes),
+		)`,
+		// raw sql in a plain select that is NOT part of a set operation
+		`db.select({ label: sql\`'x'\` }).from(users)`,
+		// aliased through a variable-assigned branch
+		`const a = db.select({ k: sql\`'a'\`.as('k') }).from(t);
+		 const b = db.select({ k: sql\`'b'\`.as('k') }).from(t);
+		 const r = union(a, b);`,
+		// aliased ternary arm
+		`union(
+			db.select({ x: cond ? t.col : sql\`NULL\`.as('x') }).from(t),
+			db.select({ x: cond ? t.col : sql\`NULL\`.as('x') }).from(t),
+		)`,
+		// a set operation on a method (db.select().union()) with aliased fields
+		`db.select({ v: sql\`1\`.as('v') }).from(t).unionAll(db.select({ v: sql\`2\`.as('v') }).from(t))`,
+		// three-way union, every branch aliased
+		`union(
+			db.select({ role: sql\`'athlete'\`.as('role'), id: users.id }).from(a),
+			db.select({ role: sql\`'coach'\`.as('role'), id: users.id }).from(b),
+			db.select({ role: sql\`'self'\`.as('role'), id: users.id }).from(c),
+		)`,
+	],
+	invalid: [
+		// inline union, unaliased raw sql
+		{
+			code: `union(
+				db.select({ role: sql\`'coach'\`, id: users.id }).from(users),
+				db.select({ role: sql\`'athlete'\`.as('role'), id: users.id }).from(athletes),
+			)`,
+			errors: [{
+				messageId: 'enforceAliasInSetOperation',
+				data: { name: 'role', operation: 'union' },
+				suggestions: [{
+					messageId: 'addSetOperationAlias',
+					data: { name: 'role' },
+					output: `union(
+				db.select({ role: sql\`'coach'\`.as('role'), id: users.id }).from(users),
+				db.select({ role: sql\`'athlete'\`.as('role'), id: users.id }).from(athletes),
+			)`,
+				}],
+			}],
+		},
+		// variable-assigned select passed to a set operation
+		{
+			code: `const past = db.select({ requests: sql\`count(*)\` }).from(usage);
+			const today = db.select({ requests: sql\`count(*)\`.as('requests') }).from(usage);
+			const all = union(past, today);`,
+			errors: [{
+				messageId: 'enforceAliasInSetOperation',
+				data: { name: 'requests', operation: 'union' },
+				suggestions: [{
+					messageId: 'addSetOperationAlias',
+					data: { name: 'requests' },
+					output: `const past = db.select({ requests: sql\`count(*)\`.as('requests') }).from(usage);
+			const today = db.select({ requests: sql\`count(*)\`.as('requests') }).from(usage);
+			const all = union(past, today);`,
+				}],
+			}],
+		},
+		// unaliased raw sql arm of a ternary
+		{
+			code: `union(
+				db.select({ athlete: notifyCoach ? rel.code : sql\`NULL\` }).from(rel),
+				db.select({ athlete: notifyCoach ? rel.code : sql\`NULL\`.as('athlete') }).from(rel),
+			)`,
+			errors: [{
+				messageId: 'enforceAliasInSetOperation',
+				data: { name: 'athlete', operation: 'union' },
+				suggestions: [{
+					messageId: 'addSetOperationAlias',
+					data: { name: 'athlete' },
+					output: `union(
+				db.select({ athlete: notifyCoach ? rel.code : sql\`NULL\`.as('athlete') }).from(rel),
+				db.select({ athlete: notifyCoach ? rel.code : sql\`NULL\`.as('athlete') }).from(rel),
+			)`,
+				}],
+			}],
+		},
+		// several unaliased fields, other set operation (except)
+		{
+			code: `except(
+				db.select({ a: sql\`1\`, b: sql\`2\` }).from(t),
+				db.select({ a: sql\`3\`.as('a'), b: sql\`4\`.as('b') }).from(t),
+			)`,
+			errors: [
+				{
+					messageId: 'enforceAliasInSetOperation',
+					data: { name: 'a', operation: 'except' },
+					suggestions: [{
+						messageId: 'addSetOperationAlias',
+						data: { name: 'a' },
+						output: `except(
+				db.select({ a: sql\`1\`.as('a'), b: sql\`2\` }).from(t),
+				db.select({ a: sql\`3\`.as('a'), b: sql\`4\`.as('b') }).from(t),
+			)`,
+					}],
+				},
+				{
+					messageId: 'enforceAliasInSetOperation',
+					data: { name: 'b', operation: 'except' },
+					suggestions: [{
+						messageId: 'addSetOperationAlias',
+						data: { name: 'b' },
+						output: `except(
+				db.select({ a: sql\`1\`, b: sql\`2\`.as('b') }).from(t),
+				db.select({ a: sql\`3\`.as('a'), b: sql\`4\`.as('b') }).from(t),
+			)`,
+					}],
+				},
+			],
+		},
+		// set operation as a method call (`.intersect(...)`)
+		{
+			code: `db.select({ v: sql\`1\` }).from(t).intersect(db.select({ v: sql\`2\`.as('v') }).from(t))`,
+			errors: [{
+				messageId: 'enforceAliasInSetOperation',
+				data: { name: 'v', operation: 'intersect' },
+				suggestions: [{
+					messageId: 'addSetOperationAlias',
+					data: { name: 'v' },
+					output: `db.select({ v: sql\`1\`.as('v') }).from(t).intersect(db.select({ v: sql\`2\`.as('v') }).from(t))`,
+				}],
+			}],
+		},
+		// three-way union with an unaliased raw field in a non-leading branch. drizzle only
+		// throws for the trailing branches (the leading one is read raw), but every branch is
+		// flagged so the union stays correct under reordering / subquery wrapping.
+		{
+			code: `union(
+				db.select({ role: sql\`'athlete'\`.as('role') }).from(a),
+				db.select({ role: sql\`'coach'\` }).from(b),
+				db.select({ role: sql\`'self'\`.as('role') }).from(c),
+			)`,
+			errors: [{
+				messageId: 'enforceAliasInSetOperation',
+				data: { name: 'role', operation: 'union' },
+				suggestions: [{
+					messageId: 'addSetOperationAlias',
+					data: { name: 'role' },
+					output: `union(
+				db.select({ role: sql\`'athlete'\`.as('role') }).from(a),
+				db.select({ role: sql\`'coach'\`.as('role') }).from(b),
+				db.select({ role: sql\`'self'\`.as('role') }).from(c),
+			)`,
+				}],
+			}],
+		},
+		// variable-form branches carrying a full `.from().where().groupBy()` chain: the select
+		// object is still located by walking back through the chain to the variable declaration.
+		{
+			code: `const past = db.select({ ts: sql\`date_trunc('day', x)\` }).from(usage).where(cond).groupBy(x);
+			const today = db.select({ ts: sql\`date_trunc('hour', x)\`.as('ts') }).from(usage).where(cond).groupBy(x);
+			const all = union(past, today);`,
+			errors: [{
+				messageId: 'enforceAliasInSetOperation',
+				data: { name: 'ts', operation: 'union' },
+				suggestions: [{
+					messageId: 'addSetOperationAlias',
+					data: { name: 'ts' },
+					output:
+						`const past = db.select({ ts: sql\`date_trunc('day', x)\`.as('ts') }).from(usage).where(cond).groupBy(x);
+			const today = db.select({ ts: sql\`date_trunc('hour', x)\`.as('ts') }).from(usage).where(cond).groupBy(x);
+			const all = union(past, today);`,
+				}],
+			}],
+		},
+	],
+});
+
+ruleTester.run('enforce alias in subquery (subqueries & CTEs)', myRule, {
+	valid: [
+		// unaliased raw field that is never referenced -> no runtime error
+		`const sq = db.select({ foo: sql\`1\`, id: t.id }).from(t).as('sq');
+		 const r = db.select({ id: sq.id }).from(sq);`,
+		// the raw field is aliased
+		`const sq = db.select({ foo: sql\`1\`.as('foo') }).from(t).as('sq');
+		 const r = db.select({ foo: sq.foo }).from(sq);`,
+		// only a column field of the subquery is referenced
+		`const sq = db.select({ foo: sql\`1\`, id: t.id }).from(t).as('sq');
+		 const r = db.select({}).from(sq).where(eq(sq.id, 1));`,
+		// raw sql in a plain top-level select, never turned into a subquery
+		`const r = db.select({ label: sql\`'x'\` }).from(t);`,
+		// referencing a differently named field than the raw one
+		`const sq = db.select({ foo: sql\`1\`, bar: t.id }).from(t).as('sq');
+		 const r = db.select({ bar: sq.bar }).from(sq);`,
+		// not a subquery `.as()` — a column alias
+		`const c = sql\`1\`.as('c');`,
+		// a read of a same-named raw field on a DIFFERENT subquery variable must not leak
+		`const sub = db.select({ cnt: sql\`count(*)\` }).from(t).as('sub');
+		 const other = db.select({ cnt: t.id }).from(t).as('other');
+		 const r = db.select({ c: other.cnt }).from(other);`,
+		// the raw field is aliased, even though it is read
+		`const sub = db.select({ total: sql\`sum(t.x)\`.as('total') }).from(t).as('sub');
+		 const r = db.select({ tt: sub.total }).from(sub);`,
+		// select-all, but the only raw field is aliased
+		`const sub = db.select({ id: t.id, total: sql\`sum(t.x)\`.as('total') }).from(t).as('sub');
+		 const r = db.select().from(sub);`,
+		// best-effort limitation: inline (non-variable) subquery is not tracked
+		`const r = db.select().from(db.select({ x: sql\`1\` }).from(t).as('s'));`,
+		// best-effort limitation: an alias reassigned to another variable is not followed
+		`const a = db.select({ x: sql\`1\` }).from(t).as('s');
+		 const b = a;
+		 const r = db.select().from(b);`,
+		// reassigned `let` — the read resolves to the second (aliased) subquery, so nothing throws
+		`let sq = db.select({ foo: sql\`1\` }).from(t).as('sq');
+		 sq = db.select({ foo: sql\`1\`.as('foo') }).from(t).as('sq');
+		 const r = db.select({ x: sq.foo }).from(sq);`,
+	],
+	invalid: [
+		// explicit reference as an outer select value
+		{
+			code: `const sq = db.select({ foo: sql\`1\` }).from(t).as('sq');
+			const r = db.select({ foo: sq.foo }).from(sq);`,
+			output: `const sq = db.select({ foo: sql\`1\`.as('foo') }).from(t).as('sq');
+			const r = db.select({ foo: sq.foo }).from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'foo' } }],
+		},
+		// explicit reference inside a join condition
+		{
+			code: `const sq = db.select({ foo: sql\`1\` }).from(t).as('sq');
+			const r = db.select({ id: t.id }).from(t).leftJoin(sq, eq(sq.foo, t.id));`,
+			output: `const sq = db.select({ foo: sql\`1\`.as('foo') }).from(t).as('sq');
+			const r = db.select({ id: t.id }).from(t).leftJoin(sq, eq(sq.foo, t.id));`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'foo' } }],
+		},
+		// explicit reference inside .where()
+		{
+			code: `const sq = db.select({ foo: sql\`1\` }).from(t).as('sq');
+			const r = db.select({}).from(sq).where(eq(sq.foo, 1));`,
+			output: `const sq = db.select({ foo: sql\`1\`.as('foo') }).from(t).as('sq');
+			const r = db.select({}).from(sq).where(eq(sq.foo, 1));`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'foo' } }],
+		},
+		// CTE via db.$with(...).as(<select>), referenced field
+		{
+			code: `const cte = db.$with('cte').as(db.select({ n: sql\`count(*)\` }).from(t));
+			const r = db.with(cte).select({ n: cte.n }).from(cte);`,
+			output: `const cte = db.$with('cte').as(db.select({ n: sql\`count(*)\`.as('n') }).from(t));
+			const r = db.with(cte).select({ n: cte.n }).from(cte);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'n' } }],
+		},
+		// CTE via arrow `(qb) => qb.select(...)`
+		{
+			code: `const cte = db.$with('cte').as((qb) => qb.select({ n: sql\`count(*)\` }).from(t));
+			const r = db.with(cte).select({ n: cte.n }).from(cte);`,
+			output: `const cte = db.$with('cte').as((qb) => qb.select({ n: sql\`count(*)\`.as('n') }).from(t));
+			const r = db.with(cte).select({ n: cte.n }).from(cte);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'n' } }],
+		},
+		// select-all from a subquery: every unaliased raw field throws
+		{
+			code: `const sq = db.select({ foo: sql\`1\`, id: t.id }).from(t).as('sq');
+			const r = db.select().from(sq);`,
+			output: `const sq = db.select({ foo: sql\`1\`.as('foo'), id: t.id }).from(t).as('sq');
+			const r = db.select().from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'foo' } }],
+		},
+		// two unaliased raw fields, both referenced
+		{
+			code: `const sq = db.select({ a: sql\`1\`, b: sql\`2\` }).from(t).as('sq');
+			const r = db.select({ a: sq.a, b: sq.b }).from(sq);`,
+			output: `const sq = db.select({ a: sql\`1\`.as('a'), b: sql\`2\`.as('b') }).from(t).as('sq');
+			const r = db.select({ a: sq.a, b: sq.b }).from(sq);`,
+			errors: [
+				{ messageId: 'enforceAliasInSubquery', data: { name: 'a' } },
+				{ messageId: 'enforceAliasInSubquery', data: { name: 'b' } },
+			],
+		},
+		// referenced once, reported once even if accessed multiple times
+		{
+			code: `const sq = db.select({ foo: sql\`1\` }).from(t).as('sq');
+			const r = db.select({ x: sq.foo, y: sq.foo }).from(sq);`,
+			output: `const sq = db.select({ foo: sql\`1\`.as('foo') }).from(t).as('sq');
+			const r = db.select({ x: sq.foo, y: sq.foo }).from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'foo' } }],
+		},
+		// selectDistinct source (field object in the same arg position as select)
+		{
+			code: `const sq = db.selectDistinct({ total: sql\`sum(1)\` }).from(t).as('sq');
+			const r = db.select({ total: sq.total }).from(sq);`,
+			output: `const sq = db.selectDistinct({ total: sql\`sum(1)\`.as('total') }).from(t).as('sq');
+			const r = db.select({ total: sq.total }).from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'total' } }],
+		},
+		// selectDistinctOn — field object is the SECOND argument
+		{
+			code: `const sq = db.selectDistinctOn([t.id], { total: sql\`sum(1)\` }).from(t).as('sq');
+			const r = db.select({ total: sq.total }).from(sq);`,
+			output: `const sq = db.selectDistinctOn([t.id], { total: sql\`sum(1)\`.as('total') }).from(t).as('sq');
+			const r = db.select({ total: sq.total }).from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'total' } }],
+		},
+		// only the unaliased field of a mixed select is reported
+		{
+			code: `const sq = db.select({ a: sql\`1\`.as('a'), b: sql\`2\` }).from(t).as('sq');
+			const r = db.select({ a: sq.a, b: sq.b }).from(sq);`,
+			output: `const sq = db.select({ a: sql\`1\`.as('a'), b: sql\`2\`.as('b') }).from(t).as('sq');
+			const r = db.select({ a: sq.a, b: sq.b }).from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'b' } }],
+		},
+		// chain walks back past .groupBy(); the plain column `uid` is not flagged
+		{
+			code: `const sq = db.select({ total: sql\`sum(1)\`, uid: t.userId }).from(t).groupBy(t.userId).as('sq');
+			const r = db.select({ total: sq.total }).from(sq);`,
+			output:
+				`const sq = db.select({ total: sql\`sum(1)\`.as('total'), uid: t.userId }).from(t).groupBy(t.userId).as('sq');
+			const r = db.select({ total: sq.total }).from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'total' } }],
+		},
+		// an interpolated sql`` template is still an unaliased raw field
+		{
+			code: `const sq = db.select({ ratio: sql\`\${t.a}\` }).from(t).as('sq');
+			const r = db.select({ ratio: sq.ratio }).from(sq);`,
+			output: `const sq = db.select({ ratio: sql\`\${t.a}\`.as('ratio') }).from(t).as('sq');
+			const r = db.select({ ratio: sq.ratio }).from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'ratio' } }],
+		},
+		// select-all reports every unaliased raw field, aliased ones excluded
+		{
+			code: `const sq = db.select({ foo: sql\`1\`, bar: sql\`2\`.as('bar') }).from(t).as('sq');
+			const r = db.select().from(sq);`,
+			output: `const sq = db.select({ foo: sql\`1\`.as('foo'), bar: sql\`2\`.as('bar') }).from(t).as('sq');
+			const r = db.select().from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'foo' } }],
+		},
+		// computed member access with a string literal (`sq['foo']`)
+		{
+			code: `const sq = db.select({ foo: sql\`1\` }).from(t).as('sq');
+			const r = db.select({ x: sq['foo'] }).from(sq);`,
+			output: `const sq = db.select({ foo: sql\`1\`.as('foo') }).from(t).as('sq');
+			const r = db.select({ x: sq['foo'] }).from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'foo' } }],
+		},
+		// read buried two levels deep inside and()/gte(); sibling column not flagged
+		{
+			code: `const sq = db.select({ id: t.id, foo: sql\`1\` }).from(t).as('sq');
+			const r = db.select({ id: sq.id }).from(sq).where(and(gte(sq.foo, 0), eq(sq.id, 1)));`,
+			output: `const sq = db.select({ id: t.id, foo: sql\`1\`.as('foo') }).from(t).as('sq');
+			const r = db.select({ id: sq.id }).from(sq).where(and(gte(sq.foo, 0), eq(sq.id, 1)));`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'foo' } }],
+		},
+		// read hidden inside a sql`` template used as a join condition
+		{
+			code: `const sq = db.select({ foo: sql\`1\` }).from(t).as('sq');
+			const r = db.select({ id: users.id }).from(users).innerJoin(sq, sql\`\${sq.foo} = 1\`);`,
+			output: `const sq = db.select({ foo: sql\`1\`.as('foo') }).from(t).as('sq');
+			const r = db.select({ id: users.id }).from(users).innerJoin(sq, sql\`\${sq.foo} = 1\`);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'foo' } }],
+		},
+		// variable shadowing: only the inner subquery's read is attributed to the inner declaration
+		{
+			code: `const sq = db.select({ o: sql\`1\` }).from(t).as('outer');
+			{
+			  const sq = db.select({ i: sql\`2\` }).from(t).as('inner');
+			  db.select().from(sq);
+			}`,
+			output: `const sq = db.select({ o: sql\`1\` }).from(t).as('outer');
+			{
+			  const sq = db.select({ i: sql\`2\`.as('i') }).from(t).as('inner');
+			  db.select().from(sq);
+			}`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'i' } }],
+		},
+		// handle detected by shape, even with a non-literal `.as()` alias
+		{
+			code: `const name = 'sq';
+			const sq = db.select({ v: sql\`1\` }).from(t).as(name);
+			const r = db.select({ x: sq.v }).from(sq);`,
+			output: `const name = 'sq';
+			const sq = db.select({ v: sql\`1\`.as('v') }).from(t).as(name);
+			const r = db.select({ x: sq.v }).from(sq);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'v' } }],
+		},
+		// the read of the inner raw field happens inside another subquery's construction
+		{
+			code: `const inner = db.select({ raw: sql\`1\` }).from(t).as('inner');
+			const outer = db.select({ v: inner.raw }).from(inner).as('outer');`,
+			output: `const inner = db.select({ raw: sql\`1\`.as('raw') }).from(t).as('inner');
+			const outer = db.select({ v: inner.raw }).from(inner).as('outer');`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'raw' } }],
+		},
+		// CTE arrow callback with a block body (`{ return ... }`)
+		{
+			code: `const cte = db.$with('cte').as((qb) => { return qb.select({ n: sql\`1\` }).from(t); });
+			const r = db.with(cte).select({ n: cte.n }).from(cte);`,
+			output: `const cte = db.$with('cte').as((qb) => { return qb.select({ n: sql\`1\`.as('n') }).from(t); });
+			const r = db.with(cte).select({ n: cte.n }).from(cte);`,
+			errors: [{ messageId: 'enforceAliasInSubquery', data: { name: 'n' } }],
+		},
+		// dedup + unread in one snippet: a & b reported (once each), c never read
+		{
+			code: `const sq = db.select({ a: sql\`1\`, b: sql\`2\`, c: sql\`3\` }).from(t).as('sq');
+			const r = db.select({ x: sq.a }).from(sq).where(eq(sq.b, 5));`,
+			output: `const sq = db.select({ a: sql\`1\`.as('a'), b: sql\`2\`.as('b'), c: sql\`3\` }).from(t).as('sq');
+			const r = db.select({ x: sq.a }).from(sq).where(eq(sq.b, 5));`,
+			errors: [
+				{ messageId: 'enforceAliasInSubquery', data: { name: 'a' } },
+				{ messageId: 'enforceAliasInSubquery', data: { name: 'b' } },
+			],
+		},
+	],
+});


### PR DESCRIPTION
A plain column carries its own SQL name, but a raw `` sql`...` `` template does not.

Whenever drizzle needs that field's name — to build a set operation, or to read the field back out of a subquery/CTE — an unaliased raw field throws this error at **runtime**:

```
Error: You tried to reference "xyz" field from a subquery, which is a raw SQL field, but it doesn't have an alias declared. Please add an alias to the field using ".as('alias')" method.
```

This rule turns that runtime crash into a lint error (autofixable).

While #2683 asks to get rid of the constraint, which may not be feasible. At least with this change, the error is caught in the editor, not at runtime.

Notice that upgrading to drizzle v1.0.0-rc.4 seems to throw these errors more often than in 0.x… so enabling this rule by default may be very useful.

> honnest disclaimer: all the code was written by Claude: I do not know how eslint plugins work… but I tried to prompt carefully