### PR TITLE
fix(drizzle-kit): handle commas in SQLite expression index columns

### DIFF
--- a/drizzle-kit/src/serializer/sqliteSchema.ts
+++ b/drizzle-kit/src/serializer/sqliteSchema.ts
@@ -180,7 +180,8 @@ export const SQLiteSquasher = {
 
 		let columns: string[];
 		try {
-			columns = JSON.parse(columnsString);
+			const parsed = JSON.parse(columnsString);
+			columns = Array.isArray(parsed) ? parsed : columnsString.split(',');
 		} catch {
 			columns = columnsString.split(',');
 		}
@@ -200,7 +201,8 @@ export const SQLiteSquasher = {
 		const [name, columnsString] = unq.split(';');
 		let columns: string[];
 		try {
-			columns = JSON.parse(columnsString);
+			const parsed = JSON.parse(columnsString);
+			columns = Array.isArray(parsed) ? parsed : columnsString.split(',');
 		} catch {
 			columns = columnsString.split(',');
 		}

--- a/drizzle-kit/src/serializer/sqliteSchema.ts
+++ b/drizzle-kit/src/serializer/sqliteSchema.ts
@@ -173,25 +173,38 @@ export type View = TypeOf<typeof view>;
 export const SQLiteSquasher = {
 	squashIdx: (idx: Index) => {
 		index.parse(idx);
-		return `${idx.name};${idx.columns.join(',')};${idx.isUnique};${idx.where ?? ''}`;
+		return `${idx.name};${JSON.stringify(idx.columns)};${idx.isUnique};${idx.where ?? ''}`;
 	},
 	unsquashIdx: (input: string): Index => {
 		const [name, columnsString, isUnique, where] = input.split(';');
 
+		let columns: string[];
+		try {
+			columns = JSON.parse(columnsString);
+		} catch {
+			columns = columnsString.split(',');
+		}
+
 		const result: Index = index.parse({
 			name,
-			columns: columnsString.split(','),
+			columns,
 			isUnique: isUnique === 'true',
 			where: where ?? undefined,
 		});
 		return result;
 	},
 	squashUnique: (unq: UniqueConstraint) => {
-		return `${unq.name};${unq.columns.join(',')}`;
+		return `${unq.name};${JSON.stringify(unq.columns)}`;
 	},
 	unsquashUnique: (unq: string): UniqueConstraint => {
-		const [name, columns] = unq.split(';');
-		return { name, columns: columns.split(',') };
+		const [name, columnsString] = unq.split(';');
+		let columns: string[];
+		try {
+			columns = JSON.parse(columnsString);
+		} catch {
+			columns = columnsString.split(',');
+		}
+		return { name, columns };
 	},
 	squashFK: (fk: ForeignKey) => {
 		return `${fk.name};${fk.tableFrom};${fk.columnsFrom.join(',')};${fk.tableTo};${fk.columnsTo.join(',')};${

--- a/drizzle-kit/tests/sqlite-squasher.test.ts
+++ b/drizzle-kit/tests/sqlite-squasher.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'vitest';
+import { SQLiteSquasher } from 'src/serializer/sqliteSchema';
+
+test('squashIdx JSON-encodes columns so expression commas survive the round-trip', () => {
+	const squashed = SQLiteSquasher.squashIdx({
+		name: 'expr_idx',
+		columns: ["json_extract(payload, '$.ref')", 'id'],
+		isUnique: false,
+	});
+
+	expect(squashed).toBe(`expr_idx;["json_extract(payload, '$.ref')","id"];false;`);
+
+	const restored = SQLiteSquasher.unsquashIdx(squashed);
+	expect(restored.name).toBe('expr_idx');
+	expect(restored.columns).toEqual(["json_extract(payload, '$.ref')", 'id']);
+	expect(restored.isUnique).toBe(false);
+});
+
+test('unsquashIdx reads old-format comma-joined columns (backward compat)', () => {
+	const restored = SQLiteSquasher.unsquashIdx('legacy_idx;col_a,col_b;true;');
+	expect(restored.name).toBe('legacy_idx');
+	expect(restored.columns).toEqual(['col_a', 'col_b']);
+	expect(restored.isUnique).toBe(true);
+});
+
+test('unsquashIdx falls back to split when an old-format column is valid JSON but not an array', () => {
+	// A single column named "123" is valid JSON (number) but not an array.
+	const restored = SQLiteSquasher.unsquashIdx('num_idx;123;false;');
+	expect(restored.columns).toEqual(['123']);
+});
+
+test('unsquashUnique JSON-encodes expression columns and round-trips them', () => {
+	const squashed = SQLiteSquasher.squashUnique({
+		name: 'expr_unq',
+		columns: ["json_extract(payload, '$.ref')", 'id'],
+	});
+	expect(squashed).toBe(`expr_unq;["json_extract(payload, '$.ref')","id"]`);
+
+	const restored = SQLiteSquasher.unsquashUnique(squashed);
+	expect(restored.name).toBe('expr_unq');
+	expect(restored.columns).toEqual(["json_extract(payload, '$.ref')", 'id']);
+});
+
+test('unsquashUnique falls back to split when an old-format column is valid JSON but not an array', () => {
+	// A single column named "true" is valid JSON (boolean) but not an array.
+	const restored = SQLiteSquasher.unsquashUnique('bool_unq;true');
+	expect(restored.name).toBe('bool_unq');
+	expect(restored.columns).toEqual(['true']);
+});
+
+test('unsquashUnique reads old-format comma-joined columns (backward compat)', () => {
+	const restored = SQLiteSquasher.unsquashUnique('legacy_unq;col_a,col_b');
+	expect(restored.columns).toEqual(['col_a', 'col_b']);
+});


### PR DESCRIPTION
squashIdx and squashUnique used comma-joined column strings which broke when an expression column contained its own comma (e.g., `json_extract(payload, '$.ref')`). This caused  to emit invalid SQL with backtick-quoted expression fragments.\n\nUses JSON encoding for the columns array with a `split(',')` fallback for backward compatibility with existing snapshot files.\n\nFixes #6062