### PR TITLE
feat(pg): add selectFromDb option for custom types

### DIFF
--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDbFn?: (identifier: SQL) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,10 +73,21 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDbFn = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/**
+	 * Returns the SQL that should be used to select this column, allowing custom types to
+	 * wrap the column identifier in arbitrary SQL (e.g. `ST_AsText("col")` for PostGIS).
+	 * Returns `undefined` when the custom type does not define a `selectFromDb` transform.
+	 * @internal
+	 */
+	getSelectSQL(identifier: SQL): SQL | undefined {
+		return typeof this.selectFromDbFn === 'function' ? this.selectFromDbFn(identifier) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +207,33 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional function that wraps the column in custom SQL whenever it is selected from the
+	 * database. This is useful for data types whose stored representation differs from the one
+	 * you want to read back — for example PostGIS `geometry`, which has to be read through
+	 * `ST_AsText(...)`.
+	 *
+	 * The `identifier` argument is the (table-qualified when needed) column reference as an
+	 * {@link SQL} value. The value produced by the returned SQL is still passed through
+	 * `fromDriver`, so you only need to describe the SQL transform here.
+	 *
+	 * @example
+	 * ```
+	 * const pointType = customType<{ data: Point; driverData: string }>({
+	 * 	dataType() {
+	 * 		return 'geometry(Point,4326)';
+	 * 	},
+	 * 	fromDriver(value: string) {
+	 * 		// parse WKT returned by ST_AsText
+	 * 	},
+	 * 	selectFromDb(identifier) {
+	 * 		return sql`st_astext(${identifier})`;
+	 * 	},
+	 * });
+	 * ```
+	 */
+	selectFromDb?: (identifier: SQL) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -6,6 +6,7 @@ import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
 import {
 	PgColumn,
+	PgCustomColumn,
 	PgDate,
 	PgDateString,
 	PgJson,
@@ -242,7 +243,17 @@ export class PgDialect {
 						chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 					}
 				} else if (is(field, Column)) {
-					if (isSingleTable) {
+					// Custom types may wrap the column in arbitrary SQL when selected (e.g. `ST_AsText("col")`).
+					const customSelect = is(field, PgCustomColumn)
+						? field.getSelectSQL(
+							isSingleTable
+								? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+								: sql`${field}`,
+						)
+						: undefined;
+					if (customSelect) {
+						chunk.push(customSelect);
+					} else if (isSingleTable) {
 						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
 					} else {
 						chunk.push(field);

--- a/drizzle-orm/tests/pg-custom-select.test.ts
+++ b/drizzle-orm/tests/pg-custom-select.test.ts
@@ -1,0 +1,96 @@
+import postgres from 'postgres';
+import { describe, expect, it } from 'vitest';
+import { customType, integer, pgTable } from '~/pg-core';
+import { drizzle } from '~/postgres-js';
+import { sql } from '~/sql';
+
+type Point = {
+	lat: number;
+	lng: number;
+};
+
+// A custom type that has to be read through `st_astext(...)`, mirroring the PostGIS
+// geometry use case from https://github.com/drizzle-team/drizzle-orm/issues/1083
+const pointType = customType<{ data: Point; driverData: string }>({
+	dataType() {
+		return 'geometry(Point,4326)';
+	},
+	toDriver(value: Point): string {
+		return `SRID=4326;POINT(${value.lng} ${value.lat})`;
+	},
+	fromDriver(value: string): Point {
+		const matches = value.match(/POINT\((?<lng>[\d.-]+) (?<lat>[\d.-]+)\)/);
+		const { lat, lng } = matches?.groups ?? {};
+		return { lat: Number.parseFloat(String(lat)), lng: Number.parseFloat(String(lng)) };
+	},
+	selectFromDb(identifier) {
+		return sql`st_astext(${identifier})`;
+	},
+});
+
+// A plain custom type (no `selectFromDb`) to make sure behaviour is unchanged when the
+// option is omitted.
+const plainCustom = customType<{ data: string; driverData: string }>({
+	dataType() {
+		return 'text';
+	},
+});
+
+const location = pgTable('location', {
+	id: integer('id').primaryKey(),
+	coords: pointType('coords'),
+	note: plainCustom('note'),
+});
+
+const other = pgTable('other', {
+	id: integer('id').primaryKey(),
+	locationId: integer('location_id'),
+});
+
+const db = drizzle(postgres(''));
+
+describe('custom type selectFromDb', () => {
+	it('wraps the column in custom SQL for a single-table select', () => {
+		const query = db.select().from(location);
+
+		expect(query.toSQL()).toEqual({
+			sql: 'select "id", st_astext("coords"), "note" from "location"',
+			params: [],
+		});
+	});
+
+	it('wraps the table-qualified column in custom SQL when joins are present', () => {
+		const query = db
+			.select()
+			.from(location)
+			.leftJoin(other, sql`${other.locationId} = ${location.id}`);
+
+		expect(query.toSQL()).toEqual({
+			sql:
+				'select "location"."id", st_astext("location"."coords"), "location"."note", "other"."id", "other"."location_id" from "location" left join "other" on "other"."location_id" = "location"."id"',
+			params: [],
+		});
+	});
+
+	it('leaves custom types without selectFromDb untouched', () => {
+		const query = db.select({ note: location.note }).from(location);
+
+		expect(query.toSQL()).toEqual({
+			sql: 'select "note" from "location"',
+			params: [],
+		});
+	});
+
+	it('applies the transform in an insert ... returning clause', () => {
+		const query = db
+			.insert(location)
+			.values({ id: 1, coords: { lat: 1, lng: 2 }, note: 'x' })
+			.returning();
+
+		expect(query.toSQL()).toEqual({
+			sql:
+				'insert into "location" ("id", "coords", "note") values ($1, $2, $3) returning "id", st_astext("coords"), "note"',
+			params: [1, 'SRID=4326;POINT(2 1)', 'x'],
+		});
+	});
+});

--- a/drizzle-orm/type-tests/pg/tables.ts
+++ b/drizzle-orm/type-tests/pg/tables.ts
@@ -53,7 +53,7 @@ import {
 	type PgViewWithSelection,
 } from '~/pg-core/view.ts';
 import { eq, gt } from '~/sql/expressions/index.ts';
-import { sql } from '~/sql/sql.ts';
+import { type SQL, sql } from '~/sql/sql.ts';
 import type { InferInsertModel, InferSelectModel } from '~/table.ts';
 import type { Simplify } from '~/utils.ts';
 import { db } from './db.ts';
@@ -957,6 +957,28 @@ await db.refreshMaterializedView(newYorkers2).withNoData().concurrently();
 	customTextOptional('t');
 	customTextOptional({ length: 10 });
 	customTextOptional();
+}
+
+{
+	// `selectFromDb` lets a custom type wrap the column in custom SQL on select (issue #1083)
+	const point = customType<{ data: { lat: number; lng: number }; driverData: string }>({
+		dataType() {
+			return 'geometry(Point,4326)';
+		},
+
+		fromDriver(value) {
+			Expect<Equal<string, typeof value>>();
+			return { lat: 0, lng: 0 };
+		},
+
+		selectFromDb(identifier) {
+			Expect<Equal<SQL, typeof identifier>>();
+			return sql`st_astext(${identifier})`;
+		},
+	});
+
+	point('coords');
+	point();
 }
 
 {


### PR DESCRIPTION
Closes #1083

## Problem
Custom types whose stored representation differs from what you want to read back (e.g. PostGIS `geometry`, read via `ST_AsText(...)`) currently require a manual `sql` wrapper at every call site, and cannot be used with the default `select()`.

## Solution
Adds an optional `selectFromDb(identifier)` callback to `CustomTypeParams`. When defined, the Postgres dialect wraps the column in the returned SQL whenever it is selected (including `insert ... returning`). The driver value is still decoded through `fromDriver`, so no manual `.mapWith()` / `.as()` is needed.

```ts
const pointType = customType<{ data: Point; driverData: string }>({
  dataType: () => 'geometry(Point,4326)',
  fromDriver: (v: string) => parseWkt(v),
  selectFromDb: (identifier) => sql`st_astext(${identifier})`,
});
// db.select().from(location)  ->  select "id", st_astext("coords") from "location"
```

## Notes
- Fully backward compatible — the option is optional; omitting it keeps current behaviour.
- Covers `db.select()` (single-table and table-qualified/join) and `insert ... returning`.
- Also resolves the use case in #554 (wrapping a custom-type column in SQL on select).
- Relational Queries (RQB) selection is a separate builder and is out of scope here; can follow up.

## Tests
- New unit test `drizzle-orm/tests/pg-custom-select.test.ts` (4 cases, `.toSQL()` assertions).
- New type-test block in `type-tests/pg/tables.ts` asserting the `identifier` argument is `SQL`.
- Full drizzle-orm unit suite and `tsc` typecheck pass locally.
