### PR TITLE
fix(kit): resolve tsconfig paths declared in an extended config

### DIFF
--- a/drizzle-kit/src/utils/utils-node.ts
+++ b/drizzle-kit/src/utils/utils-node.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync } from 'fs';
-import { getTsconfig } from 'get-tsconfig';
+import { createPathsMatcher, getTsconfig } from 'get-tsconfig';
 import { sync as globSync } from 'glob';
 import { dirname, join, resolve } from 'path';
 import { parse, pathToFileURL } from 'url';
@@ -140,6 +140,20 @@ const getAliasesForTsconfig = (baseDir: string): Record<string, string> | undefi
 	const tsconfigBaseUrl = tsconfig.config.compilerOptions?.baseUrl ?? '.';
 	const tsconfigDir = dirname(tsconfig.path);
 
+	// Resolving the targets ourselves assumes they are relative to the tsconfig we
+	// found, which breaks when "paths" come from an extended config living in
+	// another directory. SvelteKit is the common case: its generated
+	// `.svelte-kit/tsconfig.json` declares paths relative to itself, so resolving
+	// them against the extending config points one directory too high. get-tsconfig
+	// tracks the declaring directory, so let it resolve when it can.
+	let pathsMatcher: ReturnType<typeof createPathsMatcher> = null;
+	try {
+		pathsMatcher = createPathsMatcher(tsconfig);
+	} catch {
+		// "paths" that tsc itself rejects, keep resolving them the previous way
+	}
+	const probeSegment = '__drizzle_kit_alias_probe__';
+
 	const aliases = Object.fromEntries(
 		Object.entries(tsconfigPaths).flatMap(([key, values]) => {
 			const targets = (values ?? []).filter((value): value is string => Boolean(value));
@@ -161,13 +175,18 @@ const getAliasesForTsconfig = (baseDir: string): Record<string, string> | undefi
 			}
 
 			const aliasKey = key.endsWith('/*') ? key.slice(0, -1) : key;
-			const resolvedTargets = targets.map((target) => {
-				if (supportsTrailingWildcard) {
-					const targetPrefix = target.slice(0, -1);
-					return resolve(tsconfigDir, tsconfigBaseUrl, targetPrefix);
-				}
-				return resolve(tsconfigDir, tsconfigBaseUrl, target);
-			});
+			const matched = pathsMatcher?.(supportsTrailingWildcard ? `${aliasKey}${probeSegment}` : key) ?? [];
+			const resolvedTargets = matched.length > 0
+				? matched.map((target) =>
+					resolve(supportsTrailingWildcard ? target.slice(0, -probeSegment.length) : target)
+				)
+				: targets.map((target) => {
+					if (supportsTrailingWildcard) {
+						const targetPrefix = target.slice(0, -1);
+						return resolve(tsconfigDir, tsconfigBaseUrl, targetPrefix);
+					}
+					return resolve(tsconfigDir, tsconfigBaseUrl, target);
+				});
 
 			const selectedTarget = resolvedTargets.find((candidate) => existsSync(candidate)) ?? resolvedTargets[0]!;
 			return [[aliasKey, selectedTarget]];

--- a/drizzle-kit/tests/fixtures/sveltekit-imports/.svelte-kit/tsconfig.json
+++ b/drizzle-kit/tests/fixtures/sveltekit-imports/.svelte-kit/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		"paths": {
+			"#lib": ["../src/lib"],
+			"#lib/*": ["../src/lib/*"]
+		}
+	}
+}

--- a/drizzle-kit/tests/fixtures/sveltekit-imports/entry.ts
+++ b/drizzle-kit/tests/fixtures/sveltekit-imports/entry.ts
@@ -1,0 +1,2 @@
+export * from './src/lib/profile/schema';
+export * from './src/user/schema';

--- a/drizzle-kit/tests/fixtures/sveltekit-imports/package.json
+++ b/drizzle-kit/tests/fixtures/sveltekit-imports/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "sveltekit-imports-fixture",
+	"private": true,
+	"imports": {
+		"#lib/*": "./src/lib/*"
+	}
+}

--- a/drizzle-kit/tests/fixtures/sveltekit-imports/src/lib/profile/schema.ts
+++ b/drizzle-kit/tests/fixtures/sveltekit-imports/src/lib/profile/schema.ts
@@ -1,0 +1,5 @@
+import { pgTable } from 'drizzle-orm/pg-core';
+
+export const profile = pgTable('profile', (t) => ({
+	id: t.integer().primaryKey().generatedAlwaysAsIdentity(),
+}));

--- a/drizzle-kit/tests/fixtures/sveltekit-imports/src/user/schema.ts
+++ b/drizzle-kit/tests/fixtures/sveltekit-imports/src/user/schema.ts
@@ -1,0 +1,10 @@
+import { profile } from '#lib/profile/schema';
+import { pgTable } from 'drizzle-orm/pg-core';
+
+export const user = pgTable('user', (t) => ({
+	id: t.integer().primaryKey().generatedAlwaysAsIdentity(),
+	profileId: t
+		.integer()
+		.references(() => profile.id)
+		.notNull(),
+}));

--- a/drizzle-kit/tests/fixtures/sveltekit-imports/tsconfig.json
+++ b/drizzle-kit/tests/fixtures/sveltekit-imports/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json"
+}

--- a/drizzle-kit/tests/other/load-module.test.ts
+++ b/drizzle-kit/tests/other/load-module.test.ts
@@ -9,3 +9,11 @@ test('loadModule resolves tsconfig paths', async () => {
 	expect(mod.profile).toBeDefined();
 	expect(mod.user).toBeDefined();
 });
+
+test('loadModule resolves paths declared in an extended tsconfig', async () => {
+	const modulePath = resolve('tests/fixtures/sveltekit-imports/entry.ts');
+	const mod = await loadModule<{ profile?: unknown; user?: unknown }>(modulePath);
+
+	expect(mod.profile).toBeDefined();
+	expect(mod.user).toBeDefined();
+});

--- a/drizzle-kit/tsconfig.typetest.json
+++ b/drizzle-kit/tsconfig.typetest.json
@@ -21,7 +21,8 @@
 		"baseUrl": ".",
 		"paths": {
 			"@/*": ["tests/fixtures/tsconfig-paths/src/*"],
-			"@profile": ["tests/fixtures/tsconfig-paths/src/profile/schema.ts"]
+			"@profile": ["tests/fixtures/tsconfig-paths/src/profile/schema.ts"],
+			"#lib/*": ["tests/fixtures/sveltekit-imports/src/lib/*"]
 		},
 		"outDir": "dist",
 		"noEmit": true,


### PR DESCRIPTION
closes #6056

The alias ends up one directory too high. drizzle-kit resolves tsconfig `paths`
against the config get-tsconfig hands back, which is the root one, but SvelteKit
declares them in its generated `.svelte-kit/tsconfig.json` relative to that
file. So `#lib/*` lands above the project, which is the path in the error, and
that's why the same schema loads fine with a relative import.

Subpath imports themselves are OK, it's the alias map we pass to jiti that's
off. I swapped that resolving out for get-tsconfig's `createPathsMatcher`, which
knows where each mapping was declared. It throws on `paths` tsc wouldn't accept
either (a target with no leading `./` and no `baseUrl`), so I kept the old
resolution as a fallback and nothing that works today changes.

The fixture copies the SvelteKit setup, a root tsconfig extending
`.svelte-kit/tsconfig.json` plus `#lib/*` in package.json `imports`, and the test
loads a schema through the alias. It fails on the bad path without the fix and
passes with it. I also added the fixture alias to `tsconfig.typetest.json`, same
as the tsconfig-paths one, so `test:types` stays green.
