### PR TITLE
[Pg-kit] Fix composite primary key and unique constraint column order in introspection

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1228,12 +1228,17 @@ WHERE
 					const tableResponse = await getColumnsInfoQuery({ schema: tableSchema, table: tableName, db });
 
 					const tableConstraints = await db.query(
-						`SELECT c.column_name, c.data_type, constraint_type, constraint_name, constraint_schema
+						`SELECT c.column_name, c.data_type, tc.constraint_type, tc.constraint_name, tc.constraint_schema
       FROM information_schema.table_constraints tc
-      JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name)
+      JOIN information_schema.key_column_usage AS kcu
+        ON kcu.constraint_schema = tc.constraint_schema
+        AND kcu.constraint_name = tc.constraint_name
+        AND kcu.table_schema = tc.table_schema
+        AND kcu.table_name = tc.table_name
       JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema
-        AND tc.table_name = c.table_name AND ccu.column_name = c.column_name
-      WHERE tc.table_name = '${tableName}' and constraint_schema = '${tableSchema}';`,
+        AND tc.table_name = c.table_name AND kcu.column_name = c.column_name
+      WHERE tc.table_name = '${tableName}' and tc.constraint_schema = '${tableSchema}'
+      ORDER BY tc.constraint_name, kcu.ordinal_position;`,
 					);
 
 					const tableChecks = await db.query(`SELECT 

--- a/drizzle-kit/tests/push/pg.test.ts
+++ b/drizzle-kit/tests/push/pg.test.ts
@@ -29,6 +29,7 @@ import {
 	text,
 	time,
 	timestamp,
+	unique,
 	uniqueIndex,
 	uuid,
 	varchar,
@@ -4409,4 +4410,50 @@ test('alter inherit in role', async (t) => {
 	for (const st of sqlStatements) {
 		await client.query(st);
 	}
+});
+
+test('no diff: composite primary key with key order different from column order', async () => {
+	const client = new PGlite();
+
+	const schema1 = {
+		tag: pgTable('tag', {
+			itemId: text('item_id').notNull(),
+			tag: text('tag').notNull(),
+		}, (t) => [primaryKey({ name: 'tag_pk', columns: [t.tag, t.itemId] })]),
+	};
+
+	const schema2 = {
+		tag: pgTable('tag', {
+			itemId: text('item_id').notNull(),
+			tag: text('tag').notNull(),
+		}, (t) => [primaryKey({ name: 'tag_pk', columns: [t.tag, t.itemId] })]),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasPush(client, schema1, schema2, [], false, ['public']);
+
+	expect(statements).toStrictEqual([]);
+	expect(sqlStatements).toStrictEqual([]);
+});
+
+test('no diff: composite unique constraint with key order different from column order', async () => {
+	const client = new PGlite();
+
+	const schema1 = {
+		tag: pgTable('tag', {
+			itemId: text('item_id').notNull(),
+			tag: text('tag').notNull(),
+		}, (t) => [unique('tag_unique').on(t.tag, t.itemId)]),
+	};
+
+	const schema2 = {
+		tag: pgTable('tag', {
+			itemId: text('item_id').notNull(),
+			tag: text('tag').notNull(),
+		}, (t) => [unique('tag_unique').on(t.tag, t.itemId)]),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasPush(client, schema1, schema2, [], false, ['public']);
+
+	expect(statements).toStrictEqual([]);
+	expect(sqlStatements).toStrictEqual([]);
 });


### PR DESCRIPTION
Closes #6078

## Problem

`drizzle-kit push` could non-deterministically drop and recreate an unchanged composite primary key. The PostgreSQL introspector read PK and UNIQUE columns from `information_schema.constraint_column_usage`, which has no ordinal column and was queried without ordering. The differ treats composite-key columns as an ordered list, so a flipped row order looked like a schema change.

## Fix

Read those columns from `information_schema.key_column_usage` and order them by `ordinal_position`. The join also includes table schema and table name so a same-named constraint on another table cannot be matched accidentally. Composite UNIQUE constraints get the same ordering fix.

The rc5 introspector already preserves order through `pg_constraint.conkey`; this change is for the 0.31.x serializer on `main`.

## Testing

- Added PGlite regressions for a composite primary key and composite unique constraint whose key order differs from column creation order. Both produce a false migration before the fix and zero statements after it.
- PostgreSQL push and introspection tests: 125 passed, 1 todo.
- TypeScript and dprint checks pass.
- Verified the query against PostgreSQL 16 with PK `(tag, item_id)` and UNIQUE `(c, a)`.

MySQL is not part of this change; its similar report uses a different serializer.

Best Regards, Tarik