### PR TITLE
[Kit]: Fix pull generating invalid through relations for composite foreign keys

### DIFF
--- a/drizzle-kit/src/cli/commands/pull-common.ts
+++ b/drizzle-kit/src/cli/commands/pull-common.ts
@@ -298,7 +298,10 @@ export const relationsToTypeScript = (
 					})`
 					: `[${
 						relation.columnsThroughFrom!
-							.map((it) => `r.${relation.tableFrom}.${it}.through(${relation.tableThrough}.${it})`)
+							.map(
+								(it, i) =>
+									`r.${relation.tableFrom}.${relation.columnsFrom[i]}.through(r.${relation.tableThrough}.${it})`,
+							)
 							.join(', ')
 					}]`;
 				const to = relation.columnsThroughTo!.length === 1
@@ -307,7 +310,9 @@ export const relationsToTypeScript = (
 					})`
 					: `[${
 						relation.columnsThroughTo!
-							.map((it) => `r.${relation.tableTo}.${it}.through(${relation.tableThrough}.${it})`)
+							.map(
+								(it, i) => `r.${relation.tableTo}.${relation.columnsTo![i]}.through(r.${relation.tableThrough}.${it})`,
+							)
 							.join(', ')
 					}]`;
 

--- a/drizzle-kit/tests/postgres/pull.test.ts
+++ b/drizzle-kit/tests/postgres/pull.test.ts
@@ -2746,6 +2746,45 @@ test('relations issue', async () => {
 	expect(relationsError).toBeNull();
 });
 
+// https://github.com/drizzle-team/drizzle-orm/issues/6100
+test('issue 6100', async () => {
+	await db.query(`CREATE TABLE organizations (
+		id bigint NOT NULL,
+		tenant_id bigint NOT NULL,
+		PRIMARY KEY (id, tenant_id)
+	);`);
+	await db.query(`CREATE TABLE users (
+		id bigint NOT NULL,
+		tenant_id bigint NOT NULL,
+		PRIMARY KEY (id, tenant_id)
+	);`);
+	await db.query(`CREATE TABLE assignments (
+		organization_id bigint NOT NULL,
+		organization_tenant_id bigint NOT NULL,
+		user_id bigint NOT NULL,
+		user_tenant_id bigint NOT NULL
+	);`);
+	await db.query(
+		`ALTER TABLE assignments ADD CONSTRAINT assignments_organization_fk FOREIGN KEY (organization_id, organization_tenant_id) REFERENCES organizations (id, tenant_id);`,
+	);
+	await db.query(
+		`ALTER TABLE assignments ADD CONSTRAINT assignments_user_fk FOREIGN KEY (user_id, user_tenant_id) REFERENCES users (id, tenant_id);`,
+	);
+
+	const { generateSqlStatements, generateStatements, pushSqlStatements, pushStatements, relationsError } =
+		await diffIntrospect(
+			db,
+			{},
+			'issue-6100',
+		);
+
+	expect(pushSqlStatements).toStrictEqual([]);
+	expect(generateSqlStatements).toStrictEqual([]);
+	expect(pushStatements).toStrictEqual([]);
+	expect(generateStatements).toStrictEqual([]);
+	expect(relationsError).toBeNull();
+});
+
 // https://github.com/drizzle-team/drizzle-orm/issues/5525
 test('issue 5525', async () => {
 	await db.query(`CREATE TABLE "country" (


### PR DESCRIPTION
Fixes #6100

### Problem

`relationsToTypeScript` generated invalid `relations.ts` for through relations when either foreign key was composite. The composite branches used the through-table column name on the referenced table and omitted the `r.` prefix before the through table:

```ts
// before
from: [r.organizations.organizationId.through(assignments.organizationId)]

// after
from: [r.organizations.id.through(r.assignments.organizationId)]
```

### Fix

Pair each through column with its positionally aligned referenced column and add the missing `r.` prefix. This makes both composite branches follow the same shape as the existing single-column branches.

### Testing

Added an `issue 6100` regression using composite keys on both referenced tables, so the test covers both the `from` and `to` branches. `diffIntrospect` typechecks and imports the generated file, catching both the wrong property and missing-prefix failures.

- PostgreSQL pull tests: 77 passed, 3 existing time-gated skips.
- SQLite pull tests: 22 passed.
- Drizzle Kit typecheck and dprint pass.

The affected code exists on the 1.0 line, so this PR targets `rc5`. Docker-backed dialect suites were not available locally; the PGlite and SQLite suites pass and the changed generator is shared.

AI assistance was used for the analysis, test, and fix. I am responsible for the PR and happy to address anything I missed.

Best Regards, Tarik