### PR TITLE
fix(mysql): don't fail pull on a unique index over a text column

### DIFF
--- a/drizzle-kit/src/cli/commands/pull-mysql.ts
+++ b/drizzle-kit/src/cli/commands/pull-mysql.ts
@@ -60,7 +60,7 @@ export const handle = async (
 	} else {
 		schema = await fromDatabaseForDrizzle(db.db, db.database, filter, () => {}, migrations);
 	}
-	const { ddl, errors } = interimToDDL(schema);
+	const { ddl, errors } = interimToDDL(schema, { from: 'database' });
 
 	if (errors.length > 0) {
 		throw new CommandOutputCliError('pull', 'Failed to map the introspected schema', {

--- a/drizzle-kit/src/cli/commands/push-mysql.ts
+++ b/drizzle-kit/src/cli/commands/push-mysql.ts
@@ -60,7 +60,7 @@ export const handle = async (
 
 	const interimFromFiles = fromDrizzleSchema(res.tables, res.views);
 
-	const { ddl: ddl1 } = interimToDDL(interimFromDB);
+	const { ddl: ddl1 } = interimToDDL(interimFromDB, { from: 'database' });
 	const { ddl: ddl2, errors: errors1 } = interimToDDL(interimFromFiles);
 
 	if (errors1.length > 0) {

--- a/drizzle-kit/src/dialects/mysql/ddl.ts
+++ b/drizzle-kit/src/dialects/mysql/ddl.ts
@@ -134,10 +134,19 @@ export type SchemaError = {
 	column: string;
 };
 
-export const interimToDDL = (interim: InterimSchema): { ddl: MysqlDDL; errors: SchemaError[] } => {
+export const interimToDDL = (
+	interim: InterimSchema,
+	opts?: { from?: 'database' | 'drizzle' },
+): { ddl: MysqlDDL; errors: SchemaError[] } => {
 	const errors = [] as SchemaError[];
 	const ddl = createDDL();
-	const resrtictedUniqueFor = [
+	// A unique index on a TEXT/BLOB column is valid in MySQL when it has a prefix
+	// length, so an existing database can legitimately contain one. Only guard
+	// against it for schemas authored in drizzle ('drizzle'), where a prefix length
+	// can't be expressed; when introspecting a database ('database') the index is
+	// already valid and must not fail the pull. See #6047.
+	const fromDatabase = opts?.from === 'database';
+	const restrictedUniqueFor = [
 		'blob',
 		'tinyblob',
 		'mediumblob',
@@ -189,7 +198,7 @@ export const interimToDDL = (interim: InterimSchema): { ddl: MysqlDDL; errors: S
 	}
 
 	for (const column of interim.columns.filter((it) => it.isUnique)) {
-		if (resrtictedUniqueFor.some((rc) => column.type.startsWith(rc))) {
+		if (!fromDatabase && restrictedUniqueFor.some((rc) => column.type.startsWith(rc))) {
 			errors.push({ type: 'column_unsupported_unique', columns: [column.name], table: column.table });
 		}
 
@@ -222,12 +231,12 @@ export const interimToDDL = (interim: InterimSchema): { ddl: MysqlDDL; errors: S
 
 			const column = ddl.columns.one({ table: index.table, name: col.value });
 
-			return resrtictedUniqueFor.some(
+			return restrictedUniqueFor.some(
 				(restrictedType) => column?.type.startsWith(restrictedType),
 			);
 		});
 
-		if (conflictColumns.length > 0) {
+		if (!fromDatabase && conflictColumns.length > 0) {
 			errors.push({
 				type: 'column_unsupported_unique',
 				columns: conflictColumns.map((it) => it.value),

--- a/drizzle-kit/tests/mysql/pull-6047.test.ts
+++ b/drizzle-kit/tests/mysql/pull-6047.test.ts
@@ -1,0 +1,52 @@
+import 'dotenv/config';
+import { interimToDDL } from 'src/dialects/mysql/ddl';
+import { fromDatabaseForDrizzle } from 'src/dialects/mysql/introspect';
+import { DB } from 'src/utils';
+import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
+import { prepareTestDatabase, TestDatabase } from './mocks';
+
+// Regression for https://github.com/drizzle-team/drizzle-orm/issues/6047
+// A unique index over a TEXT/BLOB column is valid in MySQL when it has a prefix
+// length, so `drizzle-kit pull` must not reject it. It used to fail the whole
+// pull with `column_unsupported_unique` ("Failed to map the introspected schema").
+
+// @vitest-environment-options {"max-concurrency":1}
+
+let _: TestDatabase;
+let db: DB;
+
+beforeAll(async () => {
+	_ = await prepareTestDatabase();
+	db = _.db;
+});
+
+afterAll(async () => {
+	await _.close();
+});
+
+beforeEach(async () => {
+	await _.clear();
+});
+
+test('#6047: pull tolerates a unique index on a text column', async () => {
+	await db.query(
+		'CREATE TABLE `notes` (`id` int, `code` text, UNIQUE KEY `notes_code_uq` (`code`(255)))',
+	);
+
+	const schema = await fromDatabaseForDrizzle(db, 'drizzle', () => true, () => {}, {
+		schema: 'drizzle',
+		table: '__drizzle_migrations',
+	});
+
+	// Introspecting a database must not raise column_unsupported_unique...
+	const fromDb = interimToDDL(schema, { from: 'database' });
+	expect(fromDb.errors.some((e) => e.type === 'column_unsupported_unique')).toBe(false);
+
+	// ...and the unique index is still captured in the pulled schema.
+	const idx = fromDb.ddl.indexes.list().find((i) => i.name === 'notes_code_uq');
+	expect(idx?.isUnique).toBe(true);
+
+	// The guard still applies to drizzle-authored schemas (the default), which is
+	// what makes an unprefixed unique on a text column fail early on push/generate.
+	expect(interimToDDL(schema).errors.some((e) => e.type === 'column_unsupported_unique')).toBe(true);
+});


### PR DESCRIPTION
closes #6047

MySQL allows a unique index on a TEXT or BLOB column when it has a prefix
length, so an existing database can legitimately contain one. But
`interimToDDL` in the mysql dialect flags every unique over a text or blob
column as `column_unsupported_unique`, regardless of whether the schema
comes from drizzle or from the database. On `drizzle-kit pull` that turns a
valid index into a hard error and the whole introspection fails with
"Failed to map the introspected schema", as the issue describes for common
columns like reset_token, prefix or code.

The check is correct for schemas authored in drizzle, where a prefix length
can't be expressed, but not when reading an existing database, where the
index already exists and is even represented in the DDL. I gave
`interimToDDL` a `from` option and pass `from: 'database'` from the pull and
push introspection paths, so the guard only applies to schemas authored in
drizzle. I also fixed the `resrtictedUniqueFor` typo while I was there.

The new test creates a table with a unique index on a text column via raw
SQL, then introspects it. Without the fix the pull errors, with the fix it
succeeds and keeps the unique index, and it still asserts the guard fires
for a schema authored in drizzle. Passes against a real MySQL.
