### PR TITLE
[sqlite] fix: type insert().returning().get() as T | undefined when an onConflict clause can affect zero rows

### DIFF
--- a/drizzle-orm/src/sqlite-core/query-builders/insert.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/insert.ts
@@ -115,7 +115,8 @@ export type SQLiteInsertWithout<T extends AnySQLiteInsert, TDynamic extends bool
 				T['_']['runResult'],
 				T['_']['returning'],
 				TDynamic,
-				T['_']['excludedMethods'] | K
+				T['_']['excludedMethods'] | K,
+				T['_']['onConflict']
 			>,
 			T['_']['excludedMethods'] | K
 		>;
@@ -131,7 +132,8 @@ export type SQLiteInsertReturning<
 		T['_']['runResult'],
 		SelectResultFields<TSelectedFields>,
 		TDynamic,
-		T['_']['excludedMethods']
+		T['_']['excludedMethods'],
+		T['_']['onConflict']
 	>,
 	TDynamic,
 	'returning'
@@ -147,7 +149,8 @@ export type SQLiteInsertReturningAll<
 		T['_']['runResult'],
 		T['_']['table']['$inferSelect'],
 		TDynamic,
-		T['_']['excludedMethods']
+		T['_']['excludedMethods'],
+		T['_']['onConflict']
 	>,
 	TDynamic,
 	'returning'
@@ -163,11 +166,28 @@ export type SQLiteInsertOnConflictDoUpdateConfig<T extends AnySQLiteInsert> = {
 	set: SQLiteUpdateSetSource<T['_']['table']>;
 };
 
-export type SQLiteInsertDynamic<T extends AnySQLiteInsert> = SQLiteInsert<
+export type SQLiteInsertDynamic<T extends AnySQLiteInsert> = SQLiteInsertBase<
 	T['_']['table'],
 	T['_']['resultType'],
 	T['_']['runResult'],
-	T['_']['returning']
+	T['_']['returning'],
+	true,
+	never,
+	T['_']['onConflict']
+>;
+
+export type SQLiteInsertOnConflict<T extends AnySQLiteInsert> = SQLiteInsertWithout<
+	SQLiteInsertBase<
+		T['_']['table'],
+		T['_']['resultType'],
+		T['_']['runResult'],
+		T['_']['returning'],
+		T['_']['dynamic'],
+		T['_']['excludedMethods'],
+		true
+	>,
+	T['_']['dynamic'],
+	never
 >;
 
 export type SQLiteInsertExecute<T extends AnySQLiteInsert> = T['_']['returning'] extends undefined ? T['_']['runResult']
@@ -180,6 +200,7 @@ export type SQLiteInsertPrepare<T extends AnySQLiteInsert> = SQLitePreparedQuery
 		all: T['_']['returning'] extends undefined ? DrizzleTypeError<'.all() cannot be used without .returning()'>
 			: T['_']['returning'][];
 		get: T['_']['returning'] extends undefined ? DrizzleTypeError<'.get() cannot be used without .returning()'>
+			: T['_']['onConflict'] extends true ? T['_']['returning'] | undefined
 			: T['_']['returning'];
 		values: T['_']['returning'] extends undefined ? DrizzleTypeError<'.values() cannot be used without .returning()'>
 			: any[][];
@@ -187,7 +208,7 @@ export type SQLiteInsertPrepare<T extends AnySQLiteInsert> = SQLitePreparedQuery
 	}
 >;
 
-export type AnySQLiteInsert = SQLiteInsertBase<any, any, any, any, any, any>;
+export type AnySQLiteInsert = SQLiteInsertBase<any, any, any, any, any, any, any>;
 
 export type SQLiteInsert<
 	TTable extends SQLiteTable = SQLiteTable,
@@ -203,6 +224,7 @@ export interface SQLiteInsertBase<
 	TReturning = undefined,
 	TDynamic extends boolean = false,
 	TExcludedMethods extends string = never,
+	TOnConflict extends boolean = false,
 > extends
 	SQLWrapper,
 	QueryPromise<TReturning extends undefined ? TRunResult : TReturning[]>,
@@ -216,6 +238,7 @@ export interface SQLiteInsertBase<
 		readonly returning: TReturning;
 		readonly dynamic: TDynamic;
 		readonly excludedMethods: TExcludedMethods;
+		readonly onConflict: TOnConflict;
 		readonly result: TReturning extends undefined ? TRunResult : TReturning[];
 	};
 }
@@ -230,6 +253,8 @@ export class SQLiteInsertBase<
 	TDynamic extends boolean = false,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	TExcludedMethods extends string = never,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	TOnConflict extends boolean = false,
 > extends QueryPromise<TReturning extends undefined ? TRunResult : TReturning[]>
 	implements RunnableQuery<TReturning extends undefined ? TRunResult : TReturning[], 'sqlite'>, SQLWrapper
 {
@@ -303,7 +328,7 @@ export class SQLiteInsertBase<
 	 *   .onConflictDoNothing({ target: cars.id });
 	 * ```
 	 */
-	onConflictDoNothing(config: { target?: IndexColumn | IndexColumn[]; where?: SQL } = {}): this {
+	onConflictDoNothing(config: { target?: IndexColumn | IndexColumn[]; where?: SQL } = {}): SQLiteInsertOnConflict<this> {
 		if (!this.config.onConflict) this.config.onConflict = [];
 
 		if (config.target === undefined) {
@@ -313,7 +338,7 @@ export class SQLiteInsertBase<
 			const whereSql = config.where ? sql` where ${config.where}` : sql``;
 			this.config.onConflict.push(sql` on conflict ${targetSql} do nothing${whereSql}`);
 		}
-		return this;
+		return this as any;
 	}
 
 	/**
@@ -345,7 +370,9 @@ export class SQLiteInsertBase<
 	 *   });
 	 * ```
 	 */
-	onConflictDoUpdate(config: SQLiteInsertOnConflictDoUpdateConfig<this>): this {
+	onConflictDoUpdate<TConfig extends SQLiteInsertOnConflictDoUpdateConfig<this>>(
+		config: TConfig,
+	): TConfig extends { where: SQL } | { setWhere: SQL } ? SQLiteInsertOnConflict<this> : this {
 		if (config.where && (config.targetWhere || config.setWhere)) {
 			throw new Error(
 				'You cannot use both "where" and "targetWhere"/"setWhere" at the same time - "where" is deprecated, use "targetWhere" or "setWhere" instead.',
@@ -362,7 +389,7 @@ export class SQLiteInsertBase<
 		this.config.onConflict.push(
 			sql` on conflict ${targetSql}${targetWhereSql} do update set ${setSql}${whereSql}${setWhereSql}`,
 		);
-		return this;
+		return this as any;
 	}
 
 	/** @internal */

--- a/drizzle-orm/type-tests/sqlite/insert.ts
+++ b/drizzle-orm/type-tests/sqlite/insert.ts
@@ -60,6 +60,57 @@ Expect<Equal<typeof users.$inferSelect, typeof insertGetReturningAll>>;
 const insertGetReturningAllBun = bunDb.insert(users).values(newUser).returning().get();
 Expect<Equal<typeof users.$inferSelect, typeof insertGetReturningAllBun>>;
 
+// https://github.com/drizzle-team/drizzle-orm/issues/6107
+// A conflict-tolerant insert can affect zero rows at runtime, so .get() must be typed as T | undefined
+const insertGetReturningAllWithConflict = db.insert(users).values(newUser)
+	.onConflictDoNothing()
+	.returning()
+	.get();
+Expect<Equal<typeof users.$inferSelect | undefined, typeof insertGetReturningAllWithConflict>>;
+
+const insertGetReturningAllWithConflictBun = bunDb.insert(users).values(newUser)
+	.onConflictDoNothing()
+	.returning()
+	.get();
+Expect<Equal<typeof users.$inferSelect | undefined, typeof insertGetReturningAllWithConflictBun>>;
+
+const insertGetReturningAllWithConflictUpdate = db.insert(users).values(newUser)
+	.onConflictDoUpdate({
+		target: users.age1,
+		set: { age1: sql`${users.age1} + 1` },
+		setWhere: sql`${users.age1} > 10`,
+	})
+	.returning()
+	.get();
+Expect<Equal<typeof users.$inferSelect | undefined, typeof insertGetReturningAllWithConflictUpdate>>;
+
+const insertGetReturningAllWithConflictUpdateBun = bunDb.insert(users).values(newUser)
+	.onConflictDoUpdate({
+		target: users.age1,
+		set: { age1: sql`${users.age1} + 1` },
+		setWhere: sql`${users.age1} > 10`,
+	})
+	.returning()
+	.get();
+Expect<Equal<typeof users.$inferSelect | undefined, typeof insertGetReturningAllWithConflictUpdateBun>>;
+
+// An unconditional on conflict do update always affects exactly one row, so .get() stays non-optional
+const insertGetReturningAllWithUnconditionalUpdate = db.insert(users).values(newUser)
+	.onConflictDoUpdate({
+		target: users.age1,
+		set: { age1: sql`${users.age1} + 1` },
+	})
+	.returning()
+	.get();
+Expect<Equal<typeof users.$inferSelect, typeof insertGetReturningAllWithUnconditionalUpdate>>;
+
+// .all() element type is unaffected by the conflict clause - the array can simply be empty
+const insertAllReturningAllWithConflict = db.insert(users).values(newUser)
+	.onConflictDoNothing()
+	.returning()
+	.all();
+Expect<Equal<typeof users.$inferSelect[], typeof insertAllReturningAllWithConflict>>;
+
 const insertValuesReturningAll = db.insert(users).values(newUser).returning().values();
 Expect<Equal<any[][], typeof insertValuesReturningAll>>;
 


### PR DESCRIPTION
Fixes #6107

## Problem

`select().get()` was typed as `T | undefined` in #595, because a `WHERE` clause can legitimately match zero rows. `insert().returning().get()` has the exact same runtime shape — the driver's `stmt.get()` returns `undefined` when the statement affects zero rows — but the type is still `TReturning`, never `TReturning | undefined`:

```ts
const inserted = db.insert(users)
  .values({ email })
  .onConflictDoNothing()
  .returning()
  .get();

inserted.id; // typed as safe, but `inserted` is `undefined` at runtime on conflict
```

A plain insert always affects the inserted rows, so `undefined` only becomes reachable when the chain includes a clause that can suppress rows: `onConflictDoNothing()`, or a conditional `onConflictDoUpdate({ setWhere })` / deprecated `onConflictDoUpdate({ where })`. An unconditional `onConflictDoUpdate` always affects exactly one row.

## Root cause

In `drizzle-orm/src/sqlite-core/query-builders/insert.ts`, `SQLiteInsertPrepare['get']` resolves unconditionally to `T['_']['returning']`. The insert builder had no type-level record of whether a conflict-tolerant clause had been added, so `.get()` could never widen to `T | undefined`.

## Fix

Add a type-level `onConflict` flag to the sqlite insert builder (`SQLiteInsertBase`, 7th type parameter, exposed as `_['onConflict']`). It is set by `onConflictDoNothing()` and by conditional `onConflictDoUpdate({ setWhere })` / `onConflictDoUpdate({ where })`; an unconditional `onConflictDoUpdate` keeps it `false`. `SQLiteInsertPrepare['get']` now widens when the flag is set:

```ts
get: T['_']['returning'] extends undefined ? DrizzleTypeError<'.get() cannot be used without .returning()'>
  : T['_']['onConflict'] extends true ? T['_']['returning'] | undefined
  : T['_']['returning'];
```

The flag is carried through `SQLiteInsertWithout`, `SQLiteInsertReturning`, `SQLiteInsertReturningAll`, `SQLiteInsertDynamic` and a new `SQLiteInsertOnConflict` helper, so the whole chain `onConflictDoNothing().returning().get()` keeps the widened type. `.all()` is intentionally unchanged: its element type never becomes optional (an empty array is already surfaced by `noUncheckedIndexedAccess` on index access, which the repo enables).

## Test

Adds type assertions to `drizzle-orm/type-tests/sqlite/insert.ts` covering both sync (better-sqlite3 `db`) and async (bun-sqlite `bunDb`) inserters:
- `onConflictDoNothing().returning().get()` → `T | undefined`
- conditional `onConflictDoUpdate({ setWhere }).returning().get()` → `T | undefined`
- unconditional `onConflictDoUpdate().returning().get()` stays `T`
- `onConflictDoNothing().returning().all()` stays `T[]`

Run with `pnpm --filter drizzle-orm run test:types` (`cd type-tests && tsc`). The new `Expect<Equal<...>>` asserts fail on the current code and pass with this fix.