### PR TITLE
feat: Add Effect adapters for Expo SQLite and OP-SQLite

### DIFF
--- a/drizzle-orm/src/effect-expo-sqlite/driver.ts
+++ b/drizzle-orm/src/effect-expo-sqlite/driver.ts
@@ -1,0 +1,78 @@
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import type { SQLiteDatabase } from 'expo-sqlite';
+import { EffectCache } from '~/cache/core/cache-effect.ts';
+import { DefaultServices } from '~/effect-core/defaults.ts';
+import { EffectLogger } from '~/effect-core/index.ts';
+import { entityKind } from '~/entity.ts';
+import type { AnyRelations, EmptyRelations } from '~/relations.ts';
+import { SQLiteDialect } from '~/sqlite-core/dialect.ts';
+import { SQLiteEffectDatabase } from '~/sqlite-core/effect/db.ts';
+import type { EffectDrizzleSQLiteConfig } from '~/sqlite-core/effect/utils.ts';
+import { jitCompatCheck } from '~/utils.ts';
+import {
+	type EffectExpoSQLiteQueryEffectHKT,
+	type EffectExpoSQLiteRunResult,
+	EffectExpoSQLiteSession,
+} from './session.ts';
+export { DefaultServices } from '~/effect-core/defaults.ts';
+
+export class ExpoSQLiteClient extends Context.Service<ExpoSQLiteClient, SQLiteDatabase>()(
+	'drizzle-orm/effect-expo-sqlite/ExpoSQLiteClient',
+) {}
+
+export class EffectExpoSQLiteDatabase<TRelations extends AnyRelations = EmptyRelations>
+	extends SQLiteEffectDatabase<EffectExpoSQLiteQueryEffectHKT, EffectExpoSQLiteRunResult, TRelations>
+{
+	static override readonly [entityKind]: string = 'EffectExpoSQLiteDatabase';
+}
+
+/**
+ * Creates an EffectExpoSQLiteDatabase instance.
+ *
+ * Requires `ExpoSQLiteClient`, `EffectLogger`, and `EffectCache` services to be provided.
+ * Use `DefaultServices` to provide default (no-op) logger and cache implementations.
+ *
+ * @example
+ * ```ts
+ * const db = yield* ExpoSQLiteDrizzle.makeWithDefaults({ relations }).pipe(
+ *   Effect.provideService(ExpoSQLiteDrizzle.ExpoSQLiteClient, client),
+ * );
+ * ```
+ */
+export const make = Effect.fn('ExpoSQLiteDrizzle.make')(
+	function*<
+		TRelations extends AnyRelations = EmptyRelations,
+	>(config: EffectDrizzleSQLiteConfig<TRelations> = {}) {
+		const client = yield* ExpoSQLiteClient;
+		const cache = yield* EffectCache;
+		const logger = yield* EffectLogger;
+
+		const dialect = new SQLiteDialect({
+			useJitMappers: jitCompatCheck(config.jit),
+		});
+
+		const relations = config.relations ?? {} as TRelations;
+		const session = new EffectExpoSQLiteSession(client, dialect, relations, {
+			logger,
+			cache,
+		});
+		const db = new EffectExpoSQLiteDatabase(dialect, session, relations);
+		(<any> db).$client = client;
+		(<any> db).$cache = cache;
+		if ((<any> db).$cache) {
+			(<any> db).$cache['invalidate'] = cache.onMutate;
+		}
+
+		return db as EffectExpoSQLiteDatabase<TRelations> & {
+			$client: SQLiteDatabase;
+		};
+	},
+);
+
+/**
+ * Convenience function that creates an EffectExpoSQLiteDatabase with `DefaultServices` already provided.
+ */
+export const makeWithDefaults = <
+	TRelations extends AnyRelations = EmptyRelations,
+>(config: EffectDrizzleSQLiteConfig<TRelations> = {}) => make(config).pipe(Effect.provide(DefaultServices));

--- a/drizzle-orm/src/effect-expo-sqlite/index.ts
+++ b/drizzle-orm/src/effect-expo-sqlite/index.ts
@@ -1,0 +1,3 @@
+export { EffectLogger } from '~/effect-core/index.ts';
+export * from './driver.ts';
+export * from './session.ts';

--- a/drizzle-orm/src/effect-expo-sqlite/migrator.ts
+++ b/drizzle-orm/src/effect-expo-sqlite/migrator.ts
@@ -1,0 +1,64 @@
+import * as Effect from 'effect/Effect';
+import type { MigrationMeta } from '~/migrator.ts';
+import { formatToMillis } from '~/migrator.utils.ts';
+import type { AnyRelations } from '~/relations.ts';
+import { migrate as coreMigrate } from '~/sqlite-core/effect/session.ts';
+import type { EffectExpoSQLiteDatabase } from './driver.ts';
+
+interface MigrationConfig {
+	journal?: {
+		entries: { idx: number; when: number; tag: string; breakpoints: boolean }[];
+	};
+	migrations: Record<string, string>;
+	migrationsTable?: string;
+	/** @internal */
+	init?: boolean;
+}
+
+function readMigrationFiles({ journal, migrations }: MigrationConfig): MigrationMeta[] {
+	if (journal) {
+		return journal.entries.map((entry) => {
+			const key = `m${entry.idx.toString().padStart(4, '0')}`;
+			const query = migrations[key] ?? migrations[entry.tag];
+			if (!query) {
+				throw new Error(`Missing migration: ${entry.tag}`);
+			}
+
+			return {
+				sql: query.split('--> statement-breakpoint'),
+				bps: entry.breakpoints,
+				folderMillis: Math.floor(entry.when / 1000) * 1000,
+				hash: '',
+				name: entry.tag,
+			};
+		});
+	}
+
+	const migrationQueries: MigrationMeta[] = [];
+
+	const sortedMigrations = Object.keys(migrations).sort();
+
+	for (const key of sortedMigrations) {
+		const query = migrations[key];
+		if (!query) {
+			throw new Error(`Missing migration: ${key}`);
+		}
+
+		migrationQueries.push({
+			sql: query.split('--> statement-breakpoint'),
+			bps: true,
+			folderMillis: formatToMillis(key.slice(0, 14)),
+			hash: '',
+			name: key,
+		});
+	}
+
+	return migrationQueries;
+}
+
+export function migrate<TRelations extends AnyRelations>(
+	db: EffectExpoSQLiteDatabase<TRelations>,
+	config: MigrationConfig,
+) {
+	return Effect.suspend(() => coreMigrate(readMigrationFiles(config), db.session, config));
+}

--- a/drizzle-orm/src/effect-expo-sqlite/session.ts
+++ b/drizzle-orm/src/effect-expo-sqlite/session.ts
@@ -1,0 +1,238 @@
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import { classifySqliteError, SqlError } from 'effect/unstable/sql/SqlError';
+import type { SQLiteDatabase, SQLiteRunResult, SQLiteStatement } from 'expo-sqlite';
+import type { EffectCacheShape } from '~/cache/core/cache-effect.ts';
+import type { WithCacheConfig } from '~/cache/core/types.ts';
+import type { EffectDrizzleQueryError } from '~/effect-core/errors.ts';
+import type { EffectLoggerShape } from '~/effect-core/logger.ts';
+import type { QueryEffectHKTBase } from '~/effect-core/query-effect.ts';
+import { entityKind } from '~/entity.ts';
+import { TransactionRollbackError } from '~/errors.ts';
+import type { AnyRelations } from '~/relations.ts';
+import type { Query } from '~/sql/sql.ts';
+import type { SQLiteDialect } from '~/sqlite-core/dialect.ts';
+import {
+	SQLiteEffectPreparedQuery,
+	type SQLiteEffectQueryExecutors,
+	SQLiteEffectSession,
+	SQLiteEffectTransaction,
+} from '~/sqlite-core/effect/session.ts';
+import type { PreparedQueryConfig, SQLiteExecuteMethod, SQLiteTransactionConfig } from '~/sqlite-core/session.ts';
+
+const makeSqlError = (cause: unknown, operation: string) =>
+	new SqlError({ reason: classifySqliteError(cause, { operation }) });
+
+export interface EffectExpoSQLiteQueryEffectHKT extends QueryEffectHKTBase {
+	readonly error: EffectDrizzleQueryError;
+	readonly context: never;
+}
+
+export type EffectExpoSQLiteRunResult = SQLiteRunResult;
+
+export interface EffectExpoSQLiteSessionOptions {
+	logger: EffectLoggerShape;
+	cache: EffectCacheShape;
+}
+
+export class EffectExpoSQLiteSession<TRelations extends AnyRelations>
+	extends SQLiteEffectSession<EffectExpoSQLiteRunResult, EffectExpoSQLiteQueryEffectHKT, TRelations>
+{
+	static override readonly [entityKind]: string = 'EffectExpoSQLiteSession';
+
+	constructor(
+		private client: SQLiteDatabase,
+		dialect: SQLiteDialect,
+		protected relations: TRelations,
+		private options: EffectExpoSQLiteSessionOptions,
+	) {
+		super(dialect);
+	}
+
+	private withStatement<A>(query: string, execute: (statement: SQLiteStatement) => A): Effect.Effect<A, SqlError> {
+		return Effect.try({
+			try: () => {
+				const statement = this.client.prepareSync(query);
+				try {
+					return execute(statement);
+				} finally {
+					statement.finalizeSync();
+				}
+			},
+			catch: (cause) => makeSqlError(cause, 'execute'),
+		});
+	}
+
+	execute(query: string): Effect.Effect<void, SqlError> {
+		return Effect.try({
+			try: () => this.client.execSync(query),
+			catch: (cause) => makeSqlError(cause, 'execute'),
+		});
+	}
+
+	override prepareQuery<T extends PreparedQueryConfig = PreparedQueryConfig>(
+		query: Query,
+		mode: 'arrays' | 'objects' | 'raw',
+		_prepare: boolean,
+		executeMethod?: SQLiteExecuteMethod,
+		mapper?: (rows: any[]) => any,
+		queryMetadata?: {
+			type: 'select' | 'update' | 'delete' | 'insert';
+			tables: string[];
+		},
+		cacheConfig?: WithCacheConfig,
+	): SQLiteEffectPreparedQuery<T, EffectExpoSQLiteQueryEffectHKT> {
+		const executors: SQLiteEffectQueryExecutors = {
+			all: (params) =>
+				this.withStatement(query.sql, (statement) => {
+					if (mode === 'arrays') {
+						return statement.executeForRawResultSync(params as any[]).getAllSync();
+					}
+					return statement.executeSync(params as any[]).getAllSync();
+				}),
+			get: (params) =>
+				this.withStatement(query.sql, (statement) => {
+					if (mode === 'arrays') {
+						return statement.executeForRawResultSync(params as any[]).getFirstSync() ?? undefined;
+					}
+					return statement.executeSync(params as any[]).getFirstSync() ?? undefined;
+				}),
+			run: (params) =>
+				this.withStatement(query.sql, (statement) => {
+					const result = statement.executeSync(params as any[]);
+					return {
+						changes: result.changes,
+						lastInsertRowId: result.lastInsertRowId,
+					};
+				}),
+			values: (params) =>
+				this.withStatement(
+					query.sql,
+					(statement) => statement.executeForRawResultSync(params as any[]).getAllSync(),
+				),
+		};
+
+		return new SQLiteEffectPreparedQuery<T, EffectExpoSQLiteQueryEffectHKT>(
+			executeMethod,
+			executors,
+			query,
+			mapper,
+			mode,
+			this.options.logger,
+			this.options.cache,
+			queryMetadata,
+			cacheConfig,
+		);
+	}
+
+	override transaction<A, E, R>(
+		transaction: (
+			tx: EffectExpoSQLiteTransaction<TRelations>,
+		) => Effect.Effect<A, E, R>,
+		config: SQLiteTransactionConfig = {},
+	): Effect.Effect<A, E | SqlError, R> {
+		const { client, dialect, relations, options } = this;
+
+		if (config.behavior !== undefined && config.behavior !== 'deferred') {
+			return Effect.fail(
+				makeSqlError(
+					new Error(`Expo SQLite transactions do not support ${config.behavior} behavior`),
+					'transaction',
+				),
+			);
+		}
+
+		return Effect.callback<A, E | SqlError, R>((resume) => {
+			let interrupted = false;
+			const rollbackMarker = new TransactionRollbackError();
+			let nativeTransaction: Promise<void>;
+
+			const awaitNativeTransaction = () =>
+				Effect.tryPromise({
+					try: () => nativeTransaction,
+					catch: (cause) => cause,
+				}).pipe(
+					Effect.catch((cause) =>
+						cause === rollbackMarker
+							? Effect.void
+							: Effect.fail(makeSqlError(cause, 'transaction'))
+					),
+				);
+
+			const runTransaction = (transactionClient: SQLiteDatabase) =>
+				new Promise<void>((resolve, reject) => {
+					if (interrupted) {
+						resolve();
+						return;
+					}
+
+					const session = new EffectExpoSQLiteSession(transactionClient, dialect, relations, options);
+					const tx = new EffectExpoSQLiteTransaction<TRelations>(dialect, session, relations);
+					resume(
+						Effect.suspend(() => transaction(tx)).pipe(
+							Effect.onExit((exit) => {
+								if (Exit.isFailure(exit)) {
+									reject(rollbackMarker);
+								} else {
+									resolve();
+								}
+								return awaitNativeTransaction();
+							}),
+						),
+					);
+				});
+
+			nativeTransaction = client.databaseName === ':memory:'
+				? client.withTransactionAsync(() => runTransaction(client))
+				: client.withExclusiveTransactionAsync(runTransaction);
+
+			void nativeTransaction.catch((cause) => {
+				if (cause !== rollbackMarker) {
+					resume(Effect.fail(makeSqlError(cause, 'transaction')));
+				}
+			});
+
+			return Effect.suspend(() => {
+				interrupted = true;
+				return awaitNativeTransaction().pipe(Effect.catch(() => Effect.void));
+			});
+		});
+	}
+}
+
+export class EffectExpoSQLiteTransaction<TRelations extends AnyRelations>
+	extends SQLiteEffectTransaction<EffectExpoSQLiteQueryEffectHKT, EffectExpoSQLiteRunResult, TRelations>
+{
+	static override readonly [entityKind]: string = 'EffectExpoSQLiteTransaction';
+
+	override transaction<A, E, R>(
+		transaction: (
+			tx: EffectExpoSQLiteTransaction<TRelations>,
+		) => Effect.Effect<A, E, R>,
+	): Effect.Effect<A, E | SqlError, R> {
+		const savepointName = `sp${this.nestedIndex}`;
+		const session = this.session as EffectExpoSQLiteSession<TRelations>;
+		const tx = new EffectExpoSQLiteTransaction(
+			this.dialect,
+			session,
+			this._.relations,
+			this.nestedIndex + 1,
+		);
+
+		return Effect.uninterruptibleMask((restore) =>
+			Effect.gen(function*() {
+				yield* session.execute(`savepoint ${savepointName}`);
+				const exit = yield* Effect.exit(restore(Effect.suspend(() => transaction(tx))));
+
+				if (Exit.isSuccess(exit)) {
+					yield* session.execute(`release savepoint ${savepointName}`);
+					return exit.value;
+				}
+
+				yield* session.execute(`rollback to savepoint ${savepointName}`);
+				yield* session.execute(`release savepoint ${savepointName}`);
+				return yield* Effect.failCause(exit.cause);
+			})
+		);
+	}
+}

--- a/drizzle-orm/src/effect-op-sqlite/driver.ts
+++ b/drizzle-orm/src/effect-op-sqlite/driver.ts
@@ -1,0 +1,74 @@
+import type { OPSQLiteConnection } from '@op-engineering/op-sqlite';
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import { EffectCache } from '~/cache/core/cache-effect.ts';
+import { DefaultServices } from '~/effect-core/defaults.ts';
+import { EffectLogger } from '~/effect-core/index.ts';
+import { entityKind } from '~/entity.ts';
+import type { AnyRelations, EmptyRelations } from '~/relations.ts';
+import { SQLiteDialect } from '~/sqlite-core/dialect.ts';
+import { SQLiteEffectDatabase } from '~/sqlite-core/effect/db.ts';
+import type { EffectDrizzleSQLiteConfig } from '~/sqlite-core/effect/utils.ts';
+import { jitCompatCheck } from '~/utils.ts';
+import { type EffectOPSQLiteQueryEffectHKT, type EffectOPSQLiteRunResult, EffectOPSQLiteSession } from './session.ts';
+export { DefaultServices } from '~/effect-core/defaults.ts';
+
+export class OPSQLiteClient extends Context.Service<OPSQLiteClient, OPSQLiteConnection>()(
+	'drizzle-orm/effect-op-sqlite/OPSQLiteClient',
+) {}
+
+export class EffectOPSQLiteDatabase<TRelations extends AnyRelations = EmptyRelations>
+	extends SQLiteEffectDatabase<EffectOPSQLiteQueryEffectHKT, EffectOPSQLiteRunResult, TRelations>
+{
+	static override readonly [entityKind]: string = 'EffectOPSQLiteDatabase';
+}
+
+/**
+ * Creates an EffectOPSQLiteDatabase instance.
+ *
+ * Requires `OPSQLiteClient`, `EffectLogger`, and `EffectCache` services to be provided.
+ * Use `DefaultServices` to provide default (no-op) logger and cache implementations.
+ *
+ * @example
+ * ```ts
+ * const db = yield* OPSQLiteDrizzle.makeWithDefaults({ relations }).pipe(
+ *   Effect.provideService(OPSQLiteDrizzle.OPSQLiteClient, client),
+ * );
+ * ```
+ */
+export const make = Effect.fn('OPSQLiteDrizzle.make')(
+	function*<
+		TRelations extends AnyRelations = EmptyRelations,
+	>(config: EffectDrizzleSQLiteConfig<TRelations> = {}) {
+		const client = yield* OPSQLiteClient;
+		const cache = yield* EffectCache;
+		const logger = yield* EffectLogger;
+
+		const dialect = new SQLiteDialect({
+			useJitMappers: jitCompatCheck(config.jit),
+		});
+
+		const relations = config.relations ?? {} as TRelations;
+		const session = new EffectOPSQLiteSession(client, dialect, relations, {
+			logger,
+			cache,
+		});
+		const db = new EffectOPSQLiteDatabase(dialect, session, relations);
+		(<any> db).$client = client;
+		(<any> db).$cache = cache;
+		if ((<any> db).$cache) {
+			(<any> db).$cache['invalidate'] = cache.onMutate;
+		}
+
+		return db as EffectOPSQLiteDatabase<TRelations> & {
+			$client: OPSQLiteConnection;
+		};
+	},
+);
+
+/**
+ * Convenience function that creates an EffectOPSQLiteDatabase with `DefaultServices` already provided.
+ */
+export const makeWithDefaults = <
+	TRelations extends AnyRelations = EmptyRelations,
+>(config: EffectDrizzleSQLiteConfig<TRelations> = {}) => make(config).pipe(Effect.provide(DefaultServices));

--- a/drizzle-orm/src/effect-op-sqlite/index.ts
+++ b/drizzle-orm/src/effect-op-sqlite/index.ts
@@ -1,0 +1,3 @@
+export { EffectLogger } from '~/effect-core/index.ts';
+export * from './driver.ts';
+export * from './session.ts';

--- a/drizzle-orm/src/effect-op-sqlite/migrator.ts
+++ b/drizzle-orm/src/effect-op-sqlite/migrator.ts
@@ -1,0 +1,64 @@
+import * as Effect from 'effect/Effect';
+import type { MigrationMeta } from '~/migrator.ts';
+import { formatToMillis } from '~/migrator.utils.ts';
+import type { AnyRelations } from '~/relations.ts';
+import { migrate as coreMigrate } from '~/sqlite-core/effect/session.ts';
+import type { EffectOPSQLiteDatabase } from './driver.ts';
+
+interface MigrationConfig {
+	journal?: {
+		entries: { idx: number; when: number; tag: string; breakpoints: boolean }[];
+	};
+	migrations: Record<string, string>;
+	migrationsTable?: string;
+	/** @internal */
+	init?: boolean;
+}
+
+function readMigrationFiles({ journal, migrations }: MigrationConfig): MigrationMeta[] {
+	if (journal) {
+		return journal.entries.map((entry) => {
+			const key = `m${entry.idx.toString().padStart(4, '0')}`;
+			const query = migrations[key] ?? migrations[entry.tag];
+			if (!query) {
+				throw new Error(`Missing migration: ${entry.tag}`);
+			}
+
+			return {
+				sql: query.split('--> statement-breakpoint'),
+				bps: entry.breakpoints,
+				folderMillis: Math.floor(entry.when / 1000) * 1000,
+				hash: '',
+				name: entry.tag,
+			};
+		});
+	}
+
+	const migrationQueries: MigrationMeta[] = [];
+
+	const sortedMigrations = Object.keys(migrations).sort();
+
+	for (const key of sortedMigrations) {
+		const query = migrations[key];
+		if (!query) {
+			throw new Error(`Missing migration: ${key}`);
+		}
+
+		migrationQueries.push({
+			sql: query.split('--> statement-breakpoint'),
+			bps: true,
+			folderMillis: formatToMillis(key.slice(0, 14)),
+			hash: '',
+			name: key,
+		});
+	}
+
+	return migrationQueries;
+}
+
+export function migrate<TRelations extends AnyRelations>(
+	db: EffectOPSQLiteDatabase<TRelations>,
+	config: MigrationConfig,
+) {
+	return Effect.suspend(() => coreMigrate(readMigrationFiles(config), db.session, config));
+}

--- a/drizzle-orm/src/effect-op-sqlite/session.ts
+++ b/drizzle-orm/src/effect-op-sqlite/session.ts
@@ -1,0 +1,211 @@
+import type { OPSQLiteConnection, QueryResult } from '@op-engineering/op-sqlite';
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import { classifySqliteError, SqlError } from 'effect/unstable/sql/SqlError';
+import type { EffectCacheShape } from '~/cache/core/cache-effect.ts';
+import type { WithCacheConfig } from '~/cache/core/types.ts';
+import type { EffectDrizzleQueryError } from '~/effect-core/errors.ts';
+import type { EffectLoggerShape } from '~/effect-core/logger.ts';
+import type { QueryEffectHKTBase } from '~/effect-core/query-effect.ts';
+import { entityKind } from '~/entity.ts';
+import { TransactionRollbackError } from '~/errors.ts';
+import type { AnyRelations } from '~/relations.ts';
+import type { Query } from '~/sql/sql.ts';
+import type { SQLiteDialect } from '~/sqlite-core/dialect.ts';
+import {
+	SQLiteEffectPreparedQuery,
+	type SQLiteEffectQueryExecutors,
+	SQLiteEffectSession,
+	SQLiteEffectTransaction,
+} from '~/sqlite-core/effect/session.ts';
+import type { PreparedQueryConfig, SQLiteExecuteMethod, SQLiteTransactionConfig } from '~/sqlite-core/session.ts';
+
+const makeSqlError = (cause: unknown, operation: string) =>
+	new SqlError({ reason: classifySqliteError(cause, { operation }) });
+
+export interface EffectOPSQLiteQueryEffectHKT extends QueryEffectHKTBase {
+	readonly error: EffectDrizzleQueryError;
+	readonly context: never;
+}
+
+export type EffectOPSQLiteRunResult = QueryResult;
+
+export interface EffectOPSQLiteSessionOptions {
+	logger: EffectLoggerShape;
+	cache: EffectCacheShape;
+}
+
+export class EffectOPSQLiteSession<TRelations extends AnyRelations>
+	extends SQLiteEffectSession<EffectOPSQLiteRunResult, EffectOPSQLiteQueryEffectHKT, TRelations>
+{
+	static override readonly [entityKind]: string = 'EffectOPSQLiteSession';
+
+	constructor(
+		private client: OPSQLiteConnection,
+		dialect: SQLiteDialect,
+		protected relations: TRelations,
+		private options: EffectOPSQLiteSessionOptions,
+	) {
+		super(dialect);
+	}
+
+	execute(query: string, params: unknown[] = []): Effect.Effect<QueryResult, SqlError> {
+		return Effect.tryPromise({
+			try: () => this.client.executeAsync(query, params as any[]),
+			catch: (cause) => makeSqlError(cause, 'execute'),
+		});
+	}
+
+	executeRaw(query: string, params: unknown[] = []): Effect.Effect<any[], SqlError> {
+		return Effect.tryPromise({
+			try: () => this.client.executeRawAsync(query, params as any[]),
+			catch: (cause) => makeSqlError(cause, 'executeRaw'),
+		});
+	}
+
+	override prepareQuery<T extends PreparedQueryConfig = PreparedQueryConfig>(
+		query: Query,
+		mode: 'arrays' | 'objects' | 'raw',
+		_prepare: boolean,
+		executeMethod?: SQLiteExecuteMethod,
+		mapper?: (rows: any[]) => any,
+		queryMetadata?: {
+			type: 'select' | 'update' | 'delete' | 'insert';
+			tables: string[];
+		},
+		cacheConfig?: WithCacheConfig,
+	): SQLiteEffectPreparedQuery<T, EffectOPSQLiteQueryEffectHKT> {
+		const executors: SQLiteEffectQueryExecutors = {
+			all: (params) => {
+				if (mode === 'arrays') return this.executeRaw(query.sql, params);
+				return this.execute(query.sql, params).pipe(Effect.map(({ rows }) => rows?._array ?? []));
+			},
+			get: (params) => {
+				if (mode === 'arrays') return this.executeRaw(query.sql, params).pipe(Effect.map((rows) => rows[0]));
+				return this.execute(query.sql, params).pipe(Effect.map(({ rows }) => rows?._array?.[0]));
+			},
+			run: (params) => this.execute(query.sql, params),
+			values: (params) => this.executeRaw(query.sql, params),
+		};
+
+		return new SQLiteEffectPreparedQuery<T, EffectOPSQLiteQueryEffectHKT>(
+			executeMethod,
+			executors,
+			query,
+			mapper,
+			mode,
+			this.options.logger,
+			this.options.cache,
+			queryMetadata,
+			cacheConfig,
+		);
+	}
+
+	override transaction<A, E, R>(
+		transaction: (
+			tx: EffectOPSQLiteTransaction<TRelations>,
+		) => Effect.Effect<A, E, R>,
+		config: SQLiteTransactionConfig = {},
+	): Effect.Effect<A, E | SqlError, R> {
+		const { client, dialect, relations } = this;
+
+		if (config.behavior !== undefined && config.behavior !== 'deferred') {
+			return Effect.fail(
+				makeSqlError(
+					new Error(`OP-SQLite transactions do not support ${config.behavior} behavior`),
+					'transaction',
+				),
+			);
+		}
+
+		const tx = new EffectOPSQLiteTransaction<TRelations>(dialect, this, relations);
+
+		return Effect.callback<A, E | SqlError, R>((resume) => {
+			let interrupted = false;
+			const rollbackMarker = new TransactionRollbackError();
+			let nativeTransaction: Promise<void>;
+
+			const awaitNativeTransaction = () =>
+				Effect.tryPromise({
+					try: () => nativeTransaction,
+					catch: (cause) => cause,
+				}).pipe(
+					Effect.catch((cause) =>
+						cause === rollbackMarker
+							? Effect.void
+							: Effect.fail(makeSqlError(cause, 'transaction'))
+					),
+				);
+
+			nativeTransaction = client.transaction(() =>
+				new Promise<void>((resolve, reject) => {
+					if (interrupted) {
+						resolve();
+						return;
+					}
+
+					resume(
+						Effect.suspend(() => transaction(tx)).pipe(
+							Effect.onExit((exit) => {
+								if (Exit.isFailure(exit)) {
+									reject(rollbackMarker);
+								} else {
+									resolve();
+								}
+								return awaitNativeTransaction();
+							}),
+						),
+					);
+				})
+			);
+
+			void nativeTransaction.catch((cause) => {
+				if (cause !== rollbackMarker) {
+					resume(Effect.fail(makeSqlError(cause, 'transaction')));
+				}
+			});
+
+			return Effect.suspend(() => {
+				interrupted = true;
+				return awaitNativeTransaction().pipe(Effect.catch(() => Effect.void));
+			});
+		});
+	}
+}
+
+export class EffectOPSQLiteTransaction<TRelations extends AnyRelations>
+	extends SQLiteEffectTransaction<EffectOPSQLiteQueryEffectHKT, EffectOPSQLiteRunResult, TRelations>
+{
+	static override readonly [entityKind]: string = 'EffectOPSQLiteTransaction';
+
+	override transaction<A, E, R>(
+		transaction: (
+			tx: EffectOPSQLiteTransaction<TRelations>,
+		) => Effect.Effect<A, E, R>,
+	): Effect.Effect<A, E | SqlError, R> {
+		const savepointName = `sp${this.nestedIndex}`;
+		const session = this.session as EffectOPSQLiteSession<TRelations>;
+		const tx = new EffectOPSQLiteTransaction(
+			this.dialect,
+			session,
+			this._.relations,
+			this.nestedIndex + 1,
+		);
+
+		return Effect.uninterruptibleMask((restore) =>
+			Effect.gen(function*() {
+				yield* session.execute(`savepoint ${savepointName}`);
+				const exit = yield* Effect.exit(restore(Effect.suspend(() => transaction(tx))));
+
+				if (Exit.isSuccess(exit)) {
+					yield* session.execute(`release savepoint ${savepointName}`);
+					return exit.value;
+				}
+
+				yield* session.execute(`rollback to savepoint ${savepointName}`);
+				yield* session.execute(`release savepoint ${savepointName}`);
+				return yield* Effect.failCause(exit.cause);
+			})
+		);
+	}
+}

--- a/drizzle-orm/tests/effect-expo-sqlite.test.ts
+++ b/drizzle-orm/tests/effect-expo-sqlite.test.ts
@@ -1,0 +1,264 @@
+import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
+import { SqlError } from 'effect/unstable/sql/SqlError';
+import type { SQLiteDatabase, SQLiteStatement } from 'expo-sqlite';
+import { describe, it } from 'vitest';
+import { ExpoSQLiteClient, makeWithDefaults } from '~/effect-expo-sqlite/index.ts';
+import { sql } from '~/sql/sql.ts';
+
+const makeDb = (client: SQLiteDatabase) =>
+	Effect.runPromise(makeWithDefaults().pipe(Effect.provideService(ExpoSQLiteClient, client)));
+
+describe('effect expo-sqlite', () => {
+	it('maps Expo query results to Effect queries and finalizes statements', async ({ expect }) => {
+		const queries: string[] = [];
+		const finalized: string[] = [];
+		const rows = [{ value: 1 }];
+		const client = {
+			prepareSync: (query: string) => {
+				queries.push(query);
+				return {
+					executeSync: () => ({
+						changes: 1,
+						lastInsertRowId: 2,
+						getAllSync: () => rows,
+						getFirstSync: () => rows[0],
+					}),
+					executeForRawResultSync: () => ({
+						getAllSync: () => [[1]],
+						getFirstSync: () => [1],
+					}),
+					finalizeSync: () => finalized.push(query),
+				} as unknown as SQLiteStatement;
+			},
+		} as unknown as SQLiteDatabase;
+		const db = await makeDb(client);
+
+		expect(await Effect.runPromise(db.all(sql.raw('objects')))).toEqual(rows);
+		expect(await Effect.runPromise(db.get(sql.raw('object')))).toEqual(rows[0]);
+		expect(await Effect.runPromise(db.values(sql.raw('values')))).toEqual([[1]]);
+		expect(await Effect.runPromise(db.run(sql.raw('run')))).toEqual({ changes: 1, lastInsertRowId: 2 });
+		expect(queries).toEqual(['objects', 'object', 'values', 'run']);
+		expect(finalized).toEqual(queries);
+	});
+
+	it('uses the exclusive transaction client, nested savepoints, and preserves failures', async ({ expect }) => {
+		const events: string[] = [];
+		const transactionClient = {
+			execSync: (query: string) => events.push(query),
+			prepareSync: (query: string) => {
+				events.push(query);
+				return {
+					executeSync: () => ({ changes: 0, lastInsertRowId: 0 }),
+					finalizeSync: () => {},
+				} as unknown as SQLiteStatement;
+			},
+		} as unknown as SQLiteDatabase;
+		const client = {
+			withExclusiveTransactionAsync: async (callback: (client: SQLiteDatabase) => Promise<void>) => {
+				events.push('begin');
+				try {
+					await callback(transactionClient);
+					events.push('commit');
+				} catch (error) {
+					events.push('rollback');
+					throw error;
+				}
+			},
+		} as unknown as SQLiteDatabase;
+		const db = await makeDb(client);
+
+		const result = await Effect.runPromise(
+			db.transaction((tx) =>
+				Effect.gen(function*() {
+					yield* tx.run(sql.raw('outer'));
+					yield* tx.transaction((nested) => nested.run(sql.raw('inner')));
+					return 42;
+				})
+			),
+		);
+
+		expect(result).toBe(42);
+		expect(events).toEqual([
+			'begin',
+			'outer',
+			'savepoint sp0',
+			'inner',
+			'release savepoint sp0',
+			'commit',
+		]);
+
+		events.length = 0;
+		await Effect.runPromise(
+			db.transaction((tx) =>
+				Effect.gen(function*() {
+					yield* tx.transaction(() => Effect.interrupt).pipe(Effect.exit);
+					yield* tx.run(sql.raw('after nested interrupt'));
+				})
+			),
+		);
+		expect(events).toEqual([
+			'begin',
+			'savepoint sp0',
+			'rollback to savepoint sp0',
+			'release savepoint sp0',
+			'after nested interrupt',
+			'commit',
+		]);
+
+		events.length = 0;
+		const failure = new Error('boom');
+		const error = await Effect.runPromise(
+			db.transaction(() => Effect.fail(failure)).pipe(Effect.flip),
+		);
+
+		expect(error).toBe(failure);
+		expect(events).toEqual(['begin', 'rollback']);
+
+		events.length = 0;
+		const defect = new Error('defect');
+		const caughtDefect = await Effect.runPromise(
+			db.transaction((): Effect.Effect<never> => {
+				throw defect;
+			}).pipe(Effect.catchDefect((cause) => Effect.succeed(cause))),
+		);
+		expect(caughtDefect).toBe(defect);
+		expect(events).toEqual(['begin', 'rollback']);
+
+		events.length = 0;
+		let nestedStartedResolve!: () => void;
+		const nestedStarted = new Promise<void>((resolve) => {
+			nestedStartedResolve = resolve;
+		});
+		const nestedFiber = Effect.runFork(
+			db.transaction((tx) =>
+				tx.transaction(() =>
+					Effect.gen(function*() {
+						yield* Effect.sync(() => nestedStartedResolve());
+						return yield* Effect.never;
+					})
+				)
+			),
+		);
+		await nestedStarted;
+		await Effect.runPromise(Fiber.interrupt(nestedFiber));
+		expect(events).toEqual([
+			'begin',
+			'savepoint sp0',
+			'rollback to savepoint sp0',
+			'release savepoint sp0',
+			'rollback',
+		]);
+	});
+
+	it('interrupts the transaction body and waits for rollback', async ({ expect }) => {
+		const events: string[] = [];
+		let bodyStartedResolve!: () => void;
+		const bodyStarted = new Promise<void>((resolve) => {
+			bodyStartedResolve = resolve;
+		});
+		let continueBodyResolve!: () => void;
+		const continueBody = new Promise<void>((resolve) => {
+			continueBodyResolve = resolve;
+		});
+		let transactionDone = false;
+		const transactionClient = {
+			prepareSync: (query: string) => ({
+				executeSync: () => {
+					events.push(query);
+					return { changes: 0, lastInsertRowId: 0 };
+				},
+				finalizeSync: () => {},
+			} as unknown as SQLiteStatement),
+		} as unknown as SQLiteDatabase;
+		const client = {
+			databaseName: 'test.db',
+			withExclusiveTransactionAsync: async (callback: (client: SQLiteDatabase) => Promise<void>) => {
+				events.push('begin');
+				try {
+					await callback(transactionClient);
+					events.push('commit');
+				} catch (error) {
+					events.push('rollback');
+					throw error;
+				} finally {
+					transactionDone = true;
+				}
+			},
+		} as unknown as SQLiteDatabase;
+		const db = await makeDb(client);
+
+		const fiber = Effect.runFork(
+			db.transaction((tx) =>
+				Effect.gen(function*() {
+					yield* Effect.sync(() => bodyStartedResolve());
+					yield* Effect.promise(() => continueBody);
+					yield* tx.run(sql.raw('write-after-interrupt'));
+				})
+			),
+		);
+
+		await bodyStarted;
+		await Effect.runPromise(Fiber.interrupt(fiber));
+		try {
+			expect(transactionDone).toBe(true);
+			expect(events).toEqual(['begin', 'rollback']);
+		} finally {
+			continueBodyResolve();
+		}
+	});
+
+	it('uses the original connection for memory database transactions', async ({ expect }) => {
+		const events: string[] = [];
+		const client = {
+			databaseName: ':memory:',
+			withTransactionAsync: async (callback: () => Promise<void>) => {
+				events.push('begin');
+				try {
+					await callback();
+					events.push('commit');
+				} catch (error) {
+					events.push('rollback');
+					throw error;
+				}
+			},
+			withExclusiveTransactionAsync: async () => {
+				events.push('exclusive');
+			},
+			prepareSync: (query: string) => ({
+				executeSync: () => {
+					events.push(query);
+					return { changes: 0, lastInsertRowId: 0 };
+				},
+				finalizeSync: () => {},
+			} as unknown as SQLiteStatement),
+		} as unknown as SQLiteDatabase;
+		const db = await makeDb(client);
+
+		const result = await Effect.runPromise(
+			db.transaction((tx) => tx.run(sql.raw('inside')).pipe(Effect.as(42))),
+		);
+
+		expect(result).toBe(42);
+		expect(events).toEqual(['begin', 'inside', 'commit']);
+	});
+
+	it('rejects transaction behaviors unsupported by the native helper', async ({ expect }) => {
+		let transactionCalls = 0;
+		const client = {
+			databaseName: 'test.db',
+			withExclusiveTransactionAsync: async () => {
+				transactionCalls++;
+			},
+		} as unknown as SQLiteDatabase;
+		const db = await makeDb(client);
+
+		for (const behavior of ['immediate', 'exclusive'] as const) {
+			const error = await Effect.runPromise(
+				db.transaction(() => Effect.void, { behavior }).pipe(Effect.flip),
+			);
+			expect(error).toBeInstanceOf(SqlError);
+		}
+		expect(transactionCalls).toBe(0);
+	});
+});

--- a/drizzle-orm/tests/effect-mobile-sqlite-migrator.test.ts
+++ b/drizzle-orm/tests/effect-mobile-sqlite-migrator.test.ts
@@ -1,0 +1,90 @@
+import { SqliteClient } from '@effect/sql-sqlite-node';
+import * as Effect from 'effect/Effect';
+import { describe, it } from 'vitest';
+import type { EffectExpoSQLiteDatabase } from '~/effect-expo-sqlite/driver.ts';
+import { migrate as migrateExpoSQLite } from '~/effect-expo-sqlite/migrator.ts';
+import type { EffectOPSQLiteDatabase } from '~/effect-op-sqlite/driver.ts';
+import { migrate as migrateOPSQLite } from '~/effect-op-sqlite/migrator.ts';
+import type { EffectSQLiteNodeDatabase } from '~/effect-sqlite-node/driver.ts';
+import { makeWithDefaults } from '~/effect-sqlite-node/index.ts';
+import { sql } from '~/sql/sql.ts';
+
+const journalEntry = {
+	idx: 0,
+	when: 1732696446109,
+	tag: '0000_cuddly_black_bolt',
+	breakpoints: true,
+};
+
+const migrationConfig = {
+	journal: { entries: [journalEntry] },
+	migrations: { m0000: 'create table should_not_exist (id integer)' },
+};
+
+const upgradeLegacyDb = (
+	migrate: (db: EffectSQLiteNodeDatabase) => Effect.Effect<unknown, unknown>,
+) =>
+	Effect.gen(function*() {
+		const db = yield* makeWithDefaults();
+		yield* db.run(`create table __drizzle_migrations (
+			id integer primary key,
+			hash text not null,
+			created_at numeric
+		)`);
+		yield* db.run(sql`insert into __drizzle_migrations (id, hash, created_at) values (1, '', ${journalEntry.when})`);
+
+		yield* migrate(db);
+
+		return {
+			migration: yield* db.get<{ name: string }>('select name from __drizzle_migrations where id = 1'),
+			table: yield* db.get<{ exists: number }>(
+				`select exists(select 1 from sqlite_master where type = 'table' and name = 'should_not_exist') as "exists"`,
+			),
+		};
+	}).pipe(Effect.provide(SqliteClient.layer({ filename: ':memory:' })));
+
+describe('effect mobile SQLite migrators', () => {
+	it('upgrades an OP-SQLite legacy migration table from a generated bundle', async ({ expect }) => {
+		const result = await Effect.runPromise(
+			upgradeLegacyDb((db) =>
+				migrateOPSQLite(db as unknown as EffectOPSQLiteDatabase<Record<string, never>>, migrationConfig)
+			),
+		);
+
+		expect(result.migration).toEqual({ name: journalEntry.tag });
+		expect(result.table).toEqual({ exists: 0 });
+	});
+
+	it('defers OP-SQLite migration parsing into Effect', async ({ expect }) => {
+		const config = { journal: { entries: [journalEntry] }, migrations: {} };
+		const db = {} as EffectOPSQLiteDatabase<Record<string, never>>;
+
+		expect(() => migrateOPSQLite(db, config)).not.toThrow();
+		const defect = await Effect.runPromise(
+			migrateOPSQLite(db, config).pipe(Effect.catchDefect((cause) => Effect.succeed(cause))),
+		);
+		expect(defect).toEqual(new Error(`Missing migration: ${journalEntry.tag}`));
+	});
+
+	it('upgrades an Expo SQLite legacy migration table from a generated bundle', async ({ expect }) => {
+		const result = await Effect.runPromise(
+			upgradeLegacyDb((db) =>
+				migrateExpoSQLite(db as unknown as EffectExpoSQLiteDatabase<Record<string, never>>, migrationConfig)
+			),
+		);
+
+		expect(result.migration).toEqual({ name: journalEntry.tag });
+		expect(result.table).toEqual({ exists: 0 });
+	});
+
+	it('defers Expo SQLite migration parsing into Effect', async ({ expect }) => {
+		const config = { journal: { entries: [journalEntry] }, migrations: {} };
+		const db = {} as EffectExpoSQLiteDatabase<Record<string, never>>;
+
+		expect(() => migrateExpoSQLite(db, config)).not.toThrow();
+		const defect = await Effect.runPromise(
+			migrateExpoSQLite(db, config).pipe(Effect.catchDefect((cause) => Effect.succeed(cause))),
+		);
+		expect(defect).toEqual(new Error(`Missing migration: ${journalEntry.tag}`));
+	});
+});

--- a/drizzle-orm/tests/effect-op-sqlite.test.ts
+++ b/drizzle-orm/tests/effect-op-sqlite.test.ts
@@ -1,0 +1,214 @@
+import type { OPSQLiteConnection, Transaction } from '@op-engineering/op-sqlite';
+import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
+import { SqlError } from 'effect/unstable/sql/SqlError';
+import { describe, it } from 'vitest';
+import { makeWithDefaults, OPSQLiteClient } from '~/effect-op-sqlite/index.ts';
+import { sql } from '~/sql/sql.ts';
+
+const makeDb = (client: OPSQLiteConnection) =>
+	Effect.runPromise(makeWithDefaults().pipe(Effect.provideService(OPSQLiteClient, client)));
+
+describe('effect op-sqlite', () => {
+	it('maps OP-SQLite query results to Effect queries', async ({ expect }) => {
+		const calls: string[] = [];
+		const rows = [{ value: 1 }];
+		const client = {
+			executeAsync: async (query: string) => {
+				calls.push(query);
+				return {
+					rowsAffected: 1,
+					rows: {
+						_array: rows,
+						length: rows.length,
+						item: (index: number) => rows[index],
+					},
+				};
+			},
+			executeRawAsync: async (query: string) => {
+				calls.push(query);
+				return [[1]];
+			},
+		} as unknown as OPSQLiteConnection;
+		const db = await makeDb(client);
+
+		expect(await Effect.runPromise(db.all(sql.raw('objects')))).toEqual(rows);
+		expect(await Effect.runPromise(db.get(sql.raw('object')))).toEqual(rows[0]);
+		expect(await Effect.runPromise(db.values(sql.raw('values')))).toEqual([[1]]);
+		expect(await Effect.runPromise(db.run(sql.raw('run')))).toMatchObject({ rowsAffected: 1 });
+		expect(calls).toEqual(['objects', 'object', 'values', 'run']);
+	});
+
+	it('uses native transactions, nested savepoints, and preserves failures', async ({ expect }) => {
+		const events: string[] = [];
+		const client = {
+			transaction: async (callback: (tx: Transaction) => Promise<void>) => {
+				events.push('begin');
+				try {
+					await callback({} as Transaction);
+					events.push('commit');
+				} catch (error) {
+					events.push('rollback');
+					throw error;
+				}
+			},
+			executeAsync: async (query: string) => {
+				events.push(query);
+				return { rowsAffected: 0 };
+			},
+			executeRawAsync: async () => [],
+		} as unknown as OPSQLiteConnection;
+		const db = await makeDb(client);
+
+		const result = await Effect.runPromise(
+			db.transaction((tx) =>
+				Effect.gen(function*() {
+					yield* tx.run(sql.raw('outer'));
+					yield* tx.transaction((nested) => nested.run(sql.raw('inner')));
+					return 42;
+				}), { behavior: 'deferred' }),
+		);
+
+		expect(result).toBe(42);
+		expect(events).toEqual([
+			'begin',
+			'outer',
+			'savepoint sp0',
+			'inner',
+			'release savepoint sp0',
+			'commit',
+		]);
+
+		events.length = 0;
+		await Effect.runPromise(
+			db.transaction((tx) =>
+				Effect.gen(function*() {
+					yield* tx.transaction(() => Effect.interrupt).pipe(Effect.exit);
+					yield* tx.run(sql.raw('after nested interrupt'));
+				})
+			),
+		);
+		expect(events).toEqual([
+			'begin',
+			'savepoint sp0',
+			'rollback to savepoint sp0',
+			'release savepoint sp0',
+			'after nested interrupt',
+			'commit',
+		]);
+
+		events.length = 0;
+		const failure = new Error('boom');
+		const error = await Effect.runPromise(
+			db.transaction(() => Effect.fail(failure)).pipe(Effect.flip),
+		);
+
+		expect(error).toBe(failure);
+		expect(events).toEqual(['begin', 'rollback']);
+
+		events.length = 0;
+		const defect = new Error('defect');
+		const caughtDefect = await Effect.runPromise(
+			db.transaction((): Effect.Effect<never> => {
+				throw defect;
+			}).pipe(Effect.catchDefect((cause) => Effect.succeed(cause))),
+		);
+		expect(caughtDefect).toBe(defect);
+		expect(events).toEqual(['begin', 'rollback']);
+
+		events.length = 0;
+		let nestedStartedResolve!: () => void;
+		const nestedStarted = new Promise<void>((resolve) => {
+			nestedStartedResolve = resolve;
+		});
+		const nestedFiber = Effect.runFork(
+			db.transaction((tx) =>
+				tx.transaction(() =>
+					Effect.gen(function*() {
+						yield* Effect.sync(() => nestedStartedResolve());
+						return yield* Effect.never;
+					})
+				)
+			),
+		);
+		await nestedStarted;
+		await Effect.runPromise(Fiber.interrupt(nestedFiber));
+		expect(events).toEqual([
+			'begin',
+			'savepoint sp0',
+			'rollback to savepoint sp0',
+			'release savepoint sp0',
+			'rollback',
+		]);
+	});
+
+	it('interrupts the transaction body and waits for rollback', async ({ expect }) => {
+		const events: string[] = [];
+		let bodyStartedResolve!: () => void;
+		const bodyStarted = new Promise<void>((resolve) => {
+			bodyStartedResolve = resolve;
+		});
+		let continueBodyResolve!: () => void;
+		const continueBody = new Promise<void>((resolve) => {
+			continueBodyResolve = resolve;
+		});
+		let transactionDone = false;
+		const client = {
+			transaction: async (callback: (tx: Transaction) => Promise<void>) => {
+				events.push('begin');
+				try {
+					await callback({} as Transaction);
+					events.push('commit');
+				} catch (error) {
+					events.push('rollback');
+					throw error;
+				} finally {
+					transactionDone = true;
+				}
+			},
+			executeAsync: async (query: string) => {
+				events.push(query);
+				return { rowsAffected: 0 };
+			},
+			executeRawAsync: async () => [],
+		} as unknown as OPSQLiteConnection;
+		const db = await makeDb(client);
+
+		const fiber = Effect.runFork(
+			db.transaction((tx) =>
+				Effect.gen(function*() {
+					yield* Effect.sync(() => bodyStartedResolve());
+					yield* Effect.promise(() => continueBody);
+					yield* tx.run(sql.raw('write-after-interrupt'));
+				})
+			),
+		);
+
+		await bodyStarted;
+		await Effect.runPromise(Fiber.interrupt(fiber));
+		try {
+			expect(transactionDone).toBe(true);
+			expect(events).toEqual(['begin', 'rollback']);
+		} finally {
+			continueBodyResolve();
+		}
+	});
+
+	it('rejects transaction behaviors unsupported by the native helper', async ({ expect }) => {
+		let transactionCalls = 0;
+		const client = {
+			transaction: async () => {
+				transactionCalls++;
+			},
+		} as unknown as OPSQLiteConnection;
+		const db = await makeDb(client);
+
+		for (const behavior of ['immediate', 'exclusive'] as const) {
+			const error = await Effect.runPromise(
+				db.transaction(() => Effect.void, { behavior }).pipe(Effect.flip),
+			);
+			expect(error).toBeInstanceOf(SqlError);
+		}
+		expect(transactionCalls).toBe(0);
+	});
+});

--- a/drizzle-orm/type-tests/sqlite/effect.ts
+++ b/drizzle-orm/type-tests/sqlite/effect.ts
@@ -1,10 +1,26 @@
 import type { SqliteClient } from '@effect/sql-sqlite-node/SqliteClient';
+import type { OPSQLiteConnection, QueryResult } from '@op-engineering/op-sqlite';
 import * as Effect from 'effect/Effect';
 import type { SqlError } from 'effect/unstable/sql/SqlError';
+import type { SQLiteDatabase, SQLiteRunResult } from 'expo-sqlite';
 import type { Equal } from 'type-tests/utils.ts';
 import { Expect } from 'type-tests/utils.ts';
 import type { EffectDrizzleQueryError, MigratorInitError } from '~/effect-core/errors.ts';
 import { QueryEffectHKTBase } from '~/effect-core/query-effect.ts';
+import {
+	type EffectExpoSQLiteDatabase,
+	ExpoSQLiteClient,
+	make as makeExpoSQLite,
+	makeWithDefaults as makeExpoSQLiteWithDefaults,
+} from '~/effect-expo-sqlite/index.ts';
+import { migrate as migrateExpoSQLite } from '~/effect-expo-sqlite/migrator.ts';
+import {
+	type EffectOPSQLiteDatabase,
+	make as makeOPSQLite,
+	makeWithDefaults as makeOPSQLiteWithDefaults,
+	OPSQLiteClient,
+} from '~/effect-op-sqlite/index.ts';
+import { migrate as migrateOPSQLite } from '~/effect-op-sqlite/migrator.ts';
 import type { EffectSQLiteNodeDatabase } from '~/effect-sqlite-node/index.ts';
 import { make, makeWithDefaults } from '~/effect-sqlite-node/index.ts';
 import { migrate } from '~/effect-sqlite-node/migrator.ts';
@@ -41,6 +57,116 @@ type AsEffect<T> = T extends Effect.Effect<infer A, infer E, infer R> ? Effect.E
 				| import('~/cache/core/cache-effect.ts').EffectCache
 				| SqliteClient
 			>
+		>
+	>;
+}
+
+{
+	const dbEffect = makeExpoSQLiteWithDefaults();
+	type DbEffect = typeof dbEffect;
+
+	Expect<
+		Equal<
+			DbEffect,
+			Effect.Effect<
+				EffectExpoSQLiteDatabase<EmptyRelations> & { $client: SQLiteDatabase },
+				never,
+				ExpoSQLiteClient
+			>
+		>
+	>;
+}
+
+{
+	const dbEffect = makeExpoSQLite();
+	type DbEffect = typeof dbEffect;
+
+	Expect<
+		Equal<
+			DbEffect,
+			Effect.Effect<
+				EffectExpoSQLiteDatabase<EmptyRelations> & { $client: SQLiteDatabase },
+				never,
+				| import('~/effect-core/logger.ts').EffectLogger
+				| import('~/cache/core/cache-effect.ts').EffectCache
+				| ExpoSQLiteClient
+			>
+		>
+	>;
+}
+
+declare const expoDb: EffectExpoSQLiteDatabase<Record<string, never>>;
+
+{
+	const run = expoDb.run('somequery');
+	type RunEffect = AsEffect<typeof run>;
+
+	Expect<Equal<RunEffect, Effect.Effect<SQLiteRunResult, EffectDrizzleQueryError, never>>>;
+}
+
+{
+	const migrateResult = migrateExpoSQLite(expoDb, { migrations: { '0000_test': 'select 1' } });
+	type MigrateEffect = typeof migrateResult;
+
+	Expect<
+		Equal<
+			MigrateEffect,
+			Effect.Effect<undefined, SqlError | EffectDrizzleQueryError | MigratorInitError, never>
+		>
+	>;
+}
+
+{
+	const dbEffect = makeOPSQLiteWithDefaults();
+	type DbEffect = typeof dbEffect;
+
+	Expect<
+		Equal<
+			DbEffect,
+			Effect.Effect<
+				EffectOPSQLiteDatabase<EmptyRelations> & { $client: OPSQLiteConnection },
+				never,
+				OPSQLiteClient
+			>
+		>
+	>;
+}
+
+{
+	const dbEffect = makeOPSQLite();
+	type DbEffect = typeof dbEffect;
+
+	Expect<
+		Equal<
+			DbEffect,
+			Effect.Effect<
+				EffectOPSQLiteDatabase<EmptyRelations> & { $client: OPSQLiteConnection },
+				never,
+				| import('~/effect-core/logger.ts').EffectLogger
+				| import('~/cache/core/cache-effect.ts').EffectCache
+				| OPSQLiteClient
+			>
+		>
+	>;
+}
+
+declare const opDb: EffectOPSQLiteDatabase<Record<string, never>>;
+
+{
+	const run = opDb.run('somequery');
+	type RunEffect = AsEffect<typeof run>;
+
+	Expect<Equal<RunEffect, Effect.Effect<QueryResult, EffectDrizzleQueryError, never>>>;
+}
+
+{
+	const migrateResult = migrateOPSQLite(opDb, { migrations: { '0000_test': 'select 1' } });
+	type MigrateEffect = typeof migrateResult;
+
+	Expect<
+		Equal<
+			MigrateEffect,
+			Effect.Effect<undefined, SqlError | EffectDrizzleQueryError | MigratorInitError, never>
 		>
 	>;
 }


### PR DESCRIPTION
tldr; Adds Effect integrations for Expo SQLite and OP-SQLite, based on the patterns used by the existing Drizzle Effect adapters

Changes: 
- Adds `effect-expo-sqlite` and `effect-op-sqlite` drivers, sessions, migrators, and exports.
- Bridges native transactions using Effect.callback so the interruption reaches the transaction fiber and waits for commit or rollback.
- Makes nested savepoint cleanup uninterruptible.
- Explicitly rejects unsupported immediate and exclusive transaction behavior instead of silently discarding it.
- Keeps Expo `:memory:` transactions on the original connection.
- Supports generated mobile migration bundles using journal metadata.
- Defers migration parsing into the Effect execution boundary.

- 1,105 unit tests passed; 7 skipped.
- Native transaction behavior is tested with injected Expo/OP-SQLite client fakes.

