### PR TITLE
Handle edge case for fix(eslint): correct no-instanceof rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,7 +17,7 @@ overrides:
       - '**/type-tests/**/*.ts'
     rules:
       import/extensions: 'off'
-      no-instanceof: 'off'
+      no-instanceof/no-instanceof: 'off'
   - files: 'eslint-plugin-drizzle/**/*'
     rules:
       import/extensions: 'off'


### PR DESCRIPTION
Corrected the rule name in `.eslintrc.yaml` overrides from `no-instanceof` to `no-instanceof/no-instanceof` to successfully disable the plugin's rule inside test files.

$ https://github.com/drizzle-team/drizzle-orm/issues/1603
Fixes https://github.com/drizzle-team/drizzle-orm/issues/1603