### PR TITLE
[MySQL] Keep an index that still backs a foreign key

### DIFF
--- a/drizzle-kit/src/dialects/mysql/diff.ts
+++ b/drizzle-kit/src/dialects/mysql/diff.ts
@@ -4,7 +4,7 @@ import type { Resolver } from '../common';
 import { diff } from '../dialect';
 import { groupDiffs, preserveEntityNames } from '../utils';
 import { fromJson } from './convertor';
-import type { Column, DiffEntities, Index, MysqlDDL, Table, View } from './ddl';
+import type { Column, DiffEntities, ForeignKey, Index, MysqlDDL, Table, View } from './ddl';
 import { fullTableFromDDL } from './ddl';
 import { charSetAndCollationCommutative, commutative, defaultNameForFK } from './grammar';
 import { prepareStatement } from './statements';
@@ -273,9 +273,42 @@ export const ddlDiff = async (
 		.filter((it) => !deletedTables.some((x) => x.name === it.table))
 		.map((it) => prepareStatement('drop_constraint', { constraint: it.name, table: it.table, dropAutoIndex: false }));
 
+	/*
+		MySQL requires every foreign key to be backed by an index whose leftmost
+		columns are the key's columns, and refuses to drop the last index that
+		does so (errno 1553). An index that is still backing a foreign key
+		therefore has to be left alone, however the schema declares it.
+
+		This is reachable whenever a constraint and the index implicitly created
+		for it stop sharing a name. MySQL names that index after the constraint,
+		and `fromDatabaseForDrizzle` uses the shared name to tell implicit
+		indexes apart from user ones — so when something renames the constraint
+		but not the index (PlanetScale/Vitess appends a random suffix to
+		constraint names when applying a migration), the index is reported as a
+		user index that the schema does not declare, and every push plans a drop
+		the database can only reject.
+	*/
+	const backsForeignKey = (index: Index) => {
+		const columnsOf = (idx: Index) => idx.columns.map((it) => (it.isExpression ? null : it.value));
+		const covers = (columns: (string | null)[], fk: ForeignKey) =>
+			fk.columns.length <= columns.length && fk.columns.every((it, i) => columns[i] === it);
+
+		const droppedFks = new Set(
+			fksDiff.filter((it) => it.$diffType === 'drop').map((it) => `${it.table}.${it.name}`),
+		);
+		const fks = ddl1.fks.list({ table: index.table })
+			.filter((fk) => !droppedFks.has(`${fk.table}.${fk.name}`))
+			.filter((fk) => covers(columnsOf(index), fk));
+		if (fks.length === 0) return false;
+
+		const others = ddl1.indexes.list({ table: index.table }).filter((it) => it.name !== index.name);
+		const pk = ddl1.pks.one({ table: index.table });
+		return fks.some((fk) => !others.some((it) => covers(columnsOf(it), fk)) && !(pk && covers(pk.columns, fk)));
+	};
+
 	const dropIndexeStatements = indexesDiff.filter((it) => it.$diffType === 'drop').filter((it) =>
 		!deletedTables.some((x) => x.name === it.table)
-	).map((it) => prepareStatement('drop_index', { index: it }));
+	).filter((it) => !backsForeignKey(it)).map((it) => prepareStatement('drop_index', { index: it }));
 
 	const dropFKStatements = fksDiff.filter((it) => it.$diffType === 'drop')
 		.filter((it) => {

--- a/drizzle-kit/tests/mysql/constraints.test.ts
+++ b/drizzle-kit/tests/mysql/constraints.test.ts
@@ -1345,3 +1345,77 @@ test('changing a column type records a `type_change` confirm_data_loss missing h
 		},
 	]);
 });
+
+/*
+	MySQL names the index it implicitly creates for a foreign key after the
+	constraint, and introspection uses that shared name to tell implicit indexes
+	apart from user ones. Anything that renames the constraint without renaming
+	the index breaks the link — PlanetScale/Vitess appends a random suffix to
+	constraint names when it applies a migration — and the index then reads as a
+	user index the schema does not declare. Dropping it is not possible: MySQL
+	refuses to drop the last index backing a foreign key with errno 1553.
+*/
+test('index backing a foreign key of another name is not dropped', async () => {
+	const parent = mysqlTable('parent', {
+		id: varchar({ length: 100 }).primaryKey(),
+	});
+	const child = (extras: 'with-index' | 'without-index') =>
+		mysqlTable('child', {
+			parentId: varchar({ length: 100 }),
+		}, (t) => [
+			...(extras === 'with-index' ? [index('child_parentId_fkey').on(t.parentId)] : []),
+			foreignKey({
+				name: 'child_parentId_fkey_9ugmls298u0uxtdy24kgydtuq',
+				columns: [t.parentId],
+				foreignColumns: [parent.id],
+			}),
+		]);
+
+	const from = { parent, child: child('with-index') };
+	const to = { parent, child: child('without-index') };
+
+	const { sqlStatements } = await diff(from, to, []);
+	expect(sqlStatements).toStrictEqual([]);
+});
+
+test('index not backing a foreign key is still dropped', async () => {
+	const from = {
+		child: mysqlTable('child', {
+			parentId: varchar({ length: 100 }),
+			other: varchar({ length: 100 }),
+		}, (t) => [index('child_other_idx').on(t.other)]),
+	};
+	const to = {
+		child: mysqlTable('child', {
+			parentId: varchar({ length: 100 }),
+			other: varchar({ length: 100 }),
+		}),
+	};
+
+	const { sqlStatements } = await diff(from, to, []);
+	expect(sqlStatements).toStrictEqual(['DROP INDEX `child_other_idx` ON `child`;']);
+});
+
+test('index backing a foreign key is dropped when another index covers it', async () => {
+	const parent = mysqlTable('parent', {
+		id: varchar({ length: 100 }).primaryKey(),
+	});
+	const child = (extras: 'both' | 'one') =>
+		mysqlTable('child', {
+			parentId: varchar({ length: 100 }),
+		}, (t) => [
+			...(extras === 'both' ? [index('child_parentId_fkey').on(t.parentId)] : []),
+			index('child_parentId_idx').on(t.parentId),
+			foreignKey({
+				name: 'child_parentId_fkey_9ugmls298u0uxtdy24kgydtuq',
+				columns: [t.parentId],
+				foreignColumns: [parent.id],
+			}),
+		]);
+
+	const from = { parent, child: child('both') };
+	const to = { parent, child: child('one') };
+
+	const { sqlStatements } = await diff(from, to, []);
+	expect(sqlStatements).toStrictEqual(['DROP INDEX `child_parentId_fkey` ON `child`;']);
+});


### PR DESCRIPTION
## Problem

MySQL requires every foreign key to be backed by an index whose leftmost columns are the key's columns, and refuses to drop the last index that does so. drizzle-kit can plan exactly that drop, so `push` fails and cannot recover:

```
Can't DROP 'AdCampaign_organizationId_fkey_clltgsf5s1uvzvga1znoe1u2w';
check that column/key exists (errno 1091)
```

MySQL names the index it implicitly creates for a foreign key after the constraint, and `fromDatabaseForDrizzle` uses that shared name to tell implicit indexes apart from user ones — `drizzle-kit/src/dialects/mysql/introspect.ts`:

```ts
skip ||= res.fks.some((fk) => x.table === fk.table && x.name === fk.name);
```

That shared name is a side effect of how MySQL creates the index, not an invariant it maintains. MySQL is perfectly happy with a backing index named anything at all. Rename the constraint and the index keeps its old name — the link is gone. Introspection then reports the index as a user index the schema does not declare, and every subsequent push plans a `DROP INDEX` the database can only reject.

This is routine on PlanetScale/Vitess, which appends a random 25-character suffix to constraint names when it applies a migration, so any database that has ever deployed a foreign key change ends up in this state permanently. It is reachable on stock MySQL too — rename a constraint, or simply name a backing index yourself.

Concretely, on a database with 103 foreign keys, all suffixed this way, `push --explain` plans 56 of these impossible drops. Every run. There is no way to converge.

## Fix

Once the names diverge, an implicit index and a user index on the same columns are indistinguishable from the catalogs, so guessing is not an option. Instead, in `diff.ts`, skip the drop when the index is still backing a foreign key that is being kept and nothing else on the table can back it:

```ts
const dropIndexeStatements = indexesDiff.filter((it) => it.$diffType === 'drop')
    .filter((it) => !deletedTables.some((x) => x.name === it.table))
    .filter((it) => !backsForeignKey(it))
    .map((it) => prepareStatement('drop_index', { index: it }));
```

`backsForeignKey` keeps an index only when all three hold:

- a foreign key on that table has the index's leading columns as its columns,
- that foreign key is not itself being dropped in this diff,
- no other index and no primary key on the table can back it.

The reasoning is narrow on purpose: a statement the database is guaranteed to reject is never the right output, regardless of how the index came to exist. Indexes that are genuinely unused are still dropped.

## Tests

Three cases in `tests/mysql/constraints.test.ts`:

| test | before | after |
| --- | --- | --- |
| index backing a foreign key of another name is not dropped | ❌ emits `DROP INDEX` | ✅ no statements |
| index not backing a foreign key is still dropped | ✅ | ✅ |
| index backing a foreign key is dropped when another index covers it | ✅ | ✅ |

The first fails on `beta` with `expected [ 'DROP INDEX \`child_parentId_fkey\` ON \`child\`;' ] to strictly equal []` and passes with the fix. The other two pass either way and are there to pin down that the filter does not over-reach.

I could not run the DB-backed suites locally (no Docker), so the tests are written against the `diff` helper, which needs no database. `tests/mysql/commutativity*.test.ts` still pass, `tsc` is clean, and `dprint` is applied.

## Related

There is a second consequence of the same assumption that this PR does **not** address. `diff.ts` decides whether dropping a constraint should also drop its implicit index by name:

```ts
let dropAutoIndex = ddl2.indexes.one({ table: it.table, name: it.name }) === null;
```

and `convertor.ts` then emits `DROP INDEX \`${st.constraint}\``. When the names have diverged, that targets an index that does not exist. Fixing it properly seems to need introspection to mark implicit indexes rather than filter them out, which is a bigger change and a maintainer's call — happy to follow up if you'd like it in the same PR.