### PR TITLE
Fix #1188: [BUG]: MySQL2 binary/varbinary types are incorrectly typed as strings instead of buffers

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -7,21 +7,21 @@ import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer | Uint8Array;
 	enumValues: undefined;
 }>;
 
-export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumnBuilder<
+export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumnBuilder<
 	T,
 	MySqlBinaryConfig
 > {
 	static override readonly [entityKind]: string = 'MySqlBinaryBuilder';
 
 	constructor(name: T['name'], length: number | undefined) {
-		super(name, 'string', 'MySqlBinary');
+		super(name, 'buffer', 'MySqlBinary');
 		this.config.length = length;
 	}
 
@@ -33,7 +33,7 @@ export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MyS
 	}
 }
 
-export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumn<
+export class MySqlBinary<T extends ColumnBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumn<
 	T,
 	MySqlBinaryConfig
 > {
@@ -41,16 +41,8 @@ export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> ex
 
 	length: number | undefined = this.config.length;
 
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
+	override mapFromDriverValue(value: Buffer | Uint8Array): Buffer {
+		return Buffer.from(value);
 	}
 
 	getSQLType(): string {

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -7,21 +7,21 @@ import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlVarBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer | Uint8Array;
 	enumValues: undefined;
 }>;
 
-export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlVarBinary'>>
+export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarBinary'>>
 	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
 {
 	static override readonly [entityKind]: string = 'MySqlVarBinaryBuilder';
 
 	/** @internal */
 	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
-		super(name, 'string', 'MySqlVarBinary');
+		super(name, 'buffer', 'MySqlVarBinary');
 		this.config.length = config?.length;
 	}
 
@@ -37,22 +37,14 @@ export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', '
 }
 
 export class MySqlVarBinary<
-	T extends ColumnBaseConfig<'string', 'MySqlVarBinary'>,
+	T extends ColumnBaseConfig<'buffer', 'MySqlVarBinary'>,
 > extends MySqlColumn<T, MySqlVarbinaryOptions> {
 	static override readonly [entityKind]: string = 'MySqlVarBinary';
 
 	length: number | undefined = this.config.length;
 
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
+	override mapFromDriverValue(value: Buffer | Uint8Array): Buffer {
+		return Buffer.from(value);
 	}
 
 	getSQLType(): string {

--- a/drizzle-orm/type-tests/mysql/tables.ts
+++ b/drizzle-orm/type-tests/mysql/tables.ts
@@ -865,7 +865,7 @@ Expect<
 		bigintdef: bigint('bigintdef', { mode: 'number' }).default(0),
 		binary: binary('binary'),
 		binary1: binary('binary1', { length: 1 }),
-		binarydef: binary('binarydef').default(''),
+		binarydef: binary('binarydef').default(Buffer.from('')),
 		boolean: boolean('boolean'),
 		booleandef: boolean('booleandef').default(false),
 		char: char('char'),
@@ -939,7 +939,7 @@ Expect<
 		tinyint2: tinyint('tinyint2', { unsigned: true }),
 		tinyintdef: tinyint('tinyintdef').default(0),
 		varbinary: varbinary('varbinary', { length: 1 }),
-		varbinarydef: varbinary('varbinarydef', { length: 1 }).default(''),
+		varbinarydef: varbinary('varbinarydef', { length: 1 }).default(Buffer.from('')),
 		varchar: varchar('varchar', { length: 1 }),
 		varchar2: varchar('varchar2', { length: 1, enum: ['a', 'b', 'c'] }),
 		varchardef: varchar('varchardef', { length: 1 }).default(''),
@@ -965,7 +965,7 @@ Expect<
 		bigintdef: bigint({ mode: 'number' }).default(0),
 		binary: binary(),
 		binrary1: binary({ length: 1 }),
-		binarydef: binary().default(''),
+		binarydef: binary().default(Buffer.from('')),
 		boolean: boolean(),
 		booleandef: boolean().default(false),
 		char: char(),
@@ -1039,13 +1039,24 @@ Expect<
 		tinyint2: tinyint({ unsigned: true }),
 		tinyintdef: tinyint().default(0),
 		varbinary: varbinary({ length: 1 }),
-		varbinarydef: varbinary({ length: 1 }).default(''),
+		varbinarydef: varbinary({ length: 1 }).default(Buffer.from('')),
 		varchar: varchar({ length: 1 }),
 		varchar2: varchar({ length: 1, enum: ['a', 'b', 'c'] }),
 		varchardef: varchar({ length: 1 }).default(''),
 		year: year(),
 		yeardef: year().default(0),
 	});
+}
+
+{
+	const binaryTypes = mysqlTable('binary_types', {
+		binary: binary(),
+		varbinary: varbinary({ length: 1 }),
+	});
+
+	type BinaryTypes = InferSelectModel<typeof binaryTypes>;
+	Expect<Equal<BinaryTypes['binary'], Buffer>>;
+	Expect<Equal<BinaryTypes['varbinary'], Buffer>>;
 }
 
 {


### PR DESCRIPTION
Closes #1188

Implementation is intentionally scoped to the bounty requirements and was independently reviewed before submission.

@algora-pbc /claim #1188