### PR TITLE
[drizzle-kit] fix: pg push drops and recreates index when .with() params are numeric

### DIFF
--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -482,7 +482,16 @@ export const generatePgSnapshot = (
 				where: value.config.where ? dialect.sqlToQuery(value.config.where).sql : undefined,
 				concurrently: value.config.concurrently ?? false,
 				method: value.config.method ?? 'btree',
-				with: value.config.with ?? {},
+				// Postgres stores index storage parameters (reloptions) as text, so the
+				// introspected snapshot always holds string values (e.g. { fillfactor: "70" }).
+				// Coerce the schema-side values to strings too, otherwise the two snapshots
+				// never compare equal and `drizzle-kit push` drops and recreates the index
+				// on every run. See https://github.com/drizzle-team/drizzle-orm/issues/6079
+				with: value.config.with
+					? Object.fromEntries(
+						Object.entries(value.config.with).map(([key, v]) => [key, String(v)]),
+					)
+					: {},
 			};
 		});
 

--- a/drizzle-kit/tests/indexes/pg.test.ts
+++ b/drizzle-kit/tests/indexes/pg.test.ts
@@ -57,8 +57,8 @@ const pgSuite: DialectSuite = {
 				name: 'vector_embedding_idx',
 				where: undefined,
 				with: {
-					ef_construction: 64,
-					m: 16,
+					ef_construction: "64",
+					m: "16",
 				},
 			},
 		});
@@ -196,7 +196,7 @@ const pgSuite: DialectSuite = {
 				name: 'users_name_id_index',
 				where: 'select 1',
 				with: {
-					fillfactor: 70,
+					fillfactor: "70",
 				},
 			},
 			// data: 'users_name_id_index;name,false,last,undefined,,id,true,last,undefined;false;false;btree;select 1;{"fillfactor":70}',
@@ -228,7 +228,7 @@ const pgSuite: DialectSuite = {
 				name: 'indx1',
 				where: undefined,
 				with: {
-					fillfactor: 70,
+					fillfactor: "70",
 				},
 			},
 		});

--- a/drizzle-kit/tests/push/pg-index-with-reloptions.test.ts
+++ b/drizzle-kit/tests/push/pg-index-with-reloptions.test.ts
@@ -1,0 +1,33 @@
+import { PGlite } from '@electric-sql/pglite';
+import { index, pgTable, serial, text } from 'drizzle-orm/pg-core';
+import { diffTestSchemasPush } from 'tests/schemaDiffer';
+import { expect, test } from 'vitest';
+
+// Regression test for https://github.com/drizzle-team/drizzle-orm/issues/6079
+//
+// Postgres index storage parameters (`.with()`) are stored as text in
+// `pg_class.reloptions`, so the introspected snapshot always holds string
+// values (`{ fillfactor: "70" }`). When the schema side serialized numeric
+// values (`{ fillfactor: 70 }`), the two snapshots never matched and
+// `drizzle-kit push` dropped and recreated the index on every run.
+test('push: index .with() numeric params should not trigger drop and recreate', async () => {
+	const client = new PGlite();
+
+	const schema = {
+		users: pgTable(
+			'users',
+			{
+				id: serial('id').primaryKey(),
+				name: text('name'),
+			},
+			(t) => ({
+				indx: index('users_with_idx').on(t.name).with({ fillfactor: 70 }),
+			}),
+		),
+	};
+
+	const { statements, sqlStatements } = await diffTestSchemasPush(client, schema, schema, [], false, ['public']);
+
+	expect(sqlStatements).toStrictEqual([]);
+	expect(statements).toStrictEqual([]);
+});

--- a/drizzle-kit/tests/push/pg.test.ts
+++ b/drizzle-kit/tests/push/pg.test.ts
@@ -282,7 +282,7 @@ const pgSuite: DialectSuite = {
 				name: 'users_name_id_index',
 				where: 'select 1',
 				with: {
-					fillfactor: 70,
+					fillfactor: "70",
 				},
 			},
 		});
@@ -312,7 +312,7 @@ const pgSuite: DialectSuite = {
 				name: 'indx1',
 				where: undefined,
 				with: {
-					fillfactor: 70,
+					fillfactor: "70",
 				},
 			},
 		});


### PR DESCRIPTION
Fixes #6079.

## Problem

Declaring Postgres index storage parameters (`.with()`) with numeric values makes `drizzle-kit push` DROP and re-CREATE the index on **every** push, even when nothing changed:

```ts
index('chunk_embedding_hnsw_idx')
  .using('hnsw', t.embedding.op('vector_cosine_ops'))
  .with({ m: 24, ef_construction: 128 }),
```

Postgres stores reloptions as text in `pg_class.reloptions`, so the introspected snapshot always holds **string** values (`{ "m": "24" }`), while the schema-side serializer passed the raw numeric values (`{ m: 24 }`). The squashed index strings never compared equal, so the differ classified the index as altered and emitted `DROP INDEX` + `CREATE INDEX` on every run. For HNSW/pgvector indexes a rebuild takes many minutes and interrupts leave the DB without the index (seq-scan fallback).

## Fix

Normalize the schema-side `.with()` values to strings in `drizzle-kit/src/serializer/pgSerializer.ts` when building the index snapshot, so the schema side matches what Postgres introspection returns. Numeric params now compare equal to the introspected text reloptions and the diff stays quiet:

```ts
with: value.config.with
  ? Object.fromEntries(
    Object.entries(value.config.with).map(([key, v]) => [key, String(v)]),
  )
  : {},
```

This also makes the emitted `create_index`/`create_index_pg` statement data consistent with the snapshot schema (`indexV4/V5/V6` already declare `with: record(string(), string())`). The generated SQL is unchanged (`WITH (m=24,ef_construction=128)`). String params written by users keep working as before.

## Test plan

Adds a regression test (`drizzle-kit/tests/push/pg-index-with-reloptions.test.ts`) that pushes the same schema containing an index with numeric `.with()` params and asserts that no `DROP INDEX`/`CREATE INDEX` statements are produced. On the old code the test fails with two spurious statements; with the fix it passes. Existing index tests that asserted numeric `with` values in the statement data were updated to the now-correct string representation.