### PR TITLE
fix(drizzle-kit): surface the real error instead of a misleading 'install latest drizzle-orm' message

### DIFF
--- a/drizzle-kit/src/cli/utils.ts
+++ b/drizzle-kit/src/cli/utils.ts
@@ -94,8 +94,28 @@ export const assertOrmCoreVersion = async () => {
 				'This version of drizzle-kit is outdated\nPlease update drizzle-kit package to the latest version 👍',
 			);
 		}
-	} catch (e) {
-		console.log('Please install latest version of drizzle-orm');
+	} catch (e: any) {
+		// The generic message below used to be shown for *any* failure here, including
+		// cases where drizzle-orm is actually installed but can't be resolved from
+		// drizzle-kit's location (e.g. npm/pnpm workspace hoisting puts drizzle-orm in a
+		// different node_modules than drizzle-kit). That left users chasing a fix that
+		// didn't apply to them. Surface the real error and give more targeted guidance
+		// when it looks like a resolution failure rather than an actual version problem.
+		const code = e?.code;
+		const isResolutionFailure = code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND';
+		const underlying = e?.message ?? String(e);
+
+		if (isResolutionFailure) {
+			console.log(
+				`Could not resolve 'drizzle-orm' from drizzle-kit.\nIf 'drizzle-orm' is already installed, this is commonly caused by a monorepo/workspace `
+					+ `setup (npm/pnpm/yarn workspaces) hoisting it to a location drizzle-kit can't resolve from. Try running `
+					+ `drizzle-kit via a package.json script in the same workspace as 'drizzle-orm', or make sure both packages `
+					+ `resolve to the same node_modules. Otherwise, please install the latest version of drizzle-orm.\n`
+					+ `Underlying error: ${underlying}`,
+			);
+		} else {
+			console.log(`Please install latest version of drizzle-orm\nUnderlying error: ${underlying}`);
+		}
 	}
 	process.exit(1);
 };


### PR DESCRIPTION
## Summary

`assertOrmCoreVersion()` in `drizzle-kit/src/cli/utils.ts` catches any failure from `await import('drizzle-orm/version')` (and `drizzle-orm/relations`) and always logs the same generic message:

```
Please install latest version of drizzle-orm
```

In practice this message fires for **any** import failure, not just "drizzle-orm isn't installed". The most common real-world trigger (see #3248, and the related #2614, #2699, #3578, #3934) is npm/pnpm/yarn workspace hoisting: `drizzle-orm` is installed, but gets hoisted to a `node_modules` directory that isn't resolvable from wherever `drizzle-kit` is running from in the monorepo. Node's dynamic `import()` throws `ERR_MODULE_NOT_FOUND` in that case — same as if the package were genuinely missing — and the original error is discarded entirely, so users only ever see "please install" even though the package is already installed at the latest version. That's led to a lot of user time lost trying reinstalls/downgrades/overrides that don't address the actual cause (see the linked issues for examples).

## Change

In the `catch` block of `assertOrmCoreVersion`:
- Always include the underlying error's message in the console output, so the real cause is visible.
- When the error looks like a module-resolution failure (`ERR_MODULE_NOT_FOUND` / `MODULE_NOT_FOUND`), show a message that explains the workspace-hoisting scenario and how to work around it, instead of asserting the package needs to be installed.
- Any other error still falls back to the original "please install latest version" wording, now with the underlying error attached for debugging.

This is intentionally scoped to the error message/diagnostics only — no change to control flow (`process.exit(1)` still happens in all failure paths, same as before), and no change to the success-path version-compatibility logic above it.

## Testing

I don't have a way to run drizzle-kit's own test/build pipeline in the environment I drafted this in, so this wasn't verified by executing the repo's test suite. What I did verify:
- Confirmed with a minimal Node repro that a missing/unresolvable ESM package import throws with `e.code === 'ERR_MODULE_NOT_FOUND'`, which is the condition the new branch checks for.
- Type-checked the modified file in isolation with `tsc` (no new type errors introduced by the change; only pre-existing "cannot find module" noise from checking the file outside the monorepo's install).
- Manually traced both branches (resolution-failure vs. other error) against the existing control flow to confirm `process.exit(1)` behavior is unchanged.

Given that, I'd appreciate a maintainer sanity-check / CI run rather than treating this as pre-verified against the full suite.

Closes #3248