### PR TITLE
[Pg] Throw when a transaction handle is used after commit/rollback (node-postgres)

### DIFF
--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -31,3 +31,11 @@ export class TransactionRollbackError extends DrizzleError {
 		super({ message: 'Rollback' });
 	}
 }
+
+export class TransactionClosedError extends DrizzleError {
+	static override readonly [entityKind]: string = 'TransactionClosedError';
+
+	constructor() {
+		super({ message: 'Cannot execute a query on a transaction that has already been committed or rolled back.' });
+	}
+}

--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -3,6 +3,7 @@ import pg from 'pg';
 import { type Cache, NoopCache } from '~/cache/core/index.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind } from '~/entity.ts';
+import { TransactionClosedError } from '~/errors.ts';
 import { type Logger, NoopLogger } from '~/logger.ts';
 import type { PgDialect } from '~/pg-core/dialect.ts';
 import { PgTransaction } from '~/pg-core/index.ts';
@@ -206,6 +207,7 @@ export class NodePgSession<
 
 	private logger: Logger;
 	private cache: Cache;
+	private closed = false;
 
 	constructor(
 		private client: NodePgClient,
@@ -216,6 +218,11 @@ export class NodePgSession<
 		super(dialect);
 		this.logger = options.logger ?? new NoopLogger();
 		this.cache = options.cache ?? new NoopCache();
+	}
+
+	/** @internal */
+	close(): void {
+		this.closed = true;
 	}
 
 	prepareQuery<T extends PreparedQueryConfig = PreparedQueryConfig>(
@@ -230,6 +237,9 @@ export class NodePgSession<
 		},
 		cacheConfig?: WithCacheConfig,
 	): PgPreparedQuery<T> {
+		if (this.closed) {
+			throw new TransactionClosedError();
+		}
 		return new NodePgPreparedQuery(
 			this.client,
 			query.sql,
@@ -252,7 +262,7 @@ export class NodePgSession<
 		const isPool = this.client instanceof Pool || Object.getPrototypeOf(this.client).constructor.name.includes('Pool'); // eslint-disable-line no-instanceof/no-instanceof
 		const session = isPool
 			? new NodePgSession(await (<pg.Pool> this.client).connect(), this.dialect, this.schema, this.options)
-			: this;
+			: new NodePgSession(this.client, this.dialect, this.schema, this.options);
 		const tx = new NodePgTransaction<TFullSchema, TSchema>(this.dialect, session, this.schema);
 		await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
 		try {
@@ -263,6 +273,7 @@ export class NodePgSession<
 			await tx.execute(sql`rollback`);
 			throw error;
 		} finally {
+			session.close();
 			if (isPool) (session.client as PoolClient).release();
 		}
 	}

--- a/integration-tests/tests/pg/node-postgres.test.ts
+++ b/integration-tests/tests/pg/node-postgres.test.ts
@@ -1,9 +1,9 @@
 import retry from 'async-retry';
-import { sql } from 'drizzle-orm';
+import { sql, TransactionClosedError } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
-import { pgTable, serial, timestamp } from 'drizzle-orm/pg-core';
+import { integer, pgTable, serial, timestamp } from 'drizzle-orm/pg-core';
 import { Client } from 'pg';
 import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
 import { skipTests } from '~/common';
@@ -489,4 +489,88 @@ test('insert via db.execute w/ query builder', async () => {
 			.returning({ id: usersTable.id, name: usersTable.name }),
 	);
 	expect(inserted.rows).toEqual([{ id: 1, name: 'John' }]);
+});
+
+test('transaction handle cannot be used after commit', async () => {
+	const users = pgTable('users_tx_handle_commit', {
+		id: serial('id').primaryKey(),
+		balance: integer('balance').notNull(),
+	});
+
+	await db.execute(sql`drop table if exists ${users}`);
+	await db.execute(sql`create table users_tx_handle_commit (id serial not null primary key, balance integer not null)`);
+
+	let leakedTx: any;
+
+	await db.transaction(async (tx) => {
+		leakedTx = tx;
+		await tx.insert(users).values({ balance: 100 });
+	});
+
+	await expect(leakedTx.insert(users).values({ balance: 200 })).rejects.toThrowError(TransactionClosedError);
+	await expect(leakedTx.select().from(users)).rejects.toThrowError(TransactionClosedError);
+	await expect(leakedTx.execute(sql`select 1`)).rejects.toThrowError(TransactionClosedError);
+
+	const result = await db.select().from(users);
+	expect(result).toEqual([{ id: 1, balance: 100 }]);
+
+	await db.execute(sql`drop table ${users}`);
+});
+
+test('transaction handle cannot be used after rollback', async () => {
+	const users = pgTable('users_tx_handle_rollback', {
+		id: serial('id').primaryKey(),
+		balance: integer('balance').notNull(),
+	});
+
+	await db.execute(sql`drop table if exists ${users}`);
+	await db.execute(
+		sql`create table users_tx_handle_rollback (id serial not null primary key, balance integer not null)`,
+	);
+
+	let leakedTx: any;
+
+	await expect((async () => {
+		await db.transaction(async (tx) => {
+			leakedTx = tx;
+			await tx.insert(users).values({ balance: 100 });
+			throw new Error('rollback');
+		});
+	})()).rejects.toThrowError('rollback');
+
+	await expect(leakedTx.insert(users).values({ balance: 200 })).rejects.toThrowError(TransactionClosedError);
+
+	const result = await db.select().from(users);
+	expect(result).toEqual([]);
+
+	await db.execute(sql`drop table ${users}`);
+});
+
+test('root db is not affected by a finished transaction', async () => {
+	const users = pgTable('users_tx_root_session', {
+		id: serial('id').primaryKey(),
+		balance: integer('balance').notNull(),
+	});
+
+	await db.execute(sql`drop table if exists ${users}`);
+	await db.execute(sql`create table users_tx_root_session (id serial not null primary key, balance integer not null)`);
+
+	await db.transaction(async (tx) => {
+		await tx.insert(users).values({ balance: 100 });
+	});
+
+	await db.insert(users).values({ balance: 200 });
+
+	await db.transaction(async (tx) => {
+		await tx.insert(users).values({ balance: 300 });
+	});
+
+	const result = await db.select().from(users);
+	expect(result).toEqual([
+		{ id: 1, balance: 100 },
+		{ id: 2, balance: 200 },
+		{ id: 3, balance: 300 },
+	]);
+
+	await db.execute(sql`drop table ${users}`);
 });


### PR DESCRIPTION
Fixes #6083

The tx handle from `db.transaction()` stays alive after the callback returns. Queries on it run in autocommit, on the released pool client in the `Pool` case (where they can also interleave into another checkout's transaction), or on the root connection in the `Client` case. Details and repro in the issue.

What this does:

- transactions now always get their own `NodePgSession` and it's closed in the `finally`. The pool branch already created one; the `Client` branch used to hand the tx the root session, which is why it couldn't be invalidated
- `NodePgSession` got a `closed` flag, and `prepareQuery` throws `TransactionClosedError` once it's set. Builders, `execute`, `all` and `count` all go through `prepareQuery`, so one check covers everything including the raw sql tag
- `TransactionClosedError` added to `errors.ts` next to `TransactionRollbackError`

Normal commits, rollbacks, nested savepoints and the root db are untouched. Added three integration tests for the new behavior, the existing suite covers the rest.

Scope: node-postgres only, targeting `main`. The other pg drivers (postgres-js, neon, pglite, ...) have the same pattern, can follow up per dialect if this approach is fine. The same defect exists on `beta`, happy to rebase or port. Not covered here: a nested savepoint handle used after `release savepoint` while the outer tx is still open. Different mechanism, follow-up material.

This turns previously silent behavior into an error. Anything that "worked" by writing through a stale handle was already running outside its transaction.
