### PR TITLE
feat: typed constraint errors (unique, not-null, fk, check)

### DIFF
--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -24,6 +24,256 @@ export class DrizzleQueryError extends Error {
 	}
 }
 
+export type ConstraintType = 'unique' | 'not_null' | 'foreign_key' | 'check';
+
+/** Driver-independent constraint failure. `cause` is the original driver error. */
+export class DrizzleConstraintError extends DrizzleQueryError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		public readonly constraintType: ConstraintType,
+		public readonly constraintName: string | undefined,
+		public readonly table: string | undefined,
+		public readonly column: string | undefined,
+	) {
+		super(query, params, cause);
+		this.name = 'DrizzleConstraintError';
+		Error.captureStackTrace(this, DrizzleConstraintError);
+	}
+}
+
+export class UniqueConstraintViolationError extends DrizzleConstraintError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		constraintName: string | undefined,
+		table: string | undefined,
+		column: string | undefined,
+	) {
+		super(query, params, cause, 'unique', constraintName, table, column);
+		this.name = 'UniqueConstraintViolationError';
+		Error.captureStackTrace(this, UniqueConstraintViolationError);
+	}
+}
+
+export class NotNullViolationError extends DrizzleConstraintError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		constraintName: string | undefined,
+		table: string | undefined,
+		column: string | undefined,
+	) {
+		super(query, params, cause, 'not_null', constraintName, table, column);
+		this.name = 'NotNullViolationError';
+		Error.captureStackTrace(this, NotNullViolationError);
+	}
+}
+
+export class ForeignKeyViolationError extends DrizzleConstraintError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		constraintName: string | undefined,
+		table: string | undefined,
+		column: string | undefined,
+	) {
+		super(query, params, cause, 'foreign_key', constraintName, table, column);
+		this.name = 'ForeignKeyViolationError';
+		Error.captureStackTrace(this, ForeignKeyViolationError);
+	}
+}
+
+export class CheckConstraintViolationError extends DrizzleConstraintError {
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error,
+		constraintName: string | undefined,
+		table: string | undefined,
+		column: string | undefined,
+	) {
+		super(query, params, cause, 'check', constraintName, table, column);
+		this.name = 'CheckConstraintViolationError';
+		Error.captureStackTrace(this, CheckConstraintViolationError);
+	}
+}
+
+/**
+ * Map a raw driver error onto a typed constraint error when the SQLSTATE / errno /
+ * SQLite code is one we know. Unknown errors still become `DrizzleQueryError`.
+ *
+ * Postgres (pg, postgres.js, neon, gel) uses SQLSTATE `code`.
+ * MySQL / SingleStore uses numeric `errno`.
+ * SQLite uses `SQLITE_CONSTRAINT_*` or a message from libsql.
+ */
+export function wrapQueryError(query: string, params: any[], error: Error): DrizzleQueryError {
+	const driverError = error as Record<string, any>;
+
+	const pgCode = driverError['code'] as string | undefined;
+	if (typeof pgCode === 'string') {
+		const table = driverError['table'] as string | undefined;
+		const column = driverError['column'] as string | undefined;
+		const constraint = driverError['constraint'] as string | undefined;
+
+		switch (pgCode) {
+			case '23505':
+				return new UniqueConstraintViolationError(query, params, error, constraint, table, column);
+			case '23502':
+				return new NotNullViolationError(query, params, error, constraint, table, column);
+			case '23503':
+				return new ForeignKeyViolationError(query, params, error, constraint, table, column);
+			case '23514':
+				return new CheckConstraintViolationError(query, params, error, constraint, table, column);
+		}
+	}
+
+	const mysqlErrno = driverError['errno'] as number | undefined;
+	if (typeof mysqlErrno === 'number') {
+		const sqlMessage = (driverError['sqlMessage'] as string | undefined)
+			?? (driverError['message'] as string | undefined);
+		const mysqlTable = extractMysqlTable(sqlMessage);
+		const mysqlColumn = extractMysqlColumn(sqlMessage, mysqlErrno);
+		const mysqlConstraint = extractMysqlConstraint(sqlMessage, mysqlErrno);
+
+		switch (mysqlErrno) {
+			case 1062:
+				return new UniqueConstraintViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+			case 1048:
+				return new NotNullViolationError(query, params, error, undefined, mysqlTable, mysqlColumn);
+			case 1452:
+			case 1216:
+				return new ForeignKeyViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+			case 3819:
+				return new CheckConstraintViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+		}
+	}
+
+	const sqliteCode = driverError['code'] as string | undefined;
+	const message = (driverError['message'] as string | undefined) ?? '';
+
+	if (typeof sqliteCode === 'string' && sqliteCode.startsWith('SQLITE_CONSTRAINT')) {
+		const sqliteTable = extractSqliteTable(message);
+		const sqliteColumn = extractSqliteColumn(message);
+
+		if (sqliteCode === 'SQLITE_CONSTRAINT_UNIQUE' || sqliteCode === 'SQLITE_CONSTRAINT_PRIMARYKEY') {
+			return new UniqueConstraintViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+		}
+		if (sqliteCode === 'SQLITE_CONSTRAINT_NOTNULL') {
+			return new NotNullViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+		}
+		if (sqliteCode === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
+			return new ForeignKeyViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+		}
+		if (sqliteCode === 'SQLITE_CONSTRAINT_CHECK') {
+			return new CheckConstraintViolationError(
+				query,
+				params,
+				error,
+				extractSqliteCheckName(message),
+				sqliteTable,
+				sqliteColumn,
+			);
+		}
+	}
+
+	if (message.includes('UNIQUE constraint failed')) {
+		return new UniqueConstraintViolationError(
+			query,
+			params,
+			error,
+			undefined,
+			extractSqliteTable(message),
+			extractSqliteColumn(message),
+		);
+	}
+	if (message.includes('NOT NULL constraint failed')) {
+		return new NotNullViolationError(
+			query,
+			params,
+			error,
+			undefined,
+			extractSqliteTable(message),
+			extractSqliteColumn(message),
+		);
+	}
+	if (message.includes('FOREIGN KEY constraint failed')) {
+		return new ForeignKeyViolationError(query, params, error, undefined, undefined, undefined);
+	}
+	if (message.includes('CHECK constraint failed')) {
+		return new CheckConstraintViolationError(
+			query,
+			params,
+			error,
+			extractSqliteCheckName(message),
+			undefined,
+			undefined,
+		);
+	}
+
+	return new DrizzleQueryError(query, params, error);
+}
+
+function extractMysqlConstraint(message: string | undefined, errno: number): string | undefined {
+	if (!message) return undefined;
+	if (errno === 1062) {
+		const match = message.match(/for key '([^']+)'/);
+		return match?.[1];
+	}
+	if (errno === 1452 || errno === 1216) {
+		const match = message.match(/CONSTRAINT `([^`]+)`/);
+		return match?.[1];
+	}
+	if (errno === 3819) {
+		const match = message.match(/Check constraint '([^']+)'/);
+		return match?.[1];
+	}
+	return undefined;
+}
+
+function extractMysqlTable(message: string | undefined): string | undefined {
+	if (!message) return undefined;
+	// FK: "fails (`db`.`posts`, CONSTRAINT ...)" or "fails (`posts`, CONSTRAINT ...)"
+	const fk = message.match(/fails \(`(?:[^`]+`\.`)?([^`]+)`/);
+	if (fk) return fk[1];
+	const qualified = message.match(/table `[^`]*`\.`([^`]+)`/);
+	if (qualified) return qualified[1];
+	const simple = message.match(/table `([^`]+)`/);
+	return simple?.[1];
+}
+
+function extractMysqlColumn(message: string | undefined, errno: number): string | undefined {
+	if (!message) return undefined;
+	if (errno === 1048) {
+		const match = message.match(/Column '([^']+)'/);
+		return match?.[1];
+	}
+	if (errno === 1452 || errno === 1216) {
+		const match = message.match(/FOREIGN KEY \(`([^`]+)`\)/);
+		return match?.[1];
+	}
+	return undefined;
+}
+
+function extractSqliteTable(message: string): string | undefined {
+	const match = message.match(/constraint failed: ([^.]+)\./);
+	return match?.[1];
+}
+
+function extractSqliteColumn(message: string): string | undefined {
+	const match = message.match(/constraint failed: [^.]+\.(\S+)/);
+	return match?.[1];
+}
+
+function extractSqliteCheckName(message: string): string | undefined {
+	const match = message.match(/CHECK constraint failed:\s*(\S+)/);
+	return match?.[1];
+}
+
 export class TransactionRollbackError extends DrizzleError {
 	static override readonly [entityKind]: string = 'TransactionRollbackError';
 

--- a/drizzle-orm/src/errors.ts
+++ b/drizzle-orm/src/errors.ts
@@ -11,6 +11,8 @@ export class DrizzleError extends Error {
 }
 
 export class DrizzleQueryError extends Error {
+	static readonly [entityKind]: string = 'DrizzleQueryError';
+
 	constructor(
 		public query: string,
 		public params: any[],
@@ -28,6 +30,8 @@ export type ConstraintType = 'unique' | 'not_null' | 'foreign_key' | 'check';
 
 /** Driver-independent constraint failure. `cause` is the original driver error. */
 export class DrizzleConstraintError extends DrizzleQueryError {
+	static override readonly [entityKind]: string = 'DrizzleConstraintError';
+
 	constructor(
 		query: string,
 		params: any[],
@@ -44,6 +48,8 @@ export class DrizzleConstraintError extends DrizzleQueryError {
 }
 
 export class UniqueConstraintViolationError extends DrizzleConstraintError {
+	static override readonly [entityKind]: string = 'UniqueConstraintViolationError';
+
 	constructor(
 		query: string,
 		params: any[],
@@ -59,6 +65,8 @@ export class UniqueConstraintViolationError extends DrizzleConstraintError {
 }
 
 export class NotNullViolationError extends DrizzleConstraintError {
+	static override readonly [entityKind]: string = 'NotNullViolationError';
+
 	constructor(
 		query: string,
 		params: any[],
@@ -74,6 +82,8 @@ export class NotNullViolationError extends DrizzleConstraintError {
 }
 
 export class ForeignKeyViolationError extends DrizzleConstraintError {
+	static override readonly [entityKind]: string = 'ForeignKeyViolationError';
+
 	constructor(
 		query: string,
 		params: any[],
@@ -89,6 +99,8 @@ export class ForeignKeyViolationError extends DrizzleConstraintError {
 }
 
 export class CheckConstraintViolationError extends DrizzleConstraintError {
+	static override readonly [entityKind]: string = 'CheckConstraintViolationError';
+
 	constructor(
 		query: string,
 		params: any[],
@@ -107,12 +119,17 @@ export class CheckConstraintViolationError extends DrizzleConstraintError {
  * Map a raw driver error onto a typed constraint error when the SQLSTATE / errno /
  * SQLite code is one we know. Unknown errors still become `DrizzleQueryError`.
  *
- * Postgres (pg, postgres.js, neon, gel) uses SQLSTATE `code`.
+ * Postgres-family drivers use SQLSTATE `code`.
  * MySQL / SingleStore uses numeric `errno`.
  * SQLite uses `SQLITE_CONSTRAINT_*` or a message from libsql.
+ *
+ * @internal
  */
-export function wrapQueryError(query: string, params: any[], error: Error): DrizzleQueryError {
-	const driverError = error as Record<string, any>;
+export function wrapQueryError(query: string, params: any[], error: unknown): DrizzleQueryError {
+	const driverError = typeof error === 'object' && error !== null
+		? error as Record<string, unknown>
+		: {};
+	const cause = error as Error;
 
 	const pgCode = driverError['code'] as string | undefined;
 	if (typeof pgCode === 'string') {
@@ -122,13 +139,13 @@ export function wrapQueryError(query: string, params: any[], error: Error): Driz
 
 		switch (pgCode) {
 			case '23505':
-				return new UniqueConstraintViolationError(query, params, error, constraint, table, column);
+				return new UniqueConstraintViolationError(query, params, cause, constraint, table, column);
 			case '23502':
-				return new NotNullViolationError(query, params, error, constraint, table, column);
+				return new NotNullViolationError(query, params, cause, constraint, table, column);
 			case '23503':
-				return new ForeignKeyViolationError(query, params, error, constraint, table, column);
+				return new ForeignKeyViolationError(query, params, cause, constraint, table, column);
 			case '23514':
-				return new CheckConstraintViolationError(query, params, error, constraint, table, column);
+				return new CheckConstraintViolationError(query, params, cause, constraint, table, column);
 		}
 	}
 
@@ -142,14 +159,16 @@ export function wrapQueryError(query: string, params: any[], error: Error): Driz
 
 		switch (mysqlErrno) {
 			case 1062:
-				return new UniqueConstraintViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+				return new UniqueConstraintViolationError(query, params, cause, mysqlConstraint, mysqlTable, mysqlColumn);
 			case 1048:
-				return new NotNullViolationError(query, params, error, undefined, mysqlTable, mysqlColumn);
+				return new NotNullViolationError(query, params, cause, undefined, mysqlTable, mysqlColumn);
+			case 1451:
 			case 1452:
 			case 1216:
-				return new ForeignKeyViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+			case 1217:
+				return new ForeignKeyViolationError(query, params, cause, mysqlConstraint, mysqlTable, mysqlColumn);
 			case 3819:
-				return new CheckConstraintViolationError(query, params, error, mysqlConstraint, mysqlTable, mysqlColumn);
+				return new CheckConstraintViolationError(query, params, cause, mysqlConstraint, mysqlTable, mysqlColumn);
 		}
 	}
 
@@ -161,19 +180,19 @@ export function wrapQueryError(query: string, params: any[], error: Error): Driz
 		const sqliteColumn = extractSqliteColumn(message);
 
 		if (sqliteCode === 'SQLITE_CONSTRAINT_UNIQUE' || sqliteCode === 'SQLITE_CONSTRAINT_PRIMARYKEY') {
-			return new UniqueConstraintViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+			return new UniqueConstraintViolationError(query, params, cause, undefined, sqliteTable, sqliteColumn);
 		}
 		if (sqliteCode === 'SQLITE_CONSTRAINT_NOTNULL') {
-			return new NotNullViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+			return new NotNullViolationError(query, params, cause, undefined, sqliteTable, sqliteColumn);
 		}
 		if (sqliteCode === 'SQLITE_CONSTRAINT_FOREIGNKEY') {
-			return new ForeignKeyViolationError(query, params, error, undefined, sqliteTable, sqliteColumn);
+			return new ForeignKeyViolationError(query, params, cause, undefined, sqliteTable, sqliteColumn);
 		}
 		if (sqliteCode === 'SQLITE_CONSTRAINT_CHECK') {
 			return new CheckConstraintViolationError(
 				query,
 				params,
-				error,
+				cause,
 				extractSqliteCheckName(message),
 				sqliteTable,
 				sqliteColumn,
@@ -185,7 +204,7 @@ export function wrapQueryError(query: string, params: any[], error: Error): Driz
 		return new UniqueConstraintViolationError(
 			query,
 			params,
-			error,
+			cause,
 			undefined,
 			extractSqliteTable(message),
 			extractSqliteColumn(message),
@@ -195,27 +214,27 @@ export function wrapQueryError(query: string, params: any[], error: Error): Driz
 		return new NotNullViolationError(
 			query,
 			params,
-			error,
+			cause,
 			undefined,
 			extractSqliteTable(message),
 			extractSqliteColumn(message),
 		);
 	}
 	if (message.includes('FOREIGN KEY constraint failed')) {
-		return new ForeignKeyViolationError(query, params, error, undefined, undefined, undefined);
+		return new ForeignKeyViolationError(query, params, cause, undefined, undefined, undefined);
 	}
 	if (message.includes('CHECK constraint failed')) {
 		return new CheckConstraintViolationError(
 			query,
 			params,
-			error,
+			cause,
 			extractSqliteCheckName(message),
 			undefined,
 			undefined,
 		);
 	}
 
-	return new DrizzleQueryError(query, params, error);
+	return new DrizzleQueryError(query, params, cause);
 }
 
 function extractMysqlConstraint(message: string | undefined, errno: number): string | undefined {
@@ -224,7 +243,7 @@ function extractMysqlConstraint(message: string | undefined, errno: number): str
 		const match = message.match(/for key '([^']+)'/);
 		return match?.[1];
 	}
-	if (errno === 1452 || errno === 1216) {
+	if (errno === 1451 || errno === 1452 || errno === 1216 || errno === 1217) {
 		const match = message.match(/CONSTRAINT `([^`]+)`/);
 		return match?.[1];
 	}
@@ -252,7 +271,7 @@ function extractMysqlColumn(message: string | undefined, errno: number): string 
 		const match = message.match(/Column '([^']+)'/);
 		return match?.[1];
 	}
-	if (errno === 1452 || errno === 1216) {
+	if (errno === 1451 || errno === 1452 || errno === 1216 || errno === 1217) {
 		const match = message.match(/FOREIGN KEY \(`([^`]+)`\)/);
 		return match?.[1];
 	}
@@ -265,7 +284,7 @@ function extractSqliteTable(message: string): string | undefined {
 }
 
 function extractSqliteColumn(message: string): string | undefined {
-	const match = message.match(/constraint failed: [^.]+\.(\S+)/);
+	const match = message.match(/constraint failed: [^.]+\.([^,\s]+)/);
 	return match?.[1];
 }
 

--- a/drizzle-orm/src/gel-core/session.ts
+++ b/drizzle-orm/src/gel-core/session.ts
@@ -1,7 +1,7 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { TransactionRollbackError, wrapQueryError } from '~/errors.ts';
 import type { TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
 import type { Query, SQL } from '~/sql/index.ts';
@@ -48,7 +48,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -57,7 +57,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -75,7 +75,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -84,7 +84,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -100,7 +100,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapQueryError(queryString, params, e as Error);
 				}
 
 				// put actual key
@@ -121,7 +121,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapQueryError(queryString, params, e as Error);
 		}
 	}
 

--- a/drizzle-orm/src/gel-core/session.ts
+++ b/drizzle-orm/src/gel-core/session.ts
@@ -1,7 +1,7 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { TransactionRollbackError, wrapQueryError } from '~/errors.ts';
+import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
 import type { TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
 import type { Query, SQL } from '~/sql/index.ts';
@@ -48,7 +48,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 			try {
 				return await query();
 			} catch (e) {
-				throw wrapQueryError(queryString, params, e as Error);
+				throw new DrizzleQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -57,7 +57,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 			try {
 				return await query();
 			} catch (e) {
-				throw wrapQueryError(queryString, params, e as Error);
+				throw new DrizzleQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -75,7 +75,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 				]);
 				return res;
 			} catch (e) {
-				throw wrapQueryError(queryString, params, e as Error);
+				throw new DrizzleQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -84,7 +84,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 			try {
 				return await query();
 			} catch (e) {
-				throw wrapQueryError(queryString, params, e as Error);
+				throw new DrizzleQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -100,7 +100,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 				try {
 					result = await query();
 				} catch (e) {
-					throw wrapQueryError(queryString, params, e as Error);
+					throw new DrizzleQueryError(queryString, params, e as Error);
 				}
 
 				// put actual key
@@ -121,7 +121,7 @@ export abstract class GelPreparedQuery<T extends PreparedQueryConfig> implements
 		try {
 			return await query();
 		} catch (e) {
-			throw wrapQueryError(queryString, params, e as Error);
+			throw new DrizzleQueryError(queryString, params, e as Error);
 		}
 	}
 

--- a/drizzle-orm/src/mysql-core/session.ts
+++ b/drizzle-orm/src/mysql-core/session.ts
@@ -1,7 +1,7 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { TransactionRollbackError, wrapQueryError } from '~/errors.ts';
 import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
 import { type Query, type SQL, sql } from '~/sql/sql.ts';
 import type { Assume, Equal } from '~/utils.ts';
@@ -76,7 +76,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -85,7 +85,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -103,7 +103,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -112,7 +112,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -128,7 +128,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapQueryError(queryString, params, e as Error);
 				}
 
 				// put actual key
@@ -149,7 +149,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapQueryError(queryString, params, e as Error);
 		}
 	}
 

--- a/drizzle-orm/src/pg-core/session.ts
+++ b/drizzle-orm/src/pg-core/session.ts
@@ -1,7 +1,7 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { TransactionRollbackError, wrapQueryError } from '~/errors.ts';
 import type { TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
 import { type Query, type SQL, sql } from '~/sql/index.ts';
@@ -70,7 +70,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -79,7 +79,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -97,7 +97,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -106,7 +106,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -122,7 +122,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapQueryError(queryString, params, e as Error);
 				}
 				// put actual key
 				await this.cache.put(
@@ -142,7 +142,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapQueryError(queryString, params, e as Error);
 		}
 	}
 

--- a/drizzle-orm/src/singlestore-core/session.ts
+++ b/drizzle-orm/src/singlestore-core/session.ts
@@ -1,7 +1,7 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { TransactionRollbackError, wrapQueryError } from '~/errors.ts';
 import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
 import { type Query, type SQL, sql } from '~/sql/sql.ts';
 import type { Assume, Equal } from '~/utils.ts';
@@ -74,7 +74,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -83,7 +83,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -101,7 +101,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -110,7 +110,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -126,7 +126,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapQueryError(queryString, params, e as Error);
 				}
 
 				// put actual key
@@ -147,7 +147,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapQueryError(queryString, params, e as Error);
 		}
 	}
 

--- a/drizzle-orm/src/sqlite-core/session.ts
+++ b/drizzle-orm/src/sqlite-core/session.ts
@@ -1,7 +1,7 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleError, DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { DrizzleError, TransactionRollbackError, wrapQueryError } from '~/errors.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
@@ -77,7 +77,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -86,7 +86,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -104,7 +104,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -113,7 +113,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapQueryError(queryString, params, e as Error);
 			}
 		}
 
@@ -129,7 +129,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapQueryError(queryString, params, e as Error);
 				}
 
 				// put actual key
@@ -150,7 +150,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapQueryError(queryString, params, e as Error);
 		}
 	}
 

--- a/drizzle-orm/tests/errors.test.ts
+++ b/drizzle-orm/tests/errors.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from 'vitest';
+import {
+	CheckConstraintViolationError,
+	DrizzleConstraintError,
+	DrizzleQueryError,
+	ForeignKeyViolationError,
+	NotNullViolationError,
+	UniqueConstraintViolationError,
+	wrapQueryError,
+} from '~/errors.ts';
+
+const query = 'insert into users (email) values ($1)';
+const params = ['test@example.com'];
+
+describe('wrapQueryError', () => {
+	describe('Postgres / Gel (SQLSTATE)', () => {
+		test('wraps unique_violation (23505)', () => {
+			const pgError = Object.assign(new Error('duplicate key value violates unique constraint'), {
+				code: '23505',
+				table: 'users',
+				column: undefined,
+				constraint: 'users_email_key',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect(wrapped).toBeInstanceOf(DrizzleConstraintError);
+			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
+			expect((wrapped as UniqueConstraintViolationError).constraintType).toBe('unique');
+			expect((wrapped as UniqueConstraintViolationError).constraintName).toBe('users_email_key');
+			expect((wrapped as UniqueConstraintViolationError).table).toBe('users');
+			expect(wrapped.cause).toBe(pgError);
+		});
+
+		test('wraps not_null_violation (23502)', () => {
+			const pgError = Object.assign(new Error('null value in column "name" violates not-null constraint'), {
+				code: '23502',
+				table: 'users',
+				column: 'name',
+				constraint: undefined,
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(NotNullViolationError);
+			expect((wrapped as NotNullViolationError).constraintType).toBe('not_null');
+			expect((wrapped as NotNullViolationError).table).toBe('users');
+			expect((wrapped as NotNullViolationError).column).toBe('name');
+			expect(wrapped.cause).toBe(pgError);
+		});
+
+		test('wraps foreign_key_violation (23503)', () => {
+			const pgError = Object.assign(new Error('insert or update on table "posts" violates foreign key constraint'), {
+				code: '23503',
+				table: 'posts',
+				column: undefined,
+				constraint: 'posts_user_id_fkey',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(ForeignKeyViolationError);
+			expect((wrapped as ForeignKeyViolationError).constraintType).toBe('foreign_key');
+			expect((wrapped as ForeignKeyViolationError).constraintName).toBe('posts_user_id_fkey');
+			expect(wrapped.cause).toBe(pgError);
+		});
+
+		test('wraps check_violation (23514)', () => {
+			const pgError = Object.assign(new Error('new row for relation "users" violates check constraint'), {
+				code: '23514',
+				table: 'users',
+				column: undefined,
+				constraint: 'users_age_check',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(CheckConstraintViolationError);
+			expect((wrapped as CheckConstraintViolationError).constraintType).toBe('check');
+			expect((wrapped as CheckConstraintViolationError).constraintName).toBe('users_age_check');
+			expect(wrapped.cause).toBe(pgError);
+		});
+	});
+
+	describe('MySQL / SingleStore (errno)', () => {
+		test('wraps ER_DUP_ENTRY (1062)', () => {
+			const mysqlError = Object.assign(new Error("Duplicate entry 'test@example.com' for key 'users_email_unique'"), {
+				errno: 1062,
+				sqlMessage: "Duplicate entry 'test@example.com' for key 'users_email_unique'",
+			});
+
+			const wrapped = wrapQueryError(query, params, mysqlError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect((wrapped as UniqueConstraintViolationError).constraintName).toBe('users_email_unique');
+			expect(wrapped.cause).toBe(mysqlError);
+		});
+
+		test('wraps ER_BAD_NULL_ERROR (1048)', () => {
+			const mysqlError = Object.assign(new Error("Column 'name' cannot be null"), {
+				errno: 1048,
+				sqlMessage: "Column 'name' cannot be null",
+			});
+
+			const wrapped = wrapQueryError(query, params, mysqlError);
+
+			expect(wrapped).toBeInstanceOf(NotNullViolationError);
+			expect((wrapped as NotNullViolationError).column).toBe('name');
+			expect(wrapped.cause).toBe(mysqlError);
+		});
+
+		test('wraps ER_NO_REFERENCED_ROW_2 (1452) and extracts table, column, constraint', () => {
+			const mysqlError = Object.assign(
+				new Error(
+					'Cannot add or update a child row: a foreign key constraint fails (`db`.`posts`, CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))',
+				),
+				{
+					errno: 1452,
+					sqlMessage:
+						'Cannot add or update a child row: a foreign key constraint fails (`db`.`posts`, CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))',
+				},
+			);
+
+			const wrapped = wrapQueryError(query, params, mysqlError) as ForeignKeyViolationError;
+
+			expect(wrapped).toBeInstanceOf(ForeignKeyViolationError);
+			expect(wrapped.constraintName).toBe('posts_user_id_fk');
+			expect(wrapped.table).toBe('posts');
+			expect(wrapped.column).toBe('user_id');
+			expect(wrapped.cause).toBe(mysqlError);
+		});
+
+		test('wraps ER_CHECK_CONSTRAINT_VIOLATED (3819)', () => {
+			const mysqlError = Object.assign(new Error("Check constraint 'users_age_check' is violated."), {
+				errno: 3819,
+				sqlMessage: "Check constraint 'users_age_check' is violated.",
+			});
+
+			const wrapped = wrapQueryError(query, params, mysqlError);
+
+			expect(wrapped).toBeInstanceOf(CheckConstraintViolationError);
+			expect((wrapped as CheckConstraintViolationError).constraintName).toBe('users_age_check');
+			expect(wrapped.cause).toBe(mysqlError);
+		});
+	});
+
+	describe('SQLite', () => {
+		test('wraps SQLITE_CONSTRAINT_UNIQUE via code', () => {
+			const sqliteError = Object.assign(new Error('UNIQUE constraint failed: users.email'), {
+				code: 'SQLITE_CONSTRAINT_UNIQUE',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect((wrapped as UniqueConstraintViolationError).table).toBe('users');
+			expect((wrapped as UniqueConstraintViolationError).column).toBe('email');
+			expect(wrapped.cause).toBe(sqliteError);
+		});
+
+		test('wraps SQLITE_CONSTRAINT_NOTNULL via code', () => {
+			const sqliteError = Object.assign(new Error('NOT NULL constraint failed: users.name'), {
+				code: 'SQLITE_CONSTRAINT_NOTNULL',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(NotNullViolationError);
+			expect((wrapped as NotNullViolationError).table).toBe('users');
+			expect((wrapped as NotNullViolationError).column).toBe('name');
+			expect(wrapped.cause).toBe(sqliteError);
+		});
+
+		test('wraps SQLITE_CONSTRAINT_FOREIGNKEY via code', () => {
+			const sqliteError = Object.assign(new Error('FOREIGN KEY constraint failed'), {
+				code: 'SQLITE_CONSTRAINT_FOREIGNKEY',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(ForeignKeyViolationError);
+			expect(wrapped.cause).toBe(sqliteError);
+		});
+
+		test('wraps SQLITE_CONSTRAINT_CHECK via code', () => {
+			const sqliteError = Object.assign(new Error('CHECK constraint failed: users_age_check'), {
+				code: 'SQLITE_CONSTRAINT_CHECK',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(CheckConstraintViolationError);
+			expect((wrapped as CheckConstraintViolationError).constraintName).toBe('users_age_check');
+			expect(wrapped.cause).toBe(sqliteError);
+		});
+
+		test('wraps UNIQUE constraint from message (libsql fallback)', () => {
+			const sqliteError = new Error('UNIQUE constraint failed: users.email');
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect((wrapped as UniqueConstraintViolationError).table).toBe('users');
+			expect((wrapped as UniqueConstraintViolationError).column).toBe('email');
+		});
+
+		test('wraps NOT NULL constraint from message (libsql fallback)', () => {
+			const sqliteError = new Error('NOT NULL constraint failed: users.name');
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(NotNullViolationError);
+			expect((wrapped as NotNullViolationError).table).toBe('users');
+			expect((wrapped as NotNullViolationError).column).toBe('name');
+		});
+
+		test('wraps SQLITE_CONSTRAINT_PRIMARYKEY as unique', () => {
+			const sqliteError = Object.assign(new Error('UNIQUE constraint failed: users.id'), {
+				code: 'SQLITE_CONSTRAINT_PRIMARYKEY',
+			});
+
+			const wrapped = wrapQueryError(query, params, sqliteError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+		});
+	});
+
+	describe('unknown errors', () => {
+		test('falls back to DrizzleQueryError for unknown SQLSTATE', () => {
+			const unknownError = Object.assign(new Error('some random error'), {
+				code: '42P01',
+			});
+
+			const wrapped = wrapQueryError(query, params, unknownError);
+
+			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
+			expect(wrapped).not.toBeInstanceOf(DrizzleConstraintError);
+			expect(wrapped.cause).toBe(unknownError);
+		});
+
+		test('falls back for errors with no recognizable properties', () => {
+			const plainError = new Error('connection refused');
+
+			const wrapped = wrapQueryError(query, params, plainError);
+
+			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
+			expect(wrapped).not.toBeInstanceOf(DrizzleConstraintError);
+		});
+	});
+
+	describe('instanceof chain', () => {
+		test('UniqueConstraintViolationError is instanceof all parent classes', () => {
+			const pgError = Object.assign(new Error('duplicate key'), {
+				code: '23505',
+				table: 'users',
+				constraint: 'users_email_key',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError);
+
+			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
+			expect(wrapped).toBeInstanceOf(DrizzleConstraintError);
+			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
+			expect(wrapped).toBeInstanceOf(Error);
+		});
+
+		test('query and params are accessible on constraint errors', () => {
+			const pgError = Object.assign(new Error('duplicate key'), {
+				code: '23505',
+				table: 'users',
+				constraint: 'users_email_key',
+			});
+
+			const wrapped = wrapQueryError(query, params, pgError) as UniqueConstraintViolationError;
+
+			expect(wrapped.query).toBe(query);
+			expect(wrapped.params).toEqual(params);
+			expect(wrapped.constraintType).toBe('unique');
+			expect(wrapped.constraintName).toBe('users_email_key');
+			expect(wrapped.table).toBe('users');
+		});
+	});
+});

--- a/drizzle-orm/tests/errors.test.ts
+++ b/drizzle-orm/tests/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest';
+import { is } from '~/entity.ts';
 import {
 	CheckConstraintViolationError,
 	DrizzleConstraintError,
@@ -131,6 +132,26 @@ describe('wrapQueryError', () => {
 			expect(wrapped.cause).toBe(mysqlError);
 		});
 
+		test('wraps ER_ROW_IS_REFERENCED_2 (1451) on delete', () => {
+			const mysqlError = Object.assign(
+				new Error(
+					'Cannot delete or update a parent row: a foreign key constraint fails (`db`.`posts`, CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))',
+				),
+				{
+					errno: 1451,
+					sqlMessage:
+						'Cannot delete or update a parent row: a foreign key constraint fails (`db`.`posts`, CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`))',
+				},
+			);
+
+			const wrapped = wrapQueryError(query, params, mysqlError) as ForeignKeyViolationError;
+
+			expect(wrapped).toBeInstanceOf(ForeignKeyViolationError);
+			expect(wrapped.constraintName).toBe('posts_user_id_fk');
+			expect(wrapped.table).toBe('posts');
+			expect(wrapped.column).toBe('user_id');
+		});
+
 		test('wraps ER_CHECK_CONSTRAINT_VIOLATED (3819)', () => {
 			const mysqlError = Object.assign(new Error("Check constraint 'users_age_check' is violated."), {
 				errno: 3819,
@@ -224,6 +245,14 @@ describe('wrapQueryError', () => {
 
 			expect(wrapped).toBeInstanceOf(UniqueConstraintViolationError);
 		});
+
+		test('returns a clean first column for a composite SQLite constraint', () => {
+			const sqliteError = new Error('UNIQUE constraint failed: users.email, users.tenant_id');
+
+			const wrapped = wrapQueryError(query, params, sqliteError) as UniqueConstraintViolationError;
+
+			expect(wrapped.column).toBe('email');
+		});
 	});
 
 	describe('unknown errors', () => {
@@ -247,6 +276,15 @@ describe('wrapQueryError', () => {
 			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
 			expect(wrapped).not.toBeInstanceOf(DrizzleConstraintError);
 		});
+
+		test('preserves a non-Error thrown value without masking it', () => {
+			const thrown = 'connection refused';
+
+			const wrapped = wrapQueryError(query, params, thrown);
+
+			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
+			expect(wrapped.cause).toBe(thrown);
+		});
 	});
 
 	describe('instanceof chain', () => {
@@ -263,6 +301,9 @@ describe('wrapQueryError', () => {
 			expect(wrapped).toBeInstanceOf(DrizzleConstraintError);
 			expect(wrapped).toBeInstanceOf(DrizzleQueryError);
 			expect(wrapped).toBeInstanceOf(Error);
+			expect(is(wrapped, UniqueConstraintViolationError)).toBe(true);
+			expect(is(wrapped, DrizzleConstraintError)).toBe(true);
+			expect(is(wrapped, DrizzleQueryError)).toBe(true);
 		});
 
 		test('query and params are accessible on constraint errors', () => {


### PR DESCRIPTION
/claim #376
Fixes #376

# feat: typed constraint errors across pg, mysql, sqlite, and singlestore

This builds on the typed-error hierarchy explored in #5383 and keeps its public class names, while completing SingleStore wiring, repo-standard `is()` support, delete-side MySQL FK errors, and safe handling of non-`Error` throws.

Catching a unique-violation today means parsing driver-specific `code` / `errno` / message strings. This wraps those into one typed `instanceof` / `is()` chain that still keeps the original driver error on `.cause`.

```ts
try {
  await db.insert(users).values({ email });
} catch (e) {
  if (e instanceof UniqueConstraintViolationError) {
    e.constraintName; // 'users_email_key'
    e.table;          // 'users'
    e.cause;          // original pg/mysql2/libsql error
  }
}
```

`DrizzleQueryError` keeps the same behavior for everything that is not a constraint failure (syntax, connection, missing relation, …). Additive — no existing catch of `DrizzleQueryError` breaks.

## Mapping

| | unique | not null | foreign key | check |
| --- | --- | --- | --- | --- |
| Postgres | `23505` | `23502` | `23503` | `23514` |
| MySQL / SingleStore | `1062` | `1048` | `1451`/`1452`/`1216`/`1217` | `3819` |
| SQLite | `SQLITE_CONSTRAINT_UNIQUE` / `PRIMARYKEY` + libsql message | `NOTNULL` | `FOREIGNKEY` | `CHECK` |

Wired in the one place every driver already goes through: `queryWithCache` in `pg-core`, `mysql-core`, `sqlite-core`, and **`singlestore-core`**.

Classes are exported from `drizzle-orm` (`export * from './errors.ts'` already).

## Related open work

| PR | Difference |
| --- | --- |
| **#3996** | WIP since May 2025; covers broader debugging/logging and currently only postgres.js |
| **#5383** | Typed-error foundation used here; this PR adds SingleStore, Drizzle `is()`, complete MySQL FK extraction/delete codes, and non-`Error` safety |
| **#6064** | Postgres-only; its synchronous `try/catch` around a thenable does not cover async rejections |
| **#5877** | Also adds an `onError` hook and changes 68 files; broader, separate scope |
| **#5412** | Adds an `onError` callback rather than typed constraint classes |

No `onError` hook in this PR. Constraint classes first; a hook can sit on top later.

## Tests

`drizzle-orm/tests/errors.test.ts` — 22 cases, no live database: SQLSTATE, mysql errno (including FK table/column/constraint extraction), sqlite codes + libsql message fallback, unknown codes stay `DrizzleQueryError`, `instanceof` / `is()` behavior, and non-`Error` throws.
