### PR TITLE
Add proper error handling and wrapping (#376)

### DIFF
--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -18,8 +18,6 @@ export class DrizzleQueryError extends Error {
 	) {
 		super(`Failed query: ${query}\nparams: ${params}`);
 		Error.captureStackTrace(this, DrizzleQueryError);
-
-		// ES2022+: preserves original error on `.cause`
 		if (cause) (this as any).cause = cause;
 	}
 }
@@ -29,5 +27,94 @@ export class TransactionRollbackError extends DrizzleError {
 
 	constructor() {
 		super({ message: 'Rollback' });
+	}
+}
+
+// ---- New typed Postgres error classes ----
+
+/**
+ * Base class for all Postgres integrity constraint errors.
+ * Exposes the raw postgres error fields.
+ */
+export class PostgresError extends DrizzleError {
+	/** Postgres error code (e.g., '23505') */
+	code: string;
+	/** Name of the constraint that was violated (if any) */
+	constraint?: string;
+	/** Name of the table involved */
+	table?: string;
+	/** Name of the schema */
+	schema?: string;
+	/** Detail message from Postgres */
+	detail?: string;
+	/** Column name, if applicable */
+	column?: string;
+
+	constructor(cause: Error & { code?: string; constraint?: string; table?: string; schema?: string; detail?: string; column?: string }) {
+		super({ message: cause.message, cause });
+		this.name = 'PostgresError';
+		this.code = cause.code ?? '';
+		this.constraint = cause.constraint;
+		this.table = cause.table;
+		this.schema = cause.schema;
+		this.detail = cause.detail;
+		this.column = cause.column;
+	}
+}
+
+export class UniqueConstraintError extends PostgresError {
+	static override readonly [entityKind]: string = 'UniqueConstraintError';
+	static readonly code = '23505';
+
+	constructor(cause: Error & { code?: string; constraint?: string; table?: string; schema?: string; detail?: string; column?: string }) {
+		super(cause);
+		this.name = 'UniqueConstraintError';
+	}
+}
+
+export class ForeignKeyViolationError extends PostgresError {
+	static override readonly [entityKind]: string = 'ForeignKeyViolationError';
+	static readonly code = '23503';
+
+	constructor(cause: Error & { code?: string; constraint?: string; table?: string; schema?: string; detail?: string; column?: string }) {
+		super(cause);
+		this.name = 'ForeignKeyViolationError';
+	}
+}
+
+export class NotNullViolationError extends PostgresError {
+	static override readonly [entityKind]: string = 'NotNullViolationError';
+	static readonly code = '23502';
+
+	constructor(cause: Error & { code?: string; constraint?: string; table?: string; schema?: string; detail?: string; column?: string }) {
+		super(cause);
+		this.name = 'NotNullViolationError';
+	}
+}
+
+export class CheckViolationError extends PostgresError {
+	static override readonly [entityKind]: string = 'CheckViolationError';
+	static readonly code = '23514';
+
+	constructor(cause: Error & { code?: string; constraint?: string; table?: string; schema?: string; detail?: string; column?: string }) {
+		super(cause);
+		this.name = 'CheckViolationError';
+	}
+}
+
+/**
+ * Map a raw postgres error code to the appropriate Drizzle error class.
+ * Returns the original error if no mapping exists.
+ */
+export function wrapPostgresError(error: Error): Error {
+	const code = (error as any).code;
+	if (!code) return error;
+
+	switch (code) {
+		case '23505': return new UniqueConstraintError(error as any);
+		case '23503': return new ForeignKeyViolationError(error as any);
+		case '23502': return new NotNullViolationError(error as any);
+		case '23514': return new CheckViolationError(error as any);
+		default: return error;
 	}
 }

--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -13,6 +13,7 @@ import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations
 import { fillPlaceholders, type Query, type SQL, sql } from '~/sql/sql.ts';
 import { tracer } from '~/tracing.ts';
 import { type Assume, mapResultRow } from '~/utils.ts';
+import { wrapPostgresError } from '~/errors.ts';
 
 const { Pool, types } = pg;
 
@@ -145,9 +146,13 @@ export class NodePgPreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 						'drizzle.query.text': rawQuery.text,
 						'drizzle.query.params': JSON.stringify(params),
 					});
-					return this.queryWithCache(rawQuery.text, params, async () => {
-						return await client.query(rawQuery, params);
-					});
+					try {
+						return await this.queryWithCache(rawQuery.text, params, async () => {
+							return await client.query(rawQuery, params);
+						});
+					} catch (e) {
+						throw wrapPostgresError(e as Error);
+					}
 				});
 			}
 
@@ -157,9 +162,13 @@ export class NodePgPreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 					'drizzle.query.text': query.text,
 					'drizzle.query.params': JSON.stringify(params),
 				});
-				return this.queryWithCache(query.text, params, async () => {
-					return await client.query(query, params);
-				});
+				try {
+					return this.queryWithCache(query.text, params, async () => {
+						return await client.query(query, params);
+					});
+				} catch (e) {
+					throw wrapPostgresError(e as Error);
+				}
 			});
 
 			return tracer.startActiveSpan('drizzle.mapResponse', () => {
@@ -180,9 +189,13 @@ export class NodePgPreparedQuery<T extends PreparedQueryConfig> extends PgPrepar
 					'drizzle.query.text': this.rawQueryConfig.text,
 					'drizzle.query.params': JSON.stringify(params),
 				});
-				return this.queryWithCache(this.rawQueryConfig.text, params, async () => {
-					return this.client.query(this.rawQueryConfig, params);
-				}).then((result) => result.rows);
+				try {
+					return this.queryWithCache(this.rawQueryConfig.text, params, async () => {
+						return this.client.query(this.rawQueryConfig, params);
+					}).then((result) => result.rows);
+				} catch (e) {
+					throw wrapPostgresError(e as Error);
+				}
 			});
 		});
 	}


### PR DESCRIPTION
Implements typed error classes for common Postgres constraint violations (unique, foreign key, not null, check). Wraps raw driver errors in NodePgPreparedQuery. `/claim #376`