### PR TITLE
[Pg] Respect client prepare option in postgres-js unsafe() calls

### DIFF
--- a/drizzle-orm/src/postgres-js/session.ts
+++ b/drizzle-orm/src/postgres-js/session.ts
@@ -50,7 +50,7 @@ export class PostgresJsPreparedQuery<T extends PreparedQueryConfig> extends PgPr
 			if (!fields && !customResultMapper) {
 				return tracer.startActiveSpan('drizzle.driver.execute', () => {
 					return this.queryWithCache(query, params, async () => {
-						return await client.unsafe(query, params as any[]);
+						return await client.unsafe(query, params as any[], { prepare: client.options.prepare });
 					});
 				});
 			}
@@ -61,7 +61,7 @@ export class PostgresJsPreparedQuery<T extends PreparedQueryConfig> extends PgPr
 					'drizzle.query.params': JSON.stringify(params),
 				});
 				return this.queryWithCache(query, params, async () => {
-					return await client.unsafe(query, params as any[]).values();
+					return await client.unsafe(query, params as any[], { prepare: client.options.prepare }).values();
 				});
 			});
 
@@ -87,7 +87,7 @@ export class PostgresJsPreparedQuery<T extends PreparedQueryConfig> extends PgPr
 					'drizzle.query.params': JSON.stringify(params),
 				});
 				return this.queryWithCache(this.queryString, params, async () => {
-					return this.client.unsafe(this.queryString, params as any[]);
+					return this.client.unsafe(this.queryString, params as any[], { prepare: this.client.options.prepare });
 				});
 			});
 		});
@@ -154,14 +154,14 @@ export class PostgresJsSession<
 
 	query(query: string, params: unknown[]): Promise<RowList<Row[]>> {
 		this.logger.logQuery(query, params);
-		return this.client.unsafe(query, params as any[]).values();
+		return this.client.unsafe(query, params as any[], { prepare: this.client.options.prepare }).values();
 	}
 
 	queryObjects<T extends Row>(
 		query: string,
 		params: unknown[],
 	): Promise<RowList<T[]>> {
-		return this.client.unsafe(query, params as any[]);
+		return this.client.unsafe(query, params as any[], { prepare: this.client.options.prepare });
 	}
 
 	override transaction<T>(

--- a/drizzle-orm/tests/postgres-js/prepare.test.ts
+++ b/drizzle-orm/tests/postgres-js/prepare.test.ts
@@ -1,0 +1,45 @@
+import type { Sql } from 'postgres';
+import postgres from 'postgres';
+import { describe, test } from 'vitest';
+import { integer, pgTable } from '~/pg-core/index.ts';
+import { drizzle } from '~/postgres-js/index.ts';
+
+const users = pgTable('users', {
+	id: integer('id').primaryKey(),
+});
+
+function clientWithObservedUnsafeOptions(prepare: boolean) {
+	const client = postgres('postgres://unused:unused@127.0.0.1:1/unused', { prepare }) as Sql & {
+		observedUnsafeOptions: unknown[];
+	};
+	client.observedUnsafeOptions = [];
+	// @ts-expect-error - replaced for observation, never opens a real connection
+	client.unsafe = (_query: string, _params: unknown[], options?: unknown) => {
+		client.observedUnsafeOptions.push(options);
+		return { values: async () => [] };
+	};
+	return client;
+}
+
+describe.concurrent('postgres-js prepare option', () => {
+	/**
+	 * @see https://github.com/drizzle-team/drizzle-orm/issues/6096
+	 */
+	test('a client configured with prepare: true is passed through to unsafe()', async ({ expect }) => {
+		const client = clientWithObservedUnsafeOptions(true);
+		const db = drizzle(client);
+
+		await db.select().from(users);
+
+		expect(client.observedUnsafeOptions).toEqual([{ prepare: true }]);
+	});
+
+	test('a client configured with prepare: false is passed through to unsafe()', async ({ expect }) => {
+		const client = clientWithObservedUnsafeOptions(false);
+		const db = drizzle(client);
+
+		await db.select().from(users);
+
+		expect(client.observedUnsafeOptions).toEqual([{ prepare: false }]);
+	});
+});


### PR DESCRIPTION
Fixes #6096

## What's broken

A `postgres` client created with `{ prepare: true }` still runs every query unprepared through the postgres-js driver. `client.options.prepare` is `true`, but the queries that actually go over the wire ignore it.

## Why

Every call site in `postgres-js/session.ts` (`PostgresJsPreparedQuery.execute`, `.all`, and `PostgresJsSession.query`/`.queryObjects`) calls `client.unsafe(query, params)` with no third argument. postgres.js's own `unsafe()` implementation is:

```js
function unsafe(string, args = [], options = {}) {
  const query = new Query([string], args, handler, cancel, {
    prepare: false,
    ...options,
  })
  ...
}
```

so when nobody passes an `options` object, `prepare` falls straight to postgres.js's own hardcoded `false`, no matter what the client itself was configured with.

## The fix

Pass `{ prepare: client.options.prepare }` explicitly at each of the five call sites, so ordinary queries follow whatever the client was actually configured with instead of postgres.js's internal default.

## How I checked it

Ran a small script against both trees, patching `client.unsafe` to record what it was called with:

```
# main, client configured with prepare: true
client.options.prepare: true
observed options passed to unsafe(): undefined

# this branch, same client
client.options.prepare: true
observed options passed to unsafe(): { prepare: true }
```

Also checked the `prepare: false` direction so the fix doesn't just hardcode `true` and break clients that explicitly opt out:

```
# this branch, client configured with prepare: false
observed options passed to unsafe(): { prepare: false }
```

Added `tests/postgres-js/prepare.test.ts` covering both directions, using a client whose `unsafe` is overridden the same way to avoid needing a live database. It fails on `main` (`expected [ undefined ] to deeply equal [ { prepare: true } ]`) and passes with this change. Ran the full `drizzle-orm` unit suite (`vitest run tests/`): 544 passed, including the two new ones; the two pre-existing failures are an unrelated `better-sqlite3` native-binding issue in this environment, not caused by this change.

## Type

🐛 Bug Fix
