### PR TITLE
fix(orm): consistent number-word boundary in toSnakeCase/toCamelCase

### DIFF
--- a/drizzle-orm/src/casing.ts
+++ b/drizzle-orm/src/casing.ts
@@ -3,10 +3,16 @@ import { entityKind } from './entity.ts';
 import { Table } from './table.ts';
 import type { Casing } from './utils.ts';
 
+/**
+ * Splits an identifier into words, treating a run of digits as part of the word it follows
+ * (e.g. `M3` and `ID2` are single words) rather than a separate word.
+ */
+const WORD_BOUNDARY = /[\da-z]+|[A-Z]+\d*(?![a-z])|[A-Z][\da-z]+/g;
+
 export function toSnakeCase(input: string) {
 	const words = input
 		.replace(/['\u2019]/g, '')
-		.match(/[\da-z]+|[A-Z]+(?![a-z])|[A-Z][\da-z]+/g) ?? [];
+		.match(WORD_BOUNDARY) ?? [];
 
 	return words.map((word) => word.toLowerCase()).join('_');
 }
@@ -14,7 +20,7 @@ export function toSnakeCase(input: string) {
 export function toCamelCase(input: string) {
 	const words = input
 		.replace(/['\u2019]/g, '')
-		.match(/[\da-z]+|[A-Z]+(?![a-z])|[A-Z][\da-z]+/g) ?? [];
+		.match(WORD_BOUNDARY) ?? [];
 
 	return words.reduce((acc, word, i) => {
 		const formattedWord = i === 0 ? word.toLowerCase() : `${word[0]!.toUpperCase()}${word.slice(1)}`;

--- a/drizzle-orm/tests/casing/casing.test.ts
+++ b/drizzle-orm/tests/casing/casing.test.ts
@@ -25,4 +25,46 @@ describe.concurrent('casing', () => {
 	it('transforms to camel case 1', ({ expect }) => {
 		expect(toCamelCase('drizzle_kit')).toEqual('drizzleKit');
 	});
+
+	// number-word boundary: digits attach to the word they follow, regardless of the
+	// preceding letter casing (lowercase, uppercase abbreviation, or capitalized word)
+	it('keeps a digit attached to a preceding capitalized word when transforming to snake case', ({ expect }) => {
+		expect(toSnakeCase('testStuffM3')).toEqual('test_stuff_m3');
+	});
+
+	it('keeps a digit attached to a preceding uppercase abbreviation when transforming to snake case', ({ expect }) => {
+		expect(toSnakeCase('userID2')).toEqual('user_id2');
+	});
+
+	it('keeps a digit attached to a preceding uppercase abbreviation followed by more words when transforming to snake case', ({ expect }) => {
+		expect(toSnakeCase('totalUsageM3PerA')).toEqual('total_usage_m3_per_a');
+	});
+
+	it('keeps a digit attached to a mixed-case abbreviation when transforming to snake case', ({ expect }) => {
+		expect(toSnakeCase('parentEN1Proof')).toEqual('parent_en1_proof');
+	});
+
+	it('leaves a digit already attached to a lowercase word unchanged when transforming to snake case', ({ expect }) => {
+		expect(toSnakeCase('foo2Bar')).toEqual('foo2_bar');
+	});
+
+	it('leaves a digit already attached to a camel case abbreviation unchanged when transforming to snake case', ({ expect }) => {
+		expect(toSnakeCase('parentEn1Proof')).toEqual('parent_en1_proof');
+	});
+
+	it('does not split an uppercase acronym followed by another word when a digit is not involved', ({ expect }) => {
+		expect(toSnakeCase('drizzleORMAndKit')).toEqual('drizzle_orm_and_kit');
+	});
+
+	it('keeps a digit attached to a preceding capitalized word when transforming to camel case', ({ expect }) => {
+		expect(toCamelCase('test_stuff_m3')).toEqual('testStuffM3');
+	});
+
+	it('keeps a digit attached to a preceding uppercase abbreviation when transforming to camel case', ({ expect }) => {
+		expect(toCamelCase('user_id2')).toEqual('userId2');
+	});
+
+	it('leaves a digit already attached to a lowercase word unchanged when transforming to camel case', ({ expect }) => {
+		expect(toCamelCase('foo2_bar')).toEqual('foo2Bar');
+	});
 });


### PR DESCRIPTION
## Summary

`toSnakeCase`/`toCamelCase` share a tokenizer regex whose abbreviation alternative, `[A-Z]+(?![a-z])`, stops matching before a trailing digit and leaves it as a separate word — unlike the other two alternatives, which already absorb trailing digits into the word. So whether a digit stays attached to the preceding word depended inconsistently on that word's casing.

| Input | Before | After |
|---|---|---|
| `testStuffM3` | `test_stuff_m_3` | `test_stuff_m3` |
| `totalUsageM3PerA` | `total_usage_m_3_per_a` | `total_usage_m3_per_a` |
| `parentEN1Proof` | `parent_en_1_proof` | `parent_en1_proof` |
| `userID2` | `user_id_2` | `user_id2` |
| `foo2Bar` | `foo2_bar` | `foo2_bar` (unchanged) |
| `parentEn1Proof` | `parent_en1_proof` | `parent_en1_proof` (unchanged) |
| `drizzleORM` | `drizzle_orm` | `drizzle_orm` (unchanged) |
| `drizzleORMAndKit` | `drizzle_orm_and_kit` | `drizzle_orm_and_kit` (unchanged) |

Fix: `[A-Z]+(?![a-z])` → `[A-Z]+\d*(?![a-z])`, and extracted the shared regex into a single `WORD_BOUNDARY` constant used by both `toSnakeCase` and `toCamelCase` (previously duplicated verbatim in each), so any future change stays in sync between the two.

Closes #6037

## Test plan

- Added regression tests to `tests/casing/casing.test.ts` covering every row in the table above plus symmetric `toCamelCase` round-trips.
- `pnpm vitest run tests/casing` — 92/92 passing (all dialect casing suites: mysql/pg/sqlite × snake/camel, plus casing.test.ts).
- Manually verified the backtracking case that a fix like this risks breaking — an all-caps abbreviation immediately followed by another capitalized word, e.g. `drizzleORMAndKit` — stays unaffected (no digit follows `ORM`, so `\d*` matches zero digits).
- Checked `drizzle-kit`'s introspection code (also imports `toCamelCase`/`toSnakeCase`) for any snapshot/golden output depending on the old digit-splitting behavior — found none.
