### PR TITLE
feat(mysql): add mode buffer|string for binary and varbinary

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
+import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
@@ -58,19 +58,88 @@ export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> ex
 	}
 }
 
-export interface MySqlBinaryConfig {
+export type MySqlBinaryBufferBuilderInitial<TName extends string> = MySqlBinaryBufferBuilder<{
+	name: TName;
+	dataType: 'buffer';
+	columnType: 'MySqlBinaryBuffer';
+	data: Buffer;
+	driverParam: Buffer | string;
+	enumValues: undefined;
+}>;
+
+export class MySqlBinaryBufferBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinaryBuffer'>>
+	extends MySqlColumnBuilder<T, MySqlBinaryConfig>
+{
+	static override readonly [entityKind]: string = 'MySqlBinaryBufferBuilder';
+
+	constructor(name: T['name'], length: number | undefined) {
+		super(name, 'buffer', 'MySqlBinaryBuffer');
+		this.config.length = length;
+	}
+
+	/** @internal */
+	override build<TTableName extends string>(
+		table: AnyMySqlTable<{ name: TTableName }>,
+	): MySqlBinaryBuffer<MakeColumnConfig<T, TTableName>> {
+		return new MySqlBinaryBuffer<MakeColumnConfig<T, TTableName>>(
+			table,
+			this.config as ColumnBuilderRuntimeConfig<any, any>,
+		);
+	}
+}
+
+export class MySqlBinaryBuffer<T extends ColumnBaseConfig<'buffer', 'MySqlBinaryBuffer'>> extends MySqlColumn<
+	T,
+	MySqlBinaryConfig
+> {
+	static override readonly [entityKind]: string = 'MySqlBinaryBuffer';
+
+	length: number | undefined = this.config.length;
+
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		// drivers that decode binary columns as strings hand back one character per byte,
+		// so latin1 is what round-trips those bytes losslessly
+		if (typeof value === 'string') return Buffer.from(value, 'latin1');
+
+		return Buffer.from(value);
+	}
+
+	override mapToDriverValue(value: Buffer | Uint8Array | string): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'latin1');
+
+		return Buffer.from(value);
+	}
+
+	getSQLType(): string {
+		return this.length === undefined ? `binary` : `binary(${this.length})`;
+	}
+}
+
+export type BinaryMode = 'string' | 'buffer';
+
+export interface MySqlBinaryConfig<TMode extends BinaryMode = BinaryMode> {
 	length?: number;
+	/**
+	 * `'string'` (default) maps the column to `string`, `'buffer'` maps it to `Buffer`,
+	 * which is what `mysql2` returns for `binary` columns.
+	 */
+	mode?: TMode;
 }
 
 export function binary(): MySqlBinaryBuilderInitial<''>;
-export function binary(
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<''>;
-export function binary<TName extends string>(
+export function binary<TMode extends BinaryMode = 'string'>(
+	config?: MySqlBinaryConfig<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<''> : MySqlBinaryBuilderInitial<''>;
+export function binary<TName extends string, TMode extends BinaryMode = 'string'>(
 	name: TName,
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<TName>;
+	config?: MySqlBinaryConfig<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<TName> : MySqlBinaryBuilderInitial<TName>;
 export function binary(a?: string | MySqlBinaryConfig, b: MySqlBinaryConfig = {}) {
 	const { name, config } = getColumnNameAndConfig<MySqlBinaryConfig>(a, b);
+	if (config.mode === 'buffer') {
+		return new MySqlBinaryBufferBuilder(name, config.length);
+	}
 	return new MySqlBinaryBuilder(name, config.length);
 }

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
+import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
@@ -60,18 +60,88 @@ export class MySqlVarBinary<
 	}
 }
 
-export interface MySqlVarbinaryOptions {
-	length: number;
+export type MySqlVarBinaryBufferBuilderInitial<TName extends string> = MySqlVarBinaryBufferBuilder<{
+	name: TName;
+	dataType: 'buffer';
+	columnType: 'MySqlVarBinaryBuffer';
+	data: Buffer;
+	driverParam: Buffer | string;
+	enumValues: undefined;
+}>;
+
+export class MySqlVarBinaryBufferBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarBinaryBuffer'>>
+	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
+{
+	static override readonly [entityKind]: string = 'MySqlVarBinaryBufferBuilder';
+
+	/** @internal */
+	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
+		super(name, 'buffer', 'MySqlVarBinaryBuffer');
+		this.config.length = config?.length;
+	}
+
+	/** @internal */
+	override build<TTableName extends string>(
+		table: AnyMySqlTable<{ name: TTableName }>,
+	): MySqlVarBinaryBuffer<MakeColumnConfig<T, TTableName>> {
+		return new MySqlVarBinaryBuffer<MakeColumnConfig<T, TTableName>>(
+			table,
+			this.config as ColumnBuilderRuntimeConfig<any, any>,
+		);
+	}
 }
 
-export function varbinary(
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<''>;
-export function varbinary<TName extends string>(
+export class MySqlVarBinaryBuffer<
+	T extends ColumnBaseConfig<'buffer', 'MySqlVarBinaryBuffer'>,
+> extends MySqlColumn<T, MySqlVarbinaryOptions> {
+	static override readonly [entityKind]: string = 'MySqlVarBinaryBuffer';
+
+	length: number | undefined = this.config.length;
+
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		// drivers that decode binary columns as strings hand back one character per byte,
+		// so latin1 is what round-trips those bytes losslessly
+		if (typeof value === 'string') return Buffer.from(value, 'latin1');
+
+		return Buffer.from(value);
+	}
+
+	override mapToDriverValue(value: Buffer | Uint8Array | string): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'latin1');
+
+		return Buffer.from(value);
+	}
+
+	getSQLType(): string {
+		return this.length === undefined ? `varbinary` : `varbinary(${this.length})`;
+	}
+}
+
+export type VarBinaryMode = 'string' | 'buffer';
+
+export interface MySqlVarbinaryOptions<TMode extends VarBinaryMode = VarBinaryMode> {
+	length: number;
+	/**
+	 * `'string'` (default) maps the column to `string`, `'buffer'` maps it to `Buffer`,
+	 * which is what `mysql2` returns for `varbinary` columns.
+	 */
+	mode?: TMode;
+}
+
+export function varbinary<TMode extends VarBinaryMode = 'string'>(
+	config: MySqlVarbinaryOptions<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<''> : MySqlVarBinaryBuilderInitial<''>;
+export function varbinary<TName extends string, TMode extends VarBinaryMode = 'string'>(
 	name: TName,
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<TName>;
+	config: MySqlVarbinaryOptions<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<TName>
+	: MySqlVarBinaryBuilderInitial<TName>;
 export function varbinary(a?: string | MySqlVarbinaryOptions, b?: MySqlVarbinaryOptions) {
 	const { name, config } = getColumnNameAndConfig<MySqlVarbinaryOptions>(a, b);
+	if (config.mode === 'buffer') {
+		return new MySqlVarBinaryBufferBuilder(name, config);
+	}
 	return new MySqlVarBinaryBuilder(name, config);
 }

--- a/drizzle-orm/type-tests/mysql/tables.ts
+++ b/drizzle-orm/type-tests/mysql/tables.ts
@@ -865,6 +865,7 @@ Expect<
 		bigintdef: bigint('bigintdef', { mode: 'number' }).default(0),
 		binary: binary('binary'),
 		binary1: binary('binary1', { length: 1 }),
+		binary2: binary('binary2', { length: 16, mode: 'buffer' }),
 		binarydef: binary('binarydef').default(''),
 		boolean: boolean('boolean'),
 		booleandef: boolean('booleandef').default(false),
@@ -939,6 +940,7 @@ Expect<
 		tinyint2: tinyint('tinyint2', { unsigned: true }),
 		tinyintdef: tinyint('tinyintdef').default(0),
 		varbinary: varbinary('varbinary', { length: 1 }),
+		varbinary2: varbinary('varbinary2', { length: 16, mode: 'buffer' }),
 		varbinarydef: varbinary('varbinarydef', { length: 1 }).default(''),
 		varchar: varchar('varchar', { length: 1 }),
 		varchar2: varchar('varchar2', { length: 1, enum: ['a', 'b', 'c'] }),
@@ -965,6 +967,7 @@ Expect<
 		bigintdef: bigint({ mode: 'number' }).default(0),
 		binary: binary(),
 		binrary1: binary({ length: 1 }),
+		binary2: binary({ length: 16, mode: 'buffer' }),
 		binarydef: binary().default(''),
 		boolean: boolean(),
 		booleandef: boolean().default(false),
@@ -1039,6 +1042,7 @@ Expect<
 		tinyint2: tinyint({ unsigned: true }),
 		tinyintdef: tinyint().default(0),
 		varbinary: varbinary({ length: 1 }),
+		varbinary2: varbinary({ length: 16, mode: 'buffer' }),
 		varbinarydef: varbinary({ length: 1 }).default(''),
 		varchar: varchar({ length: 1 }),
 		varchar2: varchar({ length: 1, enum: ['a', 'b', 'c'] }),
@@ -1078,4 +1082,34 @@ Expect<
 	const res = await db.select({ enum: table.enum }).from(table);
 
 	Expect<Equal<{ enum: Role | null }[], typeof res>>;
+}
+
+{
+	const binaryModes = mysqlTable('binary_modes', {
+		binary: binary('binary', { length: 16 }),
+		binaryString: binary('binary_string', { length: 16, mode: 'string' }),
+		binaryBuffer: binary('binary_buffer', { length: 16, mode: 'buffer' }),
+		varbinary: varbinary('varbinary', { length: 16 }),
+		varbinaryString: varbinary('varbinary_string', { length: 16, mode: 'string' }),
+		varbinaryBuffer: varbinary('varbinary_buffer', { length: 16, mode: 'buffer' }),
+	});
+
+	Expect<
+		Equal<{
+			binary: string | null;
+			binaryString: string | null;
+			binaryBuffer: Buffer | null;
+			varbinary: string | null;
+			varbinaryString: string | null;
+			varbinaryBuffer: Buffer | null;
+		}, InferSelectModel<typeof binaryModes>>
+	>;
+
+	binary({ mode: 'buffer' }).default(Buffer.from('drizzle'));
+	varbinary({ length: 16, mode: 'buffer' }).default(Buffer.from('drizzle'));
+
+	// @ts-expect-error buffer mode columns don't accept string defaults
+	binary({ mode: 'buffer' }).default('drizzle');
+	// @ts-expect-error string mode columns don't accept buffer defaults
+	varbinary({ length: 16 }).default(Buffer.from('drizzle'));
 }


### PR DESCRIPTION
/claim #1188

# [mysql] Add `mode: 'string' | 'buffer'` to `binary()` and `varbinary()`

Closes #1188.

## Problem

`mysql2` returns `binary`/`varbinary` columns as `Buffer`, but drizzle types (and maps) them as
`string`. `MySqlBinary.mapFromDriverValue` already *accepts* `string | Buffer | Uint8Array` — it just
always returns a string, so binary payloads get UTF-8-mangled and the inferred model type lies about
what you get back at runtime.

The obvious fix — "just make it `Buffer`" — is why the previous attempt (#425) was closed and why
#5858 / #5605 / #5800 / #5904 / #5914 are hard breaks: the correct type depends on the driver.
`mysql2` gives you a `Buffer`; `@planetscale/database` gives you a `string`. One column type cannot be
both without an explicit mode.

## Solution

Mirror the mode paradigm the codebase already uses for `sqlite blob({ mode: 'buffer' | 'json' | 'bigint' })`
and `mysql bigint({ mode: 'number' | 'bigint' })`: a config flag that selects a distinct column class.

```ts
// unchanged, still `string` — nothing existing breaks
binary('hash', { length: 32 });
varbinary('data', { length: 255 });

// opt in to what mysql2 actually hands you
binary('hash', { length: 32, mode: 'buffer' });          // data: Buffer
varbinary('data', { length: 255, mode: 'buffer' });      // data: Buffer
```

**The default stays `'string'`.** Omitting `mode` produces exactly today's builder, class, column type
and mapping — including the odd `Uint8Array` bit-string path. PlanetScale users and every existing
schema are untouched; this is a purely additive change.

### What's added

`drizzle-orm/src/mysql-core/columns/binary.ts`:

- `MySqlBinaryBufferBuilder` / `MySqlBinaryBuffer` (`dataType: 'buffer'`, `columnType: 'MySqlBinaryBuffer'`),
  `data: Buffer`, `driverParam: Buffer | string`.
- `MySqlBinaryConfig` gains `mode?: 'string' | 'buffer'`; `binary()` overloads resolve the builder type
  from the mode, the same way `blob()` does.

`drizzle-orm/src/mysql-core/columns/varbinary.ts`: the same, as
`MySqlVarBinaryBufferBuilder` / `MySqlVarBinaryBuffer` (`columnType: 'MySqlVarBinaryBuffer'`), with
`mode?` added to `MySqlVarbinaryOptions`.

Buffer-mode mapping:

- `mapFromDriverValue`: `Buffer` passes through by identity (the `mysql2` path, no copy); `Uint8Array` is
  wrapped; a `string` is decoded as `latin1`, which is the encoding that round-trips one-character-per-byte
  output from drivers that decode binary columns as text.
- `mapToDriverValue`: `Buffer` passes through unchanged, which is what `mysql2` expects for a parameter;
  `Uint8Array`/`string` are normalized to `Buffer` so drivers never see a non-`Buffer` for a buffer column.

`getSQLType()` is identical in both modes (`binary(n)` / `varbinary(n)`), so **drizzle-kit produces no
migration diff** when a column switches mode.

## Why separate classes instead of one class with a runtime flag

It matches `blob`, `bigint`, `timestamp` and `datetime` in this repo, and it keeps downstream packages
correct without touching them: `drizzle-zod` (and typebox/valibot/arktype) already branch on
`dataType === 'buffer'`, so buffer-mode columns get a buffer schema instead of a string schema with a
length constraint. `drizzle-seed` keys off `getSQLType()`, which is unchanged.

## Scope

`mysql-core` only. `singlestore-core` is deliberately untouched — the issue is about `mysql2`, and
changing SingleStore's binary columns (as #5858 does) is an unrelated break. No new dependencies, no
drive-by reformatting.

## Tests

`drizzle-orm/type-tests/mysql/tables.ts`:

- buffer-mode `binary`/`varbinary` added to the `all_columns` and `all_columns_without_name` tables;
- a `binary_modes` block asserting the inferred select model — default and `mode: 'string'` infer
  `string | null`, `mode: 'buffer'` infers `Buffer | null` — plus `@ts-expect-error` checks that a
  buffer column rejects a string default and a string column rejects a `Buffer` default.

Verified by type-checking these files against the full `drizzle-orm` source tree, and by a runtime check
of the mapping functions: buffer mode returns byte-identical `Buffer`s from `Buffer`, `Uint8Array` and
latin1 `string` driver values, passes `Buffer` params through untouched, and string mode still returns
`'101'` for the `Uint8Array` bit-string case.

## Comparison with the other open PRs

| PR | Approach | Breaking |
| --- | --- | --- |
| #425 (closed) | mysql2 → `Buffer`, planetscale → `string \| null` | yes, and self-contradictory across drivers |
| #5605, #5800, #5904, #5914 | hard switch to `Buffer` | yes |
| #5858 | hard switch to `Buffer`, incl. singlestore | yes, wider blast radius |
| #5983 | `mode: 'buffer' \| 'string'` | no — same shape as this PR |
| **this** | `mode?: 'string' \| 'buffer'`, default `'string'` | no |