### PR TITLE
fix(mysql): preserve buffers for binary and varbinary

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -1,28 +1,38 @@
-import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnConfig } from '~/column-builder.ts';
+import type {
+	ColumnBuilderBaseConfig,
+	ColumnBuilderRuntimeConfig,
+	HasDefault,
+	MakeColumnConfig,
+} from '~/column-builder.ts';
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
+import type { SQL } from '~/sql/sql.ts';
 import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer;
 	enumValues: undefined;
 }>;
 
-export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumnBuilder<
+export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumnBuilder<
 	T,
 	MySqlBinaryConfig
 > {
 	static override readonly [entityKind]: string = 'MySqlBinaryBuilder';
 
 	constructor(name: T['name'], length: number | undefined) {
-		super(name, 'string', 'MySqlBinary');
+		super(name, 'buffer', 'MySqlBinary');
 		this.config.length = length;
+	}
+
+	override default(value: Buffer | string | SQL): HasDefault<this> {
+		return super.default(value as Buffer | SQL);
 	}
 
 	/** @internal */
@@ -33,7 +43,7 @@ export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MyS
 	}
 }
 
-export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumn<
+export class MySqlBinary<T extends ColumnBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumn<
 	T,
 	MySqlBinaryConfig
 > {
@@ -41,16 +51,9 @@ export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> ex
 
 	length: number | undefined = this.config.length;
 
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		return Buffer.from(value);
 	}
 
 	getSQLType(): string {

--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -52,8 +52,16 @@ export class MySqlBinary<T extends ColumnBaseConfig<'buffer', 'MySqlBinary'>> ex
 	length: number | undefined = this.config.length;
 
 	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
-		if (Buffer.isBuffer(value)) return value;
-		return Buffer.from(value);
+		if (typeof Buffer !== 'undefined') {
+			if (Buffer.isBuffer(value)) return value;
+			return Buffer.from(value);
+		}
+
+		if (typeof value === 'string') {
+			return new TextEncoder().encode(value) as Buffer;
+		}
+
+		return value as Buffer;
 	}
 
 	getSQLType(): string {

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -1,28 +1,38 @@
-import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnConfig } from '~/column-builder.ts';
+import type {
+	ColumnBuilderBaseConfig,
+	ColumnBuilderRuntimeConfig,
+	HasDefault,
+	MakeColumnConfig,
+} from '~/column-builder.ts';
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
+import type { SQL } from '~/sql/sql.ts';
 import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlVarBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer;
 	enumValues: undefined;
 }>;
 
-export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlVarBinary'>>
+export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarBinary'>>
 	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
 {
 	static override readonly [entityKind]: string = 'MySqlVarBinaryBuilder';
 
 	/** @internal */
 	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
-		super(name, 'string', 'MySqlVarBinary');
+		super(name, 'buffer', 'MySqlVarBinary');
 		this.config.length = config?.length;
+	}
+
+	override default(value: Buffer | string | SQL): HasDefault<this> {
+		return super.default(value as Buffer | SQL);
 	}
 
 	/** @internal */
@@ -37,22 +47,15 @@ export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', '
 }
 
 export class MySqlVarBinary<
-	T extends ColumnBaseConfig<'string', 'MySqlVarBinary'>,
+	T extends ColumnBaseConfig<'buffer', 'MySqlVarBinary'>,
 > extends MySqlColumn<T, MySqlVarbinaryOptions> {
 	static override readonly [entityKind]: string = 'MySqlVarBinary';
 
 	length: number | undefined = this.config.length;
 
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		return Buffer.from(value);
 	}
 
 	getSQLType(): string {

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -54,8 +54,16 @@ export class MySqlVarBinary<
 	length: number | undefined = this.config.length;
 
 	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
-		if (Buffer.isBuffer(value)) return value;
-		return Buffer.from(value);
+		if (typeof Buffer !== 'undefined') {
+			if (Buffer.isBuffer(value)) return value;
+			return Buffer.from(value);
+		}
+
+		if (typeof value === 'string') {
+			return new TextEncoder().encode(value) as Buffer;
+		}
+
+		return value as Buffer;
 	}
 
 	getSQLType(): string {

--- a/drizzle-orm/tests/mysql-binary-buffer.test.ts
+++ b/drizzle-orm/tests/mysql-binary-buffer.test.ts
@@ -9,7 +9,7 @@ const table = mysqlTable('binary_buffer_test', {
 
 describe.concurrent('MySQL binary columns', () => {
 	test('preserve Buffer values returned by mysql2', ({ expect }) => {
-		const value = Buffer.from('hello world');
+		const value = Buffer.from([0x00, 0xff, 0x80, 0x31]);
 
 		const binaryValue = table.binary.mapFromDriverValue(value);
 		const varbinaryValue = table.varbinary.mapFromDriverValue(value);
@@ -20,7 +20,19 @@ describe.concurrent('MySQL binary columns', () => {
 		expect(varbinaryValue).toEqual(value);
 	});
 
-	test('convert string values returned by string-based adapters to Buffer', ({ expect }) => {
+	test('convert Uint8Array values returned by binary adapters to Buffer without changing bytes', ({ expect }) => {
+		const value = new Uint8Array([0x00, 0xff, 0x80, 0x31]);
+
+		const binaryValue = table.binary.mapFromDriverValue(value);
+		const varbinaryValue = table.varbinary.mapFromDriverValue(value);
+
+		expect(Buffer.isBuffer(binaryValue)).toBe(true);
+		expect(Buffer.isBuffer(varbinaryValue)).toBe(true);
+		expect(binaryValue).toEqual(Buffer.from(value));
+		expect(varbinaryValue).toEqual(Buffer.from(value));
+	});
+
+	test('convert legacy string driver values to Buffer', ({ expect }) => {
 		const binaryValue = table.binary.mapFromDriverValue('hello world');
 		const varbinaryValue = table.varbinary.mapFromDriverValue('hello world');
 

--- a/drizzle-orm/tests/mysql-binary-buffer.test.ts
+++ b/drizzle-orm/tests/mysql-binary-buffer.test.ts
@@ -1,0 +1,30 @@
+import { Buffer } from 'node:buffer';
+import { describe, test } from 'vitest';
+import { binary, mysqlTable, varbinary } from '~/mysql-core/index.ts';
+
+const table = mysqlTable('binary_buffer_test', {
+	binary: binary('binary', { length: 11 }).notNull(),
+	varbinary: varbinary('varbinary', { length: 11 }).notNull(),
+});
+
+describe.concurrent('MySQL binary columns', () => {
+	test('preserve Buffer values returned by mysql2', ({ expect }) => {
+		const value = Buffer.from('hello world');
+
+		const binaryValue = table.binary.mapFromDriverValue(value);
+		const varbinaryValue = table.varbinary.mapFromDriverValue(value);
+
+		expect(Buffer.isBuffer(binaryValue)).toBe(true);
+		expect(Buffer.isBuffer(varbinaryValue)).toBe(true);
+		expect(binaryValue).toEqual(value);
+		expect(varbinaryValue).toEqual(value);
+	});
+
+	test('convert string values returned by string-based adapters to Buffer', ({ expect }) => {
+		const binaryValue = table.binary.mapFromDriverValue('hello world');
+		const varbinaryValue = table.varbinary.mapFromDriverValue('hello world');
+
+		expect(binaryValue).toEqual(Buffer.from('hello world'));
+		expect(varbinaryValue).toEqual(Buffer.from('hello world'));
+	});
+});

--- a/drizzle-orm/tests/mysql-binary-buffer.test.ts
+++ b/drizzle-orm/tests/mysql-binary-buffer.test.ts
@@ -7,7 +7,7 @@ const table = mysqlTable('binary_buffer_test', {
 	varbinary: varbinary('varbinary', { length: 11 }).notNull(),
 });
 
-describe.concurrent('MySQL binary columns', () => {
+describe('MySQL binary columns', () => {
 	test('preserve Buffer values returned by mysql2', ({ expect }) => {
 		const value = Buffer.from([0x00, 0xff, 0x80, 0x31]);
 
@@ -30,6 +30,33 @@ describe.concurrent('MySQL binary columns', () => {
 		expect(Buffer.isBuffer(varbinaryValue)).toBe(true);
 		expect(binaryValue).toEqual(Buffer.from(value));
 		expect(varbinaryValue).toEqual(Buffer.from(value));
+	});
+
+	test('preserve Uint8Array bytes when the Node Buffer global is unavailable', ({ expect }) => {
+		const originalBuffer = globalThis.Buffer;
+		const value = new Uint8Array([0x00, 0xff, 0x80, 0x31]);
+
+		try {
+			Object.defineProperty(globalThis, 'Buffer', {
+				value: undefined,
+				configurable: true,
+				writable: true,
+			});
+
+			const binaryValue = table.binary.mapFromDriverValue(value);
+			const varbinaryValue = table.varbinary.mapFromDriverValue(value);
+
+			expect(binaryValue).toBeInstanceOf(Uint8Array);
+			expect(varbinaryValue).toBeInstanceOf(Uint8Array);
+			expect([...binaryValue]).toEqual([...value]);
+			expect([...varbinaryValue]).toEqual([...value]);
+		} finally {
+			Object.defineProperty(globalThis, 'Buffer', {
+				value: originalBuffer,
+				configurable: true,
+				writable: true,
+			});
+		}
 	});
 
 	test('convert legacy string driver values to Buffer', ({ expect }) => {

--- a/drizzle-orm/type-tests/mysql/binary-buffer.ts
+++ b/drizzle-orm/type-tests/mysql/binary-buffer.ts
@@ -1,0 +1,17 @@
+import { type Equal, Expect } from 'type-tests/utils.ts';
+import { binary, mysqlTable, varbinary } from '~/mysql-core/index.ts';
+
+const table = mysqlTable('binary_buffer_types', {
+	binary: binary('binary').notNull(),
+	varbinary: varbinary('varbinary', { length: 255 }).notNull(),
+});
+
+Expect<Equal<typeof table.$inferSelect.binary, Buffer>>;
+Expect<Equal<typeof table.$inferSelect.varbinary, Buffer>>;
+Expect<Equal<typeof table.$inferInsert.binary, Buffer>>;
+Expect<Equal<typeof table.$inferInsert.varbinary, Buffer>>;
+
+// Keep accepting string SQL defaults for backwards compatibility while
+// the selected/inserted application data type is correctly inferred as Buffer.
+binary('binary_default').default('');
+varbinary('varbinary_default', { length: 255 }).default('');

--- a/integration-tests/tests/mysql/mysql-planetscale.test.ts
+++ b/integration-tests/tests/mysql/mysql-planetscale.test.ts
@@ -1,7 +1,9 @@
 import { Client } from '@planetscale/database';
+import { sql } from 'drizzle-orm';
+import { binary, mysqlTable, varbinary } from 'drizzle-orm/mysql-core';
 import type { PlanetScaleDatabase } from 'drizzle-orm/planetscale-serverless';
 import { drizzle } from 'drizzle-orm/planetscale-serverless';
-import { beforeAll, beforeEach } from 'vitest';
+import { beforeAll, beforeEach, expect, test } from 'vitest';
 import { skipTests } from '~/common';
 import { tests } from './mysql-common';
 import { TestCache, TestGlobalCache, tests as cacheTests } from './mysql-common-cache';
@@ -83,6 +85,27 @@ skipTests([
 	'delete returning sql',
 	'insert returning sql',
 ]);
+
+test('binary and varbinary preserve non-UTF-8 bytes', async () => {
+	const table = mysqlTable('binary_buffer_planetscale', {
+		binary: binary('binary', { length: 4 }).notNull(),
+		varbinary: varbinary('varbinary', { length: 4 }).notNull(),
+	});
+	const value = Buffer.from([0x00, 0xff, 0x80, 0x31]);
+
+	await db.execute(sql`drop table if exists ${table}`);
+	await db.execute(sql`create table ${table} (binary binary(4) not null, varbinary varbinary(4) not null)`);
+	await db.insert(table).values({ binary: value, varbinary: value });
+
+	const [row] = await db.select().from(table);
+
+	expect(Buffer.isBuffer(row!.binary)).toBe(true);
+	expect(Buffer.isBuffer(row!.varbinary)).toBe(true);
+	expect(row!.binary).toEqual(value);
+	expect(row!.varbinary).toEqual(value);
+
+	await db.execute(sql`drop table ${table}`);
+});
 
 tests('planetscale');
 cacheTests();

--- a/integration-tests/tests/mysql/mysql-planetscale.test.ts
+++ b/integration-tests/tests/mysql/mysql-planetscale.test.ts
@@ -94,7 +94,7 @@ test('binary and varbinary preserve non-UTF-8 bytes', async () => {
 	const value = Buffer.from([0x00, 0xff, 0x80, 0x31]);
 
 	await db.execute(sql`drop table if exists ${table}`);
-	await db.execute(sql`create table ${table} (binary binary(4) not null, varbinary varbinary(4) not null)`);
+	await db.execute(sql`create table ${table} (\`binary\` binary(4) not null, \`varbinary\` varbinary(4) not null)`);
 	await db.insert(table).values({ binary: value, varbinary: value });
 
 	const [row] = await db.select().from(table);

--- a/integration-tests/tests/mysql/mysql.test.ts
+++ b/integration-tests/tests/mysql/mysql.test.ts
@@ -1,8 +1,10 @@
 import retry from 'async-retry';
+import { sql } from 'drizzle-orm';
+import { binary, mysqlTable, varbinary } from 'drizzle-orm/mysql-core';
 import type { MySql2Database } from 'drizzle-orm/mysql2';
 import { drizzle } from 'drizzle-orm/mysql2';
 import * as mysql from 'mysql2/promise';
-import { afterAll, beforeAll, beforeEach } from 'vitest';
+import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
 import { createDockerDB, tests } from './mysql-common';
 import { TestCache, TestGlobalCache, tests as cacheTests } from './mysql-common-cache';
 
@@ -55,6 +57,27 @@ beforeEach((ctx) => {
 		db: cachedDb,
 		dbGlobalCached,
 	};
+});
+
+test('binary and varbinary preserve non-UTF-8 bytes', async () => {
+	const table = mysqlTable('binary_buffer_mysql2', {
+		binary: binary('binary', { length: 4 }).notNull(),
+		varbinary: varbinary('varbinary', { length: 4 }).notNull(),
+	});
+	const value = Buffer.from([0x00, 0xff, 0x80, 0x31]);
+
+	await db.execute(sql`drop table if exists ${table}`);
+	await db.execute(sql`create table ${table} (binary binary(4) not null, varbinary varbinary(4) not null)`);
+	await db.insert(table).values({ binary: value, varbinary: value });
+
+	const [row] = await db.select().from(table);
+
+	expect(Buffer.isBuffer(row!.binary)).toBe(true);
+	expect(Buffer.isBuffer(row!.varbinary)).toBe(true);
+	expect(row!.binary).toEqual(value);
+	expect(row!.varbinary).toEqual(value);
+
+	await db.execute(sql`drop table ${table}`);
 });
 
 cacheTests();

--- a/integration-tests/tests/mysql/mysql.test.ts
+++ b/integration-tests/tests/mysql/mysql.test.ts
@@ -67,7 +67,7 @@ test('binary and varbinary preserve non-UTF-8 bytes', async () => {
 	const value = Buffer.from([0x00, 0xff, 0x80, 0x31]);
 
 	await db.execute(sql`drop table if exists ${table}`);
-	await db.execute(sql`create table ${table} (binary binary(4) not null, varbinary varbinary(4) not null)`);
+	await db.execute(sql`create table ${table} (\`binary\` binary(4) not null, \`varbinary\` varbinary(4) not null)`);
 	await db.insert(table).values({ binary: value, varbinary: value });
 
 	const [row] = await db.select().from(table);


### PR DESCRIPTION
Fixes #1188

/claim #1188

## Summary

- Type MySQL `binary` and `varbinary` columns as `Buffer` instead of `string`.
- Preserve `Buffer` values returned by mysql2.
- Normalize binary `Uint8Array` values to `Buffer` without changing bytes.
- Keep accepting legacy string driver values and string SQL defaults for backwards compatibility.
- Add focused runtime/type tests plus mysql2 and PlanetScale round-trip integration coverage.

## Why `Buffer` by default is viable now

The original direct-`Buffer` attempt in #425 was closed for one specific reason: mysql2 returned `Buffer`, while the PlanetScale driver returned strings. That made one shared MySQL column type inconsistent across adapters at the time.

Current `@planetscale/database` no longer has that blocker:

- its binary-field cast path returns `Uint8Array` for binary fields (`charset === 63`): https://github.com/planetscale/database-js/blob/main/src/cast.ts
- its query-value sanitizer handles `Uint8Array` directly: https://github.com/planetscale/database-js/blob/main/src/sanitization.ts

`Buffer` is a `Uint8Array`, so binary data can stay binary through both current mysql2 and PlanetScale paths. Drizzle normalizes a PlanetScale `Uint8Array` to `Buffer` without a UTF-8 string round-trip.

## Historical review context

#425 was also explicitly asked to add runtime insert/select integration coverage for these columns. This PR now includes that exact evidence for both adapters, using non-UTF-8 bytes (`00 ff 80 31`) so a lossy string conversion cannot pass unnoticed.

The later direct-Buffer work in #1253 reached a maintainer comment that it “looks good to be merged” before stalling on signed commits and eventually being closed. The adapter behavior that made the older work difficult is what the current PlanetScale implementation has since changed.

## Compatibility

Application/select/insert data is inferred as `Buffer`, matching binary semantics. Existing schema code that uses string SQL defaults such as `binary(...).default('')` remains accepted through a narrow builder override, so this fix does not require rewriting those default declarations.

## Verification

- Reproduced the current lossy mapping with non-UTF-8 bytes (`00 ff 80 31`).
- Added focused mapping tests for mysql2 `Buffer`, binary-adapter `Uint8Array`, and legacy string values.
- Added type-level assertions that `binary`/`varbinary` select and insert data infer as `Buffer` while string defaults remain accepted.
- Added mysql2 and PlanetScale insert/select round-trip integration tests with the same non-UTF-8 bytes.
- Changed TypeScript sources passed the available syntax/override-signature checks.

Upstream Actions are currently `action_required` with no jobs started, so the repository’s first-time-contributor workflow approval is still required before the integration/CI jobs can execute.