### PR TITLE
[Pg-kit]: Bind positional parameters over the AWS Data API

### DIFF
--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -15,6 +15,7 @@ import type { BenchmarkProxy, QueriesTimings, TransactionProxy } from '../utils'
 import { assertUnreachable } from '../utils';
 import type { LibSQLDB } from '../utils';
 import type { DB, Proxy, SQLiteDB } from '../utils';
+import { prepareAwsDataApiSql } from '../utils/aws-data-api-placeholders';
 import { normaliseSQLiteUrl } from '../utils/utils-node';
 import { JSONB } from '../utils/when-json-met-bigint';
 import type { ProxyParams } from './commands/studio';
@@ -99,7 +100,7 @@ export const preparePostgresDB = async (
 						execute: any[];
 					}
 				>(
-					{ sql, params: params ?? [] },
+					{ sql: prepareAwsDataApiSql(sql, params?.length ?? 0), params: params ?? [] },
 					'objects',
 					false,
 					undefined,
@@ -120,7 +121,7 @@ export const preparePostgresDB = async (
 					}
 				>(
 					{
-						sql: params.sql,
+						sql: prepareAwsDataApiSql(params.sql, params.params?.length ?? 0),
 						params: params.params ?? [],
 					},
 					params.mode === 'array' ? 'arrays' : 'objects',

--- a/drizzle-kit/src/utils/aws-data-api-placeholders.ts
+++ b/drizzle-kit/src/utils/aws-data-api-placeholders.ts
@@ -1,0 +1,172 @@
+/**
+ * Rewrites Postgres positional placeholders (`$1`) into the named form the AWS
+ * Data API binds (`:1`). The Data API binds named parameters only, so SQL that
+ * does not come from the ORM dialect, such as the raw SQL studio forwards,
+ * would otherwise arrive with nothing bound.
+ *
+ * The scan is literal aware: comments, string constants, dollar-quoted bodies,
+ * and identifiers pass through untouched, so a `$` that is not a placeholder is
+ * never rewritten. Only `$N` with `1 <= N <= parameterCount` is converted.
+ *
+ * Assumes `standard_conforming_strings` is on, which is the default and what
+ * Aurora ships; with it off, backslashes escape in every string constant.
+ */
+export function prepareAwsDataApiSql(sql: string, parameterCount: number): string {
+	if (parameterCount < 1) return sql;
+
+	/** Indexing past the end yields '', which every character test rejects. */
+	const at = (index: number): string => sql.charAt(index);
+
+	const isDigit = (char: string): boolean => char >= '0' && char <= '9';
+	// Postgres treats every non-ASCII byte as an identifier character, so `é$1`
+	// is one identifier and `$é$` is a valid dollar-quote tag.
+	const isIdentifierChar = (char: string): boolean => /[A-Za-z0-9_$]/.test(char) || char >= '\u0080';
+	const isTagChar = (char: string): boolean => /[A-Za-z0-9_]/.test(char) || char >= '\u0080';
+	const isNewline = (char: string): boolean => char === '\n' || char === '\r';
+	const isSpace = (char: string): boolean => char === ' ' || char === '\t' || char === '\f' || char === '\v';
+
+	/** End of the line comment opening at `start`. Postgres ends these at CR as well as LF. */
+	const endOfLineComment = (start: number): number => {
+		let j = start + 2;
+		while (j < sql.length && !isNewline(at(j))) j++;
+		return j;
+	};
+
+	/** End of the block comment opening at `start`. Postgres nests these. */
+	const endOfBlockComment = (start: number): number => {
+		let depth = 1;
+		let j = start + 2;
+		while (j < sql.length && depth > 0) {
+			if (at(j) === '/' && at(j + 1) === '*') {
+				depth++;
+				j += 2;
+			} else if (at(j) === '*' && at(j + 1) === '/') {
+				depth--;
+				j += 2;
+			} else {
+				j++;
+			}
+		}
+		return j;
+	};
+
+	/** End of one quoted segment. A doubled quote is an escaped quote. */
+	const endOfStringSegment = (start: number, isEString: boolean): number => {
+		let j = start + 1;
+		while (j < sql.length) {
+			if (isEString && at(j) === '\\') {
+				j += 2;
+			} else if (at(j) === "'") {
+				if (at(j + 1) === "'") {
+					j += 2;
+				} else {
+					return j + 1;
+				}
+			} else {
+				j++;
+			}
+		}
+		return j;
+	};
+
+	/**
+	 * The quote continuing a string constant, or null. Postgres concatenates two
+	 * string constants separated by whitespace containing at least one newline,
+	 * and the continuation keeps the escape-string property of the first. Line
+	 * comments count as whitespace here, and the newline ending one satisfies the
+	 * newline requirement.
+	 */
+	const continuationQuote = (from: number): number | null => {
+		let j = from;
+		let sawNewline = false;
+		while (j < sql.length) {
+			const char = at(j);
+			if (isNewline(char)) {
+				sawNewline = true;
+				j++;
+			} else if (isSpace(char)) {
+				j++;
+			} else if (char === '-' && at(j + 1) === '-') {
+				j = endOfLineComment(j);
+			} else {
+				break;
+			}
+		}
+		return sawNewline && at(j) === "'" ? j : null;
+	};
+
+	/** End of the string constant opening at `start`, including any continuations. */
+	const endOfString = (start: number): number => {
+		const previous = at(start - 1);
+		const isEString = (previous === 'e' || previous === 'E') && !isIdentifierChar(at(start - 2));
+
+		let j = endOfStringSegment(start, isEString);
+		for (let next = continuationQuote(j); next !== null; next = continuationQuote(j)) {
+			j = endOfStringSegment(next, isEString);
+		}
+		return j;
+	};
+
+	/** End of the quoted identifier opening at `start`. */
+	const endOfQuotedIdentifier = (start: number): number => {
+		let j = start + 1;
+		while (j < sql.length && at(j) !== '"') j++;
+		return Math.min(j + 1, sql.length);
+	};
+
+	/**
+	 * The `$$` or `$tag$` marker opening at `start`, or null when what follows is
+	 * not a marker. A tag never starts with a digit, which keeps `$1` a placeholder.
+	 */
+	const dollarQuoteMarker = (start: number): string | null => {
+		let j = start + 1;
+		if (isDigit(at(j))) return null;
+		while (j < sql.length && isTagChar(at(j))) j++;
+		return at(j) === '$' ? sql.slice(start, j + 1) : null;
+	};
+
+	/** The placeholder opening at `start`, or null when `$` is not followed by digits. */
+	const placeholderAt = (start: number): { index: number; end: number } | null => {
+		let j = start + 1;
+		while (j < sql.length && isDigit(at(j))) j++;
+		if (j === start + 1) return null;
+		return { index: Number(sql.slice(start + 1, j)), end: j };
+	};
+
+	let out = '';
+	let i = 0;
+
+	while (i < sql.length) {
+		const char = at(i);
+		let end = i + 1;
+
+		if (char === '-' && at(i + 1) === '-') {
+			end = endOfLineComment(i);
+		} else if (char === '/' && at(i + 1) === '*') {
+			end = endOfBlockComment(i);
+		} else if (char === "'") {
+			end = endOfString(i);
+		} else if (char === '"') {
+			end = endOfQuotedIdentifier(i);
+		} else if (char === '$' && !isIdentifierChar(at(i - 1))) {
+			const marker = dollarQuoteMarker(i);
+			if (marker !== null) {
+				// An unterminated body runs to the end, as Postgres would read it.
+				const close = sql.indexOf(marker, i + marker.length);
+				end = close === -1 ? sql.length : close + marker.length;
+			} else {
+				const placeholder = placeholderAt(i);
+				if (placeholder !== null && placeholder.index >= 1 && placeholder.index <= parameterCount) {
+					out += `:${placeholder.index}`;
+					i = placeholder.end;
+					continue;
+				}
+			}
+		}
+
+		out += sql.slice(i, end);
+		i = end;
+	}
+
+	return out;
+}

--- a/drizzle-kit/tests/other/aws-data-api-placeholders.test.ts
+++ b/drizzle-kit/tests/other/aws-data-api-placeholders.test.ts
@@ -1,0 +1,150 @@
+import { prepareAwsDataApiSql } from 'src/utils/aws-data-api-placeholders';
+import { describe, expect, test } from 'vitest';
+
+describe('prepareAwsDataApiSql', () => {
+	test('returns the SQL untouched when there are no parameters', () => {
+		const sql = 'select * from users where id = $1';
+		expect(prepareAwsDataApiSql(sql, 0)).toBe(sql);
+	});
+
+	test('rewrites a single placeholder', () => {
+		expect(prepareAwsDataApiSql('select * from users where id = $1', 1))
+			.toBe('select * from users where id = :1');
+	});
+
+	test('rewrites several placeholders, in any order', () => {
+		expect(prepareAwsDataApiSql('select * from users where id = $2 and org = $1', 2))
+			.toBe('select * from users where id = :2 and org = :1');
+	});
+
+	test('rewrites a placeholder used more than once', () => {
+		expect(prepareAwsDataApiSql('select $1, $1', 1)).toBe('select :1, :1');
+	});
+
+	test('rewrites a placeholder at the very end of the string', () => {
+		expect(prepareAwsDataApiSql('select $1', 1)).toBe('select :1');
+	});
+
+	test('rewrites a two-digit placeholder', () => {
+		expect(prepareAwsDataApiSql('select $10', 10)).toBe('select :10');
+	});
+
+	test('leaves a placeholder index beyond the parameter count alone', () => {
+		expect(prepareAwsDataApiSql('select $1, $9', 1)).toBe('select :1, $9');
+	});
+
+	test('leaves $0 alone, since Postgres placeholders are one-based', () => {
+		expect(prepareAwsDataApiSql('select $0, $1', 1)).toBe('select $0, :1');
+	});
+
+	test('leaves a lone $ alone', () => {
+		expect(prepareAwsDataApiSql('select $ , $1', 1)).toBe('select $ , :1');
+	});
+
+	test('does not touch a $N inside a single-quoted string', () => {
+		expect(prepareAwsDataApiSql("select '$1' , $1", 1)).toBe("select '$1' , :1");
+	});
+
+	test('handles a doubled quote inside a single-quoted string', () => {
+		expect(prepareAwsDataApiSql("select 'it''s $1' , $1", 1)).toBe("select 'it''s $1' , :1");
+	});
+
+	test('handles a backslash-escaped quote inside an E-string', () => {
+		expect(prepareAwsDataApiSql("select e'it\\'s $1' , $1", 1)).toBe("select e'it\\'s $1' , :1");
+	});
+
+	test('does not treat a quote after an identifier ending in e as an E-string', () => {
+		expect(prepareAwsDataApiSql("select type'\\' , $1", 1)).toBe("select type'\\' , :1");
+	});
+
+	test('does not touch a $N inside an untagged dollar-quoted body', () => {
+		expect(prepareAwsDataApiSql('select $$ $1 $$ , $1', 1)).toBe('select $$ $1 $$ , :1');
+	});
+
+	test('does not touch a $N inside a tagged dollar-quoted body', () => {
+		expect(prepareAwsDataApiSql('select $body$ $1 $body$ , $1', 1))
+			.toBe('select $body$ $1 $body$ , :1');
+	});
+
+	test('treats an unterminated dollar-quoted body as running to the end', () => {
+		expect(prepareAwsDataApiSql('select $$ $1', 1)).toBe('select $$ $1');
+	});
+
+	test('does not touch a $N inside a line comment', () => {
+		expect(prepareAwsDataApiSql('select $1 -- $1\nfrom t where a = $1', 1))
+			.toBe('select :1 -- $1\nfrom t where a = :1');
+	});
+
+	test('does not touch a $N inside a block comment', () => {
+		expect(prepareAwsDataApiSql('select /* $1 */ $1', 1)).toBe('select /* $1 */ :1');
+	});
+
+	test('handles nested block comments', () => {
+		expect(prepareAwsDataApiSql('select /* a /* $1 */ b */ $1', 1))
+			.toBe('select /* a /* $1 */ b */ :1');
+	});
+
+	test('does not touch a $N inside a quoted identifier', () => {
+		expect(prepareAwsDataApiSql('select "a $1 b" from t where c = $1', 1))
+			.toBe('select "a $1 b" from t where c = :1');
+	});
+
+	test('does not touch a $ inside a bare identifier', () => {
+		expect(prepareAwsDataApiSql('select foo$1 from t where c = $1', 1))
+			.toBe('select foo$1 from t where c = :1');
+	});
+
+	test('does not touch a $ inside a non-ASCII bare identifier', () => {
+		expect(prepareAwsDataApiSql('select é$1 from t where c = $1', 1))
+			.toBe('select é$1 from t where c = :1');
+	});
+
+	test('does not touch a $N inside a body with a non-ASCII dollar-quote tag', () => {
+		expect(prepareAwsDataApiSql('select $é$ $1 $é$ , $1', 1)).toBe('select $é$ $1 $é$ , :1');
+	});
+
+	test('ends a line comment at a carriage return', () => {
+		expect(prepareAwsDataApiSql('select $1 -- $1\r, $1', 1)).toBe('select :1 -- $1\r, :1');
+	});
+
+	test('keeps escape-string semantics across a continued string constant', () => {
+		expect(prepareAwsDataApiSql("select E'a'\n'it\\'s $1' , $1", 1))
+			.toBe("select E'a'\n'it\\'s $1' , :1");
+	});
+
+	test('keeps escape-string semantics across a continuation separated by a line comment', () => {
+		expect(prepareAwsDataApiSql("select E'a'\n-- c\n'it\\'s $1' , $1", 1))
+			.toBe("select E'a'\n-- c\n'it\\'s $1' , :1");
+	});
+
+	test('treats a comment that carries the newline as continuation whitespace', () => {
+		expect(prepareAwsDataApiSql("select E'a' -- c\n'it\\'s $1' , $1", 1))
+			.toBe("select E'a' -- c\n'it\\'s $1' , :1");
+	});
+
+	test('does not continue a string when the gap has no newline', () => {
+		expect(prepareAwsDataApiSql("select 'a' 'b' , $1", 1)).toBe("select 'a' 'b' , :1");
+	});
+
+	test('rewrites a placeholder in a cast-bearing count query', () => {
+		expect(
+			prepareAwsDataApiSql('select count(*)::text as n from regions where country_code = $1', 1),
+		).toBe('select count(*)::text as n from regions where country_code = :1');
+	});
+
+	test('rewrites placeholders in a multi-line introspection query', () => {
+		const sql = `SELECT conname AS primary_key
+FROM pg_constraint join pg_class on (pg_class.oid = conrelid)
+WHERE contype = 'p'
+AND connamespace = $1::regnamespace
+AND pg_class.relname = $2;`;
+
+		expect(prepareAwsDataApiSql(sql, 2)).toBe(
+			`SELECT conname AS primary_key
+FROM pg_constraint join pg_class on (pg_class.oid = conrelid)
+WHERE contype = 'p'
+AND connamespace = :1::regnamespace
+AND pg_class.relname = :2;`,
+		);
+	});
+});


### PR DESCRIPTION
Fixes #6147.

## The problem

The RDS Data API binds **named** parameters (`:1`) only. It never binds Postgres positional placeholders (`$1`), and reports the mismatch as:

```
bind message supplies 0 parameters, but prepared statement "sqlx_s_35" requires 1; SQLState: 08P01
```

SQL that drizzle-orm *generates* already arrives in named form, because `AwsPgDialect.escapeParam()` emits `:${index + 1}`. drizzle-kit's `query` and `proxy` for this driver do not go through the dialect: they hand whatever SQL they receive to `session.prepareQuery` unchanged, so a caller that supplies `$N` gets nothing bound.

On `beta` I have not found a caller that does this in normal use; Studio's client escapes with `AwsPgDialect` for this driver (see [#6147](https://github.com/drizzle-team/drizzle-orm/issues/6147#issuecomment-5650035780)). So on this branch the change is hardening: the adapter accepts both placeholder forms. On `main` (`0.31.10`) the composite primary key introspection query in `pgSerializer.ts` does send `$1` and `$2` through this path, which is #2372.

## The change

`prepareAwsDataApiSql(sql: string, parameterCount: number): string` in `drizzle-kit/src/utils/aws-data-api-placeholders.ts`, applied at both Data API adapter entry points in `cli/connections.ts`. Both entry points get the same treatment, since they are the same adapter and introspection on this branch happens to be parameter-free.

It takes the parameter count rather than the parameter array because the count is its entire dependency: nothing in the rewrite inspects a value. That keeps the signature free of `any` and `unknown`.

The rewrite is literal aware, because a blind `$N` replace corrupts valid SQL. These spans are copied through untouched:

- line comments, ending at CR as well as LF, and **nestable** block comments;
- string constants, including `''` escapes, `E'...\'...'`, and continuations across a newline (line comments included), which keep the escape-string property of the first segment;
- dollar-quoted bodies, tagged or not (`$$ ... $$`, `$tag$ ... $tag$`), including an unterminated body, which runs to end of input the way Postgres would read it;
- quoted identifiers (`"a $1 b"`);
- identifiers, including non-ASCII ones, since Postgres treats every non-ASCII byte as an identifier character and permits `$` after the first character. `foo$1` and `é$1` are each a single identifier, and `$é$` is a valid dollar-quote tag.

Two deliberately conservative choices:

- Only `$N` where `1 <= N <= parameterCount` is rewritten. A stray `$9` in a two-parameter query is left for the server to reject rather than silently renamed.
- With no parameters, the input is returned unchanged, so the scanner never runs on the introspection path.

The one documented limitation is that it assumes `standard_conforming_strings` is on, which is the default and what Aurora ships.

## Tests

`drizzle-kit/tests/other/aws-data-api-placeholders.test.ts`, 30 cases covering every span type above plus the boundaries: `$0`, a lone `$`, a two-digit index, an index beyond the parameter count, a repeated placeholder, a placeholder at end of input, and a quote following an identifier ending in `e` (which is not an E-string).

The lexical edge cases are not guesses. I checked each one against real Postgres via PGlite, the same engine this package already tests against, and the tests encode the observed behavior:

| Construct | Postgres |
|---|---|
| `SELECT E'a'\n'it\'s'` | `ait's`, so a continuation keeps escape-string semantics |
| `SELECT E'a' -- c\n'it\'s'` | `ait's`, so a line comment is continuation whitespace, and a block comment there is a syntax error |
| `SELECT 'a' 'b'` on one line | syntax error, so a continuation requires a newline |
| `SELECT 1 AS a --c<CR>, 2 AS b` | two columns, so CR ends a line comment |
| `SELECT 1 AS é$1` | one column named `é$1` |
| `SELECT $é$ hi $é$` | valid dollar-quoted string |
| `SELECT $1abc` | `trailing junk after parameter`, so it is not a placeholder to preserve |

The function is pure, so these need no database and no AWS account; they run in `tests/other` with the rest of the Docker-free suite.

## What I verified, and what I did not

- The 30 tests pass **inside this package**, on Node 24.19.0 with pnpm 10.15.0:

  ```
  $ cd drizzle-kit && pnpm vitest run tests/other/aws-data-api-placeholders.test.ts
   ✓ tests/other/aws-data-api-placeholders.test.ts (30 tests) 3ms
     Test Files  1 passed (1)
          Tests  30 passed (30)
  ```
- The change adds no new failures to the Docker-free `tests/other` subset. Run on `beta` at `748058e` and on this branch, the same 17 tests fail in the same files on both sides; the only difference is the passing tests this PR adds.
- `dprint check` is clean on all three files.
- The module typechecks under `--strict --noUncheckedIndexedAccess`, which is stricter than `drizzle-kit/tsconfig.json`. No `any`, no casts, no non-null assertions.
- Behavior was verified end to end against Aurora Serverless v2 (PostgreSQL 15.12) over the Data API, using a standalone reproduction: https://github.com/simiancraft/drizzle-kit-rds-data-api-repro. Its probe sends the same query twice, once without parameters and once with one, so the control isolates the failure to binding rather than to the query or the connection.
- I did **not** run the full `drizzle-kit` suite, since the rest of it stands up Docker-backed databases I cannot run here. Happy to iterate if CI surfaces anything.

I put this in drizzle-kit because `escapeParam()` is already correct and `AwsDataApiSession` is not the thing that is wrong. If you would rather the translation live in drizzle-orm's session so every consumer inherits it, say so and I will move it.

