### PR TITLE
docs: fix all config link extension in eslint plugin readme

### DIFF
--- a/eslint-plugin-drizzle/readme.md
+++ b/eslint-plugin-drizzle/readme.md
@@ -34,7 +34,7 @@ rules:
 
 ### All config
 
-This plugin exports an [`all` config](src/configs/all.js) that makes use of all rules (except for deprecated ones).
+This plugin exports an [`all` config](src/configs/all.ts) that makes use of all rules (except for deprecated ones).
 
 ```yml
 root: true


### PR DESCRIPTION
The eslint-plugin-drizzle README links its `all` config as `src/configs/all.js`, but the plugin sources are TypeScript and there is no `all.js` in `src/configs/` (only `all.ts`), so the link 404s on GitHub and npm.

Updated the link to `src/configs/all.ts` to match the actual source file.
