### PR TITLE
fix(bun-sql): add normalizeParam for json/jsonb codecs

### DIFF
--- a/drizzle-orm/src/bun-sql/postgres/codecs.ts
+++ b/drizzle-orm/src/bun-sql/postgres/codecs.ts
@@ -144,9 +144,11 @@ export const bunSqlPgCodecs = refineGenericPgCodecs({
 	bytea: { normalizeParamArray: makePgArray },
 	enum: { normalizeParamArray: makePgArray },
 	json: {
+		normalizeParam: (v) => JSON.stringify(v),
 		normalizeParamArray: arrayCompatNormalizeInput((v) => JSON.stringify(v), true),
 	},
 	jsonb: {
+		normalizeParam: (v) => JSON.stringify(v),
 		normalizeParamArray: arrayCompatNormalizeInput((v) => JSON.stringify(v), true),
 	},
 	'geometry(point)': {

--- a/drizzle-orm/tests/bun-sql-codecs.test.ts
+++ b/drizzle-orm/tests/bun-sql-codecs.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'vitest';
+import { bunSqlPgCodecs } from '~/bun-sql/postgres/codecs.ts';
+
+describe.concurrent('bunSqlPgCodecs', () => {
+	it('serializes scalar json values via normalizeParam', ({ expect }) => {
+		const codec = bunSqlPgCodecs.json!;
+		expect(codec.normalizeParam!({ key: 'value' })).toBe('{"key":"value"}');
+		expect(codec.normalizeParam!([1, 2, 3])).toBe('[1,2,3]');
+		expect(codec.normalizeParam!('plain string')).toBe('"plain string"');
+		expect(codec.normalizeParam!(42)).toBe('42');
+		expect(codec.normalizeParam!(null)).toBe('null');
+	});
+
+	it('serializes scalar jsonb values via normalizeParam', ({ expect }) => {
+		const codec = bunSqlPgCodecs.jsonb!;
+		expect(codec.normalizeParam!({ key: 'value' })).toBe('{"key":"value"}');
+		expect(codec.normalizeParam!([1, 2, 3])).toBe('[1,2,3]');
+	});
+
+	it('serializes json arrays via normalizeParamArray', ({ expect }) => {
+		const codec = bunSqlPgCodecs.json!;
+		const input = [{ a: 1 }, { b: 2 }];
+		const output = codec.normalizeParamArray!(input, 1);
+		// Each element should be stringified, then wrapped in a PG array literal
+		expect(output).toContain('"{\\"a\\":1}"');
+		expect(output).toContain('"{\\"b\\":2}"');
+	});
+});


### PR DESCRIPTION
## Related Issue

Closes #6132

## Summary

The `bunSqlPgCodecs` only defined `normalizeParamArray` for `json` and `jsonb`, which handles array columns but leaves scalar `json`/`jsonb` values unserialized. When inserting a single JSON object, Bun's SQL client receives the raw JavaScript object and fails with `invalid input syntax for type json`.

Other PostgreSQL drivers (`neon-http`, `vercel-postgres`, `effect-postgres`) already define `normalizeParam` for `json`/`jsonb`; this brings `bun-sql` to parity.

## Changes

- **`drizzle-orm/src/bun-sql/postgres/codecs.ts`**: Added `normalizeParam: (v) => JSON.stringify(v)` to the `json` and `jsonb` codec entries.
- **`drizzle-orm/tests/bun-sql-codecs.test.ts`**: New unit tests verifying that scalar JSON values are serialized via `normalizeParam`, and that array serialization via `normalizeParamArray` still works.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)