### PR TITLE
[Kit] Fail loud on the removed v0 `casing` config param instead of silently ignoring it

### DIFF
--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -12,6 +12,7 @@ import {
 	MigrationSnapshotNotFoundCliError,
 	MigrationSqlFilesConflictCliError,
 	MissingDialectCliError,
+	RemovedConfigParamCliError,
 	RequiredParamsCliError,
 	UnsupportedCommandCliError,
 } from '../errors';
@@ -22,7 +23,7 @@ import { printConfigConnectionIssues as printCockroachIssues } from '../validati
 import type { EntitiesFilterConfig } from '../validations/common';
 import { pullParams, pushParams } from '../validations/common';
 import type { Casing, CliConfig, Driver } from '../validations/common';
-import { configCommonSchema, configMigrations, wrapParam } from '../validations/common';
+import { casingTypes, configCommonSchema, configMigrations, wrapParam } from '../validations/common';
 import { studioCliParams, studioConfig } from '../validations/common';
 import { duckdbCredentials, printConfigConnectionIssues as printIssuesDuckDb } from '../validations/duckdb';
 import type { LibSQLCredentials } from '../validations/libsql';
@@ -954,6 +955,25 @@ export const drizzleConfigFromFile = async (
 	if (!isExport) humanLog(`Reading config file '${path}'`);
 
 	const content = await loadModule<any>(path, { defaultExport: true });
+
+	// v0's top-level `casing` ("snake_case" | "camelCase") was removed in 1.0.0-rc.1 in favor of
+	// schema-level casing (`snakeCase.table(...)`). `configCommonSchema` is `.passthrough()`, so
+	// without this check the param is silently ignored and generate/push then propose renaming
+	// every snake_case column back to its camelCase property key. Pull's `casing`
+	// ("camel" | "preserve") is a different, still-supported param and passes through untouched.
+	if (content !== null && typeof content === 'object' && casingTypes.includes(content['casing'])) {
+		throw new RemovedConfigParamCliError(
+			'casing',
+			error(
+				`The '${
+					chalk.red('casing')
+				}' config param was removed in 1.0.0-rc.1 — casing is now declared on the schema itself:\n\n`
+					+ `  import { snakeCase } from 'drizzle-orm/pg-core';\n\n`
+					+ `  const users = snakeCase.table('users', { ... });\n\n`
+					+ `See https://github.com/drizzle-team/drizzle-orm/releases/tag/v1.0.0-rc.1 for the new casing API`,
+			),
+		);
+	}
 
 	// --- get response and then check by each dialect independently
 	const res = configCommonSchema.safeParse(content);

--- a/drizzle-kit/src/cli/errors.ts
+++ b/drizzle-kit/src/cli/errors.ts
@@ -98,6 +98,12 @@ export class ConfigValidationCliError extends DrizzleCliError {
 	}
 }
 
+export class RemovedConfigParamCliError extends DrizzleCliError {
+	constructor(param: string, humanMessage: string) {
+		super('removed_config_param_error', humanMessage, { param });
+	}
+}
+
 export class MissingConfigDialectCliError extends DrizzleCliError {
 	constructor() {
 		super('missing_config_dialect_error', error("Please specify 'dialect' param in config file"), { field: 'dialect' });

--- a/drizzle-kit/tests/other/cli-generate.test.ts
+++ b/drizzle-kit/tests/other/cli-generate.test.ts
@@ -458,6 +458,24 @@ test('validate config #4', async (t) => {
 	expect((res.error as Error).name).toBe('ConfigValidationCliError');
 });
 
+// v0's top-level `casing` param was removed in 1.0.0-rc.1 (schema-level casing replaced it);
+// the passthrough config schema would silently ignore it — it must fail loud instead.
+test('validate config: removed v0 `casing` param', async (t) => {
+	const { path, name } = createConfig(
+		// @ts-expect-error
+		{ dialect: 'postgresql', schema: 'schema.ts', casing: 'snake_case' },
+		prefix,
+	);
+
+	const res = await brotest(generate, `--config=${name}`);
+
+	unlinkSync(path);
+
+	expect(res.type).toBe('error');
+	if (res.type !== 'error') return;
+	expect((res.error as Error).name).toBe('RemovedConfigParamCliError');
+});
+
 test('validate config #5', async (t) => {
 	const { path, name } = createConfig({
 		dialect: 'sqlite',


### PR DESCRIPTION
## Problem

v1.0.0-rc.1 deliberately removed the v0 config-level `casing` param (the New Casing API moved casing onto the schema: `snakeCase.table(...)`). The `Config` type correctly rejects it — but `configCommonSchema` is `.passthrough()`, so at runtime a leftover `casing: 'snake_case'` from a v0 config is **silently dropped for every command**, with no warning:

- Verified against the published `drizzle-kit@1.0.0-rc.4`: `generate` emits byte-identical DDL with and without `casing: 'snake_case'` in the config — camelCase column names, exit 0, no diagnostic.
- With a JS config (or a TS config that isn't type-checked — the situation in #5755, where the reporter saw the TS error and the silent runtime ignore), `generate`/`push` then propose renaming every snake_case column back to its camelCase property key. On `push`, accepting that prompt executes renames against a live database.

#5755 was closed with the (correct) answer that this is an intentional breaking change — this PR makes the breakage *loud* for everyone who migrates a v0 project without reading the rc.1 notes.

## Change

`drizzleConfigFromFile` now rejects a config carrying the **removed v0 vocabulary only** (`'snake_case' | 'camelCase'`, reusing the existing `casingTypes` constant) with a new `RemovedConfigParamCliError` (`removed_config_param_error`) pointing at the new API:

```
Error  The 'casing' config param was removed in 1.0.0-rc.1 — casing is now declared on the schema itself:

  import { snakeCase } from 'drizzle-orm/pg-core';

  const users = snakeCase.table('users', { ... });

See https://github.com/drizzle-team/drizzle-orm/releases/tag/v1.0.0-rc.1 for the new casing API
```

Pull's live top-level `casing` (`'camel' | 'preserve'`) is a disjoint vocabulary and passes through untouched. All commands funnel through `drizzleConfigFromFile`, so one seam covers generate/push/pull/export/studio/migrate/check/drop.

## Testing

- Added a case to `tests/other/cli-generate.test.ts` alongside the existing `validate config` cases — green.
- `pnpm vitest run tests/other/cli-generate.test.ts` on Windows: 14 pre-existing failures before and after the change (path-separator expectations, unrelated); the delta is only the new passing test.
- Manual smoke via `tsx src/cli/index.ts generate --config=...` produces the output above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
