### PR TITLE
[Pg] fix: destroy pooled client when transaction() BEGIN or ROLLBACK fails

### DIFF
--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -254,16 +254,21 @@ export class NodePgSession<
 			? new NodePgSession(await (<pg.Pool> this.client).connect(), this.dialect, this.schema, this.options)
 			: this;
 		const tx = new NodePgTransaction<TFullSchema, TSchema>(this.dialect, session, this.schema);
-		await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
+		let releaseErr: boolean | Error | undefined;
 		try {
+			await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
 			const result = await transaction(tx);
 			await tx.execute(sql`commit`);
 			return result;
 		} catch (error) {
-			await tx.execute(sql`rollback`);
+			releaseErr = error instanceof Error ? error : true;
+			try {
+				await tx.execute(sql`rollback`);
+				releaseErr = undefined;
+			} catch {}
 			throw error;
 		} finally {
-			if (isPool) (session.client as PoolClient).release();
+			if (isPool) (session.client as PoolClient).release(releaseErr);
 		}
 	}
 

--- a/integration-tests/tests/pg/node-postgres-transaction.test.ts
+++ b/integration-tests/tests/pg/node-postgres-transaction.test.ts
@@ -1,0 +1,48 @@
+import { sql } from 'drizzle-orm';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+import { createDockerDB } from './pg-common';
+
+let pool: pg.Pool;
+let db: NodePgDatabase;
+
+beforeAll(async () => {
+	let connectionString;
+	if (process.env['PG_CONNECTION_STRING']) {
+		connectionString = process.env['PG_CONNECTION_STRING'];
+	} else {
+		const { connectionString: conStr } = await createDockerDB();
+		connectionString = conStr;
+	}
+
+	// A max:1 pool with a client-side query_timeout makes the leak deterministic.
+	pool = new pg.Pool({
+		connectionString,
+		max: 1,
+		query_timeout: 300,
+		connectionTimeoutMillis: 5_000,
+		idleTimeoutMillis: 0,
+	});
+
+	db = drizzle({ client: pool });
+});
+
+afterAll(async () => {
+	await pool?.end();
+});
+
+test('a transaction that hits query_timeout must not poison the pooled client', async () => {
+	// 1. A transaction whose statement exceeds query_timeout rejects, as expected.
+	// The statement keeps running on the server, so the pooled client is broken.
+	await db.transaction(async (tx) => {
+		await tx.execute(sql`select pg_sleep(2)`);
+	}).catch(() => {});
+
+	// 2. The unrelated query must run on a fresh connection. On the buggy code the
+	// broken client is returned to the idle pool, so this fails with
+	// "Query read timeout" because it inherits the still-running pg_sleep.
+	const after = await db.execute(sql`select 1 as ok`);
+
+	expect(after.rows).toEqual([{ ok: 1 }]);
+});


### PR DESCRIPTION
Fixes #6114.

## Problem

NodePgSession.transaction() in the node-postgres driver has two defects in how it releases a pooled client. They are invisible in default configurations, but become deterministic when the pg client-side query_timeout is set.

1. A rejected BEGIN leaks the pool slot. The await tx.execute(sql begin...) runs BEFORE the try/finally block. If it rejects, the finally block never runs and release() is never called, so the client stays checked out for the life of the process. Enough occurrences exhaust the pool with no recovery.

2. A failed transaction returns a broken client to the pool. release() is always called without an error argument. After a client-side query_timeout the statement still runs on the server, the client activeQuery is still set, and the pg-pool eviction check does not remove the client. The broken client returns to the idle pool, and the next checkout inherits it: its queries wait behind a statement that can never complete, or run inside the leftover transaction.

## Reproduction (deterministic)

A max:1 pg.Pool with query_timeout: 300. A transaction that runs pg_sleep(2) rejects as expected, then a plain select 1 on the same pool fails with Query read timeout on the buggy code and passes once release(err) destroys the client. The reproduction is schema-free and runs against any reachable Postgres. It is added as an integration test.

## Fix

Move BEGIN inside the try block, and release the client with the error unless a later ROLLBACK succeeds. A server that answers ROLLBACK has shown that the connection is healthy, so an application-level error still releases the client clean and connection reuse is kept.

Before:

    await tx.execute(sql`begin...`);
    try { ... } finally { if (isPool) client.release(); }

After:

    let releaseErr;
    try {
      await tx.execute(sql`begin...`);
      const result = await transaction(tx);
      await tx.execute(sql`commit`);
      return result;
    } catch (error) {
      releaseErr = error instanceof Error ? error : true;
      try { await tx.execute(sql`rollback`); releaseErr = undefined; } catch {}
      throw error;
    } finally {
      if (isPool) client.release(releaseErr);
    }

## Test plan

Adds integration-tests/tests/pg/node-postgres-transaction.test.ts. The test requires a reachable Postgres: the repository CI provides one via the postgres:14 service at PG_CONNECTION_STRING (see .github/workflows/release-feature-branch.yaml, the other shard runs tests/pg/**/*.test.ts), and outside CI the test falls back to the createDockerDB() helper (Docker). The test fails on the current code with Query read timeout and passes with this fix.