### PR TITLE
Fix nested partial select nullified when first column is null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/map-result-row.test.ts
+++ b/drizzle-orm/tests/map-result-row.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'vitest';
+import { integer, pgTable, text } from '~/pg-core/index.ts';
+import type { SelectedFieldsOrdered } from '~/pg-core/query-builders/select.types.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const org = pgTable('org', {
+	id: integer('id'),
+	name: text('name'),
+	slug: text('slug'),
+});
+
+const orgBranding = pgTable('org_branding', {
+	orgId: integer('org_id'),
+	logo: text('logo'),
+	panelBackground: text('panel_background_colour'),
+});
+
+// `org` is the base table, `org_branding` is joined via LEFT JOIN and is therefore nullable.
+const joinsNotNullableMap = { org: true, org_branding: false };
+
+function fields(...branding: ('logo' | 'panelBackground')[]): SelectedFieldsOrdered {
+	return [
+		{ path: ['name'], field: org.name },
+		{ path: ['slug'], field: org.slug },
+		...branding.map((key) => ({ path: ['branding', key], field: orgBranding[key] })),
+	];
+}
+
+test('nested object is kept when a later column is non-null', () => {
+	// logo is NULL in the database, panel_background_colour is not.
+	const result = mapResultRow(
+		fields('logo', 'panelBackground'),
+		['Test org 2', 'test-org-2', null, '#1a8cff'],
+		joinsNotNullableMap,
+	);
+
+	expect(result).toEqual({
+		name: 'Test org 2',
+		slug: 'test-org-2',
+		branding: { logo: null, panelBackground: '#1a8cff' },
+	});
+});
+
+test('nested object is kept regardless of selected column order', () => {
+	// Same row, the two branding columns selected the other way around.
+	const result = mapResultRow(
+		fields('panelBackground', 'logo'),
+		['Test org 2', 'test-org-2', '#1a8cff', null],
+		joinsNotNullableMap,
+	);
+
+	expect(result).toEqual({
+		name: 'Test org 2',
+		slug: 'test-org-2',
+		branding: { panelBackground: '#1a8cff', logo: null },
+	});
+});
+
+test('nested object is nullified when the join did not match', () => {
+	const result = mapResultRow(
+		fields('logo', 'panelBackground'),
+		['Test org 2', 'test-org-2', null, null],
+		joinsNotNullableMap,
+	);
+
+	expect(result).toEqual({
+		name: 'Test org 2',
+		slug: 'test-org-2',
+		branding: null,
+	});
+});


### PR DESCRIPTION
Fixes #1603

## Problem

When a nested partial select reads from a left-joined table, the nested object is replaced with `null` if its **first** selected column happens to be null, even when later columns of that same object have values.

Reordering the selected columns changes the result, which is what made this look so strange in the original report:

```ts
// logo is NULL in the database, panel_background_colour is '#1a8cff'
branding: { logo: orgBranding.logo, panelBackground: orgBranding.panelBackground }
// => branding: null                                    (wrong)

branding: { panelBackground: orgBranding.panelBackground, logo: orgBranding.logo }
// => branding: { panelBackground: '#1a8cff', logo: null }   (correct)
```

## Cause

`mapResultRow` builds a `nullifyMap` to decide whether a nested object should collapse to `null` because its left join produced no row. An entry holds the table name while every column seen so far has been null, and `false` once the object is known to be non-null.

The first column initialises the entry correctly:

```ts
nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
```

but the branch handling every subsequent column only invalidated the entry when the column came from a *different* table:

```ts
} else if (
	typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
) {
	nullifyMap[objectName] = false;
}
```

So once a null first column set the entry to a table name, a later non-null column from that same table left it untouched, and the object was nullified at the end.

## Fix

Treat a non-null value as invalidating too, so an object is only nullified when every one of its columns is null:

```ts
} else if (
	typeof nullifyMap[objectName] === 'string'
	&& (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
) {
	nullifyMap[objectName] = false;
}
```

## Tests

Added `drizzle-orm/tests/map-result-row.test.ts` covering the reported case and the behaviour it must not regress:

- nested object is kept when a later column is non-null (this failed before the change)
- nested object is kept regardless of selected column order
- nested object is still nullified when the join did not match, meaning all its columns are null

The full `drizzle-orm` unit suite passes (545 tests). Two `tests/casing/sqlite-*` files fail to load in my environment because the `better-sqlite3` native binding is not built locally; they fail identically on an unmodified checkout and are unrelated to this change.
