### PR TITLE
[Pg] Run customType codec in sum()/avg() aggregates, matching max()/min()

### DIFF
--- a/drizzle-orm/src/sql/functions/aggregate.ts
+++ b/drizzle-orm/src/sql/functions/aggregate.ts
@@ -48,8 +48,12 @@ export function countDistinct(expression: SQLWrapper): SQL<number> {
  *
  * @see avgDistinct to get the average of all non-null and non-duplicate values in `expression`
  */
-export function avg(expression: SQLWrapper): SQL<string | null> {
-	return sql`avg(${expression})`.mapWith(String);
+export function avg<T extends SQLWrapper>(
+	expression: T,
+): SQL<(T extends AnyColumn ? T['_']['dataType'] extends 'custom' ? T['_']['data'] : string : string) | null> {
+	return sql`avg(${expression})`.mapWith(
+		is(expression, Column) && expression.dataType === 'custom' ? expression : String,
+	) as any;
 }
 
 /**
@@ -64,8 +68,12 @@ export function avg(expression: SQLWrapper): SQL<string | null> {
  *
  * @see avg to get the average of all non-null values in `expression`, including duplicates
  */
-export function avgDistinct(expression: SQLWrapper): SQL<string | null> {
-	return sql`avg(distinct ${expression})`.mapWith(String);
+export function avgDistinct<T extends SQLWrapper>(
+	expression: T,
+): SQL<(T extends AnyColumn ? T['_']['dataType'] extends 'custom' ? T['_']['data'] : string : string) | null> {
+	return sql`avg(distinct ${expression})`.mapWith(
+		is(expression, Column) && expression.dataType === 'custom' ? expression : String,
+	) as any;
 }
 
 /**
@@ -80,8 +88,12 @@ export function avgDistinct(expression: SQLWrapper): SQL<string | null> {
  *
  * @see sumDistinct to get the sum of all non-null and non-duplicate values in `expression`
  */
-export function sum(expression: SQLWrapper): SQL<string | null> {
-	return sql`sum(${expression})`.mapWith(String);
+export function sum<T extends SQLWrapper>(
+	expression: T,
+): SQL<(T extends AnyColumn ? T['_']['dataType'] extends 'custom' ? T['_']['data'] : string : string) | null> {
+	return sql`sum(${expression})`.mapWith(
+		is(expression, Column) && expression.dataType === 'custom' ? expression : String,
+	) as any;
 }
 
 /**
@@ -96,8 +108,12 @@ export function sum(expression: SQLWrapper): SQL<string | null> {
  *
  * @see sum to get the sum of all non-null values in `expression`, including duplicates
  */
-export function sumDistinct(expression: SQLWrapper): SQL<string | null> {
-	return sql`sum(distinct ${expression})`.mapWith(String);
+export function sumDistinct<T extends SQLWrapper>(
+	expression: T,
+): SQL<(T extends AnyColumn ? T['_']['dataType'] extends 'custom' ? T['_']['data'] : string : string) | null> {
+	return sql`sum(distinct ${expression})`.mapWith(
+		is(expression, Column) && expression.dataType === 'custom' ? expression : String,
+	) as any;
 }
 
 /**

--- a/drizzle-orm/tests/sql/aggregate.test.ts
+++ b/drizzle-orm/tests/sql/aggregate.test.ts
@@ -1,0 +1,34 @@
+import { describe, test } from 'vitest';
+import { customType, integer, pgTable } from '~/pg-core/index.ts';
+import { avg, avgDistinct, sum, sumDistinct } from '~/sql/functions/aggregate.ts';
+
+const money = customType<{ data: { usd: string }; driverData: string }>({
+	dataType: () => 'numeric(10, 2)',
+	fromDriver: (value) => ({ usd: String(value) }),
+	toDriver: (value) => value.usd,
+});
+
+const accounts = pgTable('accounts', {
+	id: integer('id').primaryKey(),
+	balance: money('balance').notNull(),
+	plainBalance: integer('plain_balance').notNull(),
+});
+
+describe.concurrent('aggregate functions', () => {
+	/**
+	 * @see https://github.com/drizzle-team/drizzle-orm/issues/6085
+	 */
+	test("sum() and avg() run a customType column's mapFromDriverValue, same as max()/min()", ({ expect }) => {
+		expect((sum(accounts.balance) as any).decoder.mapFromDriverValue('20.20')).toEqual({ usd: '20.20' });
+		expect((sumDistinct(accounts.balance) as any).decoder.mapFromDriverValue('20.20')).toEqual({ usd: '20.20' });
+		expect((avg(accounts.balance) as any).decoder.mapFromDriverValue('10.10')).toEqual({ usd: '10.10' });
+		expect((avgDistinct(accounts.balance) as any).decoder.mapFromDriverValue('10.10')).toEqual({ usd: '10.10' });
+	});
+
+	test('sum() and avg() still map plain (non-customType) columns through String', ({ expect }) => {
+		expect((sum(accounts.plainBalance) as any).decoder.mapFromDriverValue('123.45')).toBe('123.45');
+		expect((sumDistinct(accounts.plainBalance) as any).decoder.mapFromDriverValue('123.45')).toBe('123.45');
+		expect((avg(accounts.plainBalance) as any).decoder.mapFromDriverValue('123.45')).toBe('123.45');
+		expect((avgDistinct(accounts.plainBalance) as any).decoder.mapFromDriverValue('123.45')).toBe('123.45');
+	});
+});


### PR DESCRIPTION
Fixes #6085

## What's broken

`sum()` and `avg()` (and their `Distinct` variants) drop a column's `customType` codec. `max()`/`min()` already run it, and so does a plain row read, but the sum/avg family hardcodes `.mapWith(String)` no matter what column you hand it.

```ts
const money = customType<{ data: { usd: string }; driverData: string }>({
  dataType: () => 'numeric(10, 2)',
  fromDriver: (value) => ({ usd: String(value) }),
  toDriver: (value) => value.usd,
});

const accounts = pgTable('accounts', {
  balance: money('balance').notNull(),
});

(await db.select().from(accounts))[0].balance;                       // { usd: '10.10' }   codec applied
(await db.select({ m: max(accounts.balance) }).from(accounts))[0].m; // { usd: '10.10' }   codec applied
(await db.select({ s: sum(accounts.balance) }).from(accounts))[0].s; // '20.20'            raw string, codec dropped
```

Typed as `string | null`, so it still compiles and quietly concatenates instead of adding on a total.

## The fix

`max()`/`min()` already do `.mapWith(is(expression, Column) ? expression : String)` — if you pass a column, decode with the column, otherwise treat the SQL result as a plain string. `sum()`/`avg()` can't copy that as-is: unlike max/min, they compute a new value that can be far larger than anything actually stored in the column, so routing every column through its own decoder isn't safe in general (a `mapWith(Number)` on a huge `sum()` can silently overflow, which is exactly why sum/avg return a string by default).

customType is different: the user wrote `fromDriver` themselves, so they own overflow handling and whatever else the decode needs to do. So the condition is narrowed to that one case: `is(expression, Column) && expression.dataType === 'custom' ? expression : String`. Every other column type keeps mapping through `String`, unchanged.

The return type mirrors `max()`/`min()`'s existing generic shape, just gated on `dataType extends 'custom'` instead of "is any column":

```ts
export function sum<T extends SQLWrapper>(
  expression: T,
): SQL<(T extends AnyColumn ? T['_']['dataType'] extends 'custom' ? T['_']['data'] : string : string) | null> {
```

Applied to all four (`sum`, `sumDistinct`, `avg`, `avgDistinct`) since they share the exact same bug.

## How I checked it

Built the customType example from the issue and inspected each function's `.decoder.mapFromDriverValue` directly (no DB needed — same thing the query executor calls on the raw driver value):

```
# main
sum decoder result: 20.20                          <- codec dropped
max decoder result: { usd: '10.10' }                <- already correct

# this branch
sum decoder result: { usd: '20.20' }                <- codec applied
max decoder result: { usd: '10.10' }                <- unchanged
plain (non-customType) sum decoder result: 123.45   <- unchanged, still a raw string
```

Added `tests/sql/aggregate.test.ts` covering both the customType and plain-column cases for all four functions. It fails on `main` (`expected '20.20' to deeply equal { usd: '20.20' }`) and passes with this change. `tsc --noEmit` is clean on both the package build config and `type-tests/`, and the full unit suite passes (544 tests, plus the 2 new ones here).

## Type

🐛 Bug Fix
