### PR TITLE
fix(gel-core): escape embedded double quotes in escapeName (CVE-2026-39356)

### DIFF
--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -101,7 +101,7 @@ export class GelDialect {
 	// }
 
 	escapeName(name: string): string {
-		return `"${name}"`;
+		return `"${name.replace(/"/g, '""')}"`;
 	}
 
 	escapeParam(num: number): string {

--- a/drizzle-orm/tests/gel-escape-name.test.ts
+++ b/drizzle-orm/tests/gel-escape-name.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { GelDialect } from '~/gel-core/dialect.ts';
+import { sql } from '~/sql/sql.ts';
+
+describe('GelDialect escapeName', () => {
+	it('doubles embedded double quotes instead of passing them through (CVE-2026-39356)', () => {
+		const dialect = new GelDialect();
+
+		const userInput = 'id" ASC, CAST((SELECT name FROM users LIMIT 1) AS int)--';
+
+		const query = sql`SELECT * FROM ${sql.identifier('users')} ORDER BY ${sql.identifier(userInput)} ASC`;
+
+		const { sql: str } = dialect.sqlToQuery(query);
+		expect(str).toBe(
+			'SELECT * FROM "users" ORDER BY "id"" ASC, CAST((SELECT name FROM users LIMIT 1) AS int)--" ASC',
+		);
+	});
+
+	it('still escapes simple identifiers correctly', () => {
+		const dialect = new GelDialect();
+		expect(dialect.escapeName('users')).toBe('"users"');
+		expect(dialect.escapeName('weird"name')).toBe('"weird""name"');
+	});
+});


### PR DESCRIPTION
## Summary

GHSA-gpj5-g38j-94v9 / CVE-2026-39356 was fixed for `pg-core`, `mysql-core`, `sqlite-core`, and `singlestore-core` in #5534 (released as `0.45.2`), but `gel-core/dialect.ts` was not updated in that PR.

`GelDialect.escapeName()` still does:

```ts
escapeName(name: string): string {
  return `"${name}"`;
}
```

which does not double embedded `"` characters, so untrusted input passed to `sql.identifier()` / `.as()` can break out of the quoted identifier and inject arbitrary SQL — the same issue the original advisory describes, just still present in one dialect.

- Applied the same fix pattern used for the other four dialects (`name.replace(/"/g, '""')`).
- Added `drizzle-orm/tests/gel-escape-name.test.ts`, a regression test using the same injection payload from the original advisory's PG test. Confirmed it fails against the unpatched code and passes with the fix.
- Ran the full `drizzle-orm` unit test suite (568 tests) — all passing.

## Test plan

- [x] `npx vitest run tests/gel-escape-name.test.ts` passes with the fix
- [x] Same test fails when reverted to the vulnerable `escapeName` implementation (verifies the test actually catches the bug)
- [x] `npx vitest run tests/` — 568/568 passing, no regressions