### PR TITLE
[Pg]: Forward all $with arguments through withReplicas

### DIFF
--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -662,7 +662,7 @@ export const withReplicas = <
 	const selectDistinctOn: Q['selectDistinctOn'] = (...args: [any]) => getReplica(replicas).selectDistinctOn(...args);
 	const $count: Q['$count'] = (...args: [any]) => getReplica(replicas).$count(...args);
 	const _with: Q['with'] = (...args: any) => getReplica(replicas).with(...args);
-	const $with: Q['$with'] = (arg: any) => getReplica(replicas).$with(arg) as any;
+	const $with: Q['$with'] = (...args: any) => getReplica(replicas).$with(...args) as any;
 
 	const update: Q['update'] = (...args: [any]) => primary.update(...args);
 	const insert: Q['insert'] = (...args: [any]) => primary.insert(...args);

--- a/integration-tests/tests/replicas/postgres.test.ts
+++ b/integration-tests/tests/replicas/postgres.test.ts
@@ -367,6 +367,127 @@ describe('[with] read replicas postgres', () => {
 	});
 });
 
+describe('[$with] read replicas postgres', () => {
+	it('primary $with', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$with');
+		const spyRead1 = vi.spyOn(read1, '$with');
+		const spyRead2 = vi.spyOn(read2, '$with');
+		const selection = { id: users.id };
+
+		db.$primary.$with('sq', selection);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(0);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+		expect(spyPrimary).toHaveBeenCalledWith('sq', selection);
+	});
+
+	it('random replica $with', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const randomMockReplica = vi.fn().mockReturnValueOnce(read1).mockReturnValueOnce(read2);
+
+		const db = withReplicas(primaryDb, [read1, read2], () => {
+			return randomMockReplica();
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$with');
+		const spyRead1 = vi.spyOn(read1, '$with');
+		const spyRead2 = vi.spyOn(read2, '$with');
+		const selection = { id: users.id };
+
+		db.$with('sq', selection);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledWith('sq', selection);
+
+		db.$with('sq2');
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledWith('sq2');
+	});
+
+	it('single read replica $with', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$with');
+		const spyRead1 = vi.spyOn(read1, '$with');
+		const selection = { id: users.id };
+
+		db.$with('sq', selection);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledWith('sq', selection);
+
+		db.$with('sq2');
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+		expect(spyRead1).toHaveBeenCalledWith('sq2');
+	});
+
+	it('single read replica $with + primary $with', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1]);
+
+		const spyPrimary = vi.spyOn(primaryDb, '$with');
+		const spyRead1 = vi.spyOn(read1, '$with');
+		const selection = { id: users.id };
+
+		db.$with('sq', selection);
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledWith('sq', selection);
+
+		db.$primary.$with('sq2', selection);
+		expect(spyPrimary).toHaveBeenCalledTimes(1);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyPrimary).toHaveBeenCalledWith('sq2', selection);
+	});
+
+	it('always first read $with', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2], (replicas) => {
+			return replicas[0]!;
+		});
+
+		const spyPrimary = vi.spyOn(primaryDb, '$with');
+		const spyRead1 = vi.spyOn(read1, '$with');
+		const spyRead2 = vi.spyOn(read2, '$with');
+		const selection = { id: users.id };
+
+		db.$with('sq');
+
+		expect(spyPrimary).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledTimes(1);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledWith('sq');
+
+		db.$with('sq2', selection);
+		expect(spyRead1).toHaveBeenCalledTimes(2);
+		expect(spyRead2).toHaveBeenCalledTimes(0);
+		expect(spyRead1).toHaveBeenCalledWith('sq2', selection);
+	});
+});
+
 describe('[update] replicas postgres', () => {
 	it('primary update', () => {
 		const primaryDb = drizzle.mock();


### PR DESCRIPTION
## Summary

- `withReplicas` forwarded only the first argument of `$with`, so `db.$with(alias, selection)` dropped the CTE selection map on replica queries.
- `$with` now spreads all arguments, matching `with`, `select`, and the other replica wrappers.
- Added replica mock tests that assert both `alias` and `selection` are forwarded to the chosen replica or `$primary`.

## Test plan

- [x] Replica tests cover `$with` on primary, a random replica, a single replica, mixed replica + primary, and a fixed first replica
- [x] Run `cd integration-tests && pnpm exec vitest run tests/replicas/postgres.test.ts`
- [x] Confirm `db.$with('sq', { ... }).as(sql\`...\`)` works through `withReplicas`


