### PR TITLE
[Pg] Run CREATE INDEX CONCURRENTLY migration statements outside of transactions

### DIFF
--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -106,18 +106,22 @@ export class PgDialect {
 		const pendingMigrations = migrations.filter(
 			(migration) => !lastDbMigration || Number(lastDbMigration.created_at) < migration.folderMillis,
 		);
-		const journalEntry = (migration: MigrationMeta) =>
+		const insertMigrationSql = (migration: MigrationMeta) =>
 			sql`insert into ${sql.identifier(migrationsSchema)}.${
 				sql.identifier(migrationsTable)
 			} ("hash", "created_at") values(${migration.hash}, ${migration.folderMillis})`;
 
-		if (!pendingMigrations.some((migration) => migration.sql.some((stmt) => isConcurrentIndexStatement(stmt)))) {
+		const hasConcurrentIndexStatements = pendingMigrations.some(
+			(migration) => migration.sql.some((stmt) => isConcurrentIndexStatement(stmt)),
+		);
+
+		if (!hasConcurrentIndexStatements) {
 			await session.transaction(async (tx) => {
 				for (const migration of pendingMigrations) {
 					for (const stmt of migration.sql) {
 						await tx.execute(sql.raw(stmt));
 					}
-					await tx.execute(journalEntry(migration));
+					await tx.execute(insertMigrationSql(migration));
 				}
 			});
 			return;
@@ -151,7 +155,7 @@ export class PgDialect {
 					batch.push(sql.raw(stmt));
 				}
 			}
-			batch.push(journalEntry(migration));
+			batch.push(insertMigrationSql(migration));
 			await flushBatch();
 		}
 	}

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -60,6 +60,17 @@ export interface PgDialectConfig {
 	casing?: Casing;
 }
 
+const leadingSqlTrivia = /^(?:\s+|--[^\n]*\n?|\/\*[\s\S]*?\*\/)+/;
+const concurrentIndexStart = /^(?:create\s+(?:unique\s+)?index|drop\s+index)\s+concurrently\b/i;
+
+/**
+ * `create index concurrently`, `create unique index concurrently` and `drop index concurrently`
+ * cannot be executed inside a transaction block, so the migrator has to run them separately.
+ */
+function isConcurrentIndexStatement(statement: string): boolean {
+	return concurrentIndexStart.test(statement.replace(leadingSqlTrivia, ''));
+}
+
 export class PgDialect {
 	static readonly [entityKind]: string = 'PgDialect';
 
@@ -92,23 +103,57 @@ export class PgDialect {
 		);
 
 		const lastDbMigration = dbMigrations[0];
-		await session.transaction(async (tx) => {
-			for await (const migration of migrations) {
-				if (
-					!lastDbMigration
-					|| Number(lastDbMigration.created_at) < migration.folderMillis
-				) {
+		const pendingMigrations = migrations.filter(
+			(migration) => !lastDbMigration || Number(lastDbMigration.created_at) < migration.folderMillis,
+		);
+		const journalEntry = (migration: MigrationMeta) =>
+			sql`insert into ${sql.identifier(migrationsSchema)}.${
+				sql.identifier(migrationsTable)
+			} ("hash", "created_at") values(${migration.hash}, ${migration.folderMillis})`;
+
+		if (!pendingMigrations.some((migration) => migration.sql.some((stmt) => isConcurrentIndexStatement(stmt)))) {
+			await session.transaction(async (tx) => {
+				for (const migration of pendingMigrations) {
 					for (const stmt of migration.sql) {
 						await tx.execute(sql.raw(stmt));
 					}
-					await tx.execute(
-						sql`insert into ${sql.identifier(migrationsSchema)}.${
-							sql.identifier(migrationsTable)
-						} ("hash", "created_at") values(${migration.hash}, ${migration.folderMillis})`,
-					);
+					await tx.execute(journalEntry(migration));
+				}
+			});
+			return;
+		}
+
+		// Concurrent index statements are not allowed inside a transaction block and wait for all
+		// transactions that could use their target table to finish, so batched statements are
+		// committed before each of them runs. Since full atomicity is impossible here, each
+		// migration is applied and recorded individually: a failure never rolls back a migration
+		// that was already recorded as applied.
+		for (const migration of pendingMigrations) {
+			let batch: SQL[] = [];
+			const flushBatch = async () => {
+				if (batch.length === 0) {
+					return;
+				}
+				const statements = batch;
+				batch = [];
+				await session.transaction(async (tx) => {
+					for (const statement of statements) {
+						await tx.execute(statement);
+					}
+				});
+			};
+
+			for (const stmt of migration.sql) {
+				if (isConcurrentIndexStatement(stmt)) {
+					await flushBatch();
+					await session.execute(sql.raw(stmt));
+				} else {
+					batch.push(sql.raw(stmt));
 				}
 			}
-		});
+			batch.push(journalEntry(migration));
+			await flushBatch();
+		}
 	}
 
 	escapeName(name: string): string {

--- a/drizzle-orm/tests/pg-migrator.test.ts
+++ b/drizzle-orm/tests/pg-migrator.test.ts
@@ -275,6 +275,7 @@ describe('concurrent index statement detection', () => {
 		'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")',
 		'create index concurrently "users_name_index" on "users" ("name")',
 		'CREATE INDEX CONCURRENTLY IF NOT EXISTS "users_name_index" ON "users" ("name")',
+		'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "users_name_index" ON "users" ("name")',
 		'CREATE INDEX CONCURRENTLY ON "users" ("name")',
 		'CREATE UNIQUE INDEX CONCURRENTLY "users_name_index" ON "users" USING btree ("name");',
 		'\nCREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name");',
@@ -282,6 +283,7 @@ describe('concurrent index statement detection', () => {
 		'/* adds\nthe index */ CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")',
 		'create\tunique\nindex   concurrently "users_name_index" on "users" ("name")',
 		'DROP INDEX CONCURRENTLY "users_name_index"',
+		'DROP INDEX CONCURRENTLY IF EXISTS "users_name_index"',
 	])('runs outside of the transaction: %s', async (statement) => {
 		const session = new MockSession();
 		const migration1 = migration(1, statement);

--- a/drizzle-orm/tests/pg-migrator.test.ts
+++ b/drizzle-orm/tests/pg-migrator.test.ts
@@ -58,14 +58,19 @@ function migration(folderMillis: number, ...statements: string[]): MigrationMeta
 	};
 }
 
-async function migrate(
+function migrate(
 	session: MockSession,
 	migrations: MigrationMeta[],
 	config: { migrationsTable?: string; migrationsSchema?: string } = {},
-): Promise<LogEntry[]> {
-	await dialect.migrate(migrations, session as unknown as PgSession, { migrationsFolder: '', ...config });
-	// Drops the migrations schema + table setup and the applied migrations lookup,
-	// which are identical for every run.
+): Promise<void> {
+	return dialect.migrate(migrations, session as unknown as PgSession, { migrationsFolder: '', ...config });
+}
+
+/**
+ * Drops the migrations schema + table setup and the applied migrations lookup,
+ * which are identical for every run.
+ */
+function appliedQueries(session: MockSession): LogEntry[] {
 	return session.log.slice(3);
 }
 
@@ -73,7 +78,7 @@ function query(sql: string): LoggedQuery {
 	return { sql, params: [] };
 }
 
-function journalEntry(
+function migrationRecord(
 	migration: MigrationMeta,
 	schema = 'drizzle',
 	table = '__drizzle_migrations',
@@ -94,16 +99,16 @@ describe('migrations without concurrent index statements', () => {
 		);
 		const migration2 = migration(2, 'CREATE INDEX "users_name_index" ON "users" ("name")');
 
-		const log = await migrate(session, [migration1, migration2]);
+		await migrate(session, [migration1, migration2]);
 
 		expect(session.log[0]).toEqual(query('CREATE SCHEMA IF NOT EXISTS "drizzle"'));
-		expect(log).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			'begin',
 			query('CREATE TABLE "users" ("id" int)'),
 			query('ALTER TABLE "users" ADD COLUMN "name" text'),
-			journalEntry(migration1),
+			migrationRecord(migration1),
 			query('CREATE INDEX "users_name_index" ON "users" ("name")'),
-			journalEntry(migration2),
+			migrationRecord(migration2),
 			'commit',
 		]);
 	});
@@ -114,12 +119,12 @@ describe('migrations without concurrent index statements', () => {
 		const migration1 = migration(1, 'CREATE TABLE "users" ("id" int)');
 		const migration2 = migration(2, 'ALTER TABLE "users" ADD COLUMN "name" text');
 
-		const log = await migrate(session, [migration1, migration2]);
+		await migrate(session, [migration1, migration2]);
 
-		expect(log).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			'begin',
 			query('ALTER TABLE "users" ADD COLUMN "name" text'),
-			journalEntry(migration2),
+			migrationRecord(migration2),
 			'commit',
 		]);
 	});
@@ -132,10 +137,10 @@ describe('migrations without concurrent index statements', () => {
 
 		await expect(migrate(session, [migration1, migration2])).rejects.toThrow('DROP TABLE "missing"');
 
-		expect(session.log.slice(3)).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			'begin',
 			query('CREATE TABLE "users" ("id" int)'),
-			journalEntry(migration1),
+			migrationRecord(migration1),
 			query('DROP TABLE "missing"'),
 			'rollback',
 		]);
@@ -152,16 +157,16 @@ describe('migrations with concurrent index statements', () => {
 			'ALTER TABLE "users" ADD COLUMN "email" text',
 		);
 
-		const log = await migrate(session, [migration1]);
+		await migrate(session, [migration1]);
 
-		expect(log).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			'begin',
 			query('CREATE TABLE "users" ("id" int, "name" text)'),
 			'commit',
 			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
 			'begin',
 			query('ALTER TABLE "users" ADD COLUMN "email" text'),
-			journalEntry(migration1),
+			migrationRecord(migration1),
 			'commit',
 		]);
 	});
@@ -172,20 +177,39 @@ describe('migrations with concurrent index statements', () => {
 		const migration2 = migration(2, 'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")');
 		const migration3 = migration(3, 'ALTER TABLE "users" ADD COLUMN "email" text');
 
-		const log = await migrate(session, [migration1, migration2, migration3]);
+		await migrate(session, [migration1, migration2, migration3]);
 
-		expect(log).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			'begin',
 			query('CREATE TABLE "users" ("id" int, "name" text)'),
-			journalEntry(migration1),
+			migrationRecord(migration1),
 			'commit',
 			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
 			'begin',
-			journalEntry(migration2),
+			migrationRecord(migration2),
 			'commit',
 			'begin',
 			query('ALTER TABLE "users" ADD COLUMN "email" text'),
-			journalEntry(migration3),
+			migrationRecord(migration3),
+			'commit',
+		]);
+	});
+
+	test('does not open empty transactions between consecutive concurrent statements', async () => {
+		const session = new MockSession();
+		const migration1 = migration(
+			1,
+			'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")',
+			'CREATE UNIQUE INDEX CONCURRENTLY "users_email_index" ON "users" ("email")',
+		);
+
+		await migrate(session, [migration1]);
+
+		expect(appliedQueries(session)).toEqual([
+			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
+			query('CREATE UNIQUE INDEX CONCURRENTLY "users_email_index" ON "users" ("email")'),
+			'begin',
+			migrationRecord(migration1),
 			'commit',
 		]);
 	});
@@ -194,15 +218,15 @@ describe('migrations with concurrent index statements', () => {
 		const session = new MockSession();
 		const migration1 = migration(1, 'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")');
 
-		const log = await migrate(session, [migration1], {
+		await migrate(session, [migration1], {
 			migrationsSchema: 'custom_schema',
 			migrationsTable: 'custom_table',
 		});
 
-		expect(log).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
 			'begin',
-			journalEntry(migration1, 'custom_schema', 'custom_table'),
+			migrationRecord(migration1, 'custom_schema', 'custom_table'),
 			'commit',
 		]);
 	});
@@ -218,7 +242,7 @@ describe('migrations with concurrent index statements', () => {
 
 		await expect(migrate(session, [migration1])).rejects.toThrow('CREATE INDEX CONCURRENTLY');
 
-		expect(session.log.slice(3)).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			'begin',
 			query('CREATE TABLE "users" ("id" int, "name" text)'),
 			'commit',
@@ -234,10 +258,10 @@ describe('migrations with concurrent index statements', () => {
 
 		await expect(migrate(session, [migration1, migration2])).rejects.toThrow('DROP TABLE "missing"');
 
-		expect(session.log.slice(3)).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
 			'begin',
-			journalEntry(migration1),
+			migrationRecord(migration1),
 			'commit',
 			'begin',
 			query('DROP TABLE "missing"'),
@@ -262,12 +286,12 @@ describe('concurrent index statement detection', () => {
 		const session = new MockSession();
 		const migration1 = migration(1, statement);
 
-		const log = await migrate(session, [migration1]);
+		await migrate(session, [migration1]);
 
-		expect(log).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			query(statement),
 			'begin',
-			journalEntry(migration1),
+			migrationRecord(migration1),
 			'commit',
 		]);
 	});
@@ -283,12 +307,12 @@ describe('concurrent index statement detection', () => {
 		const session = new MockSession();
 		const migration1 = migration(1, statement);
 
-		const log = await migrate(session, [migration1]);
+		await migrate(session, [migration1]);
 
-		expect(log).toEqual([
+		expect(appliedQueries(session)).toEqual([
 			'begin',
 			query(statement),
-			journalEntry(migration1),
+			migrationRecord(migration1),
 			'commit',
 		]);
 	});

--- a/drizzle-orm/tests/pg-migrator.test.ts
+++ b/drizzle-orm/tests/pg-migrator.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, test } from 'vitest';
+import type { MigrationMeta } from '~/migrator.ts';
+import { PgDialect } from '~/pg-core/dialect.ts';
+import type { PgSession } from '~/pg-core/session.ts';
+import type { SQL } from '~/sql/sql.ts';
+
+const dialect = new PgDialect();
+
+interface LoggedQuery {
+	sql: string;
+	params: unknown[];
+}
+
+type LogEntry = 'begin' | 'commit' | 'rollback' | LoggedQuery;
+
+class MockSession {
+	readonly log: LogEntry[] = [];
+	appliedMigrations: { id: number; hash: string; created_at: string }[] = [];
+	failOnSql: string | undefined;
+
+	private record(query: SQL): void {
+		const { sql: queryString, params } = dialect.sqlToQuery(query);
+		this.log.push({ sql: queryString, params });
+		if (this.failOnSql !== undefined && queryString.includes(this.failOnSql)) {
+			throw new Error(`query failed: ${queryString}`);
+		}
+	}
+
+	async execute(query: SQL): Promise<unknown> {
+		this.record(query);
+		return [];
+	}
+
+	async all(query: SQL): Promise<unknown[]> {
+		this.record(query);
+		return this.appliedMigrations;
+	}
+
+	async transaction<T>(transaction: (tx: { execute(query: SQL): Promise<unknown> }) => Promise<T>): Promise<T> {
+		this.log.push('begin');
+		try {
+			const result = await transaction({ execute: async (query) => this.record(query) });
+			this.log.push('commit');
+			return result;
+		} catch (error) {
+			this.log.push('rollback');
+			throw error;
+		}
+	}
+}
+
+function migration(folderMillis: number, ...statements: string[]): MigrationMeta {
+	return {
+		sql: statements,
+		folderMillis,
+		hash: `hash${folderMillis}`,
+		bps: true,
+	};
+}
+
+async function migrate(
+	session: MockSession,
+	migrations: MigrationMeta[],
+	config: { migrationsTable?: string; migrationsSchema?: string } = {},
+): Promise<LogEntry[]> {
+	await dialect.migrate(migrations, session as unknown as PgSession, { migrationsFolder: '', ...config });
+	// Drops the migrations schema + table setup and the applied migrations lookup,
+	// which are identical for every run.
+	return session.log.slice(3);
+}
+
+function query(sql: string): LoggedQuery {
+	return { sql, params: [] };
+}
+
+function journalEntry(
+	migration: MigrationMeta,
+	schema = 'drizzle',
+	table = '__drizzle_migrations',
+): LoggedQuery {
+	return {
+		sql: `insert into "${schema}"."${table}" ("hash", "created_at") values($1, $2)`,
+		params: [migration.hash, migration.folderMillis],
+	};
+}
+
+describe('migrations without concurrent index statements', () => {
+	test('applies all pending migrations in a single transaction', async () => {
+		const session = new MockSession();
+		const migration1 = migration(
+			1,
+			'CREATE TABLE "users" ("id" int)',
+			'ALTER TABLE "users" ADD COLUMN "name" text',
+		);
+		const migration2 = migration(2, 'CREATE INDEX "users_name_index" ON "users" ("name")');
+
+		const log = await migrate(session, [migration1, migration2]);
+
+		expect(session.log[0]).toEqual(query('CREATE SCHEMA IF NOT EXISTS "drizzle"'));
+		expect(log).toEqual([
+			'begin',
+			query('CREATE TABLE "users" ("id" int)'),
+			query('ALTER TABLE "users" ADD COLUMN "name" text'),
+			journalEntry(migration1),
+			query('CREATE INDEX "users_name_index" ON "users" ("name")'),
+			journalEntry(migration2),
+			'commit',
+		]);
+	});
+
+	test('skips migrations that were already applied', async () => {
+		const session = new MockSession();
+		session.appliedMigrations = [{ id: 1, hash: 'hash1', created_at: '1' }];
+		const migration1 = migration(1, 'CREATE TABLE "users" ("id" int)');
+		const migration2 = migration(2, 'ALTER TABLE "users" ADD COLUMN "name" text');
+
+		const log = await migrate(session, [migration1, migration2]);
+
+		expect(log).toEqual([
+			'begin',
+			query('ALTER TABLE "users" ADD COLUMN "name" text'),
+			journalEntry(migration2),
+			'commit',
+		]);
+	});
+
+	test('rolls back all pending migrations when a statement fails', async () => {
+		const session = new MockSession();
+		session.failOnSql = 'DROP TABLE "missing"';
+		const migration1 = migration(1, 'CREATE TABLE "users" ("id" int)');
+		const migration2 = migration(2, 'DROP TABLE "missing"');
+
+		await expect(migrate(session, [migration1, migration2])).rejects.toThrow('DROP TABLE "missing"');
+
+		expect(session.log.slice(3)).toEqual([
+			'begin',
+			query('CREATE TABLE "users" ("id" int)'),
+			journalEntry(migration1),
+			query('DROP TABLE "missing"'),
+			'rollback',
+		]);
+	});
+});
+
+describe('migrations with concurrent index statements', () => {
+	test('runs the concurrent statement outside of the transaction and commits preceding statements first', async () => {
+		const session = new MockSession();
+		const migration1 = migration(
+			1,
+			'CREATE TABLE "users" ("id" int, "name" text)',
+			'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")',
+			'ALTER TABLE "users" ADD COLUMN "email" text',
+		);
+
+		const log = await migrate(session, [migration1]);
+
+		expect(log).toEqual([
+			'begin',
+			query('CREATE TABLE "users" ("id" int, "name" text)'),
+			'commit',
+			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
+			'begin',
+			query('ALTER TABLE "users" ADD COLUMN "email" text'),
+			journalEntry(migration1),
+			'commit',
+		]);
+	});
+
+	test('applies and records each migration separately', async () => {
+		const session = new MockSession();
+		const migration1 = migration(1, 'CREATE TABLE "users" ("id" int, "name" text)');
+		const migration2 = migration(2, 'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")');
+		const migration3 = migration(3, 'ALTER TABLE "users" ADD COLUMN "email" text');
+
+		const log = await migrate(session, [migration1, migration2, migration3]);
+
+		expect(log).toEqual([
+			'begin',
+			query('CREATE TABLE "users" ("id" int, "name" text)'),
+			journalEntry(migration1),
+			'commit',
+			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
+			'begin',
+			journalEntry(migration2),
+			'commit',
+			'begin',
+			query('ALTER TABLE "users" ADD COLUMN "email" text'),
+			journalEntry(migration3),
+			'commit',
+		]);
+	});
+
+	test('uses the configured migrations schema and table', async () => {
+		const session = new MockSession();
+		const migration1 = migration(1, 'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")');
+
+		const log = await migrate(session, [migration1], {
+			migrationsSchema: 'custom_schema',
+			migrationsTable: 'custom_table',
+		});
+
+		expect(log).toEqual([
+			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
+			'begin',
+			journalEntry(migration1, 'custom_schema', 'custom_table'),
+			'commit',
+		]);
+	});
+
+	test('does not record a migration whose concurrent statement fails', async () => {
+		const session = new MockSession();
+		session.failOnSql = 'CREATE INDEX CONCURRENTLY';
+		const migration1 = migration(
+			1,
+			'CREATE TABLE "users" ("id" int, "name" text)',
+			'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")',
+		);
+
+		await expect(migrate(session, [migration1])).rejects.toThrow('CREATE INDEX CONCURRENTLY');
+
+		expect(session.log.slice(3)).toEqual([
+			'begin',
+			query('CREATE TABLE "users" ("id" int, "name" text)'),
+			'commit',
+			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
+		]);
+	});
+
+	test('keeps recorded migrations when a later migration fails', async () => {
+		const session = new MockSession();
+		session.failOnSql = 'DROP TABLE "missing"';
+		const migration1 = migration(1, 'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")');
+		const migration2 = migration(2, 'DROP TABLE "missing"');
+
+		await expect(migrate(session, [migration1, migration2])).rejects.toThrow('DROP TABLE "missing"');
+
+		expect(session.log.slice(3)).toEqual([
+			query('CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")'),
+			'begin',
+			journalEntry(migration1),
+			'commit',
+			'begin',
+			query('DROP TABLE "missing"'),
+			'rollback',
+		]);
+	});
+});
+
+describe('concurrent index statement detection', () => {
+	test.each([
+		'CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")',
+		'create index concurrently "users_name_index" on "users" ("name")',
+		'CREATE INDEX CONCURRENTLY IF NOT EXISTS "users_name_index" ON "users" ("name")',
+		'CREATE INDEX CONCURRENTLY ON "users" ("name")',
+		'CREATE UNIQUE INDEX CONCURRENTLY "users_name_index" ON "users" USING btree ("name");',
+		'\nCREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name");',
+		'-- adds the index\nCREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")',
+		'/* adds\nthe index */ CREATE INDEX CONCURRENTLY "users_name_index" ON "users" ("name")',
+		'create\tunique\nindex   concurrently "users_name_index" on "users" ("name")',
+		'DROP INDEX CONCURRENTLY "users_name_index"',
+	])('runs outside of the transaction: %s', async (statement) => {
+		const session = new MockSession();
+		const migration1 = migration(1, statement);
+
+		const log = await migrate(session, [migration1]);
+
+		expect(log).toEqual([
+			query(statement),
+			'begin',
+			journalEntry(migration1),
+			'commit',
+		]);
+	});
+
+	test.each([
+		'CREATE INDEX "users_name_index" ON "users" ("name")',
+		'CREATE UNIQUE INDEX "users_name_index" ON "users" ("name")',
+		'CREATE INDEX concurrently_index ON "users" ("name")',
+		'CREATE INDEX "concurrently" ON "users" ("name")',
+		'DROP INDEX "users_name_index"',
+		`INSERT INTO "log" ("message") VALUES ('create index concurrently')`,
+	])('runs inside of the transaction: %s', async (statement) => {
+		const session = new MockSession();
+		const migration1 = migration(1, statement);
+
+		const log = await migrate(session, [migration1]);
+
+		expect(log).toEqual([
+			'begin',
+			query(statement),
+			journalEntry(migration1),
+			'commit',
+		]);
+	});
+});

--- a/integration-tests/drizzle2/pg-concurrently/0000_concurrent_index.sql
+++ b/integration-tests/drizzle2/pg-concurrently/0000_concurrent_index.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "users_concurrently" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX CONCURRENTLY "users_concurrently_name_index" ON "users_concurrently" ("name");--> statement-breakpoint
+CREATE UNIQUE INDEX CONCURRENTLY "users_concurrently_email_index" ON "users_concurrently" ("email");

--- a/integration-tests/drizzle2/pg-concurrently/0001_add_last_name.sql
+++ b/integration-tests/drizzle2/pg-concurrently/0001_add_last_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users_concurrently" ADD COLUMN "last_name" text;

--- a/integration-tests/drizzle2/pg-concurrently/meta/_journal.json
+++ b/integration-tests/drizzle2/pg-concurrently/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1754000000000,
+      "tag": "0000_concurrent_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1754000000001,
+      "tag": "0001_add_last_name",
+      "breakpoints": true
+    }
+  ]
+}

--- a/integration-tests/tests/pg/node-postgres.test.ts
+++ b/integration-tests/tests/pg/node-postgres.test.ts
@@ -181,7 +181,9 @@ test('migrator : migration with create index concurrently', async () => {
 	);
 	await expect(
 		db.execute(sql`insert into users_concurrently ("name", "email") values ('Jane', 'john@example.com')`),
-	).rejects.toThrow();
+	).rejects.toMatchObject({
+		cause: expect.objectContaining({ constraint: 'users_concurrently_email_index' }),
+	});
 
 	await db.execute(sql`drop table users_concurrently`);
 	await db.execute(sql`drop table "drizzle"."__drizzle_migrations"`);

--- a/integration-tests/tests/pg/node-postgres.test.ts
+++ b/integration-tests/tests/pg/node-postgres.test.ts
@@ -150,6 +150,43 @@ test('migrator : migrate with custom table and custom schema', async () => {
 	await db.execute(sql`drop table ${sql.identifier(customSchema)}.${sql.identifier(customTable)}`);
 });
 
+test('migrator : migration with create index concurrently', async () => {
+	await db.execute(sql`drop table if exists users_concurrently`);
+	await db.execute(sql`drop table if exists "drizzle"."__drizzle_migrations"`);
+
+	await migrate(db, { migrationsFolder: './drizzle2/pg-concurrently' });
+
+	// test that both concurrently built indexes exist and are valid
+	const { rows: indexes } = await db.execute(
+		sql`select i.relname as name, ix.indisvalid as valid
+			from pg_index ix
+			join pg_class i on i.oid = ix.indexrelid
+			join pg_class t on t.oid = ix.indrelid
+			where t.relname = 'users_concurrently' and not ix.indisprimary
+			order by i.relname`,
+	);
+	expect(indexes).toEqual([
+		{ name: 'users_concurrently_email_index', valid: true },
+		{ name: 'users_concurrently_name_index', valid: true },
+	]);
+
+	// test that all migrations were recorded and a second run is a no-op
+	await migrate(db, { migrationsFolder: './drizzle2/pg-concurrently' });
+	const { rows: migrations } = await db.execute(sql`select hash from "drizzle"."__drizzle_migrations"`);
+	expect(migrations).toHaveLength(2);
+
+	// test that the migrated table and the unique index are working as expected
+	await db.execute(
+		sql`insert into users_concurrently ("name", "email", "last_name") values ('John', 'john@example.com', 'Doe')`,
+	);
+	await expect(
+		db.execute(sql`insert into users_concurrently ("name", "email") values ('Jane', 'john@example.com')`),
+	).rejects.toThrow();
+
+	await db.execute(sql`drop table users_concurrently`);
+	await db.execute(sql`drop table "drizzle"."__drizzle_migrations"`);
+});
+
 test('all date and time columns without timezone first case mode string', async () => {
 	const table = pgTable('all_columns', {
 		id: serial('id').primaryKey(),


### PR DESCRIPTION
Fixes #860

## Problem

`PgDialect.migrate()` wraps all pending migrations in a single transaction. PostgreSQL forbids `CREATE INDEX CONCURRENTLY` (and `CREATE UNIQUE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY`) inside a transaction block, so any migration generated from an index with `.concurrently()` failed with:

```
CREATE INDEX CONCURRENTLY cannot run inside a transaction block
```

drizzle-kit already generates the `CONCURRENTLY` SQL; it just could not be applied by `migrate()` (or by `drizzle-kit migrate`, which delegates to the same code).

## Solution

The Postgres migrator now detects statements that start with `CREATE [UNIQUE] INDEX CONCURRENTLY` or `DROP INDEX CONCURRENTLY` (after leading whitespace/comments) and executes them outside of the migration transaction:

- **No concurrent statements pending (the common case):** behavior is byte-for-byte identical to before. All pending migrations and their journal entries run in one transaction, all-or-nothing.
- **A pending migration contains a concurrent statement:** statements batched so far are committed first (required: `CREATE INDEX CONCURRENTLY` waits for open transactions to finish, so keeping our own transaction open would self-deadlock), the concurrent statement runs on the session directly, and the remaining statements resume in a new transaction. Each migration is applied and recorded in `__drizzle_migrations` individually, so a failure never rolls back a migration that was already recorded as applied.

Since concurrent index builds are inherently non-transactional, a migration containing one cannot be fully atomic. If such a statement fails mid-build, PostgreSQL can leave an `INVALID` index behind, which has to be dropped before retrying - the same caveat as running `CREATE INDEX CONCURRENTLY` manually.

Notes:
- Only statement detection, no SQL rewriting: exactly the statements in the migration files are executed.
- Drivers without transaction support (`neon-http`, `xata-http`) already ran statements individually and are unaffected. All drivers that use `PgDialect.migrate` (node-postgres, postgres-js, pglite, neon-serverless, vercel-postgres, aws-data-api, bun-sql, netlify) inherit the fix.
- Migrations generated with `breakpoints: false` (all statements in one string) remain unsupported for `CONCURRENTLY`, as before.

## Tests

- `drizzle-orm/tests/pg-migrator.test.ts` (new, 24 unit tests): single-transaction behavior preserved (including rollback of all pending migrations on failure), transaction boundaries and journal placement around concurrent statements, per-migration recording, custom `migrationsTable`/`migrationsSchema`, failure ordering, and positive/negative statement classification (case-insensitivity, `UNIQUE`, `IF NOT EXISTS`, leading comments, quoted identifiers named `concurrently`, etc.).
- `integration-tests/tests/pg/node-postgres.test.ts` + `integration-tests/drizzle2/pg-concurrently/` fixture (new): applies a migration with two `CONCURRENTLY` indexes plus a follow-up migration against real PostgreSQL, verifies both indexes exist and are `indisvalid`, both migrations are journaled, a second `migrate()` call is a no-op, and the unique index enforces uniqueness. Without the fix this test fails with the exact error from #860 (verified).
- Full `drizzle-orm` unit suite (590 tests), `drizzle-orm` type tests, `integration-tests` tsc, existing migrator integration tests for node-postgres, postgres-js and pglite, and dprint all pass.

Made with [Cursor](https://cursor.com)