### PR TITLE
fix(drizzle-kit): write migrate failure to stderr so the error is visible in non-TTY logs

### DIFF
--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -112,6 +112,22 @@ export const generate = command({
 	},
 });
 
+// hanji's renderWithTask swallows task rejections — it renders the view's
+// 'rejected' state and calls process.exit(1) before the surrounding try/catch
+// in the handler can run. As a result the real error was invisible in non-TTY
+// capture (CI logs, docker logs, redirected stdout) because the progress
+// spinner rewrites stdout. Surface the failure to stderr (which the spinner
+// never touches) and re-throw so the process still exits 1.
+const logMigrateError = (err: unknown) => {
+	const message = err instanceof Error ? err.message : String(err);
+	process.stderr.write(`[migrate] FAILED: ${message}\n`);
+	const cause = err instanceof Error ? err.cause : undefined;
+	if (cause instanceof Error && cause.message) {
+		process.stderr.write(`[migrate] CAUSE: ${cause.message}\n`);
+	}
+	throw err;
+};
+
 export const migrate = command({
 	name: 'migrate',
 	options: {
@@ -155,7 +171,7 @@ export const migrate = command({
 						migrationsFolder: out,
 						migrationsTable: table,
 						migrationsSchema: schema,
-					}),
+					}).catch(logMigrateError),
 				);
 			} else if (dialect === 'mysql') {
 				const { connectToMySQL } = await import('./connections');
@@ -166,7 +182,7 @@ export const migrate = command({
 						migrationsFolder: out,
 						migrationsTable: table,
 						migrationsSchema: schema,
-					}),
+					}).catch(logMigrateError),
 				);
 			} else if (dialect === 'singlestore') {
 				const { connectToSingleStore } = await import('./connections');
@@ -177,7 +193,7 @@ export const migrate = command({
 						migrationsFolder: out,
 						migrationsTable: table,
 						migrationsSchema: schema,
-					}),
+					}).catch(logMigrateError),
 				);
 			} else if (dialect === 'sqlite') {
 				const { connectToSQLite } = await import('./connections');
@@ -188,7 +204,7 @@ export const migrate = command({
 						migrationsFolder: opts.out,
 						migrationsTable: table,
 						migrationsSchema: schema,
-					}),
+					}).catch(logMigrateError),
 				);
 			} else if (dialect === 'turso') {
 				const { connectToLibSQL } = await import('./connections');
@@ -199,7 +215,7 @@ export const migrate = command({
 						migrationsFolder: opts.out,
 						migrationsTable: table,
 						migrationsSchema: schema,
-					}),
+					}).catch(logMigrateError),
 				);
 			} else if (dialect === 'gel') {
 				console.log(

--- a/drizzle-kit/tests/cli-migrate-error.test.ts
+++ b/drizzle-kit/tests/cli-migrate-error.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { migrate } from '../src/cli/schema';
+
+// The migrate handler only reaches the DB connection layer after asserting that
+// the correct version of drizzle-orm is installed. Those guards are not the
+// subject under test, so we stub them out.
+vi.mock('../src/cli/utils', async (importOriginal) => {
+	const mod = await importOriginal<typeof import('../src/cli/utils')>();
+	return {
+		...mod,
+		assertOrmCoreVersion: vi.fn(async () => {}),
+		assertPackages: vi.fn(async () => {}),
+	};
+});
+
+// Simulate the migrator throwing (e.g. a failed migration such as the 42P07
+// "relation already exists" error from the issue) without needing a live
+// database.
+vi.mock('../src/cli/connections', () => ({
+	preparePostgresDB: vi.fn(async () => ({
+		migrate: vi.fn(async () => {
+			throw new Error('relation "account" already exists', {
+				cause: new Error('42P07'),
+			});
+		}),
+	})),
+}));
+
+const stderrWrites: string[] = [];
+
+beforeEach(() => {
+	stderrWrites.length = 0;
+	vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+		stderrWrites.push(String(chunk));
+		return true;
+	});
+	// hanji's renderWithTask terminates the process with process.exit(1) when a
+	// task rejects. Capture that instead of letting it kill the test runner.
+	vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+test('migrate writes the migrator failure to stderr when it throws', async () => {
+	await migrate.handler?.({
+		dialect: 'postgresql',
+		out: 'drizzle',
+		credentials: {
+			url: 'postgresql://postgres:postgres@127.0.0.1:5432/db',
+		},
+		schema: undefined,
+		table: undefined,
+	});
+
+	const output = stderrWrites.join('');
+	expect(output).toContain('[migrate] FAILED');
+	expect(output).toContain('relation "account" already exists');
+	expect(output).toContain('[migrate] CAUSE: 42P07');
+});


### PR DESCRIPTION
## Problem

When `drizzle-kit migrate` fails (e.g. Postgres 42P07 `relation "account" already exists`, or 42704 `type ... does not exist`), it exits 1 but the real error message is invisible in any non-TTY capture (CI logs, `docker logs`, redirected stdout, log aggregators). Fixes #6121.

`docker logs` only shows the spinner's ANSI frames (`[2K[1G[⣯] applying migrations...`) and a `NOTICE`, with no `ERROR`/stack trace anywhere.

## Root cause

The CLI's progress spinner is rendered by `hanji@0.0.8` `renderWithTask`. On task rejection it renders the view's `'rejected'` state on **stdout** (using ANSI erase sequences to rewrite the line) and then calls `process.exit(1)` internally — before the `try/catch` surrounding the `renderWithTask` call in the `migrate` command handler can run. `MigrateProgress.render('rejected', err)` only returns `[⣷] applying migrations...` and ignores the error, so the error is never written anywhere: not to stdout, not to stderr, and the process has already exited before the handler's `catch (e) { console.error(e); process.exit(1); }` could fire.

## Fix

Surface the failure to **stderr**, which the spinner never touches. Wrap the migrator task passed to `renderWithTask` in a `.catch(logMigrateError)` that writes:

```
[migrate] FAILED: <error message>
[migrate] CAUSE: <cause message>   (only when a cause is present)
```

and re-throws so the process still exits 1 (hanji's `renderWithTask` handles that). This is applied to all five dialect branches of the `migrate` command (postgresql, mysql, singlestore, sqlite, turso).

## Tests

- `drizzle-kit/tests/cli-migrate-error.test.ts` — unit test that simulates the migrator throwing (the `connections` layer is mocked, no live database needed) and asserts the error message and cause are written to stderr. Fails on `main` before this change, passes after.
- Existing CLI test scope (`cli-migrate`, `cli-push`, `cli-generate`, `cli-export`, `bin`, `validations`, `wrap-param`) passes with no regressions.