### PR TITLE
feat(pg): selectFromDb on customType for PostGIS-like columns

### DIFF
--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private mapSelect?: (identifier: SQL) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,10 +73,16 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.mapSelect = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSelectSQL(identifier: SQL): SQL | undefined {
+		return typeof this.mapSelect === 'function' ? this.mapSelect(identifier) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +202,26 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional selection function, that wraps the column reference in every `select` and `returning`
+	 * clause, for types that cannot be read in their on-disk representation
+	 *
+	 * The received `identifier` is the already qualified column reference, so it is safe to use in
+	 * joins as well. Return the wrapping expression only - the alias is added by the dialect, which
+	 * keeps the selected field name equal to the column name.
+	 *
+	 * `fromDriver` is still applied to the returned value, so there is no need to decode here.
+	 *
+	 * @example
+	 * For example, PostGIS `geometry` has to be read as text
+	 * ```
+	 * selectFromDb(identifier) {
+	 * 	return sql`st_astext(${identifier})`;
+	 * },
+	 * ```
+	 */
+	selectFromDb?: (identifier: SQL) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -6,6 +6,7 @@ import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
 import {
 	PgColumn,
+	PgCustomColumn,
 	PgDate,
 	PgDateString,
 	PgJson,
@@ -242,7 +243,18 @@ export class PgDialect {
 						chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 					}
 				} else if (is(field, Column)) {
-					if (isSingleTable) {
+					const customSelect = is(field, PgCustomColumn)
+						? field.getSelectSQL(
+							isSingleTable
+								? sql`${sql.identifier(this.casing.getColumnCasing(field))}`
+								: sql`${field}`,
+						)
+						: undefined;
+
+					if (customSelect) {
+						chunk.push(customSelect);
+						chunk.push(sql` as ${sql.identifier(this.casing.getColumnCasing(field))}`);
+					} else if (isSingleTable) {
 						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
 					} else {
 						chunk.push(field);

--- a/drizzle-orm/tests/pg-custom-select.test.ts
+++ b/drizzle-orm/tests/pg-custom-select.test.ts
@@ -1,0 +1,157 @@
+import postgres from 'postgres';
+import { expect, test } from 'vitest';
+import { alias, customType, integer, pgTable, text } from '~/pg-core';
+import { drizzle } from '~/postgres-js';
+import { relations } from '~/relations';
+import { eq, sql } from '~/sql';
+
+type Point = { x: number; y: number };
+
+const geometry = customType<{ data: Point; driverData: string }>({
+	dataType() {
+		return 'geometry(Point)';
+	},
+	toDriver(value) {
+		return `point(${value.x} ${value.y})`;
+	},
+	fromDriver(value) {
+		const [x, y] = value.slice('point('.length, -1).split(' ');
+		return { x: Number(x), y: Number(y) };
+	},
+	selectFromDb(identifier) {
+		return sql`st_astext(${identifier})`;
+	},
+});
+
+const plainCustom = customType<{ data: string }>({
+	dataType() {
+		return 'text';
+	},
+});
+
+const location = pgTable('location', {
+	id: integer('id').primaryKey(),
+	name: text('name'),
+	coords: geometry('coords'),
+	label: plainCustom('label'),
+});
+
+const visit = pgTable('visit', {
+	id: integer('id').primaryKey(),
+	locationId: integer('location_id'),
+});
+
+const locationRelations = relations(location, ({ many }) => ({
+	visits: many(visit),
+}));
+
+const visitRelations = relations(visit, ({ one }) => ({
+	location: one(location, {
+		fields: [visit.locationId],
+		references: [location.id],
+	}),
+}));
+
+const schema = { location, visit, locationRelations, visitRelations };
+
+const db = drizzle(postgres(''), { schema });
+
+test('select() wraps the custom column and aliases it back to the column name', () => {
+	const query = db.select().from(location).toSQL();
+
+	expect(query.sql).toBe(
+		'select "id", "name", st_astext("coords") as "coords", "label" from "location"',
+	);
+});
+
+test('partial select() wraps the custom column', () => {
+	const query = db.select({ coords: location.coords }).from(location).toSQL();
+
+	expect(query.sql).toBe('select st_astext("coords") as "coords" from "location"');
+});
+
+test('join keeps the column reference qualified', () => {
+	const query = db
+		.select()
+		.from(visit)
+		.innerJoin(location, eq(visit.locationId, location.id))
+		.toSQL();
+
+	expect(query.sql).toBe(
+		'select "visit"."id", "visit"."location_id", "location"."id", "location"."name", st_astext("location"."coords") as "coords", "location"."label" from "visit" inner join "location" on "visit"."location_id" = "location"."id"',
+	);
+});
+
+test('aliased table keeps the alias in the wrapped reference', () => {
+	const l = alias(location, 'l');
+	const query = db
+		.select({ coords: l.coords })
+		.from(visit)
+		.innerJoin(l, eq(visit.locationId, l.id))
+		.toSQL();
+
+	expect(query.sql).toBe(
+		'select st_astext("l"."coords") as "coords" from "visit" inner join "location" "l" on "visit"."location_id" = "l"."id"',
+	);
+});
+
+test('custom type without selectFromDb is not wrapped', () => {
+	const query = db.select({ label: location.label }).from(location).toSQL();
+
+	expect(query.sql).toBe('select "label" from "location"');
+});
+
+test('insert().returning() applies the wrap', () => {
+	const query = db
+		.insert(location)
+		.values({ id: 1, name: 'home', coords: { x: 1, y: 2 } })
+		.returning()
+		.toSQL();
+
+	expect(query.sql).toBe(
+		'insert into "location" ("id", "name", "coords", "label") values ($1, $2, $3, default) returning "id", "name", st_astext("coords") as "coords", "label"',
+	);
+	expect(query.params).toStrictEqual([1, 'home', 'point(1 2)']);
+});
+
+test('update().returning() applies the wrap', () => {
+	const query = db
+		.update(location)
+		.set({ name: 'work' })
+		.where(eq(location.id, 1))
+		.returning({ coords: location.coords })
+		.toSQL();
+
+	expect(query.sql).toBe(
+		'update "location" set "name" = $1 where "location"."id" = $2 returning st_astext("coords") as "coords"',
+	);
+});
+
+test('delete().returning() applies the wrap', () => {
+	const query = db.delete(location).returning({ coords: location.coords }).toSQL();
+
+	expect(query.sql).toBe('delete from "location" returning st_astext("coords") as "coords"');
+});
+
+test('relational query with columns: true applies the wrap', () => {
+	const query = db.query.location.findMany().toSQL();
+
+	// findMany with no joins is a single-table select, so the identifier is not table-qualified
+	expect(query.sql).toContain('st_astext("coords") as "coords"');
+});
+
+test('casing is applied to both the reference and the alias', () => {
+	const camel = pgTable('camel', {
+		id: integer().primaryKey(),
+		homeCoords: geometry(),
+	});
+	const camelDb = drizzle(postgres(''), { casing: 'snake_case' });
+
+	const query = camelDb.select({ homeCoords: camel.homeCoords }).from(camel).toSQL();
+
+	expect(query.sql).toBe('select st_astext("home_coords") as "home_coords" from "camel"');
+});
+
+test('the column decoder still runs on the wrapped value', () => {
+	expect(location.coords.mapFromDriverValue('point(3 4)')).toStrictEqual({ x: 3, y: 4 });
+});


### PR DESCRIPTION
/claim #1083
/claim #554
Fixes #1083
Fixes #554

# feat(pg): `selectFromDb` on `customType` so PostGIS (and similar) select themselves

Postgres types whose on-disk form is not what you want back (PostGIS `geometry`, etc.) currently force every query to wrap the column by hand:

```ts
coords: sql<Point>`st_astext(${location.coords})`.mapWith(decoder).as('coords')
```

That does not work with `db.select().from(table)` or with relational `columns: true`.

## API

Optional callback on the existing `customType` factory. Omitted → today's behaviour.

```ts
const geometry = customType<{ data: Point; driverData: string }>({
  dataType() { return 'geometry(Point)'; },
  fromDriver(value) { /* parse WKT */ },
  selectFromDb(identifier) {
    return sql`st_astext(${identifier})`;
  },
});
```

`identifier` is already the (table-qualified when needed) column ref, so joins and aliases work. `fromDriver` still decodes the result — the callback is SQL-only.

The dialect aliases the wrap back to the column name (`st_astext("coords") as "coords"`). Without that alias, postgres names the result `st_astext` and `mapResultRow` misses the field. That is why #6090's snapshot (`st_astext("coords")` with no `as`) is not enough.

`buildSelection` is shared by `select`, `insert/update/delete returning`, and relational queries, so one wiring covers them.

## Scope

`pg-core` only. The issue is PostGIS. mysql/sqlite/gel/singlestore copies (#1423, #5746, #5796) inflate the review for a use case they don't have.

#554 is the same request ("always select `fn(column)` instead of `column`").

## Tests

`drizzle-orm/tests/pg-custom-select.test.ts` — `toSQL()` only, no live Postgres:

- full and partial `select()` wrap + alias
- join: qualified `"location"."coords"` inside `st_astext`
- table alias `"l"."coords"`
- custom type without the option is untouched
- insert/update/delete `returning()`
- relational `findMany()`
- `casing: 'snake_case'` applies to both the reference and the alias
- `fromDriver` still runs on the wrapped value
