### PR TITLE
[ORM] Preserve custom codecs for aggregate functions

### DIFF
--- a/drizzle-orm/src/sql/functions/aggregate.ts
+++ b/drizzle-orm/src/sql/functions/aggregate.ts
@@ -2,6 +2,10 @@ import { type AnyColumn, Column } from '~/column.ts';
 import { is } from '~/entity.ts';
 import { type SQL, sql, type SQLWrapper } from '../sql.ts';
 
+type NumericAggregate<T extends SQLWrapper> = T extends AnyColumn
+	? T['_']['dataType'] extends 'custom' ? T['_']['data'] : string
+	: string;
+
 /**
  * Returns the number of values in `expression`.
  *
@@ -48,7 +52,7 @@ export function countDistinct(expression: SQLWrapper): SQL<number> {
  *
  * @see avgDistinct to get the average of all non-null and non-duplicate values in `expression`
  */
-export function avg<T extends SQLWrapper>(expression: T): SQL<(T extends AnyColumn ? T['_']['data'] : string) | null> {
+export function avg<T extends SQLWrapper>(expression: T): SQL<NumericAggregate<T> | null> {
 	return sql`avg(${expression})`.mapWith(aggregateDecoder(expression)) as any;
 }
 
@@ -66,7 +70,7 @@ export function avg<T extends SQLWrapper>(expression: T): SQL<(T extends AnyColu
  */
 export function avgDistinct<T extends SQLWrapper>(
 	expression: T,
-): SQL<(T extends AnyColumn ? T['_']['data'] : string) | null> {
+): SQL<NumericAggregate<T> | null> {
 	return sql`avg(distinct ${expression})`.mapWith(aggregateDecoder(expression)) as any;
 }
 
@@ -82,7 +86,7 @@ export function avgDistinct<T extends SQLWrapper>(
  *
  * @see sumDistinct to get the sum of all non-null and non-duplicate values in `expression`
  */
-export function sum<T extends SQLWrapper>(expression: T): SQL<(T extends AnyColumn ? T['_']['data'] : string) | null> {
+export function sum<T extends SQLWrapper>(expression: T): SQL<NumericAggregate<T> | null> {
 	return sql`sum(${expression})`.mapWith(aggregateDecoder(expression)) as any;
 }
 
@@ -100,7 +104,7 @@ export function sum<T extends SQLWrapper>(expression: T): SQL<(T extends AnyColu
  */
 export function sumDistinct<T extends SQLWrapper>(
 	expression: T,
-): SQL<(T extends AnyColumn ? T['_']['data'] : string) | null> {
+): SQL<NumericAggregate<T> | null> {
 	return sql`sum(distinct ${expression})`.mapWith(aggregateDecoder(expression)) as any;
 }
 

--- a/drizzle-orm/src/sql/functions/aggregate.ts
+++ b/drizzle-orm/src/sql/functions/aggregate.ts
@@ -48,8 +48,8 @@ export function countDistinct(expression: SQLWrapper): SQL<number> {
  *
  * @see avgDistinct to get the average of all non-null and non-duplicate values in `expression`
  */
-export function avg(expression: SQLWrapper): SQL<string | null> {
-	return sql`avg(${expression})`.mapWith(String);
+export function avg<T extends SQLWrapper>(expression: T): SQL<(T extends AnyColumn ? T['_']['data'] : string) | null> {
+	return sql`avg(${expression})`.mapWith(aggregateDecoder(expression)) as any;
 }
 
 /**
@@ -64,8 +64,10 @@ export function avg(expression: SQLWrapper): SQL<string | null> {
  *
  * @see avg to get the average of all non-null values in `expression`, including duplicates
  */
-export function avgDistinct(expression: SQLWrapper): SQL<string | null> {
-	return sql`avg(distinct ${expression})`.mapWith(String);
+export function avgDistinct<T extends SQLWrapper>(
+	expression: T,
+): SQL<(T extends AnyColumn ? T['_']['data'] : string) | null> {
+	return sql`avg(distinct ${expression})`.mapWith(aggregateDecoder(expression)) as any;
 }
 
 /**
@@ -80,8 +82,8 @@ export function avgDistinct(expression: SQLWrapper): SQL<string | null> {
  *
  * @see sumDistinct to get the sum of all non-null and non-duplicate values in `expression`
  */
-export function sum(expression: SQLWrapper): SQL<string | null> {
-	return sql`sum(${expression})`.mapWith(String);
+export function sum<T extends SQLWrapper>(expression: T): SQL<(T extends AnyColumn ? T['_']['data'] : string) | null> {
+	return sql`sum(${expression})`.mapWith(aggregateDecoder(expression)) as any;
 }
 
 /**
@@ -96,8 +98,14 @@ export function sum(expression: SQLWrapper): SQL<string | null> {
  *
  * @see sum to get the sum of all non-null values in `expression`, including duplicates
  */
-export function sumDistinct(expression: SQLWrapper): SQL<string | null> {
-	return sql`sum(distinct ${expression})`.mapWith(String);
+export function sumDistinct<T extends SQLWrapper>(
+	expression: T,
+): SQL<(T extends AnyColumn ? T['_']['data'] : string) | null> {
+	return sql`sum(distinct ${expression})`.mapWith(aggregateDecoder(expression)) as any;
+}
+
+function aggregateDecoder(expression: SQLWrapper) {
+	return is(expression, Column) && expression.dataType === 'custom' ? expression : String;
 }
 
 /**

--- a/drizzle-orm/tests/mappers.test.ts
+++ b/drizzle-orm/tests/mappers.test.ts
@@ -23,7 +23,7 @@ import {
 	type RelationalQueryMapperConfig,
 	type RelationsBuilder,
 } from '~/relations';
-import { eq, max, sql } from '~/sql';
+import { avg, avgDistinct, eq, max, sql, sum, sumDistinct } from '~/sql';
 import {
 	getColumns,
 	getTableColumns,
@@ -1326,6 +1326,39 @@ const codecDb = createDB({ codecUsers, codecUsersView }, (r) => ({
 	codecUsers: { self: r.one.codecUsers({ from: r.codecUsers.id, to: r.codecUsers.id }) },
 	codecUsersView: { self: r.one.codecUsersView({ from: r.codecUsersView.id, to: r.codecUsersView.id }) },
 }));
+
+const aggregateCodec = customType<{ data: { usd: string }; driverData: string }>({
+	dataType: () => 'numeric(10, 2)',
+	fromDriver: (value) => ({ usd: String(value) }),
+	toDriver: (value) => value.usd,
+});
+
+const aggregateTable = pgTable('aggregate_codec_jit', {
+	customAmount: aggregateCodec('custom_amount').notNull(),
+	integerAmount: integer('integer_amount').notNull(),
+});
+
+const aggregateDb = drizzle('memory://', { jit: true });
+
+test('Column as decoder: aggregate functions preserve custom column decoders', () => {
+	const mapper = aggregateDb.select({
+		customAvg: avg(aggregateTable.customAmount),
+		customAvgDistinct: avgDistinct(aggregateTable.customAmount),
+		customSum: sum(aggregateTable.customAmount),
+		customSumDistinct: sumDistinct(aggregateTable.customAmount),
+		integerAvg: avg(aggregateTable.integerAmount),
+		integerSum: sum(aggregateTable.integerAmount),
+	}).from(aggregateTable).prepare().mapper!;
+
+	expect(mapper([['10.10', '10.10', '20.20', '20.20', '10.10', '20.20']])).toStrictEqual([{
+		customAvg: { usd: '10.10' },
+		customAvgDistinct: { usd: '10.10' },
+		customSum: { usd: '20.20' },
+		customSumDistinct: { usd: '20.20' },
+		integerAvg: '10.10',
+		integerSum: '20.20',
+	}]);
+});
 
 const nulls = (n: number) => [Array.from({ length: n }, () => null)];
 


### PR DESCRIPTION
## Summary

- Preserve custom column decoders for `avg`, `avgDistinct`, `sum`, and `sumDistinct`.
- Keep the existing `String` mapping for ordinary columns and non-column SQL expressions.
- Add mapper coverage for custom codecs and the ordinary integer aggregate behavior.

Fixes #6085

## Validation

- `pnpm exec vitest run --config drizzle-orm/vitest.config.ts drizzle-orm/tests/mappers.test.ts` (29 passed)
- `pnpm exec oxlint drizzle-orm/src/sql/functions/aggregate.ts drizzle-orm/tests/mappers.test.ts`
- `pnpm exec dprint check drizzle-orm/src/sql/functions/aggregate.ts drizzle-orm/tests/mappers.test.ts`
- Full package tests: 1038 passed; unrelated existing failures remain in `tests/sql-builder.test.ts`, missing `cjs-module-lexer`, and unavailable `better-sqlite3` bindings.
- Type tests are blocked by unrelated baseline errors in `src/op-sqlite` and `src/postgres/shape.ts`.
