### PR TITLE
Drop @opentelemetry/api from peerDependencies

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -52,7 +52,6 @@
 		"@libsql/client-wasm": ">=0.10.0",
 		"@neondatabase/serverless": ">=0.10.0",
 		"@op-engineering/op-sqlite": ">=2",
-		"@opentelemetry/api": "^1.4.1",
 		"@planetscale/database": ">=1.13",
 		"@prisma/client": "*",
 		"@tidbcloud/serverless": "*",
@@ -137,9 +136,6 @@
 			"optional": true
 		},
 		"@libsql/client-wasm": {
-			"optional": true
-		},
-		"@opentelemetry/api": {
 			"optional": true
 		},
 		"expo-sqlite": {


### PR DESCRIPTION
Small one, from #6115.

### Why

`@opentelemetry/api` is only used for types in `src/tracing.ts`, and the runtime import is commented out:

```ts
import type { Span, Tracer } from '@opentelemetry/api';
let otel: typeof import('@opentelemetry/api') | undefined;
// try {
// 	otel = await import('@opentelemetry/api');
// } catch (err: any) { ... }
```

So `otel` is never assigned and `startActiveSpan` always takes the `if (!otel) return fn()` path. `tracer` is `@internal` and isn't exported from the public entry, so published 1.0.0-rc.1 has no runtime or `.d.ts` reference to it.

It's already in `devDependencies`, so types still resolve when you build.

### What it fixes

Listing it as an optional peer makes package managers that install a separate copy per peer combination give each consumer its own copy of drizzle-orm. TypeScript then treats those copies as unrelated, so values like `SQL` stop being assignable between packages in a workspace. In ours that was one of the causes of ~50 type errors.

This drops one cause of that and costs nothing here.

### Scope

Four deleted lines in `drizzle-orm/package.json`. No code changes. If you'd rather keep the peer entry for documentation, feel free to close — the other suggestions in #6115 are the larger part.