### PR TITLE
Support rename/create hints in payload `generateMigration`

### DIFF
--- a/drizzle-kit/src/cli/errors.ts
+++ b/drizzle-kit/src/cli/errors.ts
@@ -1,3 +1,4 @@
+import type { MissingHint } from './hints';
 import { QueryError } from './utils';
 import { error, errText, info } from './views';
 
@@ -213,6 +214,29 @@ export class CheckCliError extends DrizzleCliError {
 export class InvalidHintsCliError extends DrizzleCliError {
 	constructor(humanMessage: string, meta?: DrizzleCliErrorMeta, options?: ErrorOptions) {
 		super('invalid_hints', humanMessage, meta, options);
+	}
+}
+
+const missingHintsMessage = (missingHints: readonly MissingHint[]): string => {
+	const lines = missingHints.map((it) => {
+		const entity = `${it.kind} ${it.entity.join('.')}`;
+		return it.type === 'rename_or_create'
+			? `- ${entity}: rename of a deleted ${it.kind} or a new one?`
+			: `- ${entity}: data loss must be confirmed`;
+	});
+
+	return `Ambiguous schema changes require hints to resolve:\n${lines.join('\n')}\n`
+		+ 'Provide a { type: "rename" | "create", ... } hint for each entity via the hints option.';
+};
+
+export class MissingHintsError extends DrizzleCliError {
+	readonly missingHints: readonly MissingHint[];
+
+	constructor(missingHints: readonly MissingHint[]) {
+		super('missing_hints', missingHintsMessage(missingHints), {
+			unresolved: missingHints as unknown as JsonValue[],
+		});
+		this.missingHints = missingHints;
 	}
 }
 

--- a/drizzle-kit/src/ext/api-postgres.ts
+++ b/drizzle-kit/src/ext/api-postgres.ts
@@ -2,6 +2,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import type { Relations } from 'drizzle-orm/_relations';
 import type { AnyPgTable } from 'drizzle-orm/pg-core';
 import type { PgAsyncDatabase } from 'drizzle-orm/pg-core/async';
+import type { Hint } from '../cli/hints';
 import type { EntitiesFilterConfig } from '../cli/validations/common';
 import type { PostgresCredentials } from '../cli/validations/postgres';
 import type {
@@ -71,9 +72,12 @@ export const generateDrizzleJson = async (
 export const generateMigration = async (
 	prev: PostgresSnapshot,
 	cur: PostgresSnapshot,
+	options?: { hints?: Hint[] },
 ) => {
 	const { resolver } = await import('../cli/prompts');
 	const { ddlDiff } = await import('../dialects/postgres/diff');
+	const { HintsHandler, parseHints } = await import('../cli/hints');
+	const { runWithCliContext } = await import('../cli/context');
 	const from = createDDL();
 	const to = createDDL();
 
@@ -84,25 +88,33 @@ export const generateMigration = async (
 		to.entities.push(it);
 	}
 
-	const { sqlStatements } = await ddlDiff(
-		from,
-		to,
-		resolver<Schema>('schema'),
-		resolver<Enum>('enum'),
-		resolver<Sequence>('sequence'),
-		resolver<Policy>('policy'),
-		resolver<Role>('role'),
-		resolver<Privilege>('privilege'),
-		resolver<PostgresEntities['tables']>('table'),
-		resolver<Column>('column'),
-		resolver<View>('view'),
-		resolver<UniqueConstraint>('unique'),
-		resolver<Index>('index'),
-		resolver<CheckConstraint>('check'),
-		resolver<PrimaryKey>('primary_key'),
-		resolver<ForeignKey>('foreign key'),
-		'default',
-	);
+	const hints = new HintsHandler(parseHints(options?.hints ?? []));
+
+	const { sqlStatements } = await runWithCliContext({ output: 'json', interactive: false }, () =>
+		ddlDiff(
+			from,
+			to,
+			resolver<Schema>('schema', hints),
+			resolver<Enum>('enum', hints),
+			resolver<Sequence>('sequence', hints),
+			resolver<Policy>('policy', hints),
+			resolver<Role>('role', hints),
+			resolver<Privilege>('privilege', hints),
+			resolver<PostgresEntities['tables']>('table', hints),
+			resolver<Column>('column', hints),
+			resolver<View>('view', hints),
+			resolver<UniqueConstraint>('unique', hints),
+			resolver<Index>('index', hints),
+			resolver<CheckConstraint>('check', hints),
+			resolver<PrimaryKey>('primary_key', hints),
+			resolver<ForeignKey>('foreign key', hints),
+			'default',
+		));
+
+	if (hints.hasMissingHints()) {
+		const { MissingHintsError } = await import('../cli/errors');
+		throw new MissingHintsError(hints.missingHints);
+	}
 
 	return sqlStatements;
 };
@@ -251,3 +263,6 @@ export const startStudioServer = async (
 };
 
 export const up = upToV8;
+
+export type { MissingHintsError } from '../cli/errors';
+export type { Hint, MissingHint } from '../cli/hints';

--- a/drizzle-kit/src/payload/mssql.ts
+++ b/drizzle-kit/src/payload/mssql.ts
@@ -1,4 +1,5 @@
 import type { MsSqlDatabase } from 'drizzle-orm/mssql-core';
+import type { Hint } from '../cli/hints';
 import type { EntitiesFilterConfig } from '../cli/validations/common';
 import type { MssqlCredentials } from '../cli/validations/mssql';
 import type {
@@ -59,9 +60,12 @@ export const generateDrizzleJson = async (
 export const generateMigration = async (
 	prev: MssqlSnapshot,
 	cur: MssqlSnapshot,
+	options?: { hints?: Hint[] },
 ) => {
 	const { resolver } = await import('../cli/prompts');
 	const { ddlDiff } = await import('../dialects/mssql/diff');
+	const { HintsHandler, parseHints } = await import('../cli/hints');
+	const { runWithCliContext } = await import('../cli/context');
 	const from = createDDL();
 	const to = createDDL();
 
@@ -72,21 +76,29 @@ export const generateMigration = async (
 		to.entities.push(it);
 	}
 
-	const { sqlStatements } = await ddlDiff(
-		from,
-		to,
-		resolver<Schema>('schema', undefined, 'dbo'),
-		resolver<MssqlEntities['tables']>('table', undefined, 'dbo'),
-		resolver<Column>('column', undefined, 'dbo'),
-		resolver<View>('view', undefined, 'dbo'),
-		resolver<UniqueConstraint>('unique', undefined, 'dbo'),
-		resolver<Index>('index', undefined, 'dbo'),
-		resolver<CheckConstraint>('check', undefined, 'dbo'),
-		resolver<PrimaryKey>('primary_key', undefined, 'dbo'),
-		resolver<ForeignKey>('foreign key', undefined, 'dbo'),
-		resolver<DefaultConstraint>('default', undefined, 'dbo'),
-		'default',
-	);
+	const hints = new HintsHandler(parseHints(options?.hints ?? []));
+
+	const { sqlStatements } = await runWithCliContext({ output: 'json', interactive: false }, () =>
+		ddlDiff(
+			from,
+			to,
+			resolver<Schema>('schema', hints, 'dbo'),
+			resolver<MssqlEntities['tables']>('table', hints, 'dbo'),
+			resolver<Column>('column', hints, 'dbo'),
+			resolver<View>('view', hints, 'dbo'),
+			resolver<UniqueConstraint>('unique', hints, 'dbo'),
+			resolver<Index>('index', hints, 'dbo'),
+			resolver<CheckConstraint>('check', hints, 'dbo'),
+			resolver<PrimaryKey>('primary_key', hints, 'dbo'),
+			resolver<ForeignKey>('foreign key', hints, 'dbo'),
+			resolver<DefaultConstraint>('default', hints, 'dbo'),
+			'default',
+		));
+
+	if (hints.hasMissingHints()) {
+		const { MissingHintsError } = await import('../cli/errors');
+		throw new MissingHintsError(hints.missingHints);
+	}
 
 	return sqlStatements;
 };
@@ -186,3 +198,6 @@ export const startStudioServer = async (
 };
 
 export { upToV2 as up } from '../dialects/mssql/versions';
+
+export type { MissingHintsError } from '../cli/errors';
+export type { Hint, MissingHint } from '../cli/hints';

--- a/drizzle-kit/src/payload/mysql.ts
+++ b/drizzle-kit/src/payload/mysql.ts
@@ -1,5 +1,6 @@
 import type { Relations } from 'drizzle-orm/_relations';
 import type { AnyMySqlTable } from 'drizzle-orm/mysql-core';
+import type { Hint } from '../cli/hints';
 import type { MysqlCredentials } from '../cli/validations/mysql';
 import type { Column, Table, View } from '../dialects/mysql/ddl';
 import { createDDL, interimToDDL } from '../dialects/mysql/ddl';
@@ -31,9 +32,12 @@ export const generateDrizzleJson = async (
 export const generateMigration = async (
 	prev: MysqlSnapshot,
 	cur: MysqlSnapshot,
+	options?: { hints?: Hint[] },
 ) => {
 	const { resolver } = await import('../cli/prompts');
 	const { ddlDiff } = await import('../dialects/mysql/diff');
+	const { HintsHandler, parseHints } = await import('../cli/hints');
+	const { runWithCliContext } = await import('../cli/context');
 	const from = createDDL();
 	const to = createDDL();
 
@@ -44,14 +48,22 @@ export const generateMigration = async (
 		to.entities.push(it);
 	}
 
-	const { sqlStatements } = await ddlDiff(
-		from,
-		to,
-		resolver<Table>('table'),
-		resolver<Column>('column'),
-		resolver<View>('view'),
-		'default',
-	);
+	const hints = new HintsHandler(parseHints(options?.hints ?? []));
+
+	const { sqlStatements } = await runWithCliContext({ output: 'json', interactive: false }, () =>
+		ddlDiff(
+			from,
+			to,
+			resolver<Table>('table', hints),
+			resolver<Column>('column', hints),
+			resolver<View>('view', hints),
+			'default',
+		));
+
+	if (hints.hasMissingHints()) {
+		const { MissingHintsError } = await import('../cli/errors');
+		throw new MissingHintsError(hints.missingHints);
+	}
 
 	return sqlStatements;
 };
@@ -163,3 +175,6 @@ export const startStudioServer = async (
 };
 
 export { upToV6 as up } from '../cli/commands/up-mysql';
+
+export type { MissingHintsError } from '../cli/errors';
+export type { Hint, MissingHint } from '../cli/hints';

--- a/drizzle-kit/src/payload/sqlite.ts
+++ b/drizzle-kit/src/payload/sqlite.ts
@@ -1,6 +1,7 @@
 /// <reference types="@cloudflare/workers-types" />
 import type { Relations } from 'drizzle-orm/_relations';
 import type { AnySQLiteTable } from 'drizzle-orm/sqlite-core';
+import type { Hint } from '../cli/hints';
 import type { SqliteCredentials } from '../cli/validations/sqlite';
 import type { Column, Table } from '../dialects/sqlite/ddl';
 import { createDDL, interimToDDL } from '../dialects/sqlite/ddl';
@@ -33,9 +34,12 @@ export const generateDrizzleJson = async (
 export const generateMigration = async (
 	prev: SqliteSnapshot,
 	cur: SqliteSnapshot,
+	options?: { hints?: Hint[] },
 ) => {
 	const { resolver } = await import('../cli/prompts');
 	const { ddlDiff } = await import('../dialects/sqlite/diff');
+	const { HintsHandler, parseHints } = await import('../cli/hints');
+	const { runWithCliContext } = await import('../cli/context');
 	const from = createDDL();
 	const to = createDDL();
 
@@ -46,13 +50,21 @@ export const generateMigration = async (
 		to.entities.push(it);
 	}
 
-	const { sqlStatements } = await ddlDiff(
-		from,
-		to,
-		resolver<Table>('table'),
-		resolver<Column>('column'),
-		'default',
-	);
+	const hints = new HintsHandler(parseHints(options?.hints ?? []));
+
+	const { sqlStatements } = await runWithCliContext({ output: 'json', interactive: false }, () =>
+		ddlDiff(
+			from,
+			to,
+			resolver<Table>('table', hints),
+			resolver<Column>('column', hints),
+			'default',
+		));
+
+	if (hints.hasMissingHints()) {
+		const { MissingHintsError } = await import('../cli/errors');
+		throw new MissingHintsError(hints.missingHints);
+	}
 
 	return sqlStatements;
 };
@@ -160,3 +172,6 @@ export const startStudioServer = async (
 };
 
 export { updateToV7 as up } from '../cli/commands/up-sqlite';
+
+export type { MissingHintsError } from '../cli/errors';
+export type { Hint, MissingHint } from '../cli/hints';

--- a/drizzle-kit/tests/other/payload-generate.test.ts
+++ b/drizzle-kit/tests/other/payload-generate.test.ts
@@ -1,0 +1,90 @@
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { integer as sqliteInteger, sqliteTable } from 'drizzle-orm/sqlite-core';
+import { MissingHintsError } from 'src/cli/errors';
+import { generateDrizzleJson as pgJson, generateMigration as pgMigration } from 'src/ext/api-postgres';
+import { generateDrizzleJson as sqliteJson, generateMigration as sqliteMigration } from 'src/payload/sqlite';
+import { expect, test, vi } from 'vitest';
+
+const pgSnapshots = async () => {
+	const prev = await pgJson({ a: pgTable('a', { id: integer('id').primaryKey() }) });
+	const cur = await pgJson({ b: pgTable('b', { id: integer('id').primaryKey(), name: text('name') }) });
+	return { prev, cur };
+};
+
+test('unresolved table create/delete ambiguity throws with the entities listed', async () => {
+	const { prev, cur } = await pgSnapshots();
+
+	const err = await pgMigration(prev, cur).catch((e) => e);
+
+	expect(err).toBeInstanceOf(MissingHintsError);
+	expect((err as MissingHintsError).missingHints).toEqual([
+		{ type: 'rename_or_create', kind: 'table', entity: ['public', 'b'] },
+	]);
+});
+
+test('create hint resolves ambiguity as create plus drop without logging', async () => {
+	const { prev, cur } = await pgSnapshots();
+	const log = vi.spyOn(console, 'log');
+
+	const sql = await pgMigration(prev, cur, {
+		hints: [{ type: 'create', kind: 'table', entity: ['public', 'b'] }],
+	});
+
+	const joined = sql.join('\n');
+	expect(joined).toContain('CREATE TABLE "b"');
+	expect(joined).toContain('DROP TABLE "a"');
+	expect(log).not.toHaveBeenCalled();
+	log.mockRestore();
+});
+
+test('rename hint emits a rename instead of drop and create', async () => {
+	const { prev, cur } = await pgSnapshots();
+
+	const sql = await pgMigration(prev, cur, {
+		hints: [{ type: 'rename', kind: 'table', from: ['public', 'a'], to: ['public', 'b'] }],
+	});
+
+	const joined = sql.join('\n');
+	expect(joined).toContain('RENAME TO "b"');
+	expect(joined).not.toContain('DROP TABLE');
+});
+
+test('column create/delete ambiguity within a table reports column hints', async () => {
+	const prev = await pgJson({
+		users: pgTable('users', { id: integer('id').primaryKey(), firstName: text('first_name') }),
+	});
+	const cur = await pgJson({
+		users: pgTable('users', { id: integer('id').primaryKey(), lastName: text('last_name') }),
+	});
+
+	const err = await pgMigration(prev, cur).catch((e) => e);
+
+	expect(err).toBeInstanceOf(MissingHintsError);
+	expect((err as MissingHintsError).missingHints).toEqual([
+		{ type: 'rename_or_create', kind: 'column', entity: ['public', 'users', 'last_name'] },
+	]);
+});
+
+test('unambiguous diff needs no hints', async () => {
+	const prev = await pgJson({});
+	const cur = await pgJson({ a: pgTable('a', { id: integer('id').primaryKey() }) });
+
+	const sql = await pgMigration(prev, cur);
+
+	expect(sql.join('\n')).toContain('CREATE TABLE "a"');
+});
+
+test('sqlite ambiguity follows the same hints contract', async () => {
+	const prev = await sqliteJson({ a: sqliteTable('a', { id: sqliteInteger('id').primaryKey() }) });
+	const cur = await sqliteJson({ b: sqliteTable('b', { id: sqliteInteger('id').primaryKey() }) });
+
+	const err = await sqliteMigration(prev, cur).catch((e) => e);
+	expect(err).toBeInstanceOf(MissingHintsError);
+
+	const sql = await sqliteMigration(prev, cur, {
+		hints: [{ type: 'create', kind: 'table', entity: ['public', 'b'] }],
+	});
+	const joined = sql.join('\n');
+	expect(joined).toContain('CREATE TABLE `b`');
+	expect(joined).toContain('DROP TABLE `a`');
+});

--- a/integration-tests/tests/mysql/mysql-common-6.ts
+++ b/integration-tests/tests/mysql/mysql-common-6.ts
@@ -160,7 +160,7 @@ export function tests(test: Test, exclude: Set<string> = new Set<string>([])) {
 	});
 
 	// https://github.com/drizzle-team/drizzle-orm/issues/4302
-	test.skipIf(Date.now() < +new Date('2026-07-10')).concurrent(
+	test.skipIf(Date.now() < +new Date('2026-09-04')).concurrent(
 		'insert $returningId: issue #4302',
 		async ({ db, push }) => {
 			const uniqueKeys = ['ao865jf3mcmkfkk8o5ri495z', 'dyqs529eom0iczo2efxzbcut'];


### PR DESCRIPTION
Fixes #6053

`generateMigration` in the payload/api entrypoints called each conflict `resolver(entity)` without a `HintsHandler`, so any diff containing both created and deleted entities of the same kind threw `Internal error: resolver(table) was called without a HintsHandler`, and a programmatic caller had no way to provide hints or enable interactive resolution.

This wires the CLI's hints contract into the programmatic API rather than silently picking a resolution:

- `generateMigration(prev, cur, options?)` accepts `options.hints` with the same shape as the CLI `--hints` flag (`rename` / `create` entries), validated via `parseHints`.
- All resolvers share one `HintsHandler`. When ambiguity remains unresolved after the diff, the call throws the new `MissingHintsError` (`code: 'missing_hints'`) carrying the structured `missingHints` list, mirroring the CLI's `missing_hints` response.
- The diff runs inside `runWithCliContext({ output: 'json', interactive: false })`, so the API never prompts and no longer prints resolver progress lines to stdout.
- Applied to all four entrypoints: `payload/postgres` (`ext/api-postgres`), `payload/sqlite`, `payload/mysql`, `payload/mssql` (keeping the `dbo` default schema). `Hint`, `MissingHint`, and `MissingHintsError` types are re-exported from each.

```ts
await generateMigration(prev, cur);
// MissingHintsError: Ambiguous schema changes require hints to resolve:
// - table public.b: rename of a deleted table or a new one?
// error.missingHints: [{ type: 'rename_or_create', kind: 'table', entity: ['public', 'b'] }]

await generateMigration(prev, cur, {
	hints: [{ type: 'create', kind: 'table', entity: ['public', 'b'] }],
});
// ['CREATE TABLE "b" (...);', 'DROP TABLE "a";']
```

Callers that want plain create + drop semantics can catch the error, map `missingHints` entries to `create` hints, and retry; the first error's list is complete, so one retry always resolves.