### PR TITLE
[Zod]: Default createSchemaFactory's coercion generic so refine callbacks keep their types

### DIFF
--- a/drizzle-orm/src/zod/schema.ts
+++ b/drizzle-orm/src/zod/schema.ts
@@ -120,7 +120,7 @@ export const createUpdateSchema: CreateUpdateSchema<undefined> = (
 };
 
 export function createSchemaFactory<
-	TCoerce extends CoerceOptions,
+	TCoerce extends CoerceOptions = undefined,
 >(options?: CreateSchemaFactoryOptions<TCoerce>) {
 	const createSelectSchema: CreateSelectSchema<TCoerce> = (
 		entity: Table | View | PgEnum<[string, ...string[]]>,

--- a/integration-tests/tests/validators/zod/pg.test.ts
+++ b/integration-tests/tests/validators/zod/pg.test.ts
@@ -576,6 +576,27 @@ test('type coercion - mixed', (t) => {
 	Expect<Equal<typeof result, typeof expected>>();
 });
 
+test('refine table - select from factory without coercion', (t) => {
+	const table = pgTable('test', {
+		c1: integer(),
+		c2: integer().notNull(),
+		c3: integer().notNull(),
+	});
+
+	const { createSelectSchema } = createSchemaFactory({ zodInstance: z });
+	const result = createSelectSchema(table, {
+		c2: (schema) => schema.lte(1000),
+		c3: z.string().transform(Number),
+	});
+	const expected = z.object({
+		c1: integerNullableSchema,
+		c2: extendedSchema,
+		c3: customSchema,
+	});
+	expectSchemaShape(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});
+
 /* Infinitely recursive type */ {
 	const TopLevelCondition: z.ZodType<TopLevelCondition> = z.custom<TopLevelCondition>().superRefine(() => {});
 


### PR DESCRIPTION
Fixes #5968.

`createSchemaFactory` declares `TCoerce extends CoerceOptions` with no default, so any call that
omits the `coerce` key leaves `TCoerce` at the constraint itself rather than resolving to a concrete
option set. That constraint then distributes through the refine field types into a union of callbacks
with different parameter types, and TypeScript can no longer contextually type the callback:

```ts
const { createSelectSchema } = createSchemaFactory({ zodInstance: z });

createSelectSchema(table, {
  c2: (schema) => schema.lte(1000),
  //   ^ TS7006: Parameter 'schema' implicitly has an 'any' type.
});
```

It reproduces with `createSchemaFactory()`, `createSchemaFactory({})`, and
`createSchemaFactory({ zodInstance: z })` — anything without `coerce`. Passing `coerce: true` or an
object works today, which is why the existing factory tests don't catch it: they all specify
`coerce`.

Defaulting the parameter to `undefined` matches what the top-level `createSelectSchema`,
`createInsertSchema` and `createUpdateSchema` exports already do — they are typed
`CreateSelectSchema<undefined>` and friends — and it matches the runtime, which treats a missing
`coerce` as `{}`. Explicit `coerce: true` and `coerce: { date: true }` still infer exactly as before.

The test is added to `integration-tests/tests/validators/zod/pg.test.ts` next to the existing
coercion cases, and mirrors the shape of the `refine table - select` test already there. Against the
current `rc5` source it reports three errors without the change (the TS7006 above, plus the
downstream argument and `Expect<Equal<...>>` failures) and none with it.

`drizzle-orm` package tests pass: 1223 passed, 7 skipped. `dprint` and `oxlint` are clean on both
touched files. The `type-tests` suite reports 52 errors both with and without this change — they all
come from `effect`/`postgres` typings in my local install and are byte-identical on a clean `rc5`
checkout, so they're unrelated.

Two earlier PRs made the same one-line change, #5973 and #6031, but both targeted `main` and edited
`drizzle-zod/src/schema.ts`, which no longer exists on this branch; both were closed by their authors
without review. This one is against `rc5` and adds the regression test.
