### PR TITLE
fix(sqlite-kit): preserve NOT NULL on non-integer primary key columns

### DIFF
--- a/drizzle-kit/src/cli/commands/up-sqlite.ts
+++ b/drizzle-kit/src/cli/commands/up-sqlite.ts
@@ -68,11 +68,14 @@ export const updateToV7 = (snapshot: SQLiteSchemaV6): SqliteSnapshot => {
 		for (const column of Object.values(table.columns)) {
 			let def: string | null = typeof column.default === 'undefined' ? null : String(column.default);
 
+			// Preserve NOT NULL as-is: SQLite allows NULLs in non-INTEGER PRIMARY KEY
+			// columns, so the flag is load-bearing there. The DDL convertor decides
+			// whether to omit it for single-column integer PKs (see convertor.ts).
 			ddl.columns.push({
 				table: table.name,
 				name: column.name,
 				type: column.type,
-				notNull: column.notNull && !column.primaryKey,
+				notNull: column.notNull,
 				default: def,
 				autoincrement: column.autoincrement,
 				generated: column.generated ?? null,

--- a/drizzle-kit/src/dialects/sqlite/drizzle.ts
+++ b/drizzle-kit/src/dialects/sqlite/drizzle.ts
@@ -73,13 +73,17 @@ export const fromDrizzleSchema = (
 				return column && !is(column, SQL) && column.name === name;
 			}));
 
+			// SQLite only enforces NOT NULL on `INTEGER PRIMARY KEY` columns (rowid alias);
+			// for every other PK shape (TEXT/BLOB/REAL, INT, composite) NULLs are allowed,
+			// so the NOT NULL flag must be preserved here and left to the DDL convertor
+			// to omit it for the single-column integer PK case (see convertor.ts).
 			return {
 				entityType: 'columns',
 				table: it.config.name,
 				name,
 				type: column.getSQLType(),
 				default: defalutValue,
-				notNull: column.notNull && !primaryKey,
+				notNull: column.notNull,
 				pk: primaryKey,
 				pkName: null,
 				autoincrement: is(column, SQLiteBaseInteger)

--- a/drizzle-kit/tests/sqlite/sqlite-pk-notnull.test.ts
+++ b/drizzle-kit/tests/sqlite/sqlite-pk-notnull.test.ts
@@ -1,0 +1,64 @@
+import { is } from 'drizzle-orm';
+import { integer, SQLiteTable, SQLiteView, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { expect, test } from 'vitest';
+import { fromJson } from 'src/dialects/sqlite/convertor';
+import { ddlDiffDry } from 'src/dialects/sqlite/diff';
+import { interimToDDL } from 'src/dialects/sqlite/ddl';
+import { fromDrizzleSchema } from 'src/dialects/sqlite/drizzle';
+import type { SQLiteDDL } from 'src/dialects/sqlite/ddl';
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6165
+// SQLite allows NULLs in PRIMARY KEY columns unless the column is an
+// INTEGER PRIMARY KEY (rowid alias), so `NOT NULL` on non-integer PKs
+// is load-bearing and must survive snapshot serialization.
+
+const toDDL = (schema: Record<string, unknown>): SQLiteDDL => {
+	const tables = Object.values(schema).filter((it) => is(it, SQLiteTable)) as SQLiteTable[];
+	const views = Object.values(schema).filter((it) => is(it, SQLiteView)) as SQLiteView[];
+	return interimToDDL(fromDrizzleSchema(tables, views)).ddl;
+};
+
+const textPkSchema = {
+	users: sqliteTable('users', {
+		id: text('id').primaryKey(),
+	}),
+};
+
+const intPkSchema = {
+	items: sqliteTable('items', {
+		id: integer('id').primaryKey(),
+	}),
+};
+
+test('text primary key keeps NOT NULL in the serialized schema', () => {
+	const ddl = toDDL(textPkSchema);
+	const column = ddl.columns.list().find((it) => it.name === 'id');
+
+	expect(column).toBeDefined();
+	expect(column!.notNull).toBe(true);
+});
+
+test('generated SQL emits NOT NULL for text primary keys', async () => {
+	const from = toDDL({});
+	const to = toDDL(textPkSchema);
+
+	const { statements } = await ddlDiffDry(from, to, 'default');
+	const { sqlStatements } = fromJson(statements);
+	const createTable = sqlStatements.find((it) => it.startsWith('CREATE TABLE'));
+
+	expect(createTable).toBeDefined();
+	expect(createTable).toContain('`id` text PRIMARY KEY NOT NULL');
+});
+
+test('generated SQL still omits NOT NULL for single-column integer primary keys', async () => {
+	const from = toDDL({});
+	const to = toDDL(intPkSchema);
+
+	const { statements } = await ddlDiffDry(from, to, 'default');
+	const { sqlStatements } = fromJson(statements);
+	const createTable = sqlStatements.find((it) => it.startsWith('CREATE TABLE'));
+
+	expect(createTable).toBeDefined();
+	expect(createTable).toContain('`id` integer PRIMARY KEY');
+	expect(createTable).not.toContain('`id` integer PRIMARY KEY NOT NULL');
+});


### PR DESCRIPTION
## Summary

Fixes #6165.

On the v1 (`beta`) line, `drizzle-kit generate` drops `NOT NULL` from **every** primary-key column when serializing a Drizzle schema into the interim/snapshot representation:

- `drizzle-kit/src/dialects/sqlite/drizzle.ts`: `notNull: column.notNull && !primaryKey`
- `drizzle-kit/src/cli/commands/up-sqlite.ts` (v6→v7 upgrader): `notNull: column.notNull && !column.primaryKey`

Since SQLite only enforces non-NULL values on `INTEGER PRIMARY KEY` columns (rowid alias), `NOT NULL` is load-bearing for every other PK shape — `text('id').primaryKey()` produced:

```sql
CREATE TABLE `users` (
	`id` text PRIMARY KEY
);
```

which silently allows `NULL` ids — a regression from 0.31 behavior and a data-integrity hazard for anyone who doesn't hand-patch their migrations.

The DDL convertor (`drizzle-kit/src/dialects/sqlite/convertor.ts`) already implements the correct SQLite-specific rule: it omits `NOT NULL` only for single-column integer PKs (`omitNotNull = isColumnPk && column.type.toLowerCase().startsWith('int')`). The serializer stripping the flag upstream of it made that logic unreachable for PK columns. This change makes the serializer faithful (`notNull: column.notNull`) and lets the convertor keep deciding what to emit, which:

- restores `NOT NULL` for TEXT/BLOB/REAL/INT PKs and any explicitly `.notNull()` PK column,
- keeps omitting redundant `NOT NULL` for single-column `integer().primaryKey()` (the behavior requested in #2611),
- keeps upgraded (v6→v7) snapshots consistent with freshly generated ones.

## Reproduction (before)

With `drizzle-orm@1.0.0-rc.4` + `drizzle-kit@1.0.0-rc.4`:

```ts
// schema.ts
import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
export const users = sqliteTable('users', { id: text('id').primaryKey() });
```

`npx drizzle-kit generate` → `` `id` text PRIMARY KEY `` (no `NOT NULL`; verified: SQLite accepts `INSERT INTO users VALUES (NULL)`).

## Testing

New regression tests in `drizzle-kit/tests/sqlite/sqlite-pk-notnull.test.ts`:

- text PK keeps `notNull: true` in the serialized schema
- generated SQL emits `` `id` text PRIMARY KEY NOT NULL `` for text PKs
- generated SQL still emits `` `id` integer PRIMARY KEY `` without `NOT NULL` for single-column integer PKs

```
✓ tests/sqlite/sqlite-pk-notnull.test.ts (3 tests) 5ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Verified red→green: with the fix stashed, 2 of the 3 new tests fail; with the fix applied all pass. Full `tests/sqlite/` suite comparison on this machine (Windows checkout lacks a better-sqlite3 prebuilt for Node 24, so DB-backed suites fail identically before and after the change): clean `beta` → 23 failed / 21 passed; with this change → 21 failed / 23 passed (+2 = the new regression tests; no previously passing test regressed).

`oxlint` clean on all changed files.