### PR TITLE
fix(effect): set the driver error as EffectDrizzleQueryError cause

### DIFF
--- a/drizzle-orm/src/mysql-core/effect/session.ts
+++ b/drizzle-orm/src/mysql-core/effect/session.ts
@@ -1,4 +1,3 @@
-import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
 import type { SqlError } from 'effect/unstable/sql/SqlError';
 import { EffectCache, type EffectCacheShape } from '~/cache/core/cache-effect.ts';
@@ -136,7 +135,7 @@ export class MySqlEffectPreparedQuery<
 		}).pipe(
 			Effect.provideService(EffectCache, this.cache),
 			Effect.catch((e) => {
-				return Effect.fail(new EffectDrizzleQueryError({ query: queryString, params, cause: Cause.fail(e) }));
+				return Effect.fail(new EffectDrizzleQueryError({ query: queryString, params, cause: e }));
 			}),
 		);
 	}

--- a/drizzle-orm/src/pg-core/effect/session.ts
+++ b/drizzle-orm/src/pg-core/effect/session.ts
@@ -1,4 +1,3 @@
-import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
 import type { SqlError } from 'effect/unstable/sql/SqlError';
 import { EffectCache, type EffectCacheShape } from '~/cache/core/cache-effect.ts';
@@ -134,7 +133,7 @@ export class PgEffectPreparedQuery<
 		}).pipe(
 			Effect.provideService(EffectCache, this.cache),
 			Effect.catch((e) => {
-				return Effect.fail(new EffectDrizzleQueryError({ query: queryString, params, cause: Cause.fail(e) }));
+				return Effect.fail(new EffectDrizzleQueryError({ query: queryString, params, cause: e }));
 			}),
 		);
 	}

--- a/drizzle-orm/src/sqlite-core/effect/session.ts
+++ b/drizzle-orm/src/sqlite-core/effect/session.ts
@@ -1,4 +1,3 @@
-import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
 import type { SqlError } from 'effect/unstable/sql/SqlError';
 import { EffectCache, type EffectCacheShape } from '~/cache/core/cache-effect.ts';
@@ -187,7 +186,7 @@ export class SQLiteEffectPreparedQuery<
 		}).pipe(
 			Effect.provideService(EffectCache, this.cache),
 			Effect.catch((e) => {
-				return Effect.fail(new EffectDrizzleQueryError({ query: queryString, params, cause: Cause.fail(e) }));
+				return Effect.fail(new EffectDrizzleQueryError({ query: queryString, params, cause: e }));
 			}),
 		);
 	}

--- a/integration-tests/tests/pg/effect-pglite.test.ts
+++ b/integration-tests/tests/pg/effect-pglite.test.ts
@@ -311,6 +311,8 @@ runCommonEffectPgTests({
 				const insertResult = yield* db.insert(users2).values({ name: 'John', email: '', age: 30 }).pipe(Effect.result);
 				assert(Result.isFailure(insertResult));
 				assert(Predicate.isTagged(insertResult.failure, 'EffectDrizzleQueryError'));
+				// cause is the driver error itself, so standard Error#cause consumers can walk the chain
+				assert(insertResult.failure.cause instanceof Error);
 
 				// insert migration with earlier timestamp
 				mkdirSync(`${migrationDir}/20240202020202_second`, { recursive: true });


### PR DESCRIPTION
## Problem

The effect drivers construct query failures as:

```ts
new EffectDrizzleQueryError({ query, params, cause: Cause.fail(e) })
```

`Cause.fail(e)` puts an Effect `Cause` data structure in the standard `Error#cause` slot. Everything that walks JS error chains stops at the first non-Error link, so the driver error underneath is unreachable for any consumer that is not Effect-aware.

Generated with the real classes (`EffectDrizzleQueryError` from 1.0.0-rc.3, `SqlError`/`UniqueViolation` from effect) around a pg unique violation:

**Cause-chain walk** (what Sentry/PostHog/Datadog-style trackers do: follow `.cause` while it is an `Error`):

```
before: EffectDrizzleQueryError
after:  EffectDrizzleQueryError -> SqlError -> UniqueViolation -> Error (pg)
```

**`util.inspect`** (what Node prints):

```
// before
cause: {
  _id: 'Cause',
  failures: [
    { _tag: 'Fail', error: { reason: [Object], _tag: 'SqlError', cause: [Object] } }
  ]
}

// after
cause: {
  _tag: 'SqlError',
  reason: {
    _tag: 'UniqueViolation',
    constraint: 'users_pkey',
    cause: Error: duplicate key value violates unique constraint "users_pkey" {
      code: '23505',
      constraint: 'users_pkey',
      table: 'users'
    }
  }
}
```

Same failure; before, the SQLSTATE/constraint/table render as `[Object]`, after they reach every standard consumer with no Effect-specific unwrapping.

## Fix

```ts
new EffectDrizzleQueryError({ query, params, cause: e })
```

`e` in this `Effect.catch` position is the typed failure (e.g. `SqlError`), a real `Error`, so the chain is walkable end to end. Effect consumers lose nothing: the fail channel already delivers the typed `EffectDrizzleQueryError`, and the `cause` field is `Schema.Unknown` either way — the wrapper added no information `e` does not carry.

This also restores the original behavior: the initial effect integration passed the driver error directly (`new TaggedDrizzleQueryError(queryString, params, e instanceof Error ? e : undefined)`, with `cause` typed `Error`). The `Cause.fail` wrapper appeared in #5306 during the `Data.TaggedError` -> `Schema.TaggedErrorClass` rewrite, with no stated rationale and no test pinning the cause shape. Passing `e` unconditionally is compatible with `cause: Schema.Unknown` and keeps the old `instanceof` narrowing unnecessary.

## Scope

Same one-line change in the pg, mysql, and sqlite effect sessions (the `Cause` import becomes unused and is removed), plus an assertion in the pglite effect test pinning that `cause` is an `Error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)