### PR TITLE
fix(drizzle-zod): give createSchemaFactory's TCoerce generic a default, fixing refine callback `any` (#5968)

### DIFF
--- a/drizzle-zod/src/schema.ts
+++ b/drizzle-zod/src/schema.ts
@@ -119,7 +119,8 @@ export const createUpdateSchema: CreateUpdateSchema<undefined> = (
 };
 
 export function createSchemaFactory<
-	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined,
+	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined =
+		undefined,
 >(options?: CreateSchemaFactoryOptions<TCoerce>) {
 	const createSelectSchema: CreateSelectSchema<TCoerce> = (
 		entity: Table | View | PgEnum<[string, ...string[]]>,


### PR DESCRIPTION
Fixes #5968.

## Root cause

`createInsertSchema` / `createSelectSchema` / `createUpdateSchema` at the top level are hardcoded consts typed `<undefined>` for their `TCoerce` parameter. But `createSchemaFactory<TCoerce extends CoerceOptions>(options?)` is generic with **no default**.

When the factory is called without a `coerce` option — e.g.

```ts
const { createInsertSchema } = createSchemaFactory({ zodInstance: z });
```

TypeScript has no call-site candidate to infer `TCoerce` from (only `zodInstance` is passed), so it falls back to the full constraint union (`Partial<Record<'bigint'|'boolean'|'date'|'number'|'string', true>> | true | undefined`) instead of `undefined`.

That wider `TCoerce` flows into `BuildRefine` → `GetZodType` → `CanCoerce`, whose conditional types distribute over the union, and the refine callback's `schema` parameter collapses to `any` (`TS7006` under `noImplicitAny`/`strict`):

```ts
export const projectInsertSchema = createInsertSchema(project, {
  title: (schema) => schema.min(1).max(200),
  //      ^ implicitly any
});
```

**Correction to the original report:** this isn't specific to extended Zod instances (e.g. `@hono/zod-openapi`'s `z`). It reproduces with **any** `createSchemaFactory` call that omits `coerce`, including plain `zod/v4`. The extended-instance case in the original issue just happened to be the one that surfaced it — I verified factory + plain zod hits the identical `TS7006` on the real published package.

## Fix

Give `TCoerce` a default of `undefined`, matching the implicit default the hardcoded top-level consts already have:

```ts
export function createSchemaFactory<
	TCoerce extends Partial<Record<'bigint' | 'boolean' | 'date' | 'number' | 'string', true>> | true | undefined =
		undefined,
>(options?: CreateSchemaFactoryOptions<TCoerce>) {
```

## Verification

Tested against the real built package (patched `.d.ts`/`.d.cts` via `patch-package` since I verified the type-level cause there first) with real `tsc --strict --noImplicitAny`:

- **Before**: `createSchemaFactory({ zodInstance: z })` — any zod instance, factory omitting `coerce` — refine callback `schema` is `any`.
- **After**: refine callback `schema` is a properly typed `ZodType` in all cases: extended instance, plain zod, and also with an explicit `coerce` option (e.g. `coerce: { number: true }` still correctly infers a coerced-number schema — the default doesn't regress explicit `coerce` usage).

Full repro + CI verification (4 cases — original repro, plain-zod-factory control, no-factory control, explicit-coerce control — all clean, workflow green):

- Repro repo: https://github.com/dumbCodesOnly/drizzle-issue-5968-repro
- Green CI run: https://github.com/dumbCodesOnly/drizzle-issue-5968-repro/actions/runs/29641936968

Happy to add a type-test case under `drizzle-zod/tests` if maintainers want one in-repo rather than just linked externally — let me know the preferred location/pattern and I'll add it.