### PR TITLE
[Gel]: Add support for Gel-only column types in drizzle-zod/-arktype/-valibot/-typebox

### DIFF
--- a/drizzle-arktype/package.json
+++ b/drizzle-arktype/package.json
@@ -57,7 +57,13 @@
 	"license": "Apache-2.0",
 	"peerDependencies": {
 		"arktype": ">=2.0.0",
-		"drizzle-orm": ">=0.36.0"
+		"drizzle-orm": ">=0.36.0",
+		"gel": ">=2"
+	},
+	"peerDependenciesMeta": {
+		"gel": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@ark/attest": "^0.45.8",
@@ -66,6 +72,7 @@
 		"arktype": "^2.1.10",
 		"cpy": "^10.1.0",
 		"drizzle-orm": "link:../drizzle-orm/dist",
+		"gel": "^2.0.0",
 		"json-rules-engine": "7.3.1",
 		"rimraf": "^5.0.0",
 		"rollup": "^3.29.5",

--- a/drizzle-arktype/src/column.ts
+++ b/drizzle-arktype/src/column.ts
@@ -54,6 +54,7 @@ import type {
 	SingleStoreYear,
 } from 'drizzle-orm/singlestore-core';
 import type { SQLiteInteger, SQLiteReal, SQLiteText } from 'drizzle-orm/sqlite-core';
+import type { DateDuration, Duration, LocalDate, LocalDateTime, LocalTime, RelativeDuration } from 'gel';
 import { CONSTANTS } from './constants.ts';
 import { isColumnType, isWithEnum } from './utils.ts';
 
@@ -61,6 +62,33 @@ export const literalSchema = type.string.or(type.number).or(type.boolean).or(typ
 export const jsonSchema = literalSchema.or(type.unknown.as<any>().array()).or(type.object.as<Record<string, any>>());
 export const bufferSchema = type.unknown.narrow((value) => value instanceof Buffer).as<Buffer>().describe( // eslint-disable-line no-instanceof/no-instanceof
 	'a Buffer instance',
+);
+
+// Gel driver classes are optional -- checked by constructor name rather than `instanceof` so drizzle-arktype
+// doesn't require the `gel` package to be installed just to type-check or run for non-Gel users.
+// NOTE: kept as 6 concrete schemas (mirroring bufferSchema above) rather than a generic
+// gelInstanceSchema<T>() helper -- arktype's `.as<T>()` requires a concrete/constrained type
+// argument (validateChainedAsArgs<T>) and rejects an unconstrained generic passed through a
+// wrapper function, even though the same `.as<Buffer>()` call works fine with a concrete type.
+const gelClassNarrow = (className: string) => (value: unknown) =>
+	value != null && typeof value === 'object' && (value as any).constructor?.name === className;
+const dateDurationSchema = type.unknown.narrow(gelClassNarrow('DateDuration')).as<DateDuration>().describe(
+	'a Gel DateDuration instance',
+);
+const durationSchema = type.unknown.narrow(gelClassNarrow('Duration')).as<Duration>().describe(
+	'a Gel Duration instance',
+);
+const relDurationSchema = type.unknown.narrow(gelClassNarrow('RelativeDuration')).as<RelativeDuration>().describe(
+	'a Gel RelativeDuration instance',
+);
+const localDateSchema = type.unknown.narrow(gelClassNarrow('LocalDate')).as<LocalDate>().describe(
+	'a Gel LocalDate instance',
+);
+const localTimeSchema = type.unknown.narrow(gelClassNarrow('LocalTime')).as<LocalTime>().describe(
+	'a Gel LocalTime instance',
+);
+const localDateTimeSchema = type.unknown.narrow(gelClassNarrow('LocalDateTime')).as<LocalDateTime>().describe(
+	'a Gel LocalDateTime instance',
 );
 
 export function columnToSchema(column: Column): Type {
@@ -115,6 +143,18 @@ export function columnToSchema(column: Column): Type {
 			schema = type.unknown;
 		} else if (column.dataType === 'buffer') {
 			schema = bufferSchema;
+		} else if (column.dataType === 'dateDuration') {
+			schema = dateDurationSchema;
+		} else if (column.dataType === 'duration') {
+			schema = durationSchema;
+		} else if (column.dataType === 'relDuration') {
+			schema = relDurationSchema;
+		} else if (column.dataType === 'localDate') {
+			schema = localDateSchema;
+		} else if (column.dataType === 'localTime') {
+			schema = localTimeSchema;
+		} else if (column.dataType === 'localDateTime') {
+			schema = localDateTimeSchema;
 		}
 	}
 

--- a/drizzle-arktype/tests/gel.test.ts
+++ b/drizzle-arktype/tests/gel.test.ts
@@ -1,0 +1,38 @@
+import { type } from 'arktype';
+import { gelTable } from 'drizzle-orm/gel-core';
+import { DateDuration, Duration, LocalDate, LocalDateTime, LocalTime, RelativeDuration } from 'gel';
+import { expect, test } from 'vitest';
+import { createSelectSchema } from '../src';
+
+test('gel - dateDuration/duration/relDuration/localDate/localTime/localDateTime - select', (t) => {
+	const table = gelTable('test', ({ dateDuration, duration, relDuration, localDate, localTime, timestamp }) => ({
+		dateDuration: dateDuration().notNull(),
+		duration: duration().notNull(),
+		relDuration: relDuration().notNull(),
+		localDate: localDate().notNull(),
+		localTime: localTime().notNull(),
+		localDateTime: timestamp().notNull(),
+	}));
+
+	const schema = createSelectSchema(table);
+
+	const valid = {
+		dateDuration: new DateDuration(0, 0, 0),
+		duration: new Duration(),
+		relDuration: new RelativeDuration(),
+		localDate: new LocalDate(2024, 1, 1),
+		localTime: new LocalTime(12, 0, 0),
+		localDateTime: new LocalDateTime(2024, 1, 1, 12, 0, 0),
+	};
+
+	// the fully valid object (real Gel driver instances) must pass
+	expect(schema(valid) instanceof type.errors).toBe(false);
+
+	// swapping any single field for a non-matching value must fail (previously these all passed as unknown)
+	expect(schema({ ...valid, dateDuration: 'P1D' }) instanceof type.errors).toBe(true);
+	expect(schema({ ...valid, duration: 'PT1H' }) instanceof type.errors).toBe(true);
+	expect(schema({ ...valid, relDuration: {} }) instanceof type.errors).toBe(true);
+	expect(schema({ ...valid, localDate: '2024-01-01' }) instanceof type.errors).toBe(true);
+	expect(schema({ ...valid, localTime: '12:00:00' }) instanceof type.errors).toBe(true);
+	expect(schema({ ...valid, localDateTime: new Date() }) instanceof type.errors).toBe(true);
+});

--- a/drizzle-typebox/package.json
+++ b/drizzle-typebox/package.json
@@ -56,7 +56,13 @@
 	"license": "Apache-2.0",
 	"peerDependencies": {
 		"@sinclair/typebox": ">=0.34.8",
-		"drizzle-orm": ">=0.36.0"
+		"drizzle-orm": ">=0.36.0",
+		"gel": ">=2"
+	},
+	"peerDependenciesMeta": {
+		"gel": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@rollup/plugin-typescript": "^11.1.0",
@@ -64,6 +70,7 @@
 		"@types/node": "^18.15.10",
 		"cpy": "^10.1.0",
 		"drizzle-orm": "link:../drizzle-orm/dist",
+		"gel": "^2.0.0",
 		"json-rules-engine": "^7.3.1",
 		"rimraf": "^5.0.0",
 		"rollup": "^3.29.5",

--- a/drizzle-typebox/src/column.ts
+++ b/drizzle-typebox/src/column.ts
@@ -55,6 +55,7 @@ import type {
 	SingleStoreYear,
 } from 'drizzle-orm/singlestore-core';
 import type { SQLiteInteger, SQLiteReal, SQLiteText } from 'drizzle-orm/sqlite-core';
+import type { DateDuration, Duration, LocalDate, LocalDateTime, LocalTime, RelativeDuration } from 'gel';
 import { CONSTANTS } from './constants.ts';
 import { isColumnType, isWithEnum } from './utils.ts';
 import type { BufferSchema, JsonSchema } from './utils.ts';
@@ -63,6 +64,26 @@ export const literalSchema = t.Union([t.String(), t.Number(), t.Boolean(), t.Nul
 export const jsonSchema: JsonSchema = t.Union([literalSchema, t.Array(t.Any()), t.Record(t.String(), t.Any())]) as any;
 TypeRegistry.Set('Buffer', (_, value) => value instanceof Buffer); // eslint-disable-line no-instanceof/no-instanceof
 export const bufferSchema: BufferSchema = { [Kind]: 'Buffer', type: 'buffer' } as any;
+
+// Gel driver classes are optional -- checked by constructor name rather than `instanceof` so drizzle-typebox
+// doesn't require the `gel` package to be installed just to type-check or run for non-Gel users.
+const gelClassNames = [
+	'DateDuration',
+	'Duration',
+	'RelativeDuration',
+	'LocalDate',
+	'LocalTime',
+	'LocalDateTime',
+] as const;
+for (const className of gelClassNames) {
+	TypeRegistry.Set(
+		`Gel${className}`,
+		(_, value) => value != null && typeof value === 'object' && (value as any).constructor?.name === className,
+	);
+}
+function gelInstanceSchema<T>(className: typeof gelClassNames[number]): TSchema {
+	return { [Kind]: `Gel${className}`, type: `gel-${className.toLowerCase()}` } as any as TSchema & T;
+}
 
 export function mapEnumValues(values: string[]) {
 	return Object.fromEntries(values.map((value) => [value, value]));
@@ -130,6 +151,18 @@ export function columnToSchema(column: Column, t: typeof typebox): TSchema {
 			schema = t.Any();
 		} else if (column.dataType === 'buffer') {
 			schema = bufferSchema;
+		} else if (column.dataType === 'dateDuration') {
+			schema = gelInstanceSchema<DateDuration>('DateDuration');
+		} else if (column.dataType === 'duration') {
+			schema = gelInstanceSchema<Duration>('Duration');
+		} else if (column.dataType === 'relDuration') {
+			schema = gelInstanceSchema<RelativeDuration>('RelativeDuration');
+		} else if (column.dataType === 'localDate') {
+			schema = gelInstanceSchema<LocalDate>('LocalDate');
+		} else if (column.dataType === 'localTime') {
+			schema = gelInstanceSchema<LocalTime>('LocalTime');
+		} else if (column.dataType === 'localDateTime') {
+			schema = gelInstanceSchema<LocalDateTime>('LocalDateTime');
 		}
 	}
 

--- a/drizzle-typebox/tests/gel.test.ts
+++ b/drizzle-typebox/tests/gel.test.ts
@@ -1,0 +1,38 @@
+import { Value } from '@sinclair/typebox/value';
+import { gelTable } from 'drizzle-orm/gel-core';
+import { DateDuration, Duration, LocalDate, LocalDateTime, LocalTime, RelativeDuration } from 'gel';
+import { expect, test } from 'vitest';
+import { createSelectSchema } from '../src';
+
+test('gel - dateDuration/duration/relDuration/localDate/localTime/localDateTime - select', (t) => {
+	const table = gelTable('test', ({ dateDuration, duration, relDuration, localDate, localTime, timestamp }) => ({
+		dateDuration: dateDuration().notNull(),
+		duration: duration().notNull(),
+		relDuration: relDuration().notNull(),
+		localDate: localDate().notNull(),
+		localTime: localTime().notNull(),
+		localDateTime: timestamp().notNull(),
+	}));
+
+	const schema = createSelectSchema(table);
+
+	const valid = {
+		dateDuration: new DateDuration(0, 0, 0),
+		duration: new Duration(),
+		relDuration: new RelativeDuration(),
+		localDate: new LocalDate(2024, 1, 1),
+		localTime: new LocalTime(12, 0, 0),
+		localDateTime: new LocalDateTime(2024, 1, 1, 12, 0, 0),
+	};
+
+	// the fully valid object (real Gel driver instances) must pass
+	expect(Value.Check(schema, valid)).toBe(true);
+
+	// swapping any single field for a non-matching value must fail (previously these all passed as t.Any())
+	expect(Value.Check(schema, { ...valid, dateDuration: 'P1D' })).toBe(false);
+	expect(Value.Check(schema, { ...valid, duration: 'PT1H' })).toBe(false);
+	expect(Value.Check(schema, { ...valid, relDuration: {} })).toBe(false);
+	expect(Value.Check(schema, { ...valid, localDate: '2024-01-01' })).toBe(false);
+	expect(Value.Check(schema, { ...valid, localTime: '12:00:00' })).toBe(false);
+	expect(Value.Check(schema, { ...valid, localDateTime: new Date() })).toBe(false);
+});

--- a/drizzle-valibot/package.json
+++ b/drizzle-valibot/package.json
@@ -56,13 +56,20 @@
 	"license": "Apache-2.0",
 	"peerDependencies": {
 		"drizzle-orm": ">=0.36.0",
+		"gel": ">=2",
 		"valibot": ">=1.0.0-beta.7"
+	},
+	"peerDependenciesMeta": {
+		"gel": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@rollup/plugin-typescript": "^11.1.0",
 		"@types/node": "^18.15.10",
 		"cpy": "^10.1.0",
 		"drizzle-orm": "link:../drizzle-orm/dist",
+		"gel": "^2.0.0",
 		"json-rules-engine": "^7.3.1",
 		"rimraf": "^5.0.0",
 		"rollup": "^3.29.5",

--- a/drizzle-valibot/src/column.ts
+++ b/drizzle-valibot/src/column.ts
@@ -53,6 +53,7 @@ import type {
 	SingleStoreYear,
 } from 'drizzle-orm/singlestore-core';
 import type { SQLiteInteger, SQLiteReal, SQLiteText } from 'drizzle-orm/sqlite-core';
+import type { DateDuration, Duration, LocalDate, LocalDateTime, LocalTime, RelativeDuration } from 'gel';
 import * as v from 'valibot';
 import { CONSTANTS } from './constants.ts';
 import { isColumnType, isWithEnum } from './utils.ts';
@@ -65,6 +66,12 @@ export const jsonSchema: v.GenericSchema<Json> = v.union([
 	v.record(v.string(), v.any()),
 ]);
 export const bufferSchema: v.GenericSchema<Buffer> = v.custom<Buffer>((v) => v instanceof Buffer); // eslint-disable-line no-instanceof/no-instanceof
+
+// Gel driver classes are optional -- checked by constructor name rather than `instanceof` so drizzle-valibot
+// doesn't require the `gel` package to be installed just to type-check or run for non-Gel users.
+function gelInstanceSchema<T>(className: string): v.GenericSchema<T> {
+	return v.custom<T>((val) => val != null && typeof val === 'object' && (val as any).constructor?.name === className);
+}
 
 export function mapEnumValues(values: string[]) {
 	return Object.fromEntries(values.map((value) => [value, value]));
@@ -115,6 +122,18 @@ export function columnToSchema(column: Column): v.GenericSchema {
 			schema = v.any();
 		} else if (column.dataType === 'buffer') {
 			schema = bufferSchema;
+		} else if (column.dataType === 'dateDuration') {
+			schema = gelInstanceSchema<DateDuration>('DateDuration');
+		} else if (column.dataType === 'duration') {
+			schema = gelInstanceSchema<Duration>('Duration');
+		} else if (column.dataType === 'relDuration') {
+			schema = gelInstanceSchema<RelativeDuration>('RelativeDuration');
+		} else if (column.dataType === 'localDate') {
+			schema = gelInstanceSchema<LocalDate>('LocalDate');
+		} else if (column.dataType === 'localTime') {
+			schema = gelInstanceSchema<LocalTime>('LocalTime');
+		} else if (column.dataType === 'localDateTime') {
+			schema = gelInstanceSchema<LocalDateTime>('LocalDateTime');
 		}
 	}
 

--- a/drizzle-valibot/tests/gel.test.ts
+++ b/drizzle-valibot/tests/gel.test.ts
@@ -1,0 +1,38 @@
+import { gelTable } from 'drizzle-orm/gel-core';
+import { DateDuration, Duration, LocalDate, LocalDateTime, LocalTime, RelativeDuration } from 'gel';
+import * as v from 'valibot';
+import { expect, test } from 'vitest';
+import { createSelectSchema } from '../src';
+
+test('gel - dateDuration/duration/relDuration/localDate/localTime/localDateTime - select', (t) => {
+	const table = gelTable('test', ({ dateDuration, duration, relDuration, localDate, localTime, timestamp }) => ({
+		dateDuration: dateDuration().notNull(),
+		duration: duration().notNull(),
+		relDuration: relDuration().notNull(),
+		localDate: localDate().notNull(),
+		localTime: localTime().notNull(),
+		localDateTime: timestamp().notNull(),
+	}));
+
+	const schema = createSelectSchema(table);
+
+	const valid = {
+		dateDuration: new DateDuration(0, 0, 0),
+		duration: new Duration(),
+		relDuration: new RelativeDuration(),
+		localDate: new LocalDate(2024, 1, 1),
+		localTime: new LocalTime(12, 0, 0),
+		localDateTime: new LocalDateTime(2024, 1, 1, 12, 0, 0),
+	};
+
+	// the fully valid object (real Gel driver instances) must pass
+	expect(v.safeParse(schema, valid).success).toBe(true);
+
+	// swapping any single field for a non-matching value must fail (previously these all passed as v.any())
+	expect(v.safeParse(schema, { ...valid, dateDuration: 'P1D' }).success).toBe(false);
+	expect(v.safeParse(schema, { ...valid, duration: 'PT1H' }).success).toBe(false);
+	expect(v.safeParse(schema, { ...valid, relDuration: {} }).success).toBe(false);
+	expect(v.safeParse(schema, { ...valid, localDate: '2024-01-01' }).success).toBe(false);
+	expect(v.safeParse(schema, { ...valid, localTime: '12:00:00' }).success).toBe(false);
+	expect(v.safeParse(schema, { ...valid, localDateTime: new Date() }).success).toBe(false);
+});

--- a/drizzle-zod/package.json
+++ b/drizzle-zod/package.json
@@ -65,13 +65,20 @@
 	"license": "Apache-2.0",
 	"peerDependencies": {
 		"drizzle-orm": ">=0.36.0",
+		"gel": ">=2",
 		"zod": "^3.25.0 || ^4.0.0"
+	},
+	"peerDependenciesMeta": {
+		"gel": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@rollup/plugin-typescript": "^11.1.0",
 		"@types/node": "^18.15.10",
 		"cpy": "^10.1.0",
 		"drizzle-orm": "link:../drizzle-orm/dist",
+		"gel": "^2.0.0",
 		"json-rules-engine": "^7.3.1",
 		"rimraf": "^5.0.0",
 		"rollup": "^3.29.5",

--- a/drizzle-zod/src/column.ts
+++ b/drizzle-zod/src/column.ts
@@ -53,6 +53,7 @@ import type {
 	SingleStoreYear,
 } from 'drizzle-orm/singlestore-core';
 import type { SQLiteInteger, SQLiteReal, SQLiteText } from 'drizzle-orm/sqlite-core';
+import type { DateDuration, Duration, LocalDate, LocalDateTime, LocalTime, RelativeDuration } from 'gel';
 import { z as zod } from 'zod/v4';
 import { CONSTANTS } from './constants.ts';
 import type { CreateSchemaFactoryOptions } from './schema.types.ts';
@@ -66,6 +67,16 @@ export const jsonSchema: zod.ZodType<Json> = zod.union([
 	zod.array(zod.any()),
 ]);
 export const bufferSchema: zod.ZodType<Buffer> = zod.custom<Buffer>((v) => v instanceof Buffer); // eslint-disable-line no-instanceof/no-instanceof
+
+// Gel driver classes (dateDuration/duration/relDuration/localDate/localTime/localDateTime) are optional --
+// checked by constructor name rather than `instanceof` so drizzle-zod doesn't require the `gel` package
+// to be installed just to type-check or run for non-Gel users.
+function gelInstanceSchema<T>(z: typeof zod, className: string): zod.ZodType<T> {
+	return z.custom<T>(
+		(v) => v != null && typeof v === 'object' && (v as any).constructor?.name === className,
+		{ message: `Expected a Gel ${className} instance` },
+	);
+}
 
 export function columnToSchema(
 	column: Column,
@@ -124,6 +135,18 @@ export function columnToSchema(
 			schema = z.any();
 		} else if (column.dataType === 'buffer') {
 			schema = bufferSchema;
+		} else if (column.dataType === 'dateDuration') {
+			schema = gelInstanceSchema<DateDuration>(z, 'DateDuration');
+		} else if (column.dataType === 'duration') {
+			schema = gelInstanceSchema<Duration>(z, 'Duration');
+		} else if (column.dataType === 'relDuration') {
+			schema = gelInstanceSchema<RelativeDuration>(z, 'RelativeDuration');
+		} else if (column.dataType === 'localDate') {
+			schema = gelInstanceSchema<LocalDate>(z, 'LocalDate');
+		} else if (column.dataType === 'localTime') {
+			schema = gelInstanceSchema<LocalTime>(z, 'LocalTime');
+		} else if (column.dataType === 'localDateTime') {
+			schema = gelInstanceSchema<LocalDateTime>(z, 'LocalDateTime');
 		}
 	}
 

--- a/drizzle-zod/tests/gel.test.ts
+++ b/drizzle-zod/tests/gel.test.ts
@@ -1,0 +1,33 @@
+import { gelTable } from 'drizzle-orm/gel-core';
+import { DateDuration, Duration, LocalDate, LocalDateTime, LocalTime, RelativeDuration } from 'gel';
+import { expect, test } from 'vitest';
+import { createSelectSchema } from '../src';
+
+test('gel - dateDuration/duration/relDuration/localDate/localTime/localDateTime - select', (t) => {
+	const table = gelTable('test', ({ dateDuration, duration, relDuration, localDate, localTime, timestamp }) => ({
+		dateDuration: dateDuration().notNull(),
+		duration: duration().notNull(),
+		relDuration: relDuration().notNull(),
+		localDate: localDate().notNull(),
+		localTime: localTime().notNull(),
+		localDateTime: timestamp().notNull(),
+	}));
+
+	const schema = createSelectSchema(table);
+
+	// each column must accept its real Gel driver instance
+	expect(schema.shape.dateDuration.safeParse(new DateDuration(0, 0, 0)).success).toBe(true);
+	expect(schema.shape.duration.safeParse(new Duration()).success).toBe(true);
+	expect(schema.shape.relDuration.safeParse(new RelativeDuration()).success).toBe(true);
+	expect(schema.shape.localDate.safeParse(new LocalDate(2024, 1, 1)).success).toBe(true);
+	expect(schema.shape.localTime.safeParse(new LocalTime(12, 0, 0)).success).toBe(true);
+	expect(schema.shape.localDateTime.safeParse(new LocalDateTime(2024, 1, 1, 12, 0, 0)).success).toBe(true);
+
+	// and must reject values that aren't the matching Gel class (previously these all passed as z.any())
+	expect(schema.shape.dateDuration.safeParse('P1D').success).toBe(false);
+	expect(schema.shape.duration.safeParse('PT1H').success).toBe(false);
+	expect(schema.shape.relDuration.safeParse({}).success).toBe(false);
+	expect(schema.shape.localDate.safeParse('2024-01-01').success).toBe(false);
+	expect(schema.shape.localTime.safeParse('12:00:00').success).toBe(false);
+	expect(schema.shape.localDateTime.safeParse(new Date()).success).toBe(false);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       drizzle-orm:
         specifier: link:../drizzle-orm/dist
         version: link:../drizzle-orm/dist
+      gel:
+        specifier: ^2.0.0
+        version: 2.1.0
       json-rules-engine:
         specifier: 7.3.1
         version: 7.3.1
@@ -571,6 +574,9 @@ importers:
       drizzle-orm:
         specifier: link:../drizzle-orm/dist
         version: link:../drizzle-orm/dist
+      gel:
+        specifier: ^2.0.0
+        version: 2.1.0
       json-rules-engine:
         specifier: ^7.3.1
         version: 7.3.1
@@ -604,6 +610,9 @@ importers:
       drizzle-orm:
         specifier: link:../drizzle-orm/dist
         version: link:../drizzle-orm/dist
+      gel:
+        specifier: ^2.0.0
+        version: 2.1.0
       json-rules-engine:
         specifier: ^7.3.1
         version: 7.3.1
@@ -640,6 +649,9 @@ importers:
       drizzle-orm:
         specifier: link:../drizzle-orm/dist
         version: link:../drizzle-orm/dist
+      gel:
+        specifier: ^2.0.0
+        version: 2.1.0
       json-rules-engine:
         specifier: ^7.3.1
         version: 7.3.1


### PR DESCRIPTION
## What

Adds real schema validation for the 6 Gel-only column types across the four schema-integration packages: `dateDuration`, `duration`, `relDuration`, `localDate`, `localTime`, `localDateTime`.

Previously, these types fell through to a permissive any-type schema in `drizzle-zod`, `drizzle-arktype`, `drizzle-valibot`, and `drizzle-typebox`, so schemas generated for Gel tables silently skipped validation on these columns.

## Changes

- Add real schema validation for the 6 Gel-only column types in `drizzle-zod`, `drizzle-arktype`, `drizzle-valibot`, and `drizzle-typebox`
- Add `gel` as an optional `peerDependency` and `devDependency` in each of the 4 packages
- `drizzle-arktype`: use 6 concrete per-type schemas instead of a generic instanceof-based schema, since arktype's `validateChainedAsArgs` type check rejects the generic form
- Add tests per package verifying the new schemas accept real Gel instances and reject non-matching values

## Testing

Added `tests/gel.test.ts` in each of the 4 packages, covering both acceptance of real Gel instances and rejection of non-matching values for all 6 new column types.

## Notes for reviewers

- This PR spans 4 packages rather than a single dialect, so I've titled it after the underlying driver (`Gel`) per the `[<dialect name>]: <subject>` convention rather than a specific package name.
- Commit is signed per the contribution guidelines.
