### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/release-latest.yaml
+++ b/.github/workflows/release-latest.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.19'
+          node-version: '22.0'
           registry-url: 'https://registry.npmjs.org'
 
       - uses: pnpm/action-setup@v3
@@ -246,7 +246,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.18'
+          node-version: '22.0'
           registry-url: 'https://registry.npmjs.org'
 
       - uses: pnpm/action-setup@v3


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `22`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `22` (using `22` where a concrete pin is needed).

- `.github/workflows/release-latest.yaml`
  - `node-version: '20.19'` → `node-version: '22.0'`
  - `node-version: '18.18'` → `node-version: '22.0'`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `22`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
