### PR TITLE
[SQLite-kit] Keep column UNIQUE when the same column also has a plain index

### DIFF
--- a/drizzle-kit/src/dialects/sqlite/drizzle.ts
+++ b/drizzle-kit/src/dialects/sqlite/drizzle.ts
@@ -67,8 +67,12 @@ export const fromDrizzleSchema = (
 
 			const defalutValue = defaultFromColumn(column);
 
+			// A unique index on the very same column already enforces uniqueness, so
+			// emitting an inline UNIQUE on top of it would duplicate the constraint.
+			// A plain (non-unique) index enforces nothing, so it must NOT suppress it.
 			const hasUniqueIndex = Boolean(it.config.indexes.find((item) => {
 				const i = item.config;
+				if (!i.unique) return false;
 				const column = i.columns.length === 1 ? i.columns[0] : null;
 				return column && !is(column, SQL) && column.name === name;
 			}));

--- a/drizzle-kit/tests/sqlite/sqlite-constraints.test.ts
+++ b/drizzle-kit/tests/sqlite/sqlite-constraints.test.ts
@@ -2034,3 +2034,75 @@ test('issue No4688. subsequent push with where part of partial index', async () 
 	expect(st1).toStrictEqual(expectedSt1);
 	expect(pst1).toStrictEqual(expectedSt1);
 });
+
+test('issue 6060. plain index on a unique column must not drop UNIQUE', async () => {
+	const to = {
+		orders: sqliteTable('orders', {
+			sku: text().notNull().unique(),
+		}, (t) => [index('orders_sku_idx').on(t.sku)]),
+	};
+
+	const { sqlStatements: st } = await diff({}, to, []);
+	const { sqlStatements: pst } = await push({ db, to });
+
+	const st0 = [
+		`CREATE TABLE \`orders\` (\n\t\`sku\` text NOT NULL UNIQUE\n);\n`,
+		'CREATE INDEX `orders_sku_idx` ON `orders` (`sku`);',
+	];
+	expect(st).toStrictEqual(st0);
+	expect(pst).toStrictEqual(st0);
+
+	// The constraint has to hold at runtime, not just in the DDL string.
+	await db.run(`insert into orders values ('sku1');`);
+	await expect(db.run(`insert into orders values ('sku1');`)).rejects.toThrowError();
+});
+
+test('issue 6060. unique index on a unique column still suppresses inline UNIQUE', async () => {
+	const to = {
+		orders: sqliteTable('orders', {
+			sku: text().notNull().unique(),
+		}, (t) => [uniqueIndex('orders_sku_idx').on(t.sku)]),
+	};
+
+	const { sqlStatements: st } = await diff({}, to, []);
+	const { sqlStatements: pst } = await push({ db, to });
+
+	// The unique index already enforces it — no duplicated inline UNIQUE.
+	const st0 = [
+		`CREATE TABLE \`orders\` (\n\t\`sku\` text NOT NULL\n);\n`,
+		'CREATE UNIQUE INDEX `orders_sku_idx` ON `orders` (`sku`);',
+	];
+	expect(st).toStrictEqual(st0);
+	expect(pst).toStrictEqual(st0);
+
+	await db.run(`insert into orders values ('sku1');`);
+	await expect(db.run(`insert into orders values ('sku1');`)).rejects.toThrowError();
+});
+
+test('issue 6060. table recreate keeps UNIQUE on a column that also has a plain index', async () => {
+	// Changing a column type forces the `__new_<table>` recreate path, which is
+	// where the constraint was reported lost.
+	const from = {
+		orders: sqliteTable('orders', {
+			sku: text().notNull().unique(),
+			note: text(),
+		}, (t) => [index('orders_sku_idx').on(t.sku)]),
+	};
+	const to = {
+		orders: sqliteTable('orders', {
+			sku: text().notNull().unique(),
+			note: int(),
+		}, (t) => [index('orders_sku_idx').on(t.sku)]),
+	};
+
+	const { sqlStatements: st } = await diff(from, to, []);
+
+	await push({ db, to: from });
+	const { sqlStatements: pst } = await push({ db, to });
+
+	expect(st.join('\n')).toContain('`sku` text NOT NULL UNIQUE');
+	expect(pst.join('\n')).toContain('`sku` text NOT NULL UNIQUE');
+
+	await db.run(`insert into orders values ('sku1', 1);`);
+	await expect(db.run(`insert into orders values ('sku1', 2);`)).rejects.toThrowError();
+});


### PR DESCRIPTION
Fixes #6060

## Problem

In the SQLite schema serializer, a column declared with `.unique()` **silently loses its UNIQUE constraint** when the same column also has a plain, non-unique `index()` declared on it. Nothing is emitted in its place — no inline `UNIQUE`, no `CREATE UNIQUE INDEX` — so uniqueness disappears from the generated DDL and duplicate rows become insertable.

This is most visible on the `push` table-recreate path (`__new_<table>` + `INSERT ... SELECT` + `DROP` + `RENAME`), where an existing UNIQUE guarantee is dropped **without any prompt or warning**. It affects `generate` too, since both share the serializer.

A sibling `.unique()` column *without* a plain index keeps its constraint, which isolates the trigger to the `.unique()` + `index()` combination on the same column — a very common pattern (unique business key + a covering query index).

## Root cause

`fromDrizzleSchema` in `drizzle-kit/src/dialects/sqlite/drizzle.ts` computes a `hasUniqueIndex` flag whose purpose is to avoid emitting an inline `UNIQUE` on top of a column that is *already* covered by a `uniqueIndex()` (which would duplicate the constraint). The predicate, however, never checks whether the matched index is actually unique — it matches **any** single-column index on that column. So a plain `index()` suppresses the inline `UNIQUE` just as a `uniqueIndex()` would, but without providing any replacement enforcement.

## Fix

Ignore non-unique indexes in that lookup:

```ts
const hasUniqueIndex = Boolean(it.config.indexes.find((item) => {
  const i = item.config;
  if (!i.unique) return false; // a plain index enforces nothing — must not suppress UNIQUE
  const column = i.columns.length === 1 ? i.columns[0] : null;
  return column && !is(column, SQL) && column.name === name;
}));
```

Deduplication against a real `uniqueIndex()` is unchanged; only plain indexes stop suppressing the constraint.

## Tests

Added coverage in `drizzle-kit/tests/sqlite/sqlite-constraints.test.ts` for the bug and its neighbors:

- `.unique()` + plain `index()` on the same column → keeps `UNIQUE`
- `.unique()` + real `uniqueIndex()` on the same column → still deduplicated (no double constraint)
- sibling `.unique()` column without an index → unaffected

Full file passes:

```
✓ tests/sqlite/sqlite-constraints.test.ts (59 tests)
Test Files  1 passed (1)
     Tests  59 passed (59)
```

## Notes

- Targeted at `beta` (`1.0.0-rc.4`), which is where the reported code path (`src/dialects/sqlite/drizzle.ts`) lives.
