### PR TITLE
fix(node-postgres): release pool client when BEGIN rejects in transaction()

### DIFF
--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -254,13 +254,15 @@ export class NodePgSession<
 			? new NodePgSession(await (<pg.Pool> this.client).connect(), this.dialect, this.schema, this.options)
 			: this;
 		const tx = new NodePgTransaction<TFullSchema, TSchema>(this.dialect, session, this.schema);
-		await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
+		let began = false;
 		try {
+			await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
+			began = true;
 			const result = await transaction(tx);
 			await tx.execute(sql`commit`);
 			return result;
 		} catch (error) {
-			await tx.execute(sql`rollback`);
+			if (began) await tx.execute(sql`rollback`);
 			throw error;
 		} finally {
 			if (isPool) (session.client as PoolClient).release();


### PR DESCRIPTION
Fixes #6023

## Problem
`NodePgSession.transaction()` checks a client out of a `pg.Pool`, then runs `BEGIN` *before* entering the `try/finally` that calls `release()`. If `BEGIN` rejects (e.g. the connection drops right after checkout), control skips both the `catch` (which would `ROLLBACK`) and the `finally` (which releases the client) — the checked-out client is never returned to the pool. Repeated failures can exhaust it.

## Fix
Move `BEGIN` inside the existing `try/finally` and track whether it actually succeeded via a `began` flag, so `ROLLBACK` is only attempted once a transaction has genuinely started, while `release()` still runs on every exit path:

```ts
let began = false;
try {
  await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
  began = true;
  const result = await transaction(tx);
  await tx.execute(sql`commit`);
  return result;
} catch (error) {
  if (began) await tx.execute(sql`rollback`);
  throw error;
} finally {
  if (isPool) (session.client as PoolClient).release();
}
```

## Verification
Ran the minimal repro from the issue (a `FailingPool`/client stub whose `query` always rejects, simulating a dropped connection on `BEGIN`) directly against the `src` in both states:

- Unpatched `main`: `released: 0` — leak reproduces
- This branch: `released: 1` — client released, no leak

Note: the currently-published `drizzle-orm@0.45.2` (npm `latest`) already contains an equivalent guard, so current stable users aren't affected — this brings `main` in line with that existing fix. Left more detail on this in the issue thread.

## Scope note
Nested transactions (`NodePgTransaction.transaction()`, the savepoint path) have a similar "no guard around the initial statement" shape, but there's no pool client to leak there since it reuses the existing session — left out of this PR to keep it minimal/single-purpose. Happy to follow up separately if maintainers want that covered too.