### PR TITLE
fix(node-postgres): release pool client when transaction BEGIN rejects

### DIFF
--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -254,14 +254,16 @@ export class NodePgSession<
 			? new NodePgSession(await (<pg.Pool> this.client).connect(), this.dialect, this.schema, this.options)
 			: this;
 		const tx = new NodePgTransaction<TFullSchema, TSchema>(this.dialect, session, this.schema);
-		await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
 		try {
-			const result = await transaction(tx);
-			await tx.execute(sql`commit`);
-			return result;
-		} catch (error) {
-			await tx.execute(sql`rollback`);
-			throw error;
+			await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
+			try {
+				const result = await transaction(tx);
+				await tx.execute(sql`commit`);
+				return result;
+			} catch (error) {
+				await tx.execute(sql`rollback`);
+				throw error;
+			}
 		} finally {
 			if (isPool) (session.client as PoolClient).release();
 		}

--- a/drizzle-orm/tests/node-postgres-transaction.test.ts
+++ b/drizzle-orm/tests/node-postgres-transaction.test.ts
@@ -1,0 +1,83 @@
+import { describe, test } from 'vitest';
+import { drizzle } from '~/node-postgres/index.ts';
+
+interface MockState {
+	queries: string[];
+	released: number;
+	connects: number;
+}
+
+function createMockPool(
+	query: (text: string, state: MockState) => Promise<unknown>,
+): { pool: any; state: MockState } {
+	const state: MockState = { queries: [], released: 0, connects: 0 };
+
+	const client = {
+		query: async (config: { text: string }, _params?: unknown[]) => {
+			state.queries.push(config.text);
+			return await query(config.text, state);
+		},
+		release: () => {
+			state.released++;
+		},
+	};
+
+	// Class name contains "Pool" so the driver's pool detection
+	// (`constructor.name.includes('Pool')`) treats it as a pool.
+	class MockPool {
+		connect = async () => {
+			state.connects++;
+			return client;
+		};
+	}
+
+	return { pool: new MockPool() as any, state };
+}
+
+const okResult = { rows: [], rowCount: 0, command: '', fields: [] };
+
+describe('node-postgres transaction pool client release', () => {
+	test('releases the pool client when BEGIN rejects and does not send ROLLBACK', async ({ expect }) => {
+		const beginError = new Error('connection interrupted');
+		const { pool, state } = createMockPool(async (text) => {
+			if (text.trim().toLowerCase().startsWith('begin')) {
+				throw beginError;
+			}
+			return okResult;
+		});
+		const db = drizzle(pool);
+
+		await expect(db.transaction(async () => undefined)).rejects.toThrowError();
+
+		expect(state.connects).toBe(1);
+		expect(state.released).toBe(1);
+		expect(state.queries).toEqual(['begin']);
+	});
+
+	test('releases the pool client exactly once on commit', async ({ expect }) => {
+		const { pool, state } = createMockPool(async () => okResult);
+		const db = drizzle(pool);
+
+		await db.transaction(async () => undefined);
+
+		expect(state.connects).toBe(1);
+		expect(state.released).toBe(1);
+		expect(state.queries).toEqual(['begin', 'commit']);
+	});
+
+	test('rolls back and releases the pool client when the callback throws', async ({ expect }) => {
+		const { pool, state } = createMockPool(async () => okResult);
+		const db = drizzle(pool);
+		const callbackError = new Error('boom');
+
+		await expect(
+			db.transaction(async () => {
+				throw callbackError;
+			}),
+		).rejects.toThrowError(callbackError);
+
+		expect(state.connects).toBe(1);
+		expect(state.released).toBe(1);
+		expect(state.queries).toEqual(['begin', 'rollback']);
+	});
+});

--- a/drizzle-orm/tests/node-postgres-transaction.test.ts
+++ b/drizzle-orm/tests/node-postgres-transaction.test.ts
@@ -47,7 +47,7 @@ describe('node-postgres transaction pool client release', () => {
 		});
 		const db = drizzle(pool);
 
-		await expect(db.transaction(async () => undefined)).rejects.toThrowError();
+		await expect(db.transaction(async () => undefined)).rejects.toThrowError('Failed query: begin');
 
 		expect(state.connects).toBe(1);
 		expect(state.released).toBe(1);


### PR DESCRIPTION
## Problem

With the node-postgres driver, a transaction whose `BEGIN` statement rejects (e.g. the connection dies right after checkout, or a server-side error) leaks the checked-out pool client: in `node-postgres/session.ts`, `await tx.execute(sql\`begin...\`)` runs *before* the `try/finally` whose `finally` releases the client, so a rejecting `BEGIN` skips `release()` entirely. Under load this exhausts the pool.

Closes #6023

## Fix

Move the `BEGIN` inside the outer `try/finally` so the client is always released, while keeping `ROLLBACK` gated on `BEGIN` having succeeded (no rollback is attempted for a transaction that never started).

## Testing

New DB-free `tests/node-postgres-transaction.test.ts` with a mock pool: `BEGIN` rejects → client released exactly once and no `ROLLBACK` issued (red before the fix: `released: 0`); commit path unchanged; callback throwing → `ROLLBACK` + release. Full drizzle-orm unit suite: 14 files, 569/569 passing; `tsc --noEmit` and `dprint check` clean.
