### PR TITLE
fix(sqlite): alias remapped select columns for D1 batch object rows

### DIFF
--- a/drizzle-orm/src/d1/session.ts
+++ b/drizzle-orm/src/d1/session.ts
@@ -147,10 +147,12 @@ export class D1Transaction<
 }
 
 /**
- * This function was taken from the D1 implementation: https://github.com/cloudflare/workerd/blob/4aae9f4c7ae30a59a88ca868c4aff88bda85c956/src/cloudflare/internal/d1-api.ts#L287
- * It may cause issues with duplicated column names in join queries, which should be fixed on the D1 side.
- * @param results
- * @returns
+ * Converts D1 object-row batch results into ordinal arrays for mapResultRow.
+ *
+ * D1's client `batch()` uses ROWS_AND_COLUMNS upstream then collapses to objects
+ * (`toArrayOfObjects`), so duplicate SQL column names would lose values here.
+ * Sqlite dialect `buildSelection` therefore emits unique `AS` aliases for selected
+ * columns when names would otherwise collide (see #6038).
  */
 function d1ToRawMapping(results: any) {
 	const rows: unknown[][] = [];

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -181,7 +181,7 @@ export abstract class SQLiteDialect {
 	): SQL {
 		const columnsLen = fields.length;
 
-		const chunks = fields.flatMap(({ field }, i) => {
+		const chunks = fields.flatMap(({ field, path }, i) => {
 			const chunk: SQLChunk[] = [];
 
 			if (is(field, SQL.Aliased) && field.isSelectionField) {
@@ -209,24 +209,35 @@ export abstract class SQLiteDialect {
 				}
 			} else if (is(field, Column)) {
 				const tableName = field.table[Table.Symbol.Name];
+				const columnName = this.casing.getColumnCasing(field);
 				if (field.columnType === 'SQLiteNumericBigInt') {
 					if (isSingleTable) {
 						chunk.push(
-							sql`cast(${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							sql`cast(${sql.identifier(columnName)} as text)`,
 						);
 					} else {
 						chunk.push(
-							sql`cast(${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							sql`cast(${sql.identifier(tableName)}.${sql.identifier(columnName)} as text)`,
 						);
 					}
 				} else {
 					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+						chunk.push(sql.identifier(columnName));
 					} else {
 						chunk.push(
-							sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
+							sql`${sql.identifier(tableName)}.${sql.identifier(columnName)}`,
 						);
 					}
+				}
+				// Alias selected columns so drivers that return object rows (notably
+				// D1 `batch()`, which converts ROWS_AND_COLUMNS → objects) keep distinct
+				// keys when the same column name appears more than once (e.g. join on id).
+				// mapResultRow still maps by ordinal position; aliases only need to be unique.
+				const selectionKey = path.length > 1 ? path.join('_') : path[0];
+				if (selectionKey && selectionKey !== columnName) {
+					chunk.push(sql` as ${sql.identifier(selectionKey)}`);
+				} else if (selectionKey && !isSingleTable) {
+					chunk.push(sql` as ${sql.identifier(`${tableName}_${columnName}`)}`);
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [

--- a/drizzle-orm/tests/sqlite-selection-aliases.test.ts
+++ b/drizzle-orm/tests/sqlite-selection-aliases.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest';
+import { eq } from '~/sql/index.ts';
+import { QueryBuilder } from '~/sqlite-core/query-builders/query-builder.ts';
+import { integer, sqliteTable, text } from '~/sqlite-core/index.ts';
+
+const users = sqliteTable('users', {
+	id: integer().primaryKey(),
+	name: text().notNull(),
+});
+
+const posts = sqliteTable('posts', {
+	id: integer().primaryKey(),
+	userId: integer()
+		.notNull()
+		.references(() => users.id),
+	title: text().notNull(),
+});
+
+test('join select remaps duplicate column names with distinct AS aliases', () => {
+	const qb = new QueryBuilder();
+	const { sql: sqlText } = qb
+		.select({
+			userId: users.id,
+			postId: posts.id,
+			postTitle: posts.title,
+		})
+		.from(posts)
+		.innerJoin(users, eq(users.id, posts.userId))
+		.toSQL();
+
+	// D1 batch returns object rows; without these aliases both ids collapse to one key.
+	expect(sqlText).toContain('"users"."id" as "userId"');
+	expect(sqlText).toContain('"posts"."id" as "postId"');
+	expect(sqlText).toContain('"posts"."title" as "postTitle"');
+});


### PR DESCRIPTION
## Summary

Fixes #6038

`db.batch()` on Cloudflare D1 returns object rows (client converts `ROWS_AND_COLUMNS` → objects). When a join select remaps two columns that share the same SQL name (e.g. `users.id` + `posts.id` as `userId`/`postId`), those keys collapse and `d1ToRawMapping` shifts values — while the identical query via `.all()` / `.raw()` stays correct.

Sqlite `buildSelection` now emits distinct `AS` aliases from the selection path (or `table_column` for multi-table selects that keep the raw column name), so object-row drivers keep one key per selected field. `mapResultRow` still maps by ordinal position.

## Test plan

- [x] `vitest run tests/sqlite-selection-aliases.test.ts` — asserts generated SQL includes `"users"."id" as "userId"`, `"posts"."id" as "postId"`, `"posts"."title" as "postTitle"`
- [ ] Repro from https://github.com/stinbox/drizzle-d1-batch-bug-repro against this branch (needs D1/wrangler)

## AI disclosure

Prepared with Claude Code / Cursor assistance. I reviewed the D1 batch → object-row path and the sqlite selection builder, and verified the new unit test locally.

Made with [Cursor](https://cursor.com)