### PR TITLE
Fix generateMigration table conflicts

### DIFF
--- a/drizzle-kit/src/api.ts
+++ b/drizzle-kit/src/api.ts
@@ -54,6 +54,17 @@ import { generateSingleStoreSnapshot } from './serializer/singlestoreSerializer'
 import { SQLiteSchema as SQLiteSchemaKit, sqliteSchema, squashSqliteScheme } from './serializer/sqliteSchema';
 import { generateSqliteSnapshot } from './serializer/sqliteSerializer';
 import type { Setup } from './serializer/studio';
+import type {
+	ColumnsResolverInput,
+	ColumnsResolverOutput,
+	ResolverInput,
+	ResolverOutput,
+	ResolverOutputWithMoved,
+	RolesResolverInput,
+	RolesResolverOutput,
+	TablePolicyResolverInput,
+	TablePolicyResolverOutput,
+} from './snapshotsDiffer';
 import type { DB, SQLiteDB } from './utils';
 import { certs } from './utils/certs';
 export type DrizzleSnapshotJSON = PgSchemaKit;
@@ -106,20 +117,62 @@ export const generateMigration = async (
 	const { sqlStatements, _meta } = await applyPgSnapshotsDiff(
 		squashedPrev,
 		squashedCur,
-		schemasResolver,
-		enumsResolver,
-		sequencesResolver,
-		policyResolver,
-		indPolicyResolver,
-		roleResolver,
-		tablesResolver,
-		columnsResolver,
-		viewsResolver,
+		resolveAsCreateAndDelete,
+		resolveAsCreateAndDeleteWithMoved,
+		resolveAsCreateAndDeleteWithMoved,
+		resolveTablePoliciesAsCreateAndDelete,
+		resolveAsCreateAndDelete,
+		resolveRolesAsCreateAndDelete,
+		resolveAsCreateAndDeleteWithMoved,
+		resolveColumnsAsCreateAndDelete,
+		resolveAsCreateAndDeleteWithMoved,
 		validatedPrev,
 		validatedCur,
 	);
 
 	return sqlStatements;
+};
+
+const resolveAsCreateAndDelete = async <T extends { name: string }>(
+	input: ResolverInput<T>,
+): Promise<ResolverOutput<T>> => {
+	return { created: input.created, renamed: [], deleted: input.deleted };
+};
+
+const resolveAsCreateAndDeleteWithMoved = async <T extends { name: string }>(
+	input: ResolverInput<T>,
+): Promise<ResolverOutputWithMoved<T>> => {
+	return { created: input.created, moved: [], renamed: [], deleted: input.deleted };
+};
+
+const resolveColumnsAsCreateAndDelete = async <T extends { name: string }>(
+	input: ColumnsResolverInput<T>,
+): Promise<ColumnsResolverOutput<T>> => {
+	return {
+		tableName: input.tableName,
+		schema: input.schema,
+		created: input.created,
+		renamed: [],
+		deleted: input.deleted,
+	};
+};
+
+const resolveTablePoliciesAsCreateAndDelete = async <T extends { name: string }>(
+	input: TablePolicyResolverInput<T>,
+): Promise<TablePolicyResolverOutput<T>> => {
+	return {
+		tableName: input.tableName,
+		schema: input.schema,
+		created: input.created,
+		renamed: [],
+		deleted: input.deleted,
+	};
+};
+
+const resolveRolesAsCreateAndDelete = async <T extends { name: string }>(
+	input: RolesResolverInput<T>,
+): Promise<RolesResolverOutput<T>> => {
+	return { created: input.created, renamed: [], deleted: input.deleted };
 };
 
 export const pushSchema = async (

--- a/drizzle-kit/tests/api.test.ts
+++ b/drizzle-kit/tests/api.test.ts
@@ -1,0 +1,22 @@
+import { integer, pgTable } from 'drizzle-orm/pg-core';
+import { expect, test } from 'vitest';
+import { generateDrizzleJson, generateMigration } from '../src/api';
+
+test('generateMigration treats unresolved table changes as create and drop', async () => {
+	const from = generateDrizzleJson({
+		users: pgTable('users', {
+			id: integer('id'),
+		}),
+	});
+
+	const to = generateDrizzleJson({
+		orders: pgTable('orders', {
+			id: integer('id'),
+		}),
+	});
+
+	const sqlStatements = await generateMigration(from, to);
+
+	expect(sqlStatements).toContain('CREATE TABLE "orders" (\n\t"id" integer\n);\n');
+	expect(sqlStatements).toContain('DROP TABLE "users" CASCADE;');
+});


### PR DESCRIPTION
Fixes #6053

`generateMigration` is a programmatic API, so it should not reuse the CLI conflict resolvers that open prompts. This switches that path to non-interactive resolvers and leaves unresolved create/delete pairs as create + drop changes.

Tested:
- `node ../node_modules/vitest/vitest.mjs run tests/api.test.ts`