### PR TITLE
[Kit]: Skip commutativity check on drizzle-kit migrate

### DIFF
--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -371,9 +371,7 @@ export const migrate = command({
 		await assertOrmCoreVersion();
 		await assertPackages('drizzle-orm');
 		assertV3OutFolder(opts.out);
-		const { dialect, schema, table, out, credentials, ignoreConflicts } = opts;
-
-		await checkHandler(out, dialect, ignoreConflicts);
+		const { dialect, schema, table, out, credentials } = opts;
 
 		if (dialect === 'postgresql') {
 			if ('driver' in credentials) {

--- a/drizzle-kit/tests/other/cli-migrate.test.ts
+++ b/drizzle-kit/tests/other/cli-migrate.test.ts
@@ -111,6 +111,21 @@ test('migrate #5', async (t) => {
 	});
 });
 
+test('migrate accepts --ignore-conflicts', async (t) => {
+	const res = await brotest(migrate, '--ignore-conflicts');
+	if (res.type !== 'handler') assert.fail(res.type, 'handler');
+	expect(res.options).toStrictEqual({
+		dialect: 'postgresql',
+		out: 'drizzle',
+		credentials: {
+			url: 'postgresql://postgres:postgres@127.0.0.1:5432/db',
+		},
+		schema: 'drizzle',
+		table: '__drizzle_migrations',
+		ignoreConflicts: true,
+	});
+});
+
 // --- errors ---
 test('err #1', async (t) => {
 	const res = await brotest(migrate, '--config=expo.config.ts');


### PR DESCRIPTION
## Summary
- Remove the unconditional commutativity check from `drizzle-kit migrate`. The check still runs on `generate` (where it can prevent conflicting snapshots) and on `drizzle-kit check` (where users opt into it).
- `--ignore-conflicts` remains accepted on `migrate` for backward compatibility.

Fixes #5777

## Test plan
- [ ] `drizzle-kit migrate` no longer runs `checkHandler` / `detectNonCommutative` before applying migrations
- [ ] `drizzle-kit generate` still runs the commutativity check
- [ ] `drizzle-kit check` still runs the commutativity check
- [ ] `drizzle-kit migrate --ignore-conflicts` still parses