### PR TITLE
fix(kit): do not infer 1-1 from a partial unique index

### DIFF
--- a/drizzle-kit/src/cli/commands/pull-common.ts
+++ b/drizzle-kit/src/cli/commands/pull-common.ts
@@ -171,10 +171,15 @@ export const relationsToTypeScript = (
 				// if this table has a unique on a column, that is used for 1-m, then we can assume that it's 1-1 relation
 				// we will check that all of the fk columns are unique, so we can assume it's 1-1
 				// not matter if it's 1 column, 2 columns or more
+				// Unique column names are stored as in the database; FK names here may
+				// already be cased, so match either form.
 				if (
 					table.uniques.find((constraint) =>
-						constraint.columns.length === columnsFrom.length
-						&& constraint.columns.every((col, i) => col === columnsFrom[i])
+						constraint.columns.length === fk.columns.length
+						&& (
+							constraint.columns.every((col, i) => col === fk.columns[i])
+							|| constraint.columns.every((col, i) => col === columnsFrom[i])
+						)
 					)
 				) {
 					// the difference between one and one-one is that one-one won't contain from and to

--- a/drizzle-kit/src/dialects/cockroach/ddl.ts
+++ b/drizzle-kit/src/dialects/cockroach/ddl.ts
@@ -485,9 +485,9 @@ export function cockroachToRelationsPull(schema: CockroachDDL): SchemaForPull {
 		return {
 			schema: rawTable.schema,
 			foreignKeys: rawTable.fks,
-			uniques: Object.values(rawTable.indexes).map((idx) => ({
+			uniques: Object.values(rawTable.indexes).filter((idx) => idx.isUnique && !idx.where).map((idx) => ({
 				columns: idx.columns.map((idxc) => {
-					if (!idxc.isExpression && idx.isUnique) {
+					if (!idxc.isExpression) {
 						return idxc.value;
 					}
 				}).filter((item) => item !== undefined),

--- a/drizzle-kit/src/dialects/postgres/ddl.ts
+++ b/drizzle-kit/src/dialects/postgres/ddl.ts
@@ -246,9 +246,11 @@ export function postgresToRelationsPull(schema: PostgresDDL): SchemaForPull {
 				...Object.values(rawTable.uniques).map((unq) => ({
 					columns: unq.columns,
 				})),
-				...Object.values(rawTable.indexes).map((idx) => ({
+				// Partial unique indexes (WHERE ...) are unique only for a subset of
+				// rows, so they must not promote the parent side of an FK to 1-1.
+				...Object.values(rawTable.indexes).filter((idx) => idx.isUnique && !idx.where).map((idx) => ({
 					columns: idx.columns.map((idxc) => {
-						if (!idxc.isExpression && idx.isUnique) {
+						if (!idxc.isExpression) {
 							return idxc.value;
 						}
 					}).filter((item) => item !== undefined),

--- a/drizzle-kit/src/dialects/sqlite/ddl.ts
+++ b/drizzle-kit/src/dialects/sqlite/ddl.ts
@@ -316,9 +316,9 @@ export function sqliteToRelationsPull(schema: SQLiteDDL): SchemaForPull {
 				...Object.values(rawTable.uniques).map((unq) => ({
 					columns: unq.columns,
 				})),
-				...Object.values(rawTable.indexes).map((idx) => ({
+				...Object.values(rawTable.indexes).filter((idx) => idx.isUnique && !idx.where).map((idx) => ({
 					columns: idx.columns.map((idxc) => {
-						if (!idxc.isExpression && idx.isUnique) {
+						if (!idxc.isExpression) {
 							return idxc.value;
 						}
 					}).filter((item) => item !== undefined),

--- a/drizzle-kit/tests/postgres/relations-pull.test.ts
+++ b/drizzle-kit/tests/postgres/relations-pull.test.ts
@@ -1,0 +1,113 @@
+import { createDDL, postgresToRelationsPull } from 'src/dialects/postgres/ddl';
+import { expect, test } from 'vitest';
+
+function usersDocumentsDdl(unique: { isUnique: boolean; where: string | null }) {
+	const ddl = createDDL();
+	ddl.tables.push({ schema: 'public', isRlsEnabled: false, name: 'users' });
+	ddl.tables.push({ schema: 'public', isRlsEnabled: false, name: 'documents' });
+	ddl.columns.push(
+		{
+			schema: 'public',
+			table: 'users',
+			name: 'id',
+			type: 'serial',
+			typeSchema: 'pg_catalog',
+			notNull: true,
+			dimensions: 0,
+			default: null,
+			generated: null,
+			identity: null,
+		} as any,
+		{
+			schema: 'public',
+			table: 'documents',
+			name: 'id',
+			type: 'serial',
+			typeSchema: 'pg_catalog',
+			notNull: true,
+			dimensions: 0,
+			default: null,
+			generated: null,
+			identity: null,
+		} as any,
+		{
+			schema: 'public',
+			table: 'documents',
+			name: 'user_id',
+			type: 'integer',
+			typeSchema: 'pg_catalog',
+			notNull: true,
+			dimensions: 0,
+			default: null,
+			generated: null,
+			identity: null,
+		} as any,
+		{
+			schema: 'public',
+			table: 'documents',
+			name: 'archived_at',
+			type: 'timestamp',
+			typeSchema: 'pg_catalog',
+			notNull: false,
+			dimensions: 0,
+			default: null,
+			generated: null,
+			identity: null,
+		} as any,
+	);
+	ddl.fks.push({
+		schema: 'public',
+		table: 'documents',
+		name: 'documents_user_id_users_id_fk',
+		nameExplicit: false,
+		columns: ['user_id'],
+		schemaTo: 'public',
+		tableTo: 'users',
+		columnsTo: ['id'],
+		onUpdate: 'NO ACTION',
+		onDelete: 'NO ACTION',
+	} as any);
+	ddl.indexes.push({
+		schema: 'public',
+		table: 'documents',
+		name: 'documents_one_active_per_user',
+		columns: [{ value: 'user_id', isExpression: false, opclass: null, nullsFirst: false, asc: true }],
+		isUnique: unique.isUnique,
+		where: unique.where,
+		with: '',
+		concurrently: false,
+		method: 'btree',
+		nameExplicit: true,
+	} as any);
+	return ddl;
+}
+
+function uniqueColumnSets(ddl: ReturnType<typeof createDDL>) {
+	const pull = postgresToRelationsPull(ddl);
+	const documents = pull.find((table) => table.foreignKeys.some((fk) => fk.table === 'documents'));
+	return documents?.uniques.map((unique) => unique.columns) ?? [];
+}
+
+test('pull ignores a partial unique index when collecting uniques for 1-1 inference (#6145)', () => {
+	const uniques = uniqueColumnSets(usersDocumentsDdl({
+		isUnique: true,
+		where: '(archived_at IS NULL)',
+	}));
+	expect(uniques).not.toContainEqual(['user_id']);
+});
+
+test('pull keeps a full unique index for 1-1 inference', () => {
+	const uniques = uniqueColumnSets(usersDocumentsDdl({
+		isUnique: true,
+		where: null,
+	}));
+	expect(uniques).toContainEqual(['user_id']);
+});
+
+test('pull ignores a non-unique index when collecting uniques', () => {
+	const uniques = uniqueColumnSets(usersDocumentsDdl({
+		isUnique: false,
+		where: null,
+	}));
+	expect(uniques).not.toContainEqual(['user_id']);
+});


### PR DESCRIPTION
## Summary

`drizzle-kit pull` treated `UNIQUE INDEX ... WHERE ...` as a full unique when deciding one-to-one vs one-to-many. A partial unique only constrains a subset of rows (e.g. one *active* document per user), so the parent side of that FK is still many.

This filters unique indexes that have a `where` predicate out of 1-1 inference for Postgres, SQLite, and Cockroach, and matches unique columns against the raw FK names so camelCase pull still sees a real full unique.

Fixes #6145

## Test plan

- [x] `pnpm exec vitest run tests/postgres/relations-pull.test.ts`: 3 passed
- [x] Same file fails on the partial-index case without the filter (`uniques` still contains `['user_id']`)
- [ ] `drizzle-kit pull` against the SQL in #6145 generates `r.many.documents()` on `users`
