### PR TITLE
test(drizzle-kit): regression test for unrelated fk on a recreated generated column

### DIFF
--- a/drizzle-kit/tests/sqlite/sqlite-generated.test.ts
+++ b/drizzle-kit/tests/sqlite/sqlite-generated.test.ts
@@ -451,6 +451,50 @@ test('generated as callback: change virtual generated constraint', async () => {
 	expect(pst).toStrictEqual(st0);
 });
 
+test('generated as callback: change virtual generated constraint on a table with a foreign key', async () => {
+	const customers = sqliteTable('customers', {
+		id: int('id').primaryKey(),
+	});
+
+	const from = {
+		customers,
+		lineItems: sqliteTable('line_items', {
+			id: int('id').primaryKey(),
+			customerId: int('customer_id').references(() => customers.id, { onDelete: 'cascade' }),
+			amountCents: int('amount_cents'),
+			amount: text('amount').generatedAlwaysAs(
+				(): SQL => sql`${from.lineItems.amountCents}`,
+			),
+		}),
+	};
+	const to = {
+		customers,
+		lineItems: sqliteTable('line_items', {
+			id: int('id').primaryKey(),
+			customerId: int('customer_id').references(() => customers.id, { onDelete: 'cascade' }),
+			amountCents: int('amount_cents'),
+			amount: text('amount').generatedAlwaysAs(
+				(): SQL => sql`${to.lineItems.amountCents} || 'hello'`,
+			),
+		}),
+	};
+
+	const { sqlStatements: st } = await diff(from, to, []);
+
+	await push({ db, to: from });
+	const { sqlStatements: pst } = await push({ db, to });
+
+	// The foreign key belongs to `customer_id`; it must not be re-emitted on the
+	// regenerated `amount` column, which would create a bogus constraint that
+	// rejects every insert.
+	const st0: string[] = [
+		'ALTER TABLE `line_items` DROP COLUMN `amount`;',
+		'ALTER TABLE `line_items` ADD `amount` text GENERATED ALWAYS AS ("amount_cents" || \'hello\') VIRTUAL;',
+	];
+	expect(st).toStrictEqual(st0);
+	expect(pst).toStrictEqual(st0);
+});
+
 test('generated as callback: add table with column with stored generated constraint', async () => {
 	const from = {};
 	const to = {


### PR DESCRIPTION
Refs #6061.

**Updated:** when I opened this, it also carried the one-line fix. That same fix has since landed on `rc5` via #6069 (`ddl2.fks.one({ table: it.table, columns: [it.name] })`), so I've dropped it and rebased — this PR is now **test-only**.

The fix is currently unguarded: there's no case in `tests/sqlite/` where a table's foreign key sits on a *different* column from the generated one being recreated, which is the exact shape that produced the bug.

This adds that case: the fk is on `customer_id`, the regenerated column is `amount`, and it asserts the emitted `ADD` carries no `REFERENCES` clause (plus the usual idempotency check that a follow-up push is empty).

Verified both directions:
- Passes on current `rc5` (all 38 tests in the file, 255 across `tests/sqlite/`).
- Reverting the `columns: [it.name]` predicate makes it fail — so it genuinely pins the behaviour rather than just passing.

Worth having, since silent fk corruption of this kind only shows up later as `FOREIGN KEY constraint failed` on every insert.