### PR TITLE
fix(pg-core): correct nested/partial select null-collapse heuristic o…

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,8 +48,15 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
 						) {
+							// Cancel the nullify candidacy for this nested object as soon as we see either a field
+							// from a different table (mixed-table nested object, can't collapse it this way), or a
+							// non-null value for a field belonging to the same table we were tracking. Without the
+							// `value !== null` check, a nested object whose first-encountered field happens to be
+							// null but whose later fields are non-null (a real matched joined row, just with a null
+							// value in its first selected column) would incorrectly collapse to `null`.
 							nullifyMap[objectName] = false;
 						}
 					}

--- a/drizzle-orm/tests/map-result-row.test.ts
+++ b/drizzle-orm/tests/map-result-row.test.ts
@@ -1,0 +1,48 @@
+import { describe, test } from 'vitest';
+import { integer, pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow } from '~/utils.ts';
+
+// Regression test for https://github.com/drizzle-team/drizzle-orm/issues/1603
+//
+// Bug: when a nested/partial select object groups multiple columns from the same
+// (potentially left-joined) table, `mapResultRow` used to decide whether to collapse
+// the whole nested object to `null` based only on the *first* field it encountered for
+// that object. If that first field happened to be `null` on an otherwise real, matched
+// row (while a later field in the same nested object was non-null), the entire nested
+// object was incorrectly nulled out.
+describe('mapResultRow', () => {
+	const brandingTable = pgTable('branding', {
+		logo: text('logo'),
+		panelBackground: text('panel_background'),
+	});
+
+	const columns = [
+		{ path: ['branding', 'logo'], field: brandingTable.logo },
+		{ path: ['branding', 'panelBackground'], field: brandingTable.panelBackground },
+	] as any;
+
+	const joinsNotNullableMap = { branding: false };
+
+	test('does not nullify a nested object when only its first field is null but a later field is non-null', ({ expect }) => {
+		// logo (first field) is null, panelBackground (second field) has a real value -> real matched row
+		const row = [null, 'https://example.com/bg.png'];
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+		expect(result).toEqual({
+			branding: { logo: null, panelBackground: 'https://example.com/bg.png' },
+		});
+	});
+
+	test('still nullifies a nested object when the entire joined row is genuinely absent (all fields null)', ({ expect }) => {
+		const row = [null, null];
+		const result: any = mapResultRow(columns, row, joinsNotNullableMap);
+		expect(result.branding).toBeNull();
+	});
+
+	test('does not nullify when the first field is non-null and a later field is null (order-independent)', ({ expect }) => {
+		const row = ['https://example.com/logo.png', null];
+		const result = mapResultRow(columns, row, joinsNotNullableMap);
+		expect(result).toEqual({
+			branding: { logo: 'https://example.com/logo.png', panelBackground: null },
+		});
+	});
+});


### PR DESCRIPTION
…n left joins

Fixes drizzle-team/drizzle-orm#1603

mapResultRow (drizzle-orm/src/utils.ts) decides whether to collapse a nested/partial-select object (e.g. .select({ branding: { logo, panelBackground } })) to null by tracking, per nested object, the table name of the first field it encounters that is null. A later field from the same table only cleared that tracked state if it belonged to a *different* table - a non-null value from the *same* table never cancelled it.

As a result, if the first column of a nested group happened to be null on an otherwise real, matched left-joined row (while a later column in the same group had a real value), the whole nested object was incorrectly collapsed to null. Swapping field order masked the bug, which was the reporter's clue that the first-field check, not the join logic itself, was at fault.

Fix: also clear the nullify candidacy as soon as any field belonging to the already-tracked table is non-null, not just when a different table appears. The heuristic now only nullifies a nested object when every observed field from that table is genuinely null, matching how full (non-partial) joins already detect an absent left-joined row.

Added tests/map-result-row.test.ts as a direct regression test for mapResultRow, verified to fail against the pre-fix code and pass after the fix. Full drizzle-orm vitest suite (569 tests) passes with no other regressions.