### PR TITLE
[SQLite-kit]: Preserve NOT NULL on non-integer primary keys

### DIFF
--- a/drizzle-kit/src/dialects/sqlite/drizzle.ts
+++ b/drizzle-kit/src/dialects/sqlite/drizzle.ts
@@ -79,7 +79,7 @@ export const fromDrizzleSchema = (
 				name,
 				type: column.getSQLType(),
 				default: defalutValue,
-				notNull: column.notNull && !primaryKey,
+				notNull: column.notNull && !(primaryKey && is(column, SQLiteBaseInteger)),
 				pk: primaryKey,
 				pkName: null,
 				autoincrement: is(column, SQLiteBaseInteger)

--- a/drizzle-kit/tests/sqlite/sqlite-constraints.test.ts
+++ b/drizzle-kit/tests/sqlite/sqlite-constraints.test.ts
@@ -641,7 +641,7 @@ test('pk #1. add pk. inline param without name', async () => {
 	const st0 = [
 		'PRAGMA foreign_keys=OFF;',
 		`CREATE TABLE \`__new_users\` (
-	\`name\` text PRIMARY KEY
+	\`name\` text PRIMARY KEY NOT NULL
 );\n`,
 		'INSERT INTO `__new_users`(`name`) SELECT `name` FROM `users`;',
 		'DROP TABLE `users`;',
@@ -1074,7 +1074,7 @@ test('pk multistep #1', async () => {
 	const { sqlStatements: st1, next: n1 } = await diff({}, sch1, []);
 	const { sqlStatements: pst1 } = await push({ db, to: sch1 });
 
-	const e1 = ['CREATE TABLE `users` (\n\t`name` text PRIMARY KEY\n);\n'];
+	const e1 = ['CREATE TABLE `users` (\n\t`name` text PRIMARY KEY NOT NULL\n);\n'];
 	expect(st1).toStrictEqual(e1);
 	expect(pst1).toStrictEqual(e1);
 
@@ -1149,7 +1149,7 @@ test('pk multistep #2', async () => {
 
 	const { sqlStatements: st1, next: n1 } = await diff({}, sch1, []);
 	const { sqlStatements: pst1 } = await push({ db, to: sch1 });
-	const e1 = ['CREATE TABLE `users` (\n\t`name` text PRIMARY KEY\n);\n'];
+	const e1 = ['CREATE TABLE `users` (\n\t`name` text PRIMARY KEY NOT NULL\n);\n'];
 	expect(st1).toStrictEqual(e1);
 	expect(pst1).toStrictEqual(e1);
 
@@ -1220,10 +1220,10 @@ test('pk multistep #3', async () => {
 	const { sqlStatements: pst1 } = await push({ db, to: sch1 });
 
 	expect(st1).toStrictEqual([
-		'CREATE TABLE `users` (\n\t`name` text PRIMARY KEY\n);\n',
+		'CREATE TABLE `users` (\n\t`name` text PRIMARY KEY NOT NULL\n);\n',
 	]);
 	expect(pst1).toStrictEqual([
-		'CREATE TABLE `users` (\n\t`name` text PRIMARY KEY\n);\n',
+		'CREATE TABLE `users` (\n\t`name` text PRIMARY KEY NOT NULL\n);\n',
 	]);
 
 	const sch2 = {

--- a/drizzle-kit/tests/sqlite/sqlite-generated.test.ts
+++ b/drizzle-kit/tests/sqlite/sqlite-generated.test.ts
@@ -1024,7 +1024,7 @@ test('generated as sql: change column with virtual generated constraint on anoth
 	const expectedSt2: string[] = [
 		'PRAGMA foreign_keys=OFF;',
 		'CREATE TABLE `__new_test_table` (\n'
-		+ '\t`id` text PRIMARY KEY,\n'
+		+ '\t`id` text PRIMARY KEY NOT NULL,\n'
 		+ '\t`likes` integer DEFAULT 0 NOT NULL,\n'
 		+ '\t`dislikes` integer DEFAULT 0 NOT NULL,\n'
 		+ '\t`votes` integer GENERATED ALWAYS AS (likes + dislikes) VIRTUAL,\n'

--- a/drizzle-kit/tests/sqlite/sqlite-tables.test.ts
+++ b/drizzle-kit/tests/sqlite/sqlite-tables.test.ts
@@ -72,6 +72,23 @@ test('add table #2', async () => {
 	expect(pst).toStrictEqual(st0);
 });
 
+test('text primary key is not null', async () => {
+	const to = {
+		users: sqliteTable('users', {
+			id: text('id').primaryKey(),
+		}),
+	};
+
+	const { sqlStatements: st } = await diff({}, to, []);
+	const { sqlStatements: pst } = await push({ db, to });
+
+	const st0: string[] = [
+		'CREATE TABLE `users` (\n\t`id` text PRIMARY KEY NOT NULL\n);\n',
+	];
+	expect(st).toStrictEqual(st0);
+	expect(pst).toStrictEqual(st0);
+});
+
 test('add table #3', async () => {
 	const to = {
 		users: sqliteTable('users', {
@@ -1085,7 +1102,7 @@ test('recreate table and add unique column', async (t) => {
 		'ALTER TABLE `users` ADD `referral_code` text;',
 		'PRAGMA foreign_keys=OFF;',
 		`CREATE TABLE \`__new_users\` (
-\t\`id\` text PRIMARY KEY,
+\t\`id\` text PRIMARY KEY NOT NULL,
 \t\`email\` text NOT NULL,
 \t\`referral_code\` text UNIQUE
 );\n`,


### PR DESCRIPTION
Preserve `NOT NULL` for non-integer SQLite primary keys when building the schema snapshot. Integer primary keys keep their existing behavior.

Updates the affected SQLite expectations and adds a regression test for `text().primaryKey()`.

Fixes #6165
