### PR TITLE
[Sqlite]: Skip undefined JOIN ON / ORDER BY / GROUP BY from sql.if(false)

### DIFF
--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -308,17 +308,15 @@ export abstract class SQLiteDialect {
 	}
 
 	private buildOrderBy(
-		orderBy: (SQLiteColumn | SQL | SQL.Aliased)[] | undefined,
+		orderBy: (SQLiteColumn | SQL | SQL.Aliased | undefined)[] | undefined,
 	): SQL | undefined {
 		const orderByList: (SQLiteColumn | SQL | SQL.Aliased)[] = [];
+		const present = orderBy?.filter((item): item is SQLiteColumn | SQL | SQL.Aliased => item !== undefined) ?? [];
 
-		if (orderBy) {
-			for (const [index, orderByValue] of orderBy.entries()) {
-				orderByList.push(orderByValue);
-
-				if (index < orderBy.length - 1) {
-					orderByList.push(sql`, `);
-				}
+		for (const [index, orderByValue] of present.entries()) {
+			orderByList.push(orderByValue);
+			if (index < present.length - 1) {
+				orderByList.push(sql`, `);
 			}
 		}
 
@@ -405,13 +403,13 @@ export abstract class SQLiteDialect {
 		const havingSql = having ? sql` having ${having}` : undefined;
 
 		const groupByList: (SQL | AnyColumn | SQL.Aliased)[] = [];
-		if (groupBy) {
-			for (const [index, groupByValue] of groupBy.entries()) {
-				groupByList.push(groupByValue);
-
-				if (index < groupBy.length - 1) {
-					groupByList.push(sql`, `);
-				}
+		const presentGroupBy = groupBy?.filter(
+			(item): item is SQL | AnyColumn | SQL.Aliased => item !== undefined,
+		) ?? [];
+		for (const [index, groupByValue] of presentGroupBy.entries()) {
+			groupByList.push(groupByValue);
+			if (index < presentGroupBy.length - 1) {
+				groupByList.push(sql`, `);
 			}
 		}
 
@@ -474,6 +472,9 @@ export abstract class SQLiteDialect {
 			// The next bit is necessary because the sql operator replaces ${table.column} with `table`.`column`
 			// which is invalid Sql syntax, Table from one of the SELECTs cannot be used in global ORDER clause
 			for (const singleOrderBy of orderBy) {
+				if (singleOrderBy === undefined) {
+					continue;
+				}
 				if (is(singleOrderBy, SQLiteColumn)) {
 					orderByValues.push(sql.identifier(singleOrderBy.name));
 				} else if (is(singleOrderBy, SQL)) {

--- a/drizzle-orm/src/sqlite-core/query-builders/select.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/select.ts
@@ -54,6 +54,11 @@ import type {
 	SQLiteSetOperatorWithResult,
 } from './select.types.ts';
 
+/** `.if(false)` leaves `undefined` holes; skip them so we don't emit `ORDER BY , col`. */
+function withoutUndefined<T>(items: readonly T[]): Exclude<T, undefined>[] {
+	return items.filter((item): item is Exclude<T, undefined> => item !== undefined);
+}
+
 export class SQLiteSelectBuilder<
 	TSelection extends SelectedFields | undefined,
 	TResultType extends 'sync' | 'async',
@@ -215,6 +220,9 @@ export abstract class SQLiteSelectQueryBuilderBase<
 		) => {
 			const baseTableName = this.tableName;
 			const tableName = getTableLikeName(table);
+			const fieldsSnapshot = this.config.fields;
+			const nullableSnapshot = this.joinsNotNullableMap;
+			const usedSnapshot = [...this.usedTables];
 
 			// store all tables used in a query
 			for (const item of extractUsedTable(table)) this.usedTables.add(item);
@@ -247,6 +255,15 @@ export abstract class SQLiteSelectQueryBuilderBase<
 						new SelectionProxyHandler({ sqlAliasedBehavior: 'sql', sqlBehavior: 'sql' }),
 					) as TSelection,
 				);
+			}
+
+			// `.if(false)` → undefined. JOIN without ON is a cartesian product in SQLite.
+			if (joinType !== 'cross' && on === undefined) {
+				this.config.fields = fieldsSnapshot;
+				this.joinsNotNullableMap = nullableSnapshot;
+				this.usedTables.clear();
+				for (const used of usedSnapshot) this.usedTables.add(used);
+				return this as any;
 			}
 
 			if (!this.config.joins) {
@@ -697,9 +714,9 @@ export abstract class SQLiteSelectQueryBuilderBase<
 					new SelectionProxyHandler({ sqlAliasedBehavior: 'alias', sqlBehavior: 'sql' }),
 				) as TSelection,
 			);
-			this.config.groupBy = Array.isArray(groupBy) ? groupBy : [groupBy];
+			this.config.groupBy = Array.isArray(groupBy) ? withoutUndefined(groupBy) : withoutUndefined([groupBy]);
 		} else {
-			this.config.groupBy = columns as (SQLiteColumn | SQL | SQL.Aliased)[];
+			this.config.groupBy = withoutUndefined(columns as (SQLiteColumn | SQL | SQL.Aliased | undefined)[]);
 		}
 		return this as any;
 	}
@@ -745,7 +762,7 @@ export abstract class SQLiteSelectQueryBuilderBase<
 				) as TSelection,
 			);
 
-			const orderByArray = Array.isArray(orderBy) ? orderBy : [orderBy];
+			const orderByArray = withoutUndefined(Array.isArray(orderBy) ? orderBy : [orderBy]);
 
 			if (this.config.setOperators.length > 0) {
 				this.config.setOperators.at(-1)!.orderBy = orderByArray;
@@ -753,7 +770,7 @@ export abstract class SQLiteSelectQueryBuilderBase<
 				this.config.orderBy = orderByArray;
 			}
 		} else {
-			const orderByArray = columns as (SQLiteColumn | SQL | SQL.Aliased)[];
+			const orderByArray = withoutUndefined(columns as (SQLiteColumn | SQL | SQL.Aliased | undefined)[]);
 
 			if (this.config.setOperators.length > 0) {
 				this.config.setOperators.at(-1)!.orderBy = orderByArray;

--- a/drizzle-orm/tests/sqlite-if-undefined.test.ts
+++ b/drizzle-orm/tests/sqlite-if-undefined.test.ts
@@ -1,0 +1,39 @@
+import { describe, test } from 'vitest';
+import { asc, desc, eq, sql } from '~/index.ts';
+import { integer, QueryBuilder, sqliteTable, text } from '~/sqlite-core/index.ts';
+
+const users = sqliteTable('users', {
+	id: integer('id').primaryKey(),
+	name: text('name'),
+});
+const pets = sqliteTable('pets', {
+	id: integer('id').primaryKey(),
+	ownerId: integer('owner_id'),
+});
+
+function qb() {
+	return new QueryBuilder();
+}
+
+describe('sqlite `.if(false)` holes', () => {
+	test('leftJoin omits JOIN when ON is undefined', ({ expect }) => {
+		const omitted = qb().select().from(users).toSQL();
+		const skipped = qb().select().from(users).leftJoin(pets, eq(users.id, pets.ownerId).if(false)).toSQL();
+		expect(skipped.sql).toBe(omitted.sql);
+		expect(skipped.sql.includes('join')).toBe(false);
+	});
+
+	test('orderBy drops undefined and does not emit a leading comma', ({ expect }) => {
+		const q = qb().select().from(users).orderBy(asc(users.id).if(false), desc(users.name)).toSQL();
+		expect(q.sql).toBe(
+			qb().select().from(users).orderBy(desc(users.name)).toSQL().sql,
+		);
+		expect(q.sql.includes('order by ,')).toBe(false);
+	});
+
+	test('groupBy drops undefined and does not emit a leading comma', ({ expect }) => {
+		const q = qb().select().from(users).groupBy(sql`${users.id}`.if(false), users.name).toSQL();
+		expect(q.sql).toBe(qb().select().from(users).groupBy(users.name).toSQL().sql);
+		expect(q.sql.includes('group by ,')).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

`sql.if(false)` returns `undefined`. SQLite already drops that in `WHERE` / `HAVING`, but:

- `leftJoin` / `innerJoin` kept the JOIN and dropped `ON` → cartesian product (2 rows became 4 in a 2×2 fixture)
- `orderBy` / `groupBy` kept an empty list slot → `ORDER BY , col` / `GROUP BY , col` (SQLite `near ",": syntax error`)

This patch skips a non-cross JOIN when `on` is `undefined` (rolling back field/nullability/used-table mutations), and filters `undefined` entries in ORDER BY / GROUP BY (builder + dialect).

## Test plan

- [x] `drizzle-orm/tests/sqlite-if-undefined.test.ts` (QueryBuilder `toSQL`)
- [x] `cd integration-tests && pnpm test` if Docker is available
