### PR TITLE
fix(pg): recreate indexes before dropping their columns (closes #6045)

### DIFF
--- a/drizzle-kit/src/dialects/postgres/diff.ts
+++ b/drizzle-kit/src/dialects/postgres/diff.ts
@@ -1256,11 +1256,15 @@ export const ddlDiff = async (
 	jsonStatements.push(...recreateEnums);
 	jsonStatements.push(...jsonRecreateColumns);
 
+	// #6045: recreate indexes (a DROP INDEX + CREATE INDEX pair) before dropping
+	// columns. Postgres implicitly drops an index when a column it references is
+	// dropped, so running the recreate afterwards makes its DROP INDEX fail with
+	// error 42704 ("index does not exist").
+	jsonStatements.push(...jsonRecreateIndex);
+
 	jsonStatements.push(...jsonDropColumnsStatemets);
 	jsonStatements.push(...jsonAlteredPKs);
 	jsonStatements.push(...jsonAlterColumns);
-
-	jsonStatements.push(...jsonRecreateIndex);
 
 	jsonStatements.push(...jsonRenamedUniqueConstraints);
 	jsonStatements.push(...jsonAddedUniqueConstraints);

--- a/drizzle-kit/tests/postgres/pg-drop-index-order.test.ts
+++ b/drizzle-kit/tests/postgres/pg-drop-index-order.test.ts
@@ -1,0 +1,59 @@
+import { index, integer, pgTable } from 'drizzle-orm/pg-core';
+import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
+import { diff, prepareTestDatabase, push, TestDatabase } from './mocks';
+
+// Regression for https://github.com/drizzle-team/drizzle-orm/issues/6045
+// When a column that belongs to an index is dropped, the index must be dropped
+// before the column. Postgres implicitly drops an index together with a column
+// it references, so a later explicit `DROP INDEX` fails with error 42704.
+
+let _: TestDatabase;
+let db: TestDatabase['db'];
+
+beforeAll(async () => {
+	_ = await prepareTestDatabase(false);
+	db = _.db;
+});
+
+afterAll(async () => {
+	await _.close();
+});
+
+beforeEach(async () => {
+	await _.clear();
+});
+
+test('#6045: index is dropped before the columns it references', async () => {
+	const schema1 = {
+		notesToTags: pgTable('notes_to_tags', {
+			noteId: integer('note_id').notNull(),
+			tagAuthorId: integer('tag_author_id').notNull(),
+			tagName: integer('tag_name').notNull(),
+		}, (t) => [
+			index('notes_to_tags_tag_idx').on(t.tagAuthorId, t.tagName),
+		]),
+	};
+	const schema2 = {
+		notesToTags: pgTable('notes_to_tags', {
+			noteId: integer('note_id').notNull(),
+			tagId: integer('tag_id').notNull(),
+		}, (t) => [
+			index('notes_to_tags_tag_idx').on(t.tagId),
+		]),
+	};
+
+	const { sqlStatements } = await diff(schema1, schema2, []);
+	// eslint-disable-next-line no-console
+	console.log('SQL:\n' + sqlStatements.map((s, i) => `${i}: ${s}`).join('\n'));
+
+	const dropIndex = sqlStatements.findIndex((s) => s.includes('DROP INDEX'));
+	const dropColumn = sqlStatements.findIndex((s) => s.includes('DROP COLUMN'));
+
+	expect(dropIndex, 'expected a DROP INDEX statement').toBeGreaterThanOrEqual(0);
+	expect(dropColumn, 'expected a DROP COLUMN statement').toBeGreaterThanOrEqual(0);
+	expect(dropIndex, 'DROP INDEX must come before DROP COLUMN').toBeLessThan(dropColumn);
+
+	// Applying the migration against a real Postgres must not raise error 42704.
+	await push({ db, to: schema1 });
+	await push({ db, to: schema2 });
+});


### PR DESCRIPTION
I hit this while removing a couple of columns that an index was built on.

On Postgres, drizzle-kit puts the DROP COLUMN statements before the DROP INDEX that comes from recreating the index. Postgres already drops an index implicitly when a column it references is dropped, so by the time the explicit DROP INDEX runs the index no longer exists and the migration stops with error 42704.

The cause is in drizzle-kit/src/dialects/postgres/diff.ts, where jsonRecreateIndex was pushed after jsonDropColumnsStatemets. I moved the index recreation ahead of the column drops, while keeping it after the column additions so a recreated index can still reference a freshly added column. There was already a TODO in that function saying indexes should be dropped before any column changes, so this matches the intended order.

I added a regression test in drizzle-kit/tests/postgres/pg-drop-index-order.test.ts. It rebuilds the scenario from the issue, asserts that DROP INDEX comes before DROP COLUMN, and pushes the migration against PGlite to confirm it applies without 42704. The test fails on the current code and passes with this change.

I also ran the existing Postgres suites (pg-indexes, pg-constraints, pg-columns, pg-tables) and this change does not add any new failures.

Closes #6045
