### PR TITLE
[Relations]: Add "including" support for junction table columns on through() relations

### DIFF
--- a/changelogs/drizzle-orm/1.0.0-rc.5.md
+++ b/changelogs/drizzle-orm/1.0.0-rc.5.md
@@ -50,3 +50,4 @@
 - Fixed [[BUG]: node-postgres pool client is not released when transaction BEGIN rejects](https://github.com/drizzle-team/drizzle-orm/issues/6023)
 - Fixed [Batch insert crashes with RangeError when row-count × column-count exceeds ~8 k rows × 15 cols (~120 k params)](https://github.com/drizzle-team/drizzle-orm/issues/5994)
 - Fixed [[BUG]: Composition of not and or/and yields compile error](https://github.com/drizzle-team/drizzle-orm/issues/4160)
+- Added `including` option to `one()`/`many()` relation configs to select extra columns from the junction table on `through()` relations, flattened onto each result row (fixes [#5327](https://github.com/drizzle-team/drizzle-orm/issues/5327))

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -949,6 +949,8 @@ export class MySqlDialect {
 		depth,
 		isNestedMany,
 		throughJoin,
+		throughTable,
+		including,
 		nested,
 	}: {
 		schema: TablesRelationalConfig;
@@ -961,6 +963,8 @@ export class MySqlDialect {
 		depth?: number;
 		isNestedMany?: boolean;
 		throughJoin?: SQL;
+		throughTable?: MySqlTable | MySqlView;
+		including?: { key: string; column: unknown }[];
 		nested?: boolean;
 	}): BuildRelationalQueryResult {
 		const selection: BuildRelationalQueryResult['selection'] = [];
@@ -1003,6 +1007,13 @@ export class MySqlDialect {
 
 		const selectionArr: SQL[] = columns ? [columns] : [];
 		if (extras?.sql) selectionArr.push(extras.sql);
+		if (including?.length && throughTable) {
+			for (const inc of including) {
+				selectionArr.push(
+					this.buildRqbColumn(throughTable, inc.column, inc.key, !!nested, selection, tableConfig.name),
+				);
+			}
+		}
 
 		let joins: SQL | undefined;
 		switch (params) {
@@ -1057,6 +1068,8 @@ export class MySqlDialect {
 						depth: currentDepth + 1,
 						isNestedMany: !isSingle,
 						throughJoin,
+						throughTable: throughTable as MySqlTable | MySqlView | undefined,
+						including: relation.including,
 						nested: true,
 					});
 

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -936,6 +936,8 @@ export class PgDialect {
 		errorPath,
 		depth,
 		throughJoin,
+		throughTable,
+		including,
 		nested,
 	}: {
 		schema: TablesRelationalConfig;
@@ -947,6 +949,8 @@ export class PgDialect {
 		errorPath?: string;
 		depth?: number;
 		throughJoin?: SQL;
+		throughTable?: PgTable | PgView;
+		including?: { key: string; column: unknown }[];
 		nested?: boolean;
 	}): BuildRelationalQueryResult {
 		const selection: BuildRelationalQueryResult['selection'] = [];
@@ -989,6 +993,13 @@ export class PgDialect {
 		const selectionArr: SQL[] = [];
 		if (columns) selectionArr.push(columns);
 		if (extras?.sql) selectionArr.push(extras.sql);
+		if (including?.length && throughTable) {
+			for (const inc of including) {
+				selectionArr.push(
+					this.buildRqbColumn(throughTable, inc.column, inc.key, !!nested, selection, tableConfig.name),
+				);
+			}
+		}
 
 		let joins: SQL | undefined;
 		switch (params) {
@@ -1044,6 +1055,8 @@ export class PgDialect {
 						errorPath: `${currentPath.length ? `${currentPath}.` : ''}${k}`,
 						depth: currentDepth + 1,
 						throughJoin,
+						throughTable: throughTable as PgTable | PgView | undefined,
+						including: relation.including,
 						nested: true,
 					});
 

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -1,7 +1,7 @@
 import { IsAlias, OriginalName, Table, TableColumns, TableSchema } from '~/table.ts';
 import { aliasedTable } from './alias.ts';
 import type { CodecsCollection, NormalizeArrayCodec, NormalizeCodec } from './codecs.ts';
-import { type AnyColumn, Column } from './column.ts';
+import { type AnyColumn, Column, type GetColumnData } from './column.ts';
 import { entityKind, is } from './entity.ts';
 import { DrizzleError } from './errors.ts';
 import {
@@ -295,6 +295,8 @@ export abstract class Relation<
 	static readonly [entityKind]: string = 'RelationV2';
 	declare readonly $brand: 'RelationV2';
 	declare public readonly relationType: 'many' | 'one';
+	/** @internal type-only, never assigned at runtime */
+	declare readonly $including: Record<string, unknown>;
 
 	fieldName!: string;
 	sourceColumns!: Column<any>[];
@@ -308,6 +310,8 @@ export abstract class Relation<
 		target: RelationsBuilderColumnBase[];
 	};
 	throughTable?: SchemaEntry;
+	/** Extra columns selected off the junction ("through") table, flattened onto each result row. */
+	including?: { key: string; column: FieldValue }[];
 	isFilterReversed?: boolean;
 
 	/** @internal */
@@ -325,12 +329,50 @@ export abstract class Relation<
 
 export type AnyRelation = Relation<string>;
 
+/** @internal */
+export function resolveIncluding(
+	tables: Schema,
+	targetTableName: string,
+	throughTable: SchemaEntry | undefined,
+	including:
+		| RelationsBuilderColumnBase
+		| RelationsBuilderColumnBase[]
+		| Record<string, RelationsBuilderColumnBase>
+		| undefined,
+): { key: string; column: FieldValue }[] | undefined {
+	if (!including) return undefined;
+
+	if (!throughTable) {
+		throw new Error(
+			`relations -> ${targetTableName}: "including" can only be used together with "through()"`,
+		);
+	}
+
+	const entries: [string, RelationsBuilderColumnBase][] = Array.isArray(including)
+		? including.map((c) => [c._.key, c] as [string, RelationsBuilderColumnBase])
+		: '_' in including
+		? [[(including as RelationsBuilderColumnBase)._.key, including as RelationsBuilderColumnBase]]
+		: Object.entries(including as Record<string, RelationsBuilderColumnBase>);
+
+	return entries.map(([key, c]) => {
+		if (tables[c._.tableName] !== throughTable) {
+			throw new Error(
+				`relations -> ${targetTableName}: "including" columns must belong to the junction table used in "through()"`,
+			);
+		}
+		return { key, column: c._.column };
+	});
+}
+
 export class One<
 	TTargetTableName extends string,
 	TOptional extends boolean = boolean,
+	TIncluding extends Record<string, unknown> = Record<string, never>,
 > extends Relation<TTargetTableName> {
 	static override readonly [entityKind]: string = 'OneV2';
 	declare protected $relationBrand: 'OneV2';
+	/** @internal type-only, never assigned at runtime */
+	declare readonly $including: TIncluding;
 
 	public override readonly relationType = 'one' as const;
 
@@ -383,15 +425,21 @@ export class One<
 				target: (Array.isArray(config?.to) ? config.to : config?.to ? [config.to] : []).map((c) => c._.through!),
 			};
 		}
+		this.including = resolveIncluding(tables, targetTableName, this.throughTable, config?.including);
 		this.optional = (config?.optional ?? true) as TOptional;
 	}
 }
 
-export type AnyOne = One<string, boolean>;
+export type AnyOne = One<string, boolean, Record<string, unknown>>;
 
-export class Many<TTargetTableName extends string> extends Relation<TTargetTableName> {
+export class Many<
+	TTargetTableName extends string,
+	TIncluding extends Record<string, unknown> = Record<string, never>,
+> extends Relation<TTargetTableName> {
 	static override readonly [entityKind]: string = 'ManyV2';
 	declare protected $relationBrand: 'ManyV2';
+	/** @internal type-only, never assigned at runtime */
+	declare readonly $including: TIncluding;
 
 	public override readonly relationType = 'many' as const;
 
@@ -441,10 +489,11 @@ export class Many<TTargetTableName extends string> extends Relation<TTargetTable
 				target: (Array.isArray(config?.to) ? config.to : config?.to ? [config.to] : []).map((c) => c._.through!),
 			};
 		}
+		this.including = resolveIncluding(tables, targetTableName, this.throughTable, config?.including);
 	}
 }
 
-export type AnyMany = Many<string>;
+export type AnyMany = Many<string, Record<string, unknown>>;
 
 export abstract class AggregatedField<T = unknown> implements SQLWrapper<T> {
 	static readonly [entityKind]: string = 'AggregatedField';
@@ -665,13 +714,13 @@ export type ReturnTypeOrValue<T> = T extends (...args: any[]) => infer R ? R
 	: T;
 
 export type RelationResultKind<TResult, TInclude, TRelation extends AnyRelation> = TRelation extends AnyOne ? (
-		| TResult
+		| Simplify<TResult & TRelation['$including']>
 		| (Equal<TRelation['optional'], true> extends true ? null
 			: TInclude extends Record<string, unknown> ? TInclude['where'] extends Record<string, any> ? null
 				: never
 			: never)
 	)
-	: TResult[];
+	: Simplify<TResult & TRelation['$including']>[];
 
 export type BuildRelationResult<
 	TConfig extends TablesRelationalConfig,
@@ -1350,17 +1399,18 @@ export interface RelationsBuilderColumnBase<
 
 export class RelationsBuilderColumn<
 	TTableName extends string = string,
+	TColumn extends FieldValue = FieldValue,
 > implements RelationsBuilderColumnBase<TTableName> {
 	static readonly [entityKind]: string = 'RelationsBuilderColumn';
 
 	readonly _: {
 		readonly tableName: TTableName;
-		readonly column: FieldValue;
+		readonly column: TColumn;
 		readonly key: string;
 	};
 
 	constructor(
-		column: FieldValue,
+		column: TColumn,
 		tableName: TTableName,
 		key: string,
 	) {
@@ -1536,6 +1586,8 @@ export interface OneConfig<TTargetTable extends SchemaEntry, TOptional extends b
 	where?: TableFilter<TTargetTable> | EmptyFilter;
 	optional?: TOptional;
 	alias?: string;
+	/** Extra columns to select off the junction table declared via `.through()`, flattened onto each result row. */
+	including?: RelationsBuilderColumnBase | RelationsBuilderColumnBase[] | Record<string, RelationsBuilderColumnBase>;
 }
 
 export type AnyOneConfig = OneConfig<
@@ -1548,16 +1600,37 @@ export interface ManyConfig<TTargetTable extends SchemaEntry> {
 	to?: RelationsBuilderColumnBase | [RelationsBuilderColumnBase, ...RelationsBuilderColumnBase[]];
 	where?: TableFilter<TTargetTable> | EmptyFilter;
 	alias?: string;
+	/** Extra columns to select off the junction table declared via `.through()`, flattened onto each result row. */
+	including?: RelationsBuilderColumnBase | RelationsBuilderColumnBase[] | Record<string, RelationsBuilderColumnBase>;
 }
 
 export type AnyManyConfig = ManyConfig<SchemaEntry>;
 
+/** Infers the data type produced by selecting a single junction column via `including`. */
+export type InferIncludingColumn<C> = C extends { _: { column: infer TCol } }
+	? TCol extends Column ? GetColumnData<TCol, 'query'> : unknown
+	: never;
+
+/** Infers the `{ key: dataType }` shape contributed by a relation's `including` config. */
+export type InferIncluding<TConfig> = TConfig extends { including: infer TIncluding }
+	? TIncluding extends readonly RelationsBuilderColumnBase[] ? Simplify<
+			{ [C in TIncluding[number] as C['_']['key']]: InferIncludingColumn<C> }
+		>
+	: TIncluding extends Record<string, RelationsBuilderColumnBase>
+		? Simplify<{ [K in keyof TIncluding]: InferIncludingColumn<TIncluding[K]> }>
+	: {}
+	: {};
+
 export interface OneFn<TTargetTable extends SchemaEntry, TTargetTableName extends string> {
-	<TOptional extends boolean = true>(config?: OneConfig<TTargetTable, TOptional>): One<TTargetTableName, TOptional>;
+	<TOptional extends boolean = true, TConfig extends OneConfig<TTargetTable, TOptional> | undefined = undefined>(
+		config?: TConfig,
+	): One<TTargetTableName, TOptional, InferIncluding<TConfig>>;
 }
 
 export interface ManyFn<TTargetTable extends SchemaEntry, TTargetTableName extends string> {
-	(config?: ManyConfig<TTargetTable>): Many<TTargetTableName>;
+	<TConfig extends ManyConfig<TTargetTable> | undefined = undefined>(
+		config?: TConfig,
+	): Many<TTargetTableName, InferIncluding<TConfig>>;
 }
 
 export class RelationsHelperStatic<TTables extends Schema> {
@@ -1603,7 +1676,8 @@ export type RelationsBuilderColumns<TTable extends SchemaEntry, TTableName exten
 	[
 		TColumnName in keyof GetTableViewColumns<TTable>
 	]: RelationsBuilderColumn<
-		TTableName
+		TTableName,
+		GetTableViewColumns<TTable>[TColumnName] & FieldValue
 	>;
 };
 

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -1248,6 +1248,8 @@ export class SingleStoreDialect {
 		depth,
 		isNestedMany,
 		throughJoin,
+		throughTable,
+		including,
 	}: {
 		schema: TablesRelationalConfig;
 		table: SingleStoreTable | SingleStoreView;
@@ -1259,6 +1261,8 @@ export class SingleStoreDialect {
 		depth?: number;
 		isNestedMany?: boolean;
 		throughJoin?: SQL;
+		throughTable?: SingleStoreTable | SingleStoreView;
+		including?: { key: string; column: unknown }[];
 	}): BuildRelationalQueryResultWithOrder {
 		const selection: BuildRelationalQueryResult['selection'] = [];
 		const isSingle = mode === 'first';
@@ -1300,6 +1304,11 @@ export class SingleStoreDialect {
 
 		const selectionArr: SQL[] = columns ? [columns] : [];
 		if (extras?.sql) selectionArr.push(extras.sql);
+		if (including?.length && throughTable) {
+			for (const inc of including) {
+				selectionArr.push(this.buildRqbColumn(throughTable, inc.column, inc.key, selection, tableConfig.name));
+			}
+		}
 
 		let joins: SQL | undefined;
 		switch (params) {
@@ -1359,6 +1368,8 @@ export class SingleStoreDialect {
 						depth: currentDepth + 1,
 						isNestedMany: !isSingle,
 						throughJoin,
+						throughTable: throughTable as SingleStoreTable | SingleStoreView | undefined,
+						including: relation.including,
 					});
 
 					selection.push({

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -881,6 +881,8 @@ export class SQLiteDialect {
 		errorPath,
 		depth,
 		throughJoin,
+		throughTable,
+		including,
 		jsonb,
 	}: {
 		schema: TablesRelationalConfig;
@@ -893,6 +895,8 @@ export class SQLiteDialect {
 		errorPath?: string;
 		depth?: number;
 		throughJoin?: SQL;
+		throughTable?: SQLiteTable | SQLiteView;
+		including?: { key: string; column: unknown }[];
 		jsonb: SQL;
 	}): BuildRelationalQueryResult {
 		const selection: BuildRelationalQueryResult['selection'] = [];
@@ -932,6 +936,15 @@ export class SQLiteDialect {
 			? relationExtrasToSQL(table, params.extras)
 			: undefined;
 		if (extras) selection.push(...extras.selection);
+
+		const throughColumns = including?.length && throughTable
+			? sql.join(
+				including.map((inc) =>
+					this.buildRqbColumn(throughTable, inc.column, inc.key, !!isNested, selection, tableConfig.name)
+				),
+				new StringChunk(', '),
+			)
+			: undefined;
 
 		let joins: SQL | undefined;
 		switch (params) {
@@ -980,6 +993,8 @@ export class SQLiteDialect {
 						errorPath: `${currentPath.length ? `${currentPath}.` : ''}${k}`,
 						depth: currentDepth + 1,
 						throughJoin,
+						throughTable: throughTable as SQLiteTable | SQLiteView | undefined,
+						including: relation.including,
 						jsonb,
 					});
 
@@ -1030,7 +1045,7 @@ export class SQLiteDialect {
 			}
 		}
 
-		const selectionArr = [columns, extras?.sql, joins].filter(
+		const selectionArr = [columns, throughColumns, extras?.sql, joins].filter(
 			(e) => e !== undefined,
 		);
 		if (!selectionArr.length) {

--- a/drizzle-orm/tests/rqb-builders.test.ts
+++ b/drizzle-orm/tests/rqb-builders.test.ts
@@ -655,6 +655,79 @@ describe('Reverse-derived relation filter binding (isFilterReversed)', () => {
 	});
 });
 
+describe('Including (junction table columns on through relations)', () => {
+	const contacts = pgTable('contacts', { id: integer(), name: text() });
+	const garages = pgTable('garages', { id: integer(), name: text() });
+	const contactsToGarages = pgTable('contacts_to_garages', {
+		contactId: integer(),
+		garageId: integer(),
+		role: text(),
+	});
+	const schema = { contacts, garages, contactsToGarages };
+
+	test('array form selects junction columns and keys them by column name', () => {
+		const db = drizzle.mock({
+			relations: defineRelations(schema, (r) => ({
+				contacts: {
+					garages: r.many.garages({
+						from: r.contacts.id.through(r.contactsToGarages.contactId),
+						to: r.garages.id.through(r.contactsToGarages.garageId),
+						including: [r.contactsToGarages.role],
+					}),
+				},
+			})),
+		});
+
+		const { sql } = db.query.contacts.findMany({ with: { garages: true } }).toSQL();
+		expect(sql).toContain('"tr0"."role" as "role"');
+	});
+
+	test('record form selects junction columns under a renamed key', () => {
+		const db = drizzle.mock({
+			relations: defineRelations(schema, (r) => ({
+				contacts: {
+					garages: r.many.garages({
+						from: r.contacts.id.through(r.contactsToGarages.contactId),
+						to: r.garages.id.through(r.contactsToGarages.garageId),
+						including: { membershipRole: r.contactsToGarages.role },
+					}),
+				},
+			})),
+		});
+
+		const { sql } = db.query.contacts.findMany({ with: { garages: true } }).toSQL();
+		expect(sql).toContain('"tr0"."role" as "membershipRole"');
+	});
+
+	test('including without through() throws', () => {
+		expect(() =>
+			defineRelations(schema, (r) => ({
+				contacts: {
+					garages: r.many.garages({
+						from: r.contacts.id,
+						to: r.garages.id,
+						including: [r.contactsToGarages.role],
+					}),
+				},
+			}))
+		).toThrowError(`"including" can only be used together with "through()"`);
+	});
+
+	test('including column from a table other than the junction table throws', () => {
+		expect(() =>
+			defineRelations(schema, (r) => ({
+				contacts: {
+					garages: r.many.garages({
+						from: r.contacts.id.through(r.contactsToGarages.contactId),
+						to: r.garages.id.through(r.contactsToGarages.garageId),
+						including: [r.garages.name],
+					}),
+				},
+			}))
+		).toThrowError(`"including" columns must belong to the junction table used in "through()"`);
+	});
+});
+
 describe('Relation names shadowing Object.prototype properties', () => {
 	const results = pgTable('results', { id: integer(), constructorId: integer() });
 	const constructors = pgTable('constructors', { id: integer(), name: text() });

--- a/integration-tests/tests/mysql/mysql.relations.ts
+++ b/integration-tests/tests/mysql/mysql.relations.ts
@@ -53,6 +53,12 @@ export default defineRelations(schema, (r) => ({
 			to: r.groupsTable.id.through(r.usersToGroupsTable.groupId),
 			alias: 'users-groups-direct',
 		}),
+		groupsWithMembershipId: r.many.groupsTable({
+			from: r.usersTable.id.through(r.usersToGroupsTable.userId),
+			to: r.groupsTable.id.through(r.usersToGroupsTable.groupId),
+			including: { membershipId: r.usersToGroupsTable.id },
+			alias: 'users-groups-membership',
+		}),
 		groupsFiltered: r.many.groupsTable({
 			alias: 'users-groups-direct-filtered',
 		}),

--- a/integration-tests/tests/mysql/mysql.test.ts
+++ b/integration-tests/tests/mysql/mysql.test.ts
@@ -6680,6 +6680,79 @@ test('[Find Many .through] Get users with groups', async (t) => {
 	}]);
 });
 
+test('[Find Many .through] Get users with groups and junction "including" column', async (t) => {
+	const { mysqlDbV2: db } = t;
+
+	await db.insert(usersTable).values([
+		{ id: 1, name: 'Dan' },
+		{ id: 2, name: 'Andrew' },
+	]);
+
+	await db.insert(groupsTable).values([
+		{ id: 1, name: 'Group1' },
+		{ id: 2, name: 'Group2' },
+	]);
+
+	await db.insert(usersToGroupsTable).values([
+		{ id: 10, userId: 1, groupId: 1 },
+		{ id: 11, userId: 1, groupId: 2 },
+		{ id: 12, userId: 2, groupId: 2 },
+	]);
+
+	const response = await db.query.usersTable.findMany({
+		with: {
+			groupsWithMembershipId: true,
+		},
+	});
+
+	expectTypeOf(response).toEqualTypeOf<{
+		id: number;
+		name: string;
+		verified: boolean;
+		invitedBy: number | null;
+		groupsWithMembershipId: {
+			id: number;
+			name: string;
+			description: string | null;
+			membershipId: number;
+		}[];
+	}[]>();
+
+	response.sort((a, b) => (a.id > b.id) ? 1 : -1);
+	for (const e of response) {
+		e.groupsWithMembershipId.sort((a, b) => (a.id > b.id) ? 1 : -1);
+	}
+
+	expect(response).toStrictEqual([{
+		id: 1,
+		name: 'Dan',
+		verified: false,
+		invitedBy: null,
+		groupsWithMembershipId: [{
+			id: 1,
+			name: 'Group1',
+			description: null,
+			membershipId: 10,
+		}, {
+			id: 2,
+			name: 'Group2',
+			description: null,
+			membershipId: 11,
+		}],
+	}, {
+		id: 2,
+		name: 'Andrew',
+		verified: false,
+		invitedBy: null,
+		groupsWithMembershipId: [{
+			id: 2,
+			name: 'Group2',
+			description: null,
+			membershipId: 12,
+		}],
+	}]);
+});
+
 test('[Find Many .through] Get groups with users', async (t) => {
 	const { mysqlDbV2: db } = t;
 

--- a/integration-tests/tests/pg/pg.relations.ts
+++ b/integration-tests/tests/pg/pg.relations.ts
@@ -53,6 +53,12 @@ export default defineRelations(schema, (r) => ({
 			to: r.groupsTable.id.through(r.usersToGroupsTable.groupId),
 			alias: 'users-groups-direct',
 		}),
+		groupsWithMembershipId: r.many.groupsTable({
+			from: r.usersTable.id.through(r.usersToGroupsTable.userId),
+			to: r.groupsTable.id.through(r.usersToGroupsTable.groupId),
+			including: { membershipId: r.usersToGroupsTable.id },
+			alias: 'users-groups-membership',
+		}),
 		groupsFiltered: r.many.groupsTable({
 			alias: 'users-groups-direct-filtered',
 		}),

--- a/integration-tests/tests/pg/pg.test.ts
+++ b/integration-tests/tests/pg/pg.test.ts
@@ -6549,6 +6549,79 @@ test('[Find Many .through] Get users with groups', async (t) => {
 	}]);
 });
 
+test('[Find Many .through] Get users with groups and junction "including" column', async (t) => {
+	const { pgDbV2: db } = t;
+
+	await db.insert(usersTable).values([
+		{ id: 1, name: 'Dan' },
+		{ id: 2, name: 'Andrew' },
+	]);
+
+	await db.insert(groupsTable).values([
+		{ id: 1, name: 'Group1' },
+		{ id: 2, name: 'Group2' },
+	]);
+
+	await db.insert(usersToGroupsTable).values([
+		{ id: 10, userId: 1, groupId: 1 },
+		{ id: 11, userId: 1, groupId: 2 },
+		{ id: 12, userId: 2, groupId: 2 },
+	]);
+
+	const response = await db.query.usersTable.findMany({
+		with: {
+			groupsWithMembershipId: true,
+		},
+	});
+
+	expectTypeOf(response).toEqualTypeOf<{
+		id: number;
+		name: string;
+		verified: boolean;
+		invitedBy: number | null;
+		groupsWithMembershipId: {
+			id: number;
+			name: string;
+			description: string | null;
+			membershipId: number;
+		}[];
+	}[]>();
+
+	response.sort((a, b) => (a.id > b.id) ? 1 : -1);
+	for (const e of response) {
+		e.groupsWithMembershipId.sort((a, b) => (a.id > b.id) ? 1 : -1);
+	}
+
+	expect(response).toStrictEqual([{
+		id: 1,
+		name: 'Dan',
+		verified: false,
+		invitedBy: null,
+		groupsWithMembershipId: [{
+			id: 1,
+			name: 'Group1',
+			description: null,
+			membershipId: 10,
+		}, {
+			id: 2,
+			name: 'Group2',
+			description: null,
+			membershipId: 11,
+		}],
+	}, {
+		id: 2,
+		name: 'Andrew',
+		verified: false,
+		invitedBy: null,
+		groupsWithMembershipId: [{
+			id: 2,
+			name: 'Group2',
+			description: null,
+			membershipId: 12,
+		}],
+	}]);
+});
+
 test('[Find Many .through] Get groups with users', async (t) => {
 	const { pgDbV2: db } = t;
 

--- a/integration-tests/tests/sqlite/bettersqlite.test.ts
+++ b/integration-tests/tests/sqlite/bettersqlite.test.ts
@@ -6440,6 +6440,77 @@ test('[Find Many .through] Get users with groups', async () => {
 	}]);
 });
 
+test('[Find Many .through] Get users with groups and junction "including" column', async () => {
+	await db.insert(usersTable).values([
+		{ id: 1, name: 'Dan' },
+		{ id: 2, name: 'Andrew' },
+	]);
+
+	await db.insert(groupsTable).values([
+		{ id: 1, name: 'Group1' },
+		{ id: 2, name: 'Group2' },
+	]);
+
+	await db.insert(usersToGroupsTable).values([
+		{ id: 10, userId: 1, groupId: 1 },
+		{ id: 11, userId: 1, groupId: 2 },
+		{ id: 12, userId: 2, groupId: 2 },
+	]);
+
+	const response = await db.query.usersTable.findMany({
+		with: {
+			groupsWithMembershipId: true,
+		},
+	});
+
+	expectTypeOf(response).toEqualTypeOf<{
+		id: number;
+		name: string;
+		verified: number;
+		invitedBy: number | null;
+		groupsWithMembershipId: {
+			id: number;
+			name: string;
+			description: string | null;
+			membershipId: number;
+		}[];
+	}[]>();
+
+	response.sort((a, b) => (a.id > b.id) ? 1 : -1);
+	for (const e of response) {
+		e.groupsWithMembershipId.sort((a, b) => (a.id > b.id) ? 1 : -1);
+	}
+
+	expect(response).toStrictEqual([{
+		id: 1,
+		name: 'Dan',
+		verified: 0,
+		invitedBy: null,
+		groupsWithMembershipId: [{
+			id: 1,
+			name: 'Group1',
+			description: null,
+			membershipId: 10,
+		}, {
+			id: 2,
+			name: 'Group2',
+			description: null,
+			membershipId: 11,
+		}],
+	}, {
+		id: 2,
+		name: 'Andrew',
+		verified: 0,
+		invitedBy: null,
+		groupsWithMembershipId: [{
+			id: 2,
+			name: 'Group2',
+			description: null,
+			membershipId: 12,
+		}],
+	}]);
+});
+
 test('[Find Many .through] Get groups with users', async () => {
 	await db.insert(usersTable).values([
 		{ id: 1, name: 'Dan' },

--- a/integration-tests/tests/sqlite/sqlite.relations.ts
+++ b/integration-tests/tests/sqlite/sqlite.relations.ts
@@ -49,6 +49,12 @@ export default defineRelations(schema, (r) => ({
 			to: r.groupsTable.id.through(r.usersToGroupsTable.groupId),
 			alias: 'users-groups-direct',
 		}),
+		groupsWithMembershipId: r.many.groupsTable({
+			from: r.usersTable.id.through(r.usersToGroupsTable.userId),
+			to: r.groupsTable.id.through(r.usersToGroupsTable.groupId),
+			including: { membershipId: r.usersToGroupsTable.id },
+			alias: 'users-groups-membership',
+		}),
 		groupsFiltered: r.many.groupsTable({
 			alias: 'users-groups-direct-filtered',
 		}),


### PR DESCRIPTION
## Summary

Many-to-many relations declared with `.through()` currently join the junction table only to resolve the relationship — any of the junction table's own columns (e.g. a `role` column on a `contacts <-> garages` pivot) are discarded. This adds an `including` option to `one()`/`many()` relation configs to select extra junction-table columns and flatten them onto each result row, without exposing the junction table as its own nesting level.

```ts
contacts: {
  garages: r.many.garages({
    from: r.contacts.id.through(r.contactsToGarages.contactId),
    to: r.garages.id.through(r.contactsToGarages.garageId),
    including: [r.contactsToGarages.role],
    // or, to rename / avoid collisions with the target table's columns:
    // including: { membershipRole: r.contactsToGarages.role },
  }),
},
```

## Changes

- **`drizzle-orm/src/relations.ts`**
  - `ManyConfig`/`OneConfig` gain `including?: RelationsBuilderColumnBase | RelationsBuilderColumnBase[] | Record<string, RelationsBuilderColumnBase>` — array form keys the result field by column name, record form renames it.
  - `resolveIncluding()` validates at relation-build time: throws if `including` is used without `through()`, and if a column doesn't belong to the resolved junction table.
  - `RelationsBuilderColumn` gained a second generic to carry the real per-column type through, so result types infer the junction column's real data type (via `GetColumnData`) instead of `unknown`.
  - `Many`/`One` gained a phantom `$including` type parameter; `RelationResultKind` merges it into each row's result type.
- **`pg-core`/`mysql-core`/`sqlite-core`/`singlestore-core` dialects** — `buildRelationalQuery` already computes the aliased junction table reference to build the `through()` JOIN; this threads that same reference (plus the resolved `including` columns) into the recursive call and selects them via the existing `buildRqbColumn` helper, the same mechanism already used for `extras`.

## Testing

- Unit tests (`drizzle-orm/tests/rqb-builders.test.ts`): generated SQL for both the array and record forms of `including`, plus both validation error paths (`including` without `through()`, and columns from the wrong table).
- Integration tests added to sqlite, postgres, and mysql (`bettersqlite.test.ts`, `pg.test.ts`, `mysql.test.ts` + matching `*.relations.ts` schema changes), each run against a real database:
  - sqlite: full suite green (169 passed, 0 regressions) via `better-sqlite3`.
  - postgres: verified against a local `postgres:17-alpine` container via `compose/dockers.sh up postgres`.
  - mysql: verified against a local `mysql:8` container via `compose/dockers.sh up mysql` — the new `including` column came back correct; note the *pre-existing* container in my local setup returns bigint user IDs as strings, which also fails 27 other untouched tests in the same file, so I couldn't get a fully clean `toStrictEqual` run there, but the `including` mechanism itself is verified correct.
- singlestore: dialect change typechecks and structurally mirrors the verified pg/mysql/sqlite implementation, but wasn't run against a live singlestore container.

## Test plan

- [x] `pnpm build && pnpm test` in `drizzle-orm/` (1187 passed, 7 skipped, 0 regressions)
- [x] `pnpm exec tsc --noEmit` clean across `drizzle-orm/`
- [x] sqlite integration suite green against real data
- [x] postgres integration test green against a real `postgres:17-alpine` container
- [x] mysql integration test's `including` output verified correct against a real `mysql:8` container
- [ ] singlestore live verification