### PR TITLE
Fix toSnakeCase/toCamelCase silently dropping non-Latin identifiers

### DIFF
--- a/drizzle-orm/src/casing.ts
+++ b/drizzle-orm/src/casing.ts
@@ -1,9 +1,15 @@
 export type Casing = 'snake_case' | 'camelCase';
 
+// Matches (in order): a run of lowercase letters/digits (ASCII or Unicode, e.g. Latin, Cyrillic,
+// Greek); a run of uppercase letters not followed by a lowercase letter (an acronym); an uppercase
+// letter followed by lowercase letters/digits (a capitalized word); or a run of caseless letters
+// (e.g. CJK ideographs, Hangul syllables) which have no upper/lower distinction to split on.
+const WORD_PATTERN = /[\p{Ll}\d]+|\p{Lu}+(?!\p{Ll})|\p{Lu}[\p{Ll}\d]+|\p{Lo}+/gu;
+
 export function toSnakeCase(input: string) {
 	const words = input
 		.replace(/['\u2019]/g, '')
-		.match(/[\da-z]+|[A-Z]+(?![a-z])|[A-Z][\da-z]+/g) ?? [];
+		.match(WORD_PATTERN) ?? [];
 
 	return words.map((word) => word.toLowerCase()).join('_');
 }
@@ -11,7 +17,7 @@ export function toSnakeCase(input: string) {
 export function toCamelCase(input: string) {
 	const words = input
 		.replace(/['\u2019]/g, '')
-		.match(/[\da-z]+|[A-Z]+(?![a-z])|[A-Z][\da-z]+/g) ?? [];
+		.match(WORD_PATTERN) ?? [];
 
 	return words.reduce((acc, word, i) => {
 		const formattedWord = i === 0 ? word.toLowerCase() : `${word[0]!.toUpperCase()}${word.slice(1)}`;

--- a/drizzle-orm/tests/casing/casing.test.ts
+++ b/drizzle-orm/tests/casing/casing.test.ts
@@ -25,4 +25,21 @@ describe.concurrent('casing', () => {
 	it('transforms to camel case 1', ({ expect }) => {
 		expect(toCamelCase('drizzle_kit')).toEqual('drizzleKit');
 	});
+
+	it('preserves non-Latin identifiers instead of dropping them (snake case)', ({ expect }) => {
+		// https://github.com/drizzle-team/drizzle-orm/issues/6082
+		expect(toSnakeCase('칼럼명')).toEqual('칼럼명');
+		expect(toSnakeCase('日本語Test')).toEqual('日本語_test');
+		expect(toSnakeCase('한글colName')).toEqual('한글_col_name');
+	});
+
+	it('preserves non-Latin identifiers instead of dropping them (camel case)', ({ expect }) => {
+		expect(toCamelCase('칼럼명')).toEqual('칼럼명');
+		expect(toCamelCase('칼럼_명')).toEqual('칼럼명');
+	});
+
+	it('does not regress accented Latin letters', ({ expect }) => {
+		expect(toSnakeCase('café')).toEqual('café');
+		expect(toSnakeCase('userNaïve')).toEqual('user_naïve');
+	});
 });


### PR DESCRIPTION
## Summary

`toSnakeCase`/`toCamelCase`'s word-splitting regex only matched ASCII letters and digits (`[\da-z]`, `[A-Z]`). `String.prototype.match()` silently discards any character that doesn't match one of the pattern's alternatives, so Korean, Japanese, Cyrillic, and other non-Latin characters were **dropped entirely** rather than left unchanged — not merely miscased.

For `snakeCase.table()` this means a Korean column name like `칼럼명` becomes an empty string, which `drizzle-kit generate` turns into an invalid empty SQL identifier (`` `` ``), and the resulting migration fails to apply.

Closes #6082

## Root cause

```ts
// before
.match(/[\da-z]+|[A-Z]+(?![a-z])|[A-Z][\da-z]+/g) ?? []
```

None of the three alternatives matches a Hangul syllable, CJK ideograph, or even accented Latin (`é`, `ñ`) — so `.match()` simply omits those characters from the result array instead of keeping them as their own word.

## Fix

Generalized the word-boundary regex with Unicode property escapes instead of ASCII character classes:

```ts
const WORD_PATTERN = /[\p{Ll}\d]+|\p{Lu}+(?!\p{Ll})|\p{Lu}[\p{Ll}\d]+|\p{Lo}+/gu;
```

- `\p{Ll}` / `\p{Lu}` extend the existing lower/upper-case logic to any script with case distinctions (Latin, Cyrillic, Greek, etc.), so accented Latin (`café`, `Résumé`) is preserved instead of stripped.
- `\p{Lo}` is a new alternative for caseless scripts (CJK ideographs, Hangul syllables) that have no upper/lower distinction to split words on.

All existing ASCII test cases keep producing byte-identical output — this only changes behavior for input that was previously being silently corrupted.

| Input | Before | After |
|---|---|---|
| `칼럼명` | `''` (bug) | `칼럼명` |
| `日本語Test` | `test` (bug, dropped 日本語) | `日本語_test` |
| `café` | `caf` (bug, dropped é) | `café` |
| `drizzleORM` | `drizzle_orm` | `drizzle_orm` (unchanged) |
| `drizzleOrmAndKit` | `drizzle_orm_and_kit` | `drizzle_orm_and_kit` (unchanged) |

## Test plan

- Added regression tests to `tests/casing/casing.test.ts` covering the exact Korean case from the issue, a mixed Japanese/Latin case, and an accented-Latin non-regression case.
- Verified red→green: with the fix stashed, exactly the 3 new tests fail (for the right reason — dropped characters) while all 6 pre-existing tests still pass; restoring the fix turns all 9 green.
- `pnpm vitest run tests/casing/casing.test.ts` — 9/9 passing.
- `pnpm vitest run tests/` (drizzle-orm package) — 967/970 passing. The 3 failures are in `tests/sql-builder.test.ts` and are **pre-existing on unmodified `beta` HEAD** — verified by stashing this fix entirely and re-running, which reproduces the same 3 failures unrelated to `casing.ts`.
- `tsc --noEmit` — no new errors. The one pre-existing error (`types-bench.ts`, missing a generated scaffold file) reproduces identically on unmodified `beta` HEAD.
- **End-to-end verification through the real `snakeCase.table()` pipeline** (not just the unit-level regex): built the package locally and ran the exact schema from the issue through `snakeCase.table()` → `getTableConfig()`. Before the fix, the Korean column resolves to `''` (bug reproduced exactly as reported); after the fix, it resolves to `칼럼명`, matching the output of an unaffected `sqliteTable()` call with the same column name.

## Why this targets `beta`

The issue's repro uses `snakeCase.table()`, which only exists on the `1.0.0-rc` line (`beta`) — it isn't present on `main` (`0.45.x`). The underlying `toSnakeCase`/`toCamelCase` regex bug is present on both branches, but only `beta` can run the exact reproduction from the issue.
