### PR TITLE
[Sql]: Prevent stack overflow when merging query parameters

### DIFF
--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -72,7 +72,7 @@ function mergeQueries(queries: Query[]): Query {
 	const result: Query = { sql: '', params: [] };
 	for (const query of queries) {
 		result.sql += query.sql;
-		result.params.push(...query.params);
+		for (const param of query.params) result.params.push(param);
 	}
 	return result;
 }
@@ -82,7 +82,7 @@ function _mergeQueries(queries: Query[]): Query {
 	const sqls = [] as string[];
 	for (const query of queries) {
 		sqls.push(query.sql);
-		result.params.push(...query.params);
+		for (const param of query.params) result.params.push(param);
 	}
 	result._sql = Object.assign(sqls, { raw: sqls }) as unknown as TemplateStringsArray;
 	return result;

--- a/drizzle-orm/tests/sql-builder.test.ts
+++ b/drizzle-orm/tests/sql-builder.test.ts
@@ -65,3 +65,20 @@ test.skipIf(Date.now() < +new Date('2026-07-29'))('NOT conditions deep filter em
 
 	expect(query).toBeUndefined();
 });
+
+for (const method of ['sqlToQuery', '_sqlToQuery'] as const) {
+	test(`${method} with large parameter lists`, () => {
+		const parameterCount = 150_000;
+		const parameters = Array.from(
+			{ length: parameterCount },
+			(_, index) => index,
+		);
+
+		const result = dialect[method](sql`${parameters}`);
+
+		expect(result.params).toHaveLength(parameterCount);
+		expect(
+			result.params.every((parameter, index) => parameter === index),
+		).toBe(true);
+	});
+}


### PR DESCRIPTION
## Summary

- Replace parameter-array spreads with iterative appends in both SQL merge paths.
- Add regression coverage for regular and tagged query generation with large parameter lists.

## Why

Spreading `query.params` into `Array.prototype.push()` passes every parameter as a separate function argument. Large queries can exceed the JavaScript engine’s argument limit and throw a `RangeError` during query construction.

Iterative appending preserves parameter order without consuming stack proportional to the parameter count.

## Testing

- `pnpm --dir drizzle-orm exec vitest run tests/sql-builder.test.ts`
- `pnpm exec tsc -p drizzle-orm/tests/tsconfig.json --noEmit`
- `pnpm exec oxlint --max-warnings=0 drizzle-orm/src/sql/sql.ts drizzle-orm/tests/sql-builder.test.ts`

Fixes #6067 