### PR TITLE
[Pg-kit] Derive array dimensions from a customType SQL type

### DIFF
--- a/drizzle-kit/src/dialects/postgres/drizzle.ts
+++ b/drizzle-kit/src/dialects/postgres/drizzle.ts
@@ -111,7 +111,7 @@ export const policyFrom = (policy: PgPolicy, dialect: PgDialect) => {
 
 export const unwrapColumn = (column: AnyPgColumn) => {
 	// In the new architecture, columns have a dimensions property directly
-	const dimensions = (column as any).dimensions ?? 0;
+	let dimensions = (column as any).dimensions ?? 0;
 	const baseColumn = column;
 
 	const isEnum = is(baseColumn, PgEnumColumn) || is(baseColumn, PgEnumObjectColumn);
@@ -125,6 +125,20 @@ export const unwrapColumn = (column: AnyPgColumn) => {
 
 	/* legacy, for not to patch orm and don't up snapshot */
 	sqlBaseType = sqlBaseType.startsWith('timestamp (') ? sqlBaseType.replace('timestamp (', 'timestamp(') : sqlBaseType;
+
+	// A `customType` has no `dimensions` property, so it spells its array-ness
+	// out in `dataType()` instead, e.g. `varchar[]`. Read the dimension back off
+	// the type name when the column did not carry one, otherwise the column
+	// looks scalar and an array default is handed to the scalar codec: that
+	// throws for the string types and silently writes an unquoted default for
+	// the rest.
+	if (dimensions === 0) {
+		const brackets = sqlBaseType.match(/(?:\[\])+$/)?.[0];
+		if (brackets) {
+			dimensions = brackets.length / 2;
+			sqlBaseType = sqlBaseType.slice(0, -brackets.length);
+		}
+	}
 
 	const { type, options } = splitSqlType(sqlBaseType);
 	const sqlType = dimensions > 0 ? `${sqlBaseType}${'[]'.repeat(dimensions)}` : sqlBaseType;

--- a/drizzle-kit/tests/postgres/pg-array.test.ts
+++ b/drizzle-kit/tests/postgres/pg-array.test.ts
@@ -1,6 +1,7 @@
 import {
 	bigint,
 	boolean,
+	customType,
 	date,
 	integer,
 	json,
@@ -345,6 +346,75 @@ test('array #13: not null', async (t) => {
 	const { sqlStatements: pst } = await push({ db, to });
 
 	const st0 = ['CREATE TABLE "table1" (\n\t"values" varchar(20)[] NOT NULL\n);\n'];
+	expect(st).toStrictEqual(st0);
+	expect(pst).toStrictEqual(st0);
+});
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6071
+test('array #14: customType array default', async (t) => {
+	const varcharArray = customType<{ data: string[] }>({
+		dataType() {
+			return 'varchar[]';
+		},
+	});
+
+	const to = {
+		test: pgTable('table1', {
+			values: varcharArray('values').default(['a', 'b']),
+		}),
+	};
+
+	const { sqlStatements: st } = await diff({}, to, []);
+	const { sqlStatements: pst } = await push({ db, to });
+
+	const st0 = ['CREATE TABLE "table1" (\n\t"values" varchar[] DEFAULT \'{a,b}\'::varchar[]\n);\n'];
+	expect(st).toStrictEqual(st0);
+	expect(pst).toStrictEqual(st0);
+});
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6071
+// A customType spells its array-ness out in `dataType()` rather than carrying a
+// `dimensions` property, so this used to serialise as a scalar: the default was
+// written unbraced and unquoted, without any error.
+test('array #15: customType array default is not scalar', async (t) => {
+	const integerArray = customType<{ data: number[] }>({
+		dataType() {
+			return 'integer[]';
+		},
+	});
+
+	const to = {
+		test: pgTable('table1', {
+			values: integerArray('values').default([1, 2]),
+		}),
+	};
+
+	const { sqlStatements: st } = await diff({}, to, []);
+	const { sqlStatements: pst } = await push({ db, to });
+
+	const st0 = ['CREATE TABLE "table1" (\n\t"values" integer[] DEFAULT \'{1,2}\'::integer[]\n);\n'];
+	expect(st).toStrictEqual(st0);
+	expect(pst).toStrictEqual(st0);
+});
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6071
+test('array #16: customType scalar is unaffected', async (t) => {
+	const citext = customType<{ data: string }>({
+		dataType() {
+			return 'varchar';
+		},
+	});
+
+	const to = {
+		test: pgTable('table1', {
+			value: citext('value').default('a'),
+		}),
+	};
+
+	const { sqlStatements: st } = await diff({}, to, []);
+	const { sqlStatements: pst } = await push({ db, to });
+
+	const st0 = ['CREATE TABLE "table1" (\n\t"value" varchar DEFAULT \'a\'\n);\n'];
 	expect(st).toStrictEqual(st0);
 	expect(pst).toStrictEqual(st0);
 });


### PR DESCRIPTION
Fixes #6071.

## The bug

A `customType` has no `dimensions` property, so it declares its array-ness in
`dataType()` instead:

```ts
const permissions = customType<{ data: string[] }>({
	dataType() {
		return 'varchar[]';
	},
});

pgTable('store_manager_permissions', {
	store: permissions('store').default([]),
});
```

`unwrapColumn` only reads the `dimensions` property, so the column is treated as a
scalar and its array default is sent down the scalar path in `defaultFromColumn`.

For the string codecs that throws, which is what #6071 reports:

```
Error: input.replace is not a function
```

`escapeForSqlDefault` is typed `(input: string, ...)` and calls `input.replace()` on the
first line, while `Char.defaultFromDrizzle` passes `value as string`. `Text` and `Varchar`
alias `Char.defaultFromDrizzle`, so all three behave the same way.

## The quieter half

The codecs that do not call `.replace()` do not throw. They emit a broken statement
instead. On `rc5` today:

```ts
const intArray = customType<{ data: number[] }>({
	dataType() {
		return 'integer[]';
	},
});

pgTable('table1', { values: intArray('values').default([1, 2]) });
```

```sql
CREATE TABLE "table1" (
	"values" integer DEFAULT 1,2
);
```

The column has lost its `[]` and `DEFAULT 1,2` is a syntax error, so that migration
cannot be applied. There is no error and no warning at generate time.

With this change, both the type and the default match what the native array column
produces:

```sql
CREATE TABLE "table1" (
	"values" integer[] DEFAULT '{1,2}'::integer[]
);
```

## The change

`unwrapColumn` reads the dimension back off the type name when the column did not carry
one, and strips the brackets so the rest of the function sees the base type it expects.
Columns that already carry `dimensions` are untouched, and so are scalar `customType`
columns.

## Why generate and push fail while migrate does not

`generate-postgres.ts` and `push-postgres.ts` both call `fromDrizzleSchema`, which walks
every column through `defaultFromColumn`. `migrate` only replays the existing SQL files
and never serialises the schema, so it never reaches the throw. That matches what the
reporter described.

## Test plan

Three tests added to `tests/postgres/pg-array.test.ts`:

- `array #14` covers the reported shape, a `varchar[]` `customType` with a string array
  default
- `array #15` covers the silent case, an `integer[]` `customType`, and asserts the column
  is not serialised as a scalar
- `array #16` is a scalar `customType`, so that the bracket matching cannot start
  swallowing non-array types

`#14` and `#15` fail without the source change and pass with it. `#16` passes either way,
which is the point of it.

```
pnpm vitest run tests/postgres/pg-array.test.ts
  Tests  16 passed (16)

pnpm vitest run tests/postgres/
  Tests  751 passed | 7 skipped
```

Two tests in `tests/postgres/` fail here with `POSTGIS_URL is not set`. They fail the same
way on a clean checkout of `rc5` without this change, so they are environmental. I did not
run the MySQL, SQLite or PostGIS suites, which need containers I do not have up. None of
them touch `dialects/postgres/`.

`oxlint` and `dprint check` are clean on both files.

## Notes

Two things I deliberately left alone, happy to fold either in if you would rather have
them here.

`escapeForSqlDefault(value as string)` in `postgres/grammar.ts` keeps its cast. The mysql
grammar already coerces with `String(value)` at the same call, so postgres is the odd one
out, but with the dimension fixed nothing reaches that path with an array any more, and
changing it would only convert a future throw into a silently wrong default.

There are twelve bare `throw new Error()` calls across `postgres/grammar.ts` and
`cockroach/grammar.ts`, for example at `postgres/grammar.ts:272`. They produce an error
with an empty message, which is harder to act on than the TypeError this PR fixes.
`text('c').array().default([1])` still fails that way.

Cockroach has its own `unwrapColumn` with the same shape and is likely to have the same
bug, but I have not reproduced it there, so I have left it out rather than guess.

## Disclosure

This change was written with AI assistance. I have reviewed every line, reproduced the bug
and verified the fix against the reproduction above, and can explain and defend it in
review.
