### PR TITLE
Add Cloudflare KV cache adapter

### DIFF
--- a/drizzle-orm/src/cache/cloudflare-kv/cache.ts
+++ b/drizzle-orm/src/cache/cloudflare-kv/cache.ts
@@ -1,0 +1,205 @@
+/// <reference types="@cloudflare/workers-types" />
+import type { MutationOption } from '~/cache/core/index.ts';
+import { Cache, hashQuery } from '~/cache/core/index.ts';
+import { entityKind, is } from '~/entity.ts';
+import { OriginalName, Table } from '~/table.ts';
+import type { CacheConfig } from '../core/types.ts';
+
+const minimumExpirationTtl = 60;
+const defaultExpirationTtl = 300;
+
+type Strategy = 'explicit' | 'all';
+type ExpirationOptions = Pick<KVNamespacePutOptions, 'expiration' | 'expirationTtl'>;
+type IndexMetadata = { cacheKey: string };
+
+export interface CloudflareKVCacheOptions {
+	/**
+	 * Cache only queries using `.$withCache()` or cache all queries.
+	 *
+	 * @default 'explicit'
+	 */
+	strategy?: Strategy;
+	/**
+	 * Prefix used for every key created by this cache.
+	 *
+	 * @default 'drizzle'
+	 */
+	prefix?: string;
+	/**
+	 * Default expiration used when a query does not provide its own cache config.
+	 *
+	 * @default { ex: 300 }
+	 */
+	config?: CacheConfig;
+}
+
+export class CloudflareKVCache extends Cache {
+	static override readonly [entityKind]: string = 'CloudflareKVCache';
+
+	private readonly strategyMode: Strategy;
+	private readonly prefix: string;
+	private readonly expiration: ExpirationOptions;
+
+	constructor(
+		private readonly kv: KVNamespace,
+		options: CloudflareKVCacheOptions = {},
+	) {
+		super();
+		this.strategyMode = options.strategy ?? 'explicit';
+		this.prefix = options.prefix ?? 'drizzle';
+		this.expiration = toExpirationOptions(options.config ?? {}, { expirationTtl: defaultExpirationTtl });
+
+		if (this.prefix.length === 0) {
+			throw new Error('Cloudflare KV cache prefix must not be empty.');
+		}
+	}
+
+	override strategy(): Strategy {
+		return this.strategyMode;
+	}
+
+	override async get(
+		key: string,
+		_tables: string[],
+		isTag: boolean,
+		_isAutoInvalidate?: boolean,
+	): Promise<any[] | undefined> {
+		const value = await this.kv.get<any[]>(this.cacheKey(key, isTag), 'json');
+		return value ?? undefined;
+	}
+
+	override async put(
+		key: string,
+		response: any,
+		tables: string[],
+		isTag: boolean,
+		config?: CacheConfig,
+	): Promise<void> {
+		const cacheKey = this.cacheKey(key, isTag);
+		const expiration = config === undefined ? this.expiration : toExpirationOptions(config, this.expiration);
+
+		await this.kv.put(cacheKey, JSON.stringify(response), expiration);
+
+		const indexId = await hashQuery(cacheKey);
+		const uniqueTables = new Set(tables);
+		const indexWrites = [...uniqueTables].map((table) => this.putTableIndex(table, indexId, cacheKey, expiration));
+
+		await Promise.all(indexWrites);
+	}
+
+	override async onMutate(params: MutationOption): Promise<void> {
+		const tags = new Set(Array.isArray(params.tags) ? params.tags : params.tags ? [params.tags] : []);
+		const tables = new Set(Array.isArray(params.tables) ? params.tables : params.tables ? [params.tables] : []);
+		const invalidations: Promise<void>[] = [];
+
+		for (const tag of tags) {
+			invalidations.push(this.kv.delete(this.cacheKey(tag, true)));
+		}
+
+		for (const table of tables) {
+			const tableName = is(table, Table) ? table[OriginalName] : table as string;
+			invalidations.push(this.invalidateTable(tableName));
+		}
+
+		await Promise.all(invalidations);
+	}
+
+	private cacheKey(key: string, isTag: boolean): string {
+		return `${this.prefix}:${isTag ? 'tag' : 'query'}:${key}`;
+	}
+
+	private tableIndexPrefix(table: string): string {
+		return `${this.prefix}:table:${encodeURIComponent(table)}:`;
+	}
+
+	private async putTableIndex(
+		table: string,
+		indexId: string,
+		cacheKey: string,
+		expiration: ExpirationOptions,
+	): Promise<void> {
+		const indexKey = `${this.tableIndexPrefix(table)}${indexId}`;
+
+		await this.kv.put(indexKey, '', {
+			...expiration,
+			metadata: { cacheKey } satisfies IndexMetadata,
+		});
+	}
+
+	private async invalidateTable(table: string): Promise<void> {
+		const prefix = this.tableIndexPrefix(table);
+		let cursor: string | undefined;
+
+		do {
+			const result = await this.kv.list<IndexMetadata>({ prefix, cursor });
+			const deletions: Promise<void>[] = [];
+
+			for (const entry of result.keys) {
+				deletions.push(this.kv.delete(entry.name));
+
+				if (entry.metadata?.cacheKey) {
+					deletions.push(this.kv.delete(entry.metadata.cacheKey));
+				}
+			}
+
+			await Promise.all(deletions);
+			cursor = result.list_complete ? undefined : result.cursor;
+		} while (cursor !== undefined);
+	}
+}
+
+function toExpirationOptions(config: CacheConfig, fallback: ExpirationOptions): ExpirationOptions {
+	if (config.keepTtl) {
+		throw new Error('Cloudflare KV does not support the keepTtl cache option.');
+	}
+	if (config.hexOptions !== undefined) {
+		throw new Error('Cloudflare KV does not support the hexOptions cache option.');
+	}
+
+	if (config.ex !== undefined) {
+		return { expirationTtl: validateExpirationTtl(config.ex) };
+	}
+	if (config.px !== undefined) {
+		return { expirationTtl: validateExpirationTtl(millisecondsToSeconds(config.px)) };
+	}
+	if (config.exat !== undefined) {
+		return { expiration: validateExpiration(config.exat) };
+	}
+	if (config.pxat !== undefined) {
+		return { expiration: validateExpiration(millisecondsToSeconds(config.pxat)) };
+	}
+
+	return fallback;
+}
+
+function millisecondsToSeconds(value: number): number {
+	if (!Number.isInteger(value)) {
+		throw new Error('Cloudflare KV expiration values in milliseconds must be integers.');
+	}
+	return Math.ceil(value / 1000);
+}
+
+function validateExpirationTtl(value: number): number {
+	if (!Number.isInteger(value) || value < minimumExpirationTtl) {
+		throw new Error(
+			`Cloudflare KV expiration TTL must be an integer of at least ${minimumExpirationTtl} seconds.`,
+		);
+	}
+	return value;
+}
+
+function validateExpiration(value: number): number {
+	if (!Number.isInteger(value) || value < Math.floor(Date.now() / 1000) + minimumExpirationTtl) {
+		throw new Error(
+			`Cloudflare KV expiration must be an integer at least ${minimumExpirationTtl} seconds in the future.`,
+		);
+	}
+	return value;
+}
+
+export function cloudflareKVCache(
+	kv: KVNamespace,
+	options?: CloudflareKVCacheOptions,
+): CloudflareKVCache {
+	return new CloudflareKVCache(kv, options);
+}

--- a/drizzle-orm/src/cache/cloudflare-kv/index.ts
+++ b/drizzle-orm/src/cache/cloudflare-kv/index.ts
@@ -1,0 +1,1 @@
+export * from './cache.ts';

--- a/drizzle-orm/src/cache/readme.md
+++ b/drizzle-orm/src/cache/readme.md
@@ -4,7 +4,7 @@ By default, Drizzle does not perform any implicit actions with your queries and 
 
 However, there are cases when you might want to implement a simple caching logic for specific queries or even for all queries. With Drizzle's cache option, you can define how and when the cache is used, how you store and retrieve data, and what actions to take when write statements are executed on the database. It's basically similar to `beforeQuery` hooks, that will be invoked before actual query will be executed. Additionally, Drizzle provides predefined logic for caching. Let's take a look at it.
 
-To make cache work you would need to define cache callbacks in drizzle instance or use a predefined ones we have in Drizzle, like a `upstashCache()` that was built together with Upstash team
+To make cache work you would need to define cache callbacks in drizzle instance or use a predefined one we have in Drizzle, like `upstashCache()` or `cloudflareKVCache()`
 
 ### Cache overview
 
@@ -13,6 +13,16 @@ To make cache work you would need to define cache callbacks in drizzle instance 
 ```ts
 const db = drizzle(process.env.DB_URL!, { cache: upstashCache() })
 ```
+
+**Using Cloudflare KV cache with drizzle**
+
+```ts
+const db = drizzle(env.DB, {
+  cache: cloudflareKVCache(env.QUERY_CACHE, { config: { ex: 300 } })
+})
+```
+
+Cloudflare KV is eventually consistent and requires expiration targets of at least 60 seconds.
 
 You can also define custom logic for your cache behavior. This is an example of our NodeKV implementation for the Drizzle cache test suites
 

--- a/drizzle-orm/tests/cache/cloudflare-kv.test.ts
+++ b/drizzle-orm/tests/cache/cloudflare-kv.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from 'vitest';
+import { cloudflareKVCache } from '~/cache/cloudflare-kv/index.ts';
+import { Table } from '~/table.ts';
+
+type StoredValue = {
+	value: string;
+	options?: KVNamespacePutOptions;
+};
+
+class MockKVNamespace {
+	readonly values = new Map<string, StoredValue>();
+
+	async get<Value = unknown>(key: string, type?: string): Promise<Value | string | null> {
+		const stored = this.values.get(key);
+		if (stored === undefined) {
+			return null;
+		}
+		return type === 'json' ? JSON.parse(stored.value) as Value : stored.value;
+	}
+
+	async put(key: string, value: string, options?: KVNamespacePutOptions): Promise<void> {
+		this.values.set(key, { value, options });
+	}
+
+	async delete(key: string): Promise<void> {
+		this.values.delete(key);
+	}
+
+	async list<Metadata = unknown>(
+		options: KVNamespaceListOptions,
+	): Promise<KVNamespaceListResult<Metadata>> {
+		const keys = [...this.values]
+			.filter(([key]) => key.startsWith(options.prefix ?? ''))
+			.map(([name, stored]) => ({
+				name,
+				metadata: stored.options?.metadata as Metadata,
+			}));
+		return { keys, list_complete: true, cacheStatus: null };
+	}
+
+	asNamespace(): KVNamespace {
+		return this as unknown as KVNamespace;
+	}
+}
+
+function setup(options?: Parameters<typeof cloudflareKVCache>[1]) {
+	const kv = new MockKVNamespace();
+	return { kv, cache: cloudflareKVCache(kv.asNamespace(), options) };
+}
+
+describe('cloudflareKVCache', () => {
+	test('uses the explicit strategy by default', () => {
+		expect(setup().cache.strategy()).toBe('explicit');
+		expect(setup({ strategy: 'all' }).cache.strategy()).toBe('all');
+	});
+
+	test('stores and retrieves query results', async () => {
+		const { cache } = setup();
+		const rows = [{ id: 1, name: 'Ada' }];
+
+		await cache.put('hash', rows, [], false);
+
+		expect(await cache.get('hash', [], false)).toEqual(rows);
+		expect(await cache.get('missing', [], false)).toBeUndefined();
+	});
+
+	test('uses separate query and tag keys', async () => {
+		const { cache } = setup({ prefix: 'app' });
+
+		await cache.put('same-key', ['query'], [], false);
+		await cache.put('same-key', ['tag'], [], true);
+
+		expect(await cache.get('same-key', [], false)).toEqual(['query']);
+		expect(await cache.get('same-key', [], true)).toEqual(['tag']);
+	});
+
+	test('uses the default and per-query expiration configs', async () => {
+		const { cache, kv } = setup({ config: { ex: 600 } });
+
+		await cache.put('default', [], [], false);
+		await cache.put('override', [], [], false, { px: 120_000 });
+		await cache.put('empty-override', [], [], false, {});
+
+		expect(kv.values.get('drizzle:query:default')?.options?.expirationTtl).toBe(600);
+		expect(kv.values.get('drizzle:query:override')?.options?.expirationTtl).toBe(120);
+		expect(kv.values.get('drizzle:query:empty-override')?.options?.expirationTtl).toBe(600);
+	});
+
+	test('rejects expiration targets below the Cloudflare KV minimum', async () => {
+		expect(() => setup({ config: { ex: 59 } })).toThrow(/at least 60 seconds/);
+
+		const { cache } = setup();
+		await expect(cache.put('hash', [], [], false, { px: 59_000 })).rejects.toThrow(/at least 60 seconds/);
+	});
+
+	test('invalidates tags directly', async () => {
+		const { cache } = setup();
+		await cache.put('dashboard', [{ value: 1 }], [], true);
+
+		await cache.onMutate({ tags: 'dashboard' });
+
+		expect(await cache.get('dashboard', [], true)).toBeUndefined();
+	});
+
+	test('invalidates all entries associated with a table', async () => {
+		const { cache } = setup();
+		await cache.put('users-1', [{ id: 1 }], ['users'], false);
+		await cache.put('users-2', [{ id: 2 }], ['users'], false);
+		await cache.put('posts', [{ id: 1 }], ['posts'], false);
+
+		await cache.onMutate({ tables: 'users' });
+
+		expect(await cache.get('users-1', [], false)).toBeUndefined();
+		expect(await cache.get('users-2', [], false)).toBeUndefined();
+		expect(await cache.get('posts', [], false)).toEqual([{ id: 1 }]);
+	});
+
+	test('keeps table index prefixes isolated', async () => {
+		const { cache } = setup();
+		await cache.put('users', [{ id: 1 }], ['users'], false);
+		await cache.put('users-archive', [{ id: 2 }], ['users:archive'], false);
+
+		await cache.onMutate({ tables: 'users' });
+
+		expect(await cache.get('users', [], false)).toBeUndefined();
+		expect(await cache.get('users-archive', [], false)).toEqual([{ id: 2 }]);
+	});
+
+	test('accepts Drizzle table objects during manual invalidation', async () => {
+		const users = new Table('users', undefined, 'users');
+		const { cache } = setup();
+		await cache.put('users', [{ id: '1' }], ['users'], false);
+
+		await cache.onMutate({ tables: users });
+
+		expect(await cache.get('users', [], false)).toBeUndefined();
+	});
+
+	test('does not create table indexes when auto invalidation is disabled', async () => {
+		const { cache, kv } = setup();
+
+		await cache.put('hash', [], [], false);
+
+		expect([...kv.values.keys()]).toEqual(['drizzle:query:hash']);
+	});
+});


### PR DESCRIPTION
## What changed

- add a first-party `cloudflareKVCache()` adapter at `drizzle-orm/cache/cloudflare-kv`
- support explicit and all-query cache strategies
- support query tags, automatic table invalidation, and manual tag/table invalidation
- support `ex`, `px`, `exat`, and `pxat` expiration settings
- reject expiration targets below Workers KV's 60-second minimum
- document the adapter configuration and Workers KV consistency constraints

## Implementation

Cached query results and tags use namespaced KV keys. Auto-invalidation uses one marker key per cached entry and table, with the cache key stored in marker metadata. This avoids read-modify-write updates to a shared table index, which would be vulnerable to lost updates and Workers KV's one-write-per-second limit for a single key.

Workers KV remains eventually consistent, so the adapter is intended for read-heavy workloads that tolerate stale data.

## Validation

- 10 focused Cloudflare KV adapter tests
- 450 package export tests
- focused strict TypeScript check
- dprint and `git diff --check`

## Documentation

The corresponding public documentation is in drizzle-team/drizzle-orm-docs#701.

Closes #5758.
