### PR TITLE
[Pg]: pin search_path to public during migrate

### DIFF
--- a/drizzle-orm/src/neon-http/migrator.ts
+++ b/drizzle-orm/src/neon-http/migrator.ts
@@ -68,6 +68,9 @@ export async function migrate<TRelations extends AnyRelations>(
 
 	const migrationsToRun = getMigrationsToRun({ localMigrations: migrations, dbMigrations });
 	const rowsToInsert: SQL[] = [];
+	// Neon HTTP has no transactions; set search_path for this session before
+	// applying unqualified migration statements (see #5889).
+	await db.session.execute(sql`set search_path to public`);
 	for await (const migration of migrationsToRun) {
 		for (const stmt of migration.sql) {
 			await db.session.execute(sql.raw(stmt));

--- a/drizzle-orm/src/pg-core/async/session.ts
+++ b/drizzle-orm/src/pg-core/async/session.ts
@@ -331,6 +331,9 @@ export async function migrate(
 
 	const migrationsToRun = getMigrationsToRun({ localMigrations: migrations, dbMigrations });
 	await db.transaction(async (tx) => {
+		// Keep unqualified CREATE TABLE on public even when migrationsSchema
+		// matches the DB username (Postgres $user search_path entry).
+		await tx.execute(sql`set local search_path to public`);
 		for (const migration of migrationsToRun) {
 			for (const stmt of migration.sql) {
 				await tx.execute(sql.raw(stmt));

--- a/drizzle-orm/src/pg-core/effect/session.ts
+++ b/drizzle-orm/src/pg-core/effect/session.ts
@@ -299,6 +299,9 @@ export const migrate = Effect.fn('migrate')(function*<TEffectHKT extends QueryEf
 
 	yield* session.transaction((tx) =>
 		Effect.gen(function*() {
+			// Keep unqualified CREATE TABLE on public even when migrationsSchema
+			// matches the DB username (Postgres $user search_path entry).
+			yield* tx.execute(sql`set local search_path to public`);
 			for (const migration of migrationsToRun) {
 				for (const stmt of migration.sql) {
 					yield* tx.execute(sql.raw(stmt));

--- a/drizzle-orm/src/pg-proxy/migrator.ts
+++ b/drizzle-orm/src/pg-proxy/migrator.ts
@@ -69,7 +69,11 @@ export async function migrate<TRelations extends AnyRelations>(
 	}
 
 	const migrationsToRun = getMigrationsToRun({ localMigrations: migrations, dbMigrations });
-	const queriesToRun: string[] = [];
+	const queriesToRun: string[] = [
+		// Keep unqualified CREATE TABLE on public even when migrationsSchema
+		// matches the DB username (Postgres $user search_path entry).
+		'set search_path to public',
+	];
 	for (const migration of migrationsToRun) {
 		queriesToRun.push(
 			...migration.sql,

--- a/integration-tests/tests/pg/node-postgres.test.ts
+++ b/integration-tests/tests/pg/node-postgres.test.ts
@@ -51,6 +51,41 @@ describe('migrator', () => {
 		await db.execute(sql`drop table ${sql.identifier(customSchema)}."__drizzle_migrations"`);
 	});
 
+	test('migrator : migrationsSchema matching DB username keeps app tables on public', async ({ db }) => {
+		// Postgres search_path is "$user", public. Creating a migrations schema
+		// named like the DB user makes unqualified CREATE TABLE land on $user
+		// unless we pin search_path to public first (#5889).
+		const userRes = await db.execute<{ current_user: string }>(sql`select current_user`);
+		const dbUser = userRes.rows[0]!.current_user;
+
+		await db.execute(sql`drop table if exists public.all_columns`);
+		await db.execute(sql`drop table if exists public.users12`);
+		await db.execute(sql`drop table if exists ${sql.identifier(dbUser)}.all_columns`);
+		await db.execute(sql`drop table if exists ${sql.identifier(dbUser)}.users12`);
+		await db.execute(sql`drop table if exists ${sql.identifier(dbUser)}."__drizzle_migrations"`);
+
+		await migrate(db, { migrationsFolder: './drizzle2/pg', migrationsSchema: dbUser });
+
+		const publicTables = await db.execute<{ tablename: string }>(
+			sql`select tablename from pg_tables where schemaname = 'public' and tablename in ('all_columns', 'users12')`,
+		);
+		expect(publicTables.rows.map((r) => r.tablename).sort()).toEqual(['all_columns', 'users12']);
+
+		const userSchemaTables = await db.execute<{ tablename: string }>(
+			sql`select tablename from pg_tables where schemaname = ${dbUser} and tablename in ('all_columns', 'users12')`,
+		);
+		expect(userSchemaTables.rows).toEqual([]);
+
+		const { rowCount } = await db.execute(
+			sql`select * from ${sql.identifier(dbUser)}."__drizzle_migrations";`,
+		);
+		expect(rowCount && rowCount > 0).toBeTruthy();
+
+		await db.execute(sql`drop table if exists public.all_columns`);
+		await db.execute(sql`drop table if exists public.users12`);
+		await db.execute(sql`drop table if exists ${sql.identifier(dbUser)}."__drizzle_migrations"`);
+	});
+
 	test('migrator : migrate with custom table', async ({ db }) => {
 		const customTable = randomString();
 		await db.execute(sql`drop table if exists all_columns`);


### PR DESCRIPTION
Fixes #5889

When `migrations.schema` matches the Postgres DB username, `CREATE SCHEMA`
makes the `$user` search_path entry resolve. Unqualified `CREATE TABLE`
statements in migration SQL then land on that schema instead of `public`,
while snapshots still record `public`.

Set `search_path` to `public` before applying user migration statements
(`SET LOCAL` inside transactions; plain `SET` for neon-http / pg-proxy).
Added a node-postgres regression that uses `migrationsSchema = current_user`.

AI disclosure: assisted with investigation and the patch. I reviewed the
change and verified the approach against the issue's root-cause writeup.

Made with [Cursor](https://cursor.com)