### PR TITLE
fix(drizzle-kit): normalize turso:// URLs and stop bundling @tursodatabase/serverless

### DIFF
--- a/drizzle-kit/build.cli.ts
+++ b/drizzle-kit/build.cli.ts
@@ -19,6 +19,7 @@ const driversPackages = [
 	'bun:sqlite',
 	'@sqlitecloud/drivers',
 	'@tursodatabase/database',
+	'@tursodatabase/serverless',
 	'bun',
 ];
 

--- a/drizzle-kit/src/utils/utils-node.ts
+++ b/drizzle-kit/src/utils/utils-node.ts
@@ -371,6 +371,12 @@ export const normaliseSQLiteUrl = (
 	type: 'libsql' | 'better-sqlite' | '@tursodatabase/database' | 'bun',
 ) => {
 	if (type === 'libsql') {
+		// `turso://` is Turso's remote scheme; the libsql-family clients speak
+		// HTTPS to the same host. Older bundled driver copies only normalize
+		// `libsql://`, so translate here to stay driver-version agnostic.
+		if (it.startsWith('turso://')) {
+			return `https://${it.slice('turso://'.length)}`;
+		}
 		if (it.startsWith('file:')) {
 			return it;
 		}

--- a/drizzle-kit/tests/other/sqlite-url.test.ts
+++ b/drizzle-kit/tests/other/sqlite-url.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest';
+import { normaliseSQLiteUrl } from 'src/utils/utils-node';
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6164
+// drizzle-kit detects the user's @tursodatabase/serverless but (before the
+// externals fix) runs a bundled older copy that lacks `turso://`
+// normalization, so turso:// URLs must be translated by the kit itself.
+
+test('turso:// URLs are normalized to https:// for libsql-family drivers', () => {
+	expect(normaliseSQLiteUrl('turso://example-db.turso.io', 'libsql')).toBe(
+		'https://example-db.turso.io',
+	);
+	expect(
+		normaliseSQLiteUrl('turso://example-db.turso.io?apiUrl=https://api.turso.io', 'libsql'),
+	).toBe('https://example-db.turso.io?apiUrl=https://api.turso.io');
+});
+
+test('libsql:// and file: URLs pass through unchanged', () => {
+	expect(normaliseSQLiteUrl('libsql://example.turso.io', 'libsql')).toBe(
+		'libsql://example.turso.io',
+	);
+	expect(normaliseSQLiteUrl('file:./local.db', 'libsql')).toBe('file:./local.db');
+	expect(normaliseSQLiteUrl('./local.db', 'libsql')).toBe('file:./local.db');
+});


### PR DESCRIPTION
## Summary

Fixes #6164.

`drizzle-kit` detects the user-installed `@tursodatabase/serverless` via `checkPackage(...)` and logs "Using '@tursodatabase/serverless' driver", but the bundled CLI (`dist/bin.cjs`) actually ships with a **pinned 1.1.3 copy** of the package. Root cause: `build.cli.ts` marks driver packages as esbuild `external` so they resolve from the user's install at runtime — commit 481ccf17 added `@tursodatabase/database`, `@sqlitecloud/drivers`, and `bun` to that list but **missed `@tursodatabase/serverless`**. The static `await import('@tursodatabase/serverless')` inside the bundle therefore resolves to the bundled snapshot, and since 1.1.3 only normalizes `libsql://` (not `turso://`), `turso://` connection URLs fail even though the user's installed driver supports them.

Two complementary changes:

1. **`build.cli.ts`**: add `'@tursodatabase/serverless'` to `driversPackages` so the user's installed version is used at runtime — matching the existing `checkPackage` intent.
2. **`src/utils/utils-node.ts`**: translate `turso://` → `https://` in the `libsql` branch of `normaliseSQLiteUrl`. The libsql-family clients speak HTTPS to the same host, and doing this in the kit keeps behavior correct regardless of which driver copy ends up resolving.

## Testing

New unit tests in `drizzle-kit/tests/other/sqlite-url.test.ts`:

- `turso://host` → `https://host` (including query strings)
- `libsql://`, `file:`, and bare paths unchanged

```
✓ tests/other/sqlite-url.test.ts (2 tests)
✓ tests/other/load-module.test.ts (1 test)

 Test Files  2 passed (2)
      Tests  3 passed (3)