### PR TITLE
[Pg, Gel]: Fix infinite recursion in ExtraConfigColumn.getSQLType()

### DIFF
--- a/drizzle-orm/src/gel-core/columns/common.ts
+++ b/drizzle-orm/src/gel-core/columns/common.ts
@@ -127,7 +127,7 @@ export abstract class GelColumnBuilder<
 	buildExtraConfigColumn<TTableName extends string>(
 		table: AnyGelTable<{ name: TTableName }>,
 	): GelExtraConfigColumn {
-		return new GelExtraConfigColumn(table, this.config);
+		return new GelExtraConfigColumn(table, this.config, () => this.build(table).getSQLType());
 	}
 }
 
@@ -157,8 +157,31 @@ export class GelExtraConfigColumn<
 > extends GelColumn<T, IndexedExtraConfigType> {
 	static override readonly [entityKind]: string = 'GelExtraConfigColumn';
 
+	/**
+	 * Resolves the SQL type of the column this one stands in for.
+	 *
+	 * A `GelExtraConfigColumn` is built from the column builder's config rather than from
+	 * the concrete column class, so it inherits no `getSQLType()` implementation of its
+	 * own — the builder supplies a resolver that defers to the real column.
+	 */
+	private readonly resolveSQLType?: () => string;
+
+	constructor(
+		table: GelTable,
+		config: ColumnBuilderRuntimeConfig<T['data'], IndexedExtraConfigType>,
+		resolveSQLType?: () => string,
+	) {
+		super(table, config);
+		this.resolveSQLType = resolveSQLType;
+	}
+
 	override getSQLType(): string {
-		return this.getSQLType();
+		if (!this.resolveSQLType) {
+			throw new Error(
+				`Cannot determine the SQL type of column "${this.name}": it was constructed without a type resolver.`,
+			);
+		}
+		return this.resolveSQLType();
 	}
 
 	indexConfig: IndexedExtraConfigType = {

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -128,7 +128,7 @@ export abstract class PgColumnBuilder<
 	buildExtraConfigColumn<TTableName extends string>(
 		table: AnyPgTable<{ name: TTableName }>,
 	): ExtraConfigColumn {
-		return new ExtraConfigColumn(table, this.config);
+		return new ExtraConfigColumn(table, this.config, () => this.build(table).getSQLType());
 	}
 }
 
@@ -158,8 +158,31 @@ export class ExtraConfigColumn<
 > extends PgColumn<T, IndexedExtraConfigType> {
 	static override readonly [entityKind]: string = 'ExtraConfigColumn';
 
+	/**
+	 * Resolves the SQL type of the column this one stands in for.
+	 *
+	 * An `ExtraConfigColumn` is built from the column builder's config rather than from
+	 * the concrete column class, so it inherits no `getSQLType()` implementation of its
+	 * own — the builder supplies a resolver that defers to the real column.
+	 */
+	private readonly resolveSQLType?: () => string;
+
+	constructor(
+		table: PgTable,
+		config: ColumnBuilderRuntimeConfig<T['data'], IndexedExtraConfigType>,
+		resolveSQLType?: () => string,
+	) {
+		super(table, config);
+		this.resolveSQLType = resolveSQLType;
+	}
+
 	override getSQLType(): string {
-		return this.getSQLType();
+		if (!this.resolveSQLType) {
+			throw new Error(
+				`Cannot determine the SQL type of column "${this.name}": it was constructed without a type resolver.`,
+			);
+		}
+		return this.resolveSQLType();
 	}
 
 	indexConfig: IndexedExtraConfigType = {

--- a/drizzle-orm/tests/extra-config-column.test.ts
+++ b/drizzle-orm/tests/extra-config-column.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest';
+import { gelTable, getTableConfig as getGelTableConfig, integer as gelInteger } from '~/gel-core/index.ts';
+import type { ExtraConfigColumn } from '~/pg-core/index.ts';
+import { customType, getTableConfig, integer, pgTable, varchar } from '~/pg-core/index.ts';
+
+describe('pg', () => {
+	const citext = customType<{ data: string }>({
+		dataType: () => 'citext',
+	});
+
+	const captured: Record<string, ExtraConfigColumn> = {};
+
+	const table = pgTable('table', {
+		id: integer('id'),
+		name: varchar('name', { length: 256 }),
+		email: citext('email'),
+		tags: integer('tags').array(),
+	}, (t) => {
+		Object.assign(captured, t);
+		return [];
+	});
+
+	// The extra config callback is invoked lazily.
+	getTableConfig(table);
+
+	test.each([
+		['id', 'integer'],
+		['name', 'varchar(256)'],
+		['email', 'citext'],
+		['tags', 'integer[]'],
+	])('%s: getSQLType() resolves to the underlying column type', (name, sqlType) => {
+		expect(captured[name]!.getSQLType()).toBe(sqlType);
+	});
+
+	test('getSQLType() matches the table column it stands in for', () => {
+		expect(captured['id']!.getSQLType()).toBe(table.id.getSQLType());
+	});
+});
+
+describe('gel', () => {
+	const captured: Record<string, { getSQLType: () => string }> = {};
+
+	const table = gelTable('table', {
+		id: gelInteger('id'),
+	}, (t) => {
+		Object.assign(captured, t);
+		return [];
+	});
+
+	getGelTableConfig(table);
+
+	test('getSQLType() resolves to the underlying column type', () => {
+		expect(captured['id']!.getSQLType()).toBe('integer');
+	});
+});


### PR DESCRIPTION
Fixes #6050.

## The bug

`ExtraConfigColumn` (pg) and `GelExtraConfigColumn` (gel) each override `getSQLType()` with a method that calls itself:

```ts
override getSQLType(): string {
	return this.getSQLType();
}
```

Every column passed to the extra config callback — `pgTable(name, columns, (t) => …)` — is one of these wrappers, so reading the SQL type of any such column throws `RangeError: Maximum call stack size exceeded`. Reproduction, with no driver and no drizzle-kit:

```js
const { pgTable, integer, getTableConfig } = require('drizzle-orm/pg-core')

let captured
const users = pgTable('users', { id: integer('id').primaryKey() }, (t) => {
  captured = t.id
  return []
})

getTableConfig(users) // runs the extra config callback

console.log(users.id.getSQLType()) // "integer"
console.log(captured.getSQLType()) // RangeError: Maximum call stack size exceeded
```

## Why there was nothing to delegate to

The obvious fix — `return super.getSQLType()` — does not work. `Column.getSQLType()` is abstract and neither `PgColumn` nor `GelColumn` implements it; the implementations live on the concrete column classes (`PgInteger`, `PgVarchar`, `PgCustomColumn`, …). But `buildExtraConfigColumn` constructs the wrapper straight from the builder's config:

```ts
return new ExtraConfigColumn(table, this.config);
```

so the wrapper never gets the concrete class, and the override has no parent implementation to call. Satisfying the abstract member is presumably why the self-call was written in the first place — it type-checks.

## The fix

The builder does know how to produce the real column, so it now passes a resolver that defers to it, and the wrapper calls that instead of itself:

```ts
return new ExtraConfigColumn(table, this.config, () => this.build(table).getSQLType());
```

The resolver is lazy, so nothing extra is constructed unless `getSQLType()` is actually called — table definition costs the same as before. The third constructor argument is optional, so existing direct constructions still compile; calling `getSQLType()` on a wrapper built that way now reports what is missing instead of overflowing the stack.

Applied to both dialects — `gel-core` carries the same code and the same bug.

## Tests

`drizzle-orm/tests/extra-config-column.test.ts` covers a plain column, a parameterised type (`varchar(256)`), a `customType`, an array column, and the gel equivalent, and asserts the wrapper agrees with the table column it stands in for. All six cases fail with `Maximum call stack size exceeded` on `main` and pass with this change.

Also run: the `drizzle-orm` unit suite (548 passing; the two `tests/casing/sqlite-*` files fail to collect in my environment because I installed with `--ignore-scripts` and `better-sqlite3` has no native build — unrelated to this change), `type-tests` via `tsc` (only pre-existing `@prisma/client` codegen errors, none from this change), and `dprint check` on the touched files.

## Notes

Nothing outside these two files calls `getSQLType()` on an extra config column — the remaining references to `ExtraConfigColumn` are type-level — and since every call previously threw, no existing behaviour can depend on it.

Found while writing a helper in [`@cipherstash/stack-drizzle`](https://github.com/cipherstash/stack/tree/main/packages/stack-drizzle) that derives expression indexes from the columns handed to the extra config callback.
