### PR TITLE
fix: preserve nullable joined objects with later values

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -47,10 +47,12 @@ export function mapResultRow<TResult>(
 						const objectName = path[0]!;
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
-						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
-						) {
-							nullifyMap[objectName] = false;
+						} else if (typeof nullifyMap[objectName] === 'string') {
+							// A nullable joined object is null only when every selected column is null.
+							// Do not let the first column's value decide the whole object's state.
+							if (value !== null || nullifyMap[objectName] !== getTableName(field.table)) {
+								nullifyMap[objectName] = false;
+							}
 						}
 					}
 				}

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+import { sqliteTable, text } from '~/sqlite-core/index.ts';
+
+const branding = sqliteTable('branding', {
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+const selectedFields = orderSelectedFields({
+	branding: {
+		logo: branding.logo,
+		panelBackground: branding.panelBackground,
+	},
+});
+
+describe('mapResultRow', () => {
+	test('keeps a nullable joined object when a later column has a value', () => {
+		const result = mapResultRow(
+			selectedFields,
+			[null, '#1a8cff'],
+			{ branding: false },
+		);
+
+		expect(result).toEqual({
+			branding: {
+				logo: null,
+				panelBackground: '#1a8cff',
+			},
+		});
+	});
+
+	test('nullifies a nullable joined object when every column is null', () => {
+		const result = mapResultRow(selectedFields, [null, null], { branding: false });
+
+		expect(result).toEqual({ branding: null });
+	});
+});

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -7,6 +7,10 @@ const branding = sqliteTable('branding', {
 	panelBackground: text('panel_background'),
 });
 
+const owner = sqliteTable('owner', {
+	name: text('name'),
+});
+
 const selectedFields = orderSelectedFields({
 	branding: {
 		logo: branding.logo,
@@ -34,5 +38,57 @@ describe('mapResultRow', () => {
 		const result = mapResultRow(selectedFields, [null, null], { branding: false });
 
 		expect(result).toEqual({ branding: null });
+	});
+
+	test('keeps a nullable joined object when an earlier column has a value', () => {
+		const result = mapResultRow(
+			orderSelectedFields({
+				branding: {
+					panelBackground: branding.panelBackground,
+					logo: branding.logo,
+				},
+			}),
+			['#1a8cff', null],
+			{ branding: false },
+		);
+
+		expect(result).toEqual({
+			branding: {
+				panelBackground: '#1a8cff',
+				logo: null,
+			},
+		});
+	});
+
+	test('preserves all-null fields for a non-nullable joined object', () => {
+		const result = mapResultRow(selectedFields, [null, null], { branding: true });
+
+		expect(result).toEqual({
+			branding: {
+				logo: null,
+				panelBackground: null,
+			},
+		});
+	});
+
+	test('does not nullify a nested object assembled from multiple tables', () => {
+		const fields = orderSelectedFields({
+			branding: {
+				logo: branding.logo,
+				ownerName: owner.name,
+			},
+		});
+
+		const result = mapResultRow(fields, [null, null], {
+			branding: false,
+			owner: false,
+		});
+
+		expect(result).toEqual({
+			branding: {
+				logo: null,
+				ownerName: null,
+			},
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1603.

mapResultRow previously treated a nullable nested object from a LEFT JOIN as null based on the first selected column. If that column was NULL while a later column from the same joined table had a value, the whole object was discarded. Nullification now occurs only when every selected column is NULL.

## Tests

- Added regression coverage for a later non-null selected column.
- Added coverage preserving null when all selected columns are null.
- git diff --check passes.

Full Vitest execution was unavailable locally because workspace dependency installation timed out against the npm registry.

/claim #1603