### PR TITLE
[ORM] Fix relations named after Object.prototype properties (definition and relational filters)

### DIFF
--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -101,7 +101,7 @@ export function processRelations(tablesConfig: TablesRelationalConfig, tables: S
 				is(relation, One) ? 'one' : 'many'
 			}.${targetTableName}(...) }`;
 
-			if (relationFieldName in tableConfig.table[TableColumns]) {
+			if (Object.prototype.hasOwnProperty.call(tableConfig.table[TableColumns], relationFieldName)) {
 				throw new Error(
 					`${relationPrintName}: relation name collides with column "${relationFieldName}" of table "${tableConfig.name}"`,
 				);
@@ -1956,7 +1956,7 @@ export function relationsFilterToSQL(
 				continue;
 			}
 			default: {
-				if (table[TableColumns][target]) {
+				if (Object.prototype.hasOwnProperty.call(table[TableColumns], target) && table[TableColumns][target]) {
 					const column = fieldSelectionToSQL(table, target);
 
 					const colFilter = relationsFieldFilterToSQL(
@@ -1968,7 +1968,9 @@ export function relationsFilterToSQL(
 					continue;
 				}
 
-				const relation = tableRelations[target];
+				const relation = Object.prototype.hasOwnProperty.call(tableRelations, target)
+					? tableRelations[target]
+					: undefined;
 				if (!relation) {
 					// Should never trigger unless the types've been violated
 					throw new DrizzleError({

--- a/drizzle-orm/tests/rqb-builders.test.ts
+++ b/drizzle-orm/tests/rqb-builders.test.ts
@@ -653,3 +653,43 @@ describe('Reverse-derived relation filter binding (isFilterReversed)', () => {
 		expect(sql).not.toContain('"d1"."name"');
 	});
 });
+
+describe('Relation names shadowing Object.prototype properties', () => {
+	const results = pgTable('results', { id: integer(), constructorId: integer() });
+	const constructors = pgTable('constructors', { id: integer(), name: text() });
+	const protoSchema = { results, constructors };
+
+	test('relation named "constructor" does not falsely collide with columns', () => {
+		expect(() =>
+			defineRelations(protoSchema, (r) => ({
+				results: {
+					constructor: r.one.constructors({ from: r.results.constructorId, to: r.constructors.id }),
+				},
+			}))
+		).not.toThrow();
+	});
+
+	test('filter on a relation named "constructor" builds a relation filter', () => {
+		const db = drizzle.mock({
+			relations: defineRelations(protoSchema, (r) => ({
+				results: {
+					constructor: r.one.constructors({ from: r.results.constructorId, to: r.constructors.id }),
+				},
+			})),
+		});
+
+		const { sql } = db.query.results.findMany({ where: { constructor: { id: 1 } } }).toSQL();
+		expect(sql).toContain('exists (select * from "constructors" as "f0" where');
+		expect(sql).not.toContain('"d0"."constructor"');
+	});
+
+	test('unknown filter field named after an inherited property throws', () => {
+		expect(() =>
+			buildFilter(table, {
+				toString: {
+					eq: 1,
+				},
+			} as any)
+		).toThrowError('Unknown relational filter field: "toString"');
+	});
+});


### PR DESCRIPTION
Fixes #6076

**What was broken**

Defining a relation named `constructor` throws `relation name collides with column "constructor"` even when no such column exists. The collision check used the `in` operator, which walks the prototype chain — `'constructor' in columns` is true for every plain object. The same root cause breaks two more places further down, so fixing the check alone just moves the crash:

1. With the definition check fixed, `where: { constructor: { ... } }` misroutes into the *column* filter path (`table[TableColumns]['constructor']` returns `Object.prototype.constructor`, which is truthy) and throws `operators[target] is not a function`.
2. The relation fall-through lookup has the same hazard: an unknown filter key named after an inherited property (e.g. `toString`) picks up `Object.prototype.toString` instead of reaching the intended `Unknown relational filter field` error, and crashes in `aliasedTable` with `Cannot create proxy with a non-object`.

**What changed**

Own-property checks at the three sites in `relations.ts`, using the existing idiom in this codebase (`Object.prototype.hasOwnProperty.call`, as in `entity.ts`). +45/−3 in 2 files.

Other lookups in the file were audited and deliberately left alone: `fieldSelectionToSQL`'s bare read is safe as-is (an inherited value fails both `is()` checks and emits byte-identical SQL either way); the dialect `with`-path lookups can't be reached with a prototype-named non-relation key without `as any`; `_relations.ts` is the legacy v1 API.

**Tests**

Three regression tests in `rqb-builders.test.ts`, each failing on rc5 head in a distinct way (fixing only the definition check makes the filter test fail with the operators TypeError; fixing the first two makes the unknown-field test fail with the proxy crash). The existing genuine-collision test still passes, and a table with a real `constructor` column still errors.

**Verification**

Full drizzle-orm package suite: 1165 passed / 7 skipped (skips pre-existing — 4 need the bun-built artifact, 3 in sql-builder). `test:types`, oxlint, and dprint all clean. Also verified `toString` / `hasOwnProperty` / `valueOf` as relation names work end-to-end, and that the generated SQL for `where: { constructor: { id: 1 } }` is identical to an identically-shaped relation with an ordinary name.

Note: #6086 fixes the definition-time check (the same one-line change); this PR additionally covers the filter path, without which a relation named `constructor` can be defined but throws on first use in `where`.
