### PR TITLE
fix(drizzle-kit): validate journal entries before converting migrations folder

### DIFF
--- a/drizzle-kit/src/cli/commands/utils.ts
+++ b/drizzle-kit/src/cli/commands/utils.ts
@@ -972,23 +972,18 @@ export const migrateToFoldersV3 = (out: string) => {
 	if (existsSync(metaPath) && existsSync(journalPath)) {
 		const journal: Journal = JSON.parse(readFileSync(journalPath).toString());
 		const sqlFiles = readdirSync(out);
-		for (const entry of journal.entries) {
-			const folderName = prepareSnapshotFolderName(entry.when);
-			// Reading Snapshots files
-			const [snapshotPrefix, ...rest] = entry.tag.split('_');
-			const migrationName = rest.join('_');
-			const oldSnapshotPath = join(metaPath, `${snapshotPrefix}_snapshot.json`);
 
+		// Validate every entry up-front. Converting is destructive (originals are
+		// deleted as each entry moves), so discovering a broken entry mid-loop
+		// used to leave the migrations folder half-converted and non-resumable.
+		for (const entry of journal.entries) {
+			const [snapshotPrefix] = entry.tag.split('_');
+			const oldSnapshotPath = join(metaPath, `${snapshotPrefix}_snapshot.json`);
 			if (!existsSync(oldSnapshotPath)) {
 				// If for some reason this happens we need to throw an error
 				// This can't happen unless there were wrong drizzle-kit migrations usage
 				throw new MigrationSnapshotNotFoundCliError(oldSnapshotPath);
 			}
-
-			const oldSnapshot = readFileSync(oldSnapshotPath);
-
-			// Reading SQL files
-			let oldSqlPath = join(out, `${entry.tag}.sql`);
 			const sqlFileFromJournal = join(out, `${entry.tag}.sql`);
 			if (!existsSync(sqlFileFromJournal)) {
 				// We will try to find it by prefix, but this is a sign that something went wrong
@@ -998,6 +993,23 @@ export const migrateToFoldersV3 = (out: string) => {
 				if (sqlFileName?.length > 1) {
 					throw new MigrationSqlFilesConflictCliError(snapshotPrefix);
 				}
+			}
+		}
+
+		for (const entry of journal.entries) {
+			const folderName = prepareSnapshotFolderName(entry.when);
+			// Reading Snapshots files
+			const [snapshotPrefix, ...rest] = entry.tag.split('_');
+			const migrationName = rest.join('_');
+			const oldSnapshotPath = join(metaPath, `${snapshotPrefix}_snapshot.json`);
+			const oldSnapshot = readFileSync(oldSnapshotPath);
+
+			// Reading SQL files
+			let oldSqlPath = join(out, `${entry.tag}.sql`);
+			const sqlFileFromJournal = join(out, `${entry.tag}.sql`);
+			if (!existsSync(sqlFileFromJournal)) {
+				const sqlFileName = sqlFiles.find((file) => file.startsWith(snapshotPrefix));
+				if (!sqlFileName) continue;
 			}
 			const oldSql = readFileSync(oldSqlPath);
 

--- a/drizzle-kit/src/cli/errors.ts
+++ b/drizzle-kit/src/cli/errors.ts
@@ -115,8 +115,13 @@ export class UnsupportedSnapshotVersionCliError extends DrizzleCliError {
 }
 
 export class MigrationSnapshotNotFoundCliError extends DrizzleCliError {
+
 	constructor(snapshotPath?: string) {
-		super('migration_snapshot_not_found_error', 'No snapshot was found', snapshotPath ? { snapshotPath } : undefined);
+		super(
+			'migration_snapshot_not_found_error',
+			snapshotPath ? `No snapshot was found for '${snapshotPath}'` : 'No snapshot was found',
+			snapshotPath ? { snapshotPath } : undefined,
+		);
 	}
 }
 

--- a/drizzle-kit/tests/other/migrate-folders-v3.test.ts
+++ b/drizzle-kit/tests/other/migrate-folders-v3.test.ts
@@ -1,0 +1,61 @@
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { expect, test } from 'vitest';
+import { migrateToFoldersV3 } from 'src/cli/commands/utils';
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6166
+// Converting a v0 migrations folder is destructive: each entry's original .sql
+// is deleted as it moves. A journal entry whose snapshot is missing used to be
+// discovered only mid-loop, after earlier entries were already converted and
+// their originals deleted - leaving the folder half-converted and the `up`
+// command non-resumable. The conversion must validate everything up-front.
+
+const makeV0Folder = (withSecondSnapshot: boolean) => {
+	const out = mkdtempSync(join(tmpdir(), 'drizzle-kit-up-'));
+	mkdirSync(join(out, 'meta'));
+	writeFileSync(
+		join(out, 'meta/_journal.json'),
+		JSON.stringify({
+			version: '5',
+			dialect: 'sqlite',
+			entries: [
+				{ idx: 0, version: '5', when: 1700000000000, tag: '0000_init', breakpoints: true },
+				{ idx: 1, version: '5', when: 1700000001000, tag: '0001_add_users', breakpoints: true },
+			],
+		}),
+	);
+	writeFileSync(join(out, 'meta/0000_snapshot.json'), '{"id":"0000"}');
+	if (withSecondSnapshot) {
+		writeFileSync(join(out, 'meta/0001_snapshot.json'), '{"id":"0001"}');
+	}
+	writeFileSync(join(out, '0000_init.sql'), 'CREATE TABLE users (id integer);');
+	writeFileSync(join(out, '0001_add_users.sql'), 'ALTER TABLE users ADD name text;');
+	return out;
+};
+
+test('missing snapshot aborts before any conversion happens', () => {
+	const out = makeV0Folder(false);
+
+	expect(() => migrateToFoldersV3(out)).toThrowError(/No snapshot was found/);
+
+	// Nothing may be converted: originals intact, no new folders, meta untouched.
+	expect(existsSync(join(out, '0000_init.sql'))).toBe(true);
+	expect(existsSync(join(out, '0001_add_users.sql'))).toBe(true);
+	expect(existsSync(join(out, 'meta/_journal.json'))).toBe(true);
+	expect(existsSync(join(out, 'meta/0000_snapshot.json'))).toBe(true);
+	const dirs = readdirSync(out).filter((it) =>
+		existsSync(join(out, it)) && !it.endsWith('.sql')
+	);
+	expect(dirs).toStrictEqual(['meta']);
+});
+
+test('a complete folder still converts fully', () => {
+	const out = makeV0Folder(true);
+
+	expect(migrateToFoldersV3(out)).toBe(true);
+
+	expect(existsSync(join(out, 'meta'))).toBe(false);
+	expect(existsSync(join(out, '0000_init.sql'))).toBe(false);
+	expect(existsSync(join(out, '0001_add_users.sql'))).toBe(false);
+});


### PR DESCRIPTION
## Summary

Fixes #6166.

`migrateToFoldersV3()` (the `drizzle-kit up` v0→v3 folder conversion) processed journal entries **incrementally and destructively**: for each entry it created the new folder, wrote `snapshot.json` + `migration.sql`, then deleted the original flat `.sql`. A journal entry whose snapshot file is missing was only discovered when the loop *reached* it — by which point every earlier entry had already been converted and its original deleted. Result: a half-converted migrations folder that `drizzle-kit up` can never finish (re-running hits `MigrationsOutdatedCliError`), with an error message ("No snapshot was found") that didn't even name the missing file.

Changes:

1. **Validate every entry up-front** before writing anything: each entry's snapshot must exist, and any SQL-file ambiguity (`MigrationSqlFilesConflictCliError`) is detected in the same pre-pass. If anything is wrong, nothing is converted — originals stay intact and the folder remains resumable once fixed.
2. **Name the missing path in the error**: `No snapshot was found for '<path>'` so users know exactly which journal entry is broken.

## Testing

New regression tests in `drizzle-kit/tests/other/migrate-folders-v3.test.ts` (pure file-based, no DB):

- a two-entry journal where the second snapshot is missing → throws, and asserts **nothing** was converted: both original `.sql` files intact, `meta/` untouched, no new folders created
- a complete folder still converts fully (meta removed, originals moved)

Red/green verified: without the fix the atomicity test fails (entry 0 already converted + original deleted when the error throws); with the fix both pass.

```
✓ tests/other/migrate-folders-v3.test.ts (2 tests) 14ms

 Test Files  1 passed (1)
      Tests  2 passed (2)