### PR TITLE
fix(pg-core): align .desc() index NULLS ordering with desc() order-by (#5978)

### DIFF
--- a/drizzle-kit/tests/indexes/pg.test.ts
+++ b/drizzle-kit/tests/indexes/pg.test.ts
@@ -1,9 +1,9 @@
-import { sql } from 'drizzle-orm';
-import { index, pgTable, serial, text, vector } from 'drizzle-orm/pg-core';
+import { desc, sql } from 'drizzle-orm';
+import { index, PgDialect, pgTable, serial, text, timestamp, vector } from 'drizzle-orm/pg-core';
 import { JsonCreateIndexStatement } from 'src/jsonStatements';
 import { PgSquasher } from 'src/serializer/pgSchema';
 import { diffTestSchemas } from 'tests/schemaDiffer';
-import { expect } from 'vitest';
+import { expect, test } from 'vitest';
 import { DialectSuite, run } from './common';
 
 const pgSuite: DialectSuite = {
@@ -128,8 +128,8 @@ const pgSuite: DialectSuite = {
 			'DROP INDEX "indx2";',
 			'DROP INDEX "indx3";',
 			'CREATE INDEX "indx4" ON "users" USING btree (lower(id)) WHERE true;',
-			'CREATE INDEX "indx" ON "users" USING btree ("name" DESC NULLS LAST);',
-			'CREATE INDEX "indx1" ON "users" USING btree ("name" DESC NULLS LAST) WHERE false;',
+			'CREATE INDEX "indx" ON "users" USING btree ("name" DESC NULLS FIRST);',
+			'CREATE INDEX "indx1" ON "users" USING btree ("name" DESC NULLS FIRST) WHERE false;',
 			'CREATE INDEX "indx2" ON "users" USING btree ("name" test) WHERE true;',
 			'CREATE INDEX "indx3" ON "users" USING btree (lower("id")) WHERE true;',
 		]);
@@ -179,7 +179,7 @@ const pgSuite: DialectSuite = {
 						asc: false,
 						expression: 'name',
 						isExpression: false,
-						nulls: 'last',
+						nulls: 'first',
 						opclass: '',
 					},
 					{
@@ -199,7 +199,7 @@ const pgSuite: DialectSuite = {
 					fillfactor: 70,
 				},
 			},
-			// data: 'users_name_id_index;name,false,last,undefined,,id,true,last,undefined;false;false;btree;select 1;{"fillfactor":70}',
+			// data: 'users_name_id_index;name,false,first,undefined,,id,true,last,undefined;false;false;btree;select 1;{"fillfactor":70}',
 		});
 		expect(statements[1]).toStrictEqual({
 			schema: '',
@@ -211,7 +211,7 @@ const pgSuite: DialectSuite = {
 						asc: false,
 						expression: 'name',
 						isExpression: false,
-						nulls: 'last',
+						nulls: 'first',
 						opclass: '',
 					},
 					{
@@ -234,12 +234,52 @@ const pgSuite: DialectSuite = {
 		});
 		expect(sqlStatements.length).toBe(2);
 		expect(sqlStatements[0]).toBe(
-			`CREATE INDEX "users_name_id_index" ON "users" USING btree ("name" DESC NULLS LAST,"id") WITH (fillfactor=70) WHERE select 1;`,
+			`CREATE INDEX "users_name_id_index" ON "users" USING btree ("name" DESC NULLS FIRST,"id") WITH (fillfactor=70) WHERE select 1;`,
 		);
 		expect(sqlStatements[1]).toBe(
-			`CREATE INDEX "indx1" ON "users" USING hash ("name" DESC NULLS LAST,"name") WITH (fillfactor=70);`,
+			`CREATE INDEX "indx1" ON "users" USING hash ("name" DESC NULLS FIRST,"name") WITH (fillfactor=70);`,
 		);
 	},
 };
 
 run(pgSuite);
+
+// Regression test for #5978: the index builder and the desc() order-by helper
+// must agree on NULLS ordering, otherwise Postgres silently refuses to use the
+// index for the ORDER BY ... LIMIT it was created for (pathkeys include the
+// nulls flag, and NOT NULL is not consulted).
+test('index #4: .desc() index and desc() order-by agree on NULLS ordering (#5978)', async () => {
+	const schema1 = {
+		items: pgTable('items', {
+			id: serial('id').primaryKey(),
+			createdAt: timestamp('created_at').notNull(),
+		}),
+	};
+	const schema2 = {
+		items: pgTable(
+			'items',
+			{
+				id: serial('id').primaryKey(),
+				createdAt: timestamp('created_at').notNull(),
+			},
+			(t) => ({
+				byCreatedAt: index('items_by_created_at').on(t.createdAt.desc()),
+			}),
+		),
+	};
+
+	const { sqlStatements } = await diffTestSchemas(schema1, schema2, []);
+
+	// A bare `.desc()` index now follows the Postgres direction default
+	// (DESC => NULLS FIRST) instead of the previously pinned DESC NULLS LAST.
+	expect(sqlStatements).toStrictEqual([
+		'CREATE INDEX "items_by_created_at" ON "items" USING btree ("created_at" DESC NULLS FIRST);',
+	]);
+
+	// The desc() order-by helper emits a bare `desc`, which Postgres reads with
+	// its DESC default of NULLS FIRST -- the same nulls ordering the index above
+	// uses, so the index can serve `ORDER BY created_at DESC LIMIT n`.
+	const orderBy = new PgDialect().sqlToQuery(desc(schema2.items.createdAt)).sql.toLowerCase();
+	expect(orderBy.endsWith(' desc')).toBe(true);
+	expect(orderBy).not.toContain('nulls');
+});

--- a/drizzle-kit/tests/push/pg.test.ts
+++ b/drizzle-kit/tests/push/pg.test.ts
@@ -265,7 +265,7 @@ const pgSuite: DialectSuite = {
 						asc: false,
 						expression: 'name',
 						isExpression: false,
-						nulls: 'last',
+						nulls: 'first',
 						opclass: undefined,
 					},
 					{
@@ -296,7 +296,7 @@ const pgSuite: DialectSuite = {
 						asc: false,
 						expression: 'name',
 						isExpression: false,
-						nulls: 'last',
+						nulls: 'first',
 						opclass: undefined,
 					},
 					{
@@ -318,10 +318,10 @@ const pgSuite: DialectSuite = {
 		});
 		expect(sqlStatements.length).toBe(2);
 		expect(sqlStatements[0]).toBe(
-			`CREATE INDEX "users_name_id_index" ON "users" USING btree ("name" DESC NULLS LAST,"id") WITH (fillfactor=70) WHERE select 1;`,
+			`CREATE INDEX "users_name_id_index" ON "users" USING btree ("name" DESC NULLS FIRST,"id") WITH (fillfactor=70) WHERE select 1;`,
 		);
 		expect(sqlStatements[1]).toBe(
-			`CREATE INDEX "indx1" ON "users" USING hash ("name" DESC NULLS LAST,"name") WITH (fillfactor=70);`,
+			`CREATE INDEX "indx1" ON "users" USING hash ("name" DESC NULLS FIRST,"name") WITH (fillfactor=70);`,
 		);
 	},
 
@@ -623,13 +623,13 @@ const pgSuite: DialectSuite = {
 			'DROP INDEX "changeWith";',
 			'DROP INDEX "removeColumn";',
 			'DROP INDEX "removeExpression";',
-			'CREATE INDEX "newName" ON "users" USING btree ("name" DESC NULLS LAST,name) WITH (fillfactor=70);',
-			'CREATE INDEX "addColumn" ON "users" USING btree ("name" DESC NULLS LAST,"id") WITH (fillfactor=70);',
-			'CREATE INDEX "changeExpression" ON "users" USING btree ("id" DESC NULLS LAST,name desc);',
+			'CREATE INDEX "newName" ON "users" USING btree ("name" DESC NULLS FIRST,name) WITH (fillfactor=70);',
+			'CREATE INDEX "addColumn" ON "users" USING btree ("name" DESC NULLS FIRST,"id") WITH (fillfactor=70);',
+			'CREATE INDEX "changeExpression" ON "users" USING btree ("id" DESC NULLS FIRST,name desc);',
 			'CREATE INDEX "changeUsing" ON "users" USING hash ("name");',
 			'CREATE INDEX "changeWith" ON "users" USING btree ("name") WITH (fillfactor=90);',
 			'CREATE INDEX "removeColumn" ON "users" USING btree ("name");',
-			'CREATE INDEX CONCURRENTLY "removeExpression" ON "users" USING btree ("name" DESC NULLS LAST);',
+			'CREATE INDEX CONCURRENTLY "removeExpression" ON "users" USING btree ("name" DESC NULLS FIRST);',
 		]);
 	},
 

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -164,7 +164,9 @@ export class ExtraConfigColumn<
 
 	indexConfig: IndexedExtraConfigType = {
 		order: this.config.order ?? 'asc',
-		nulls: this.config.nulls ?? 'last',
+		// Don't pin 'last'; leave undefined so drizzle-kit applies Postgres's direction
+		// default (desc => NULLS FIRST) to match what the desc() order-by helper emits. (#5978)
+		nulls: this.config.nulls,
 		opClass: this.config.opClass,
 	};
 	defaultConfig: IndexedExtraConfigType = {


### PR DESCRIPTION
Fixes #5978.

## What / Why

A `.desc()` index and the `desc()` order-by helper disagree on NULLS ordering, so Postgres silently refuses to use the index for the `ORDER BY ... DESC LIMIT` it was created for.

- The index builder pins `nulls: 'last'` for every column, so a `.desc()` index emits `... DESC NULLS LAST`.
- The `desc()` order-by helper emits a bare `desc`, which Postgres reads with its `DESC` default of `NULLS FIRST`.

Postgres matches an index to an `ORDER BY` on pathkeys that include the nulls flag (and does not consult `NOT NULL`), so a `DESC NULLS LAST` index can never serve `ORDER BY col DESC` — the planner falls back to a full scan + sort. That is the exact "index ignored for `ORDER BY ... DESC LIMIT`" symptom in #5978.

## Change

`drizzle-orm/src/pg-core/columns/common.ts`: stop pinning `nulls: 'last'` in the index column config. Leaving it undefined lets the drizzle-kit serializer apply Postgres's own direction-aware default (`desc => first`, `asc => last`), so a bare `.desc()` index now emits `DESC NULLS FIRST` — matching what `desc()` order-by produces.

Only bare `.desc()` changes:
- `.asc()` / default columns still resolve to `NULLS LAST` (unchanged).
- Explicit `.desc().nullsLast()` / `.nullsFirst()` are honored as before.

This is the reporter's preferred alignment direction (align the index to the query default), and it leaves the `desc()` order-by output — and therefore every existing query's NULL placement — untouched.

## Tests

`drizzle-kit/tests/indexes/pg.test.ts`: added a regression test asserting the `.desc()` index DDL is `... DESC NULLS FIRST` and that `desc()` order-by emits a bare `desc` (the same `NULLS FIRST` default), so the two agree. Updated the existing index tests (and the DB-gated push test) that encoded the old `DESC NULLS LAST` output for implicit `.desc()` columns to the corrected `NULLS FIRST`.

## Note on generated migrations

This changes generated DDL for existing implicit `.desc()` indexes: the next `drizzle-kit generate` drops + recreates them as `DESC NULLS FIRST`. That is the intended correction (the old index was unusable for the query it was built for), but flagging it so the snapshot change is expected.

`gel-core` has the identical latent line (`gel-core/columns/common.ts`); left untouched to keep this fix scoped to the Postgres issue, but happy to mirror it.

I based this on `main`; glad to retarget to `rc5` if you prefer — the affected line is identical there (`common.ts:583`).
