### PR TITLE
fix(orm): keep nested left-join object when a later column is set

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/map-result-row.test.ts
+++ b/drizzle-orm/tests/map-result-row.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'vitest';
+import { pgTable, text, uuid } from '~/pg-core/index.ts';
+import type { SelectedFieldsOrdered } from '~/pg-core/query-builders/select.types.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const organization = pgTable('organization', {
+	id: uuid('id').primaryKey(),
+	name: text('name').notNull(),
+});
+
+const organizationBranding = pgTable('organization_branding', {
+	orgId: uuid('org_id').notNull(),
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+const organizationContact = pgTable('organization_contact', {
+	orgId: uuid('org_id').notNull(),
+	email: text('email'),
+});
+
+/** `select({ name, branding: { logo, panelBackground } })` */
+const fields: SelectedFieldsOrdered = [
+	{ path: ['name'], field: organization.name },
+	{ path: ['branding', 'logo'], field: organizationBranding.logo },
+	{ path: ['branding', 'panelBackground'], field: organizationBranding.panelBackground },
+];
+
+/** Same selection, with the nested columns in the opposite order */
+const reversedFields: SelectedFieldsOrdered = [
+	{ path: ['name'], field: organization.name },
+	{ path: ['branding', 'panelBackground'], field: organizationBranding.panelBackground },
+	{ path: ['branding', 'logo'], field: organizationBranding.logo },
+];
+
+const leftJoin = { organization: true, organization_branding: false };
+const innerJoin = { organization: true, organization_branding: true };
+
+describe.concurrent('mapResultRow', () => {
+	test('keeps nested object when its first column is null and a later one is not', () => {
+		const result = mapResultRow(fields, ['Drizzle', null, '#1a8cff'], leftJoin);
+
+		expect(result).toEqual({
+			name: 'Drizzle',
+			branding: { logo: null, panelBackground: '#1a8cff' },
+		});
+	});
+
+	test('keeps nested object when its first column is not null and a later one is', () => {
+		const result = mapResultRow(reversedFields, ['Drizzle', '#1a8cff', null], leftJoin);
+
+		expect(result).toEqual({
+			name: 'Drizzle',
+			branding: { panelBackground: '#1a8cff', logo: null },
+		});
+	});
+
+	test('mapping is not affected by the order of the nested columns', () => {
+		const result = mapResultRow(fields, ['Drizzle', null, '#1a8cff'], leftJoin);
+		const reversedResult = mapResultRow(reversedFields, ['Drizzle', '#1a8cff', null], leftJoin);
+
+		expect(result).toEqual(reversedResult);
+	});
+
+	test('nullifies nested object of a missing left join row', () => {
+		const result = mapResultRow(fields, ['Drizzle', null, null], leftJoin);
+
+		expect(result).toEqual({ name: 'Drizzle', branding: null });
+	});
+
+	test('keeps all-null nested object of a not nullable join', () => {
+		const result = mapResultRow(fields, ['Drizzle', null, null], innerJoin);
+
+		expect(result).toEqual({
+			name: 'Drizzle',
+			branding: { logo: null, panelBackground: null },
+		});
+	});
+
+	test('never nullifies a nested object built from multiple tables', () => {
+		const mixedFields: SelectedFieldsOrdered = [
+			{ path: ['name'], field: organization.name },
+			{ path: ['details', 'logo'], field: organizationBranding.logo },
+			{ path: ['details', 'email'], field: organizationContact.email },
+		];
+
+		const result = mapResultRow(mixedFields, ['Drizzle', null, null], {
+			organization: true,
+			organization_branding: false,
+			organization_contact: false,
+		});
+
+		expect(result).toEqual({
+			name: 'Drizzle',
+			details: { logo: null, email: null },
+		});
+	});
+
+	test('nullifies only the nested objects whose columns are all null', () => {
+		const multipleFields: SelectedFieldsOrdered = [
+			{ path: ['name'], field: organization.name },
+			{ path: ['branding', 'logo'], field: organizationBranding.logo },
+			{ path: ['branding', 'panelBackground'], field: organizationBranding.panelBackground },
+			{ path: ['contact', 'email'], field: organizationContact.email },
+		];
+
+		const result = mapResultRow(multipleFields, ['Drizzle', null, '#1a8cff', null], {
+			organization: true,
+			organization_branding: false,
+			organization_contact: false,
+		});
+
+		expect(result).toEqual({
+			name: 'Drizzle',
+			branding: { logo: null, panelBackground: '#1a8cff' },
+			contact: null,
+		});
+	});
+
+	test('does not nullify anything without a joins map', () => {
+		const result = mapResultRow(fields, ['Drizzle', null, null], undefined);
+
+		expect(result).toEqual({
+			name: 'Drizzle',
+			branding: { logo: null, panelBackground: null },
+		});
+	});
+});


### PR DESCRIPTION
/claim #1603
Fixes #1603

# Fix nested partial select returning `null` on left join when the first column is `null`

Closes #1603

## Problem

With a nested partial select over a `leftJoin`, the whole nested object is mapped to `null` whenever the **first** selected column of that object happens to be `null` — even though the joined row exists and its other columns have values.

```ts
.select({
  name: orgTable.name,
  branding: {
    logo: orgBrandingTable.logo,                       // NULL in DB
    panelBackground: orgBrandingTable.panelBackground, // '#1a8cff'
  },
})
.from(orgTable)
.leftJoin(orgBrandingTable, eq(orgTable.id, orgBrandingTable.orgId))
```

Returns `branding: null`. Swapping the two keys inside `branding` returns `{ panelBackground: '#1a8cff', logo: null }`. The generated SQL is correct in both cases — the result is order-dependent purely because of the row mapper.

## Cause

In `mapResultRow` (`drizzle-orm/src/utils.ts`), nested objects are tracked in `nullifyMap`, where a table name means "every field seen so far for this object came from that table and was `null`" and `false` means "do not nullify".

The first column of a nested object seeds the entry:

```ts
nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
```

The `else if` for the following columns only cleared the entry when a column came from a *different* table. A later non-`null` value from the **same** table left the table name in place, so after the reduce the object was wiped for any nullable join.

## Fix

One condition, keeping the existing `string | false` encoding: also clear the entry when a later column of the same table is not `null`.

```ts
} else if (
  typeof nullifyMap[objectName] === 'string'
  && (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
) {
  nullifyMap[objectName] = false;
}
```

A missing left-join row still nullifies the nested object, because in that case *every* column is `null`, so the entry is never cleared and the existing `joinsNotNullableMap` check at the end applies unchanged.

This is the same code change as #6018; this PR adds the cases its test does not cover.

## Tests

New `drizzle-orm/tests/map-result-row.test.ts` calls `mapResultRow` directly (no database) and covers:

- the reported case — first nested column `null`, a later one not `null` → object kept,
- the inverse order — first not `null`, later `null` → object kept (regression),
- order-independence of the two above,
- missing left-join row (all nested columns `null`) → nested object is `null`,
- all nested columns `null` on a **not nullable** join → object kept,
- a nested object mixing columns from two tables → never nullified,
- several nested objects in one selection → only the all-`null` one is nullified,
- no `joinsNotNullableMap` → nothing is nullified.

Three of them fail on `main` and pass with the fix; the rest guard the behaviour that must not change.

`mapResultRow` is shared by every driver, so the fix applies to all dialects.
