### PR TITLE
[Drizzle-kit]: Add "squash" command to CLI

### DIFF
--- a/drizzle-kit/src/cli/commands/squash.ts
+++ b/drizzle-kit/src/cli/commands/squash.ts
@@ -1,0 +1,181 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import type { Dialect } from '../../utils/schemaValidator';
+import { assertV3OutFolder, prepareOutFolder } from '../../utils/utils-node';
+import { SquashCliError } from '../errors';
+import { humanLog } from '../views';
+import { embeddedMigrations } from './generate-common';
+
+export type SquashConfig = {
+	out: string;
+	dialect: Dialect;
+	start: number;
+	end: number;
+};
+
+export type SquashHandlerResult =
+	| { status: 'ok'; dialect: Dialect; squashed: string[]; created: string }
+	| { status: 'no_changes'; dialect: Dialect };
+
+type MigrationEntry = {
+	folder: string;
+	snapshotPath: string;
+	sqlPath: string;
+	id: string;
+	prevIds: string[];
+};
+
+const collectEntries = (out: string): MigrationEntry[] => {
+	const { snapshots } = prepareOutFolder(out);
+
+	return snapshots.map((snapshotPath) => {
+		const folder = basename(dirname(snapshotPath));
+		const sqlPath = join(dirname(snapshotPath), 'migration.sql');
+		if (!existsSync(sqlPath)) {
+			throw new SquashCliError(`No migration.sql file was found in '${folder}' folder`, {
+				folder,
+			});
+		}
+
+		let snapshot: { id?: unknown; prevIds?: unknown };
+		try {
+			snapshot = JSON.parse(readFileSync(snapshotPath, 'utf-8'));
+		} catch {
+			throw new SquashCliError(`Failed to read snapshot in '${folder}' folder`, { folder });
+		}
+
+		if (typeof snapshot.id !== 'string' || !Array.isArray(snapshot.prevIds)) {
+			throw new SquashCliError(
+				`Snapshot in '${folder}' folder is malformed: 'id' and 'prevIds' fields are required`,
+				{ folder },
+			);
+		}
+
+		return {
+			folder,
+			snapshotPath,
+			sqlPath,
+			id: snapshot.id,
+			prevIds: snapshot.prevIds as string[],
+		};
+	});
+};
+
+const assertSimpleChain = (entries: MigrationEntry[], squashedEntries: MigrationEntry[]) => {
+	const squashedIds = new Set(squashedEntries.map((it) => it.id));
+	const lastId = squashedEntries[squashedEntries.length - 1]!.id;
+
+	for (const entry of entries) {
+		if (squashedIds.has(entry.id)) {
+			// Any squashed migration except the first one must only have
+			// parents inside the squashed range, otherwise the range has a
+			// merge point and can't be replaced with a single migration
+			if (entry !== squashedEntries[0]) {
+				for (const prevId of entry.prevIds) {
+					if (!squashedIds.has(prevId)) {
+						throw new SquashCliError(
+							`Migration '${entry.folder}' has a parent outside of the squashed range. Squashing migrations with merged branches is not supported`,
+							{ folder: entry.folder },
+						);
+					}
+				}
+			}
+		} else {
+			// Any migration outside of the range must only reference the last
+			// squashed migration, otherwise the range has a branch and
+			// squashing would corrupt the snapshot chain
+			for (const prevId of entry.prevIds) {
+				if (squashedIds.has(prevId) && prevId !== lastId) {
+					throw new SquashCliError(
+						`Migration '${entry.folder}' branches off the middle of the squashed range. Squashing migrations with branches is not supported`,
+						{ folder: entry.folder },
+					);
+				}
+			}
+		}
+	}
+};
+
+export const squashHandler = (config: SquashConfig): SquashHandlerResult => {
+	const { out, dialect, start, end } = config;
+
+	assertV3OutFolder(out);
+
+	const entries = collectEntries(out);
+	if (entries.length === 0) {
+		throw new SquashCliError(`No migrations were found in '${out}' folder`, { out });
+	}
+
+	if (
+		!Number.isInteger(start) || !Number.isInteger(end)
+		|| start < 0 || end < start || end >= entries.length
+	) {
+		throw new SquashCliError(
+			`Invalid range ${start}-${end}: 'start' and 'end' must be indexes of existing migrations (0-${
+				entries.length - 1
+			})`,
+			{ start, end },
+		);
+	}
+
+	const squashedEntries = entries.slice(start, end + 1);
+	if (squashedEntries.length === 1) {
+		return { status: 'no_changes', dialect };
+	}
+
+	assertSimpleChain(entries, squashedEntries);
+
+	humanLog(
+		`[✓] Found ${squashedEntries.length} migrations to squash (${squashedEntries[0]!.folder} through ${
+			squashedEntries[squashedEntries.length - 1]!.folder
+		})`,
+	);
+
+	// The squashed migration reuses the first folder name to keep its position
+	// in the migration order
+	const newFolder = squashedEntries[0]!.folder;
+	const lastSnapshot = JSON.parse(
+		readFileSync(squashedEntries[squashedEntries.length - 1]!.snapshotPath, 'utf-8'),
+	) as Record<string, unknown>;
+
+	// Keep the id of the last squashed snapshot, so migrations generated after
+	// the range stay connected. Replace prevIds with the ones of the first
+	// squashed snapshot, so the history before the range stays connected
+	lastSnapshot.prevIds = squashedEntries[0]!.prevIds;
+
+	const combinedSql = squashedEntries
+		.map(
+			(entry) =>
+				`-- Start migration ${entry.folder}\n${readFileSync(entry.sqlPath, 'utf-8')}\n-- End migration ${entry.folder}`,
+		)
+		.join('\n');
+
+	for (const entry of squashedEntries) {
+		rmSync(dirname(entry.snapshotPath), { recursive: true, force: true });
+	}
+
+	const newFolderPath = join(out, newFolder);
+	mkdirSync(newFolderPath);
+	writeFileSync(join(newFolderPath, 'snapshot.json'), JSON.stringify(lastSnapshot, null, 2));
+	writeFileSync(join(newFolderPath, 'migration.sql'), combinedSql);
+
+	// Regenerate the migrations bundle for Expo / Durable SQLite drivers
+	const bundlePath = join(out, 'migrations.js');
+	if (existsSync(bundlePath)) {
+		const previousBundle = readFileSync(bundlePath, 'utf-8');
+		const driver = previousBundle.includes('Expo/React Native') ? 'expo' : undefined;
+		const { snapshots } = prepareOutFolder(out);
+		writeFileSync(bundlePath, embeddedMigrations(snapshots, driver));
+	}
+
+	humanLog(`[✓] Successfully squashed ${squashedEntries.length} migrations into ${newFolder}`);
+	humanLog(`[i] Removed: ${squashedEntries.map((it) => it.folder).join(', ')}`);
+	humanLog(`[i] Created: ${newFolder}`);
+
+	return {
+		status: 'ok',
+		dialect,
+		squashed: squashedEntries.map((it) => it.folder),
+		created: newFolder,
+	};
+};

--- a/drizzle-kit/src/cli/contract.ts
+++ b/drizzle-kit/src/cli/contract.ts
@@ -1,7 +1,15 @@
 import type { GenericBuilderInternals, Simplify } from '@drizzle-team/brocli';
 import type { Dialect } from '../utils/schemaValidator';
 import type { Hint } from './hints';
-import type { checkOptions, exportOptions, generateOptions, pullOptions, pushOptions, upOptions } from './schema';
+import type {
+	checkOptions,
+	exportOptions,
+	generateOptions,
+	pullOptions,
+	pushOptions,
+	squashOptions,
+	upOptions,
+} from './schema';
 
 type BrocliInputOf<TOptions extends Record<string, GenericBuilderInternals>> = Simplify<
 	{
@@ -35,6 +43,8 @@ export type ExportOptionsInput = BrocliInputOf<typeof exportOptions> & { dialect
 export type ExportOptions = Omit<ExportOptionsInput, 'output'>;
 
 export type UpOptionsInput = BrocliInputOf<typeof upOptions> & { dialect?: Dialect };
+
+export type SquashOptionsInput = BrocliInputOf<typeof squashOptions> & { dialect?: Dialect };
 
 export type UpOptions = Omit<UpOptionsInput, 'output'>;
 

--- a/drizzle-kit/src/cli/errors.ts
+++ b/drizzle-kit/src/cli/errors.ts
@@ -216,6 +216,12 @@ export class InvalidHintsCliError extends DrizzleCliError {
 	}
 }
 
+export class SquashCliError extends DrizzleCliError {
+	constructor(humanMessage: string, meta?: DrizzleCliErrorMeta) {
+		super('squash_error', humanMessage, meta);
+	}
+}
+
 export class MigrationsOutdatedCliError extends DrizzleCliError {
 	constructor(out: string) {
 		super(

--- a/drizzle-kit/src/cli/index.ts
+++ b/drizzle-kit/src/cli/index.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { outputFormat, runWithCliContext } from './context';
 import { DrizzleCliError, errorToEnvelope } from './errors';
 import { highlightSQL } from './highlighter';
-import { check, exportRaw, generate, mcp, migrate, pull, push, skills, studio, up } from './schema';
+import { check, exportRaw, generate, mcp, migrate, pull, push, skills, squash, studio, up } from './schema';
 import { ormCoreVersions, QueryError } from './utils';
 import { error, humanError, humanLog } from './views';
 
@@ -114,7 +114,7 @@ const legacy = [
 
 const main = async () => {
 	await runWithCliContext({ output: 'text', interactive: false }, async () => {
-		await run([generate, migrate, pull, push, studio, up, check, exportRaw, skills, mcp, ...legacy], {
+		await run([generate, migrate, pull, push, studio, up, check, exportRaw, squash, skills, mcp, ...legacy], {
 			name: 'drizzle-kit',
 			version: () => version(),
 

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -11,6 +11,7 @@ import type { MigrationConfig, MigratorInitFailResponse } from 'drizzle-orm/migr
 import { assertUnreachable } from '../utils';
 import { assertV3OutFolder } from '../utils/utils-node';
 import { checkHandler } from './commands/check';
+import { type SquashConfig, squashHandler } from './commands/squash';
 import type { Setup } from './commands/studio';
 import { upCockroachHandler } from './commands/up-cockroach';
 import { upMssqlHandler } from './commands/up-mssql';
@@ -35,6 +36,7 @@ import type {
 	GenerateOptionsInput,
 	PullOptionsInput,
 	PushOptionsInput,
+	SquashOptionsInput,
 	UpOptionsInput,
 } from './contract';
 import {
@@ -636,6 +638,51 @@ export const up = command({
 	transform: prepareUp,
 	handler: async (cfg) => {
 		const env = await runUp(cfg);
+		if (outputFormat() === 'json') process.stdout.write(JSON.stringify(env) + '\n');
+		process.exit(statusToExitCode(env.status));
+	},
+});
+
+export const squashOptions = {
+	config: optionConfig,
+	dialect: optionDialect,
+	out: optionOut,
+	start: number('start')
+		.int()
+		.min(0)
+		.required()
+		.desc('Index of the first migration to squash (0-based, in folder order)'),
+	end: number('end')
+		.int()
+		.min(0)
+		.required()
+		.desc('Index of the last migration to squash (inclusive)'),
+	output: optionOutput,
+} as const satisfies Record<string, GenericBuilderInternals>;
+
+export const prepareSquash = async (opts: SquashOptionsInput): Promise<SquashConfig> => {
+	const output = opts.output ?? outputFormat();
+	const interactive = output === 'text' && !!process.stdin.isTTY;
+	setCliContext({ output, interactive });
+	const from = assertCollisions('squash', opts, ['start', 'end', 'output'], ['dialect', 'out']);
+	const { out, dialect } = await prepareCheckParams(opts, from);
+	return { out, dialect, start: opts.start!, end: opts.end! };
+};
+
+export const runSquash = async (config: SquashConfig) => {
+	await assertOrmCoreVersion();
+	await assertPackages('drizzle-orm');
+
+	return squashHandler(config);
+};
+
+export const squash = command({
+	name: 'squash',
+	desc: 'Combine a range of consecutive migrations into a single migration',
+	options: squashOptions,
+	transform: prepareSquash,
+	handler: async (cfg) => {
+		const env = await runSquash(cfg);
 		if (outputFormat() === 'json') process.stdout.write(JSON.stringify(env) + '\n');
 		process.exit(statusToExitCode(env.status));
 	},

--- a/drizzle-kit/src/cli/validations/common.ts
+++ b/drizzle-kit/src/cli/validations/common.ts
@@ -13,7 +13,8 @@ export type Commands =
 	| 'up'
 	| 'drop'
 	| 'push'
-	| 'export';
+	| 'export'
+	| 'squash';
 
 // type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true;

--- a/drizzle-kit/tests/other/cli-squash.test.ts
+++ b/drizzle-kit/tests/other/cli-squash.test.ts
@@ -1,0 +1,265 @@
+import { test as brotest } from '@drizzle-team/brocli';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, assert, expect, test } from 'vitest';
+import { squashHandler } from '../../src/cli/commands/squash';
+import { squash } from '../../src/cli/schema';
+import { wrapParam } from '../../src/cli/validations/common';
+import { error } from '../../src/cli/views';
+import { ORIGIN } from './check-fixtures';
+import { createConfig } from './utils';
+
+const originalPrefix = process.env.TEST_CONFIG_PATH_PREFIX;
+process.env.TEST_CONFIG_PATH_PREFIX = './tests/cli/';
+afterEach(() => {
+	process.env.TEST_CONFIG_PATH_PREFIX = originalPrefix ?? './tests/cli/';
+});
+
+const stageOut = (): string => {
+	mkdirSync('tests/tmp', { recursive: true });
+	return mkdtempSync('tests/tmp/cli-squash-');
+};
+
+const writeMigration = (
+	out: string,
+	folder: string,
+	id: string,
+	prevIds: string[],
+	sql: string,
+) => {
+	const path = join(out, folder);
+	mkdirSync(path, { recursive: true });
+	writeFileSync(
+		join(path, 'snapshot.json'),
+		JSON.stringify({ version: '8', dialect: 'postgres', id, prevIds, ddl: [], renames: [] }, null, 2),
+	);
+	writeFileSync(join(path, 'migration.sql'), sql);
+};
+
+const stageChain = (count: number): string => {
+	const out = stageOut();
+	let prev = ORIGIN;
+	for (let i = 0; i < count; i++) {
+		const id = `s${i}`;
+		writeMigration(out, `${String(i).padStart(4, '0')}_migration_${i}`, id, [prev], `SELECT ${i};`);
+		prev = id;
+	}
+	return out;
+};
+
+// #region CLI option parsing
+
+test('validate config #1: cli params', async () => {
+	const res = await brotest(squash, `--dialect=postgresql --out=test --start=1 --end=2`);
+
+	assert.equal(res.type, 'handler');
+	if (res.type !== 'handler') assert.fail(res.type, 'handler');
+	expect(res.options).toStrictEqual({
+		dialect: 'postgresql',
+		out: 'test',
+		start: 1,
+		end: 2,
+	});
+});
+
+test('validate config #2: config file', async () => {
+	const prefix = process.env.TEST_CONFIG_PATH_PREFIX || '';
+	const { path, name } = createConfig({ dialect: 'postgresql', out: 'test' }, prefix);
+
+	const res = await brotest(squash, `--config=${name} --start=0 --end=1`);
+
+	unlinkSync(path);
+
+	assert.equal(res.type, 'handler');
+	if (res.type !== 'handler') assert.fail(res.type, 'handler');
+	expect(res.options).toStrictEqual({
+		dialect: 'postgresql',
+		out: 'test',
+		start: 0,
+		end: 1,
+	});
+});
+
+test('validate config #3: missing dialect', async () => {
+	const res = await brotest(squash, `--out=test --start=0 --end=1`);
+
+	expect(res.type).toBe('error');
+	if (res.type !== 'error') return;
+	expect((res.error as Error).message).toBe(
+		[error('Please provide required params:'), wrapParam('dialect', undefined)].join('\n'),
+	);
+});
+
+test('validate config #4: start and end are required', async () => {
+	const res = await brotest(squash, `--dialect=postgresql`);
+
+	expect(res.type).toBe('error');
+});
+
+// #endregion
+
+// #region integration
+
+test('squash integration: combines a range of migrations', () => {
+	const out = stageChain(4);
+
+	const result = squashHandler({ out, dialect: 'postgresql', start: 1, end: 2 });
+
+	assert.equal(result.status, 'ok');
+	if (result.status !== 'ok') return;
+
+	// one squashed folder replaced two original ones
+	const remaining = readdirSync(out).sort();
+	expect(remaining).toStrictEqual(['0000_migration_0', '0001_migration_1', '0003_migration_3']);
+
+	// squashed folder keeps the first folder name and holds the combined sql
+	const sql = readFileSync(join(out, '0001_migration_1', 'migration.sql'), 'utf-8');
+	expect(sql).toContain('-- Start migration 0001_migration_1');
+	expect(sql).toContain('SELECT 1;');
+	expect(sql).toContain('-- Start migration 0002_migration_2');
+	expect(sql).toContain('SELECT 2;');
+
+	// snapshot keeps the id of the last squashed migration and prevIds of the first one
+	const snapshot = JSON.parse(readFileSync(join(out, '0001_migration_1', 'snapshot.json'), 'utf-8'));
+	expect(snapshot.id).toBe('s2');
+	expect(snapshot.prevIds).toStrictEqual(['s0']);
+
+	// the migration after the range still points to the last squashed snapshot id
+	const after = JSON.parse(readFileSync(join(out, '0003_migration_3', 'snapshot.json'), 'utf-8'));
+	expect(after.prevIds).toStrictEqual(['s2']);
+});
+
+test('squash integration: full range', () => {
+	const out = stageChain(3);
+
+	const result = squashHandler({ out, dialect: 'postgresql', start: 0, end: 2 });
+
+	assert.equal(result.status, 'ok');
+	if (result.status !== 'ok') return;
+
+	const remaining = readdirSync(out).sort();
+	expect(remaining).toStrictEqual(['0000_migration_0']);
+
+	const snapshot = JSON.parse(readFileSync(join(out, '0000_migration_0', 'snapshot.json'), 'utf-8'));
+	expect(snapshot.id).toBe('s2');
+	expect(snapshot.prevIds).toStrictEqual([ORIGIN]);
+});
+
+test('squash integration: single migration range is a no-op', () => {
+	const out = stageChain(3);
+
+	const result = squashHandler({ out, dialect: 'postgresql', start: 1, end: 1 });
+
+	assert.equal(result.status, 'no_changes');
+	expect(readdirSync(out).sort()).toStrictEqual([
+		'0000_migration_0',
+		'0001_migration_1',
+		'0002_migration_2',
+	]);
+});
+
+test('squash integration: invalid range', () => {
+	const out = stageChain(3);
+
+	expect(() => squashHandler({ out, dialect: 'postgresql', start: 2, end: 1 })).toThrowError();
+	expect(() => squashHandler({ out, dialect: 'postgresql', start: 0, end: 3 })).toThrowError();
+});
+
+test('squash integration: empty folder', () => {
+	const out = stageOut();
+
+	expect(() => squashHandler({ out, dialect: 'postgresql', start: 0, end: 1 })).toThrowError(
+		/No migrations were found/,
+	);
+});
+
+test('squash integration: v1 folder with journal is rejected', () => {
+	const out = stageOut();
+	mkdirSync(join(out, 'meta'), { recursive: true });
+	writeFileSync(join(out, 'meta', '_journal.json'), '{}');
+
+	expect(() => squashHandler({ out, dialect: 'postgresql', start: 0, end: 1 })).toThrowError(
+		/migrations folder format is outdated/,
+	);
+});
+
+test('squash integration: missing migration.sql is rejected', () => {
+	const out = stageOut();
+	const folder = join(out, '0000_migration_0');
+	mkdirSync(folder, { recursive: true });
+	writeFileSync(
+		join(folder, 'snapshot.json'),
+		JSON.stringify({ version: '8', dialect: 'postgres', id: 's0', prevIds: [ORIGIN], ddl: [] }),
+	);
+
+	expect(() => squashHandler({ out, dialect: 'postgresql', start: 0, end: 1 })).toThrowError(
+		/No migration.sql file was found/,
+	);
+});
+
+// #endregion
+
+// #region branch guards
+
+test('squash rejects a branch off the middle of the range', () => {
+	const out = stageOut();
+	writeMigration(out, '0000_a', 's0', [ORIGIN], 'SELECT 0;');
+	writeMigration(out, '0001_b', 's1', ['s0'], 'SELECT 1;');
+	writeMigration(out, '0002_c', 's2', ['s0'], 'SELECT 2;'); // branches off s0
+
+	expect(() => squashHandler({ out, dialect: 'postgresql', start: 0, end: 1 })).toThrowError(
+		/branches off the middle of the squashed range/,
+	);
+});
+
+test('squash rejects a merge into the middle of the range', () => {
+	const out = stageOut();
+	writeMigration(out, '0000_a', 's0', [ORIGIN], 'SELECT 0;');
+	writeMigration(out, '0001_b', 's1', ['s0', ORIGIN], 'SELECT 1;'); // merges ORIGIN into s1
+
+	expect(() => squashHandler({ out, dialect: 'postgresql', start: 0, end: 1 })).toThrowError(
+		/has a parent outside of the squashed range/,
+	);
+});
+
+// #endregion
+
+// #region post-squash compatibility
+
+test('post-squash: orm migrator can still read the migrations folder', () => {
+	const out = stageChain(3);
+
+	squashHandler({ out, dialect: 'postgresql', start: 0, end: 2 });
+
+	const migrations = readMigrationFiles({ migrationsFolder: out });
+	expect(migrations).toHaveLength(1);
+	expect(migrations[0]!.sql.join('')).toContain('SELECT 0;');
+	expect(migrations[0]!.sql.join('')).toContain('SELECT 2;');
+});
+
+test('post-squash: migrations.js bundle is regenerated', () => {
+	const out = stageChain(3);
+	writeFileSync(
+		join(out, 'migrations.js'),
+		'// This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo\n',
+	);
+
+	squashHandler({ out, dialect: 'postgresql', start: 0, end: 2 });
+
+	const bundle = readFileSync(join(out, 'migrations.js'), 'utf-8');
+	expect(bundle).toContain("import m0000 from './0000_migration_0/migration.sql';");
+	expect(bundle).not.toContain('0001_migration_1');
+	expect(bundle).toContain('Expo/React Native');
+});
+
+// #endregion


### PR DESCRIPTION
This commit adds a 'squash' command to the drizzle-kit cli. This command allows users to combine a range of consecutive migrations. Squashing is particularly useful for cleaning up feature branches developed over multiple iterations that include many small, redundant, or contradictory migrations.

This is the beta (v3 folder-based migration format) port of #4927.

Changes:
- Adds squash command to CLI schema
- Implements `squash` command
  - Takes two custom arguments `start` (`i`) and `end` (`j`) representing the inclusive range of migrations to be merged
  - Combines migrations
     - Concatenates SQL files
     - Updates journal entry `i` to use snapshot from migration `j`
     - Removes journal entries `i+1`-`j`
     - Removes unused sql and snapshots
- No pre-existing code is modified or deleted
- Integration tests are included to ensure:
   - Basic functionality of CLI
   - Compatibility with existing `generate` and `migrate` commands
   
Note:
The `squash` command has a single known (and intentional) failure case when some environment has been migrated to version `i < k < j`.

Related issues/discussions: #2859 #4897 #3492 