### PR TITLE
fix(orm): preserve nested partial-select on left join when first field is null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -45,10 +45,13 @@ export function mapResultRow<TResult>(
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;
+						const tableName = getTableName(field.table);
+
 						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
+							nullifyMap[objectName] = value === null ? tableName : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== tableName || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'vitest';
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+const joinedTable = pgTable('joined', {
+	nullableField: text('nullable_field'),
+	nonNullField: text('non_null_field').notNull(),
+});
+
+test('mapResultRow keeps nested object when first joined column is null', () => {
+	const fields = {
+		joined: {
+			nullableField: joinedTable.nullableField,
+			nonNullField: joinedTable.nonNullField,
+		},
+	};
+
+	const columns = orderSelectedFields(fields);
+
+	const result = mapResultRow(
+		columns,
+		[null, 'value'],
+		{
+			joined: false,
+		},
+	);
+
+	expect(result).toEqual({
+		joined: {
+			nullableField: null,
+			nonNullField: 'value',
+		},
+	});
+});
+
+test('mapResultRow nullifies nested object when all joined columns are null', () => {
+	const fields = {
+		joined: {
+			nullableField: joinedTable.nullableField,
+			nonNullField: joinedTable.nonNullField,
+		},
+	};
+
+	const columns = orderSelectedFields(fields);
+
+	const result = mapResultRow(
+		columns,
+		[null, null],
+		{
+			joined: false,
+		},
+	);
+
+	expect(result).toEqual({
+		joined: null,
+	});
+});

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -55,3 +55,32 @@ test('mapResultRow nullifies nested object when all joined columns are null', ()
 		joined: null,
 	});
 });
+
+test('mapResultRow matches issue #1603 branding.logo-null panelBackground-non-null case', () => {
+	const orgBrandingTable = pgTable('org_branding', {
+		logo: text('logo'),
+		panelBackground: text('panel_background').notNull(),
+	});
+
+	const fields = {
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	};
+
+	const columns = orderSelectedFields(fields);
+
+	const result = mapResultRow(
+		columns,
+		[null, '#1a8cff'],
+		{ branding: false },
+	);
+
+	expect(result).toEqual({
+		branding: {
+			logo: null,
+			panelBackground: '#1a8cff',
+		},
+	});
+});


### PR DESCRIPTION
Closes #1603.

## Summary
- fix `nullifyMap` in `mapResultRow` so nested partial-select objects are not nullified when only the first joined column is null
- add `utils.test.ts` regression for mixed null/non-null joined fields and all-null joined fields

## Validation
- `pnpm exec vitest run drizzle-orm/tests/utils.test.ts` (2 tests)

/claim #1603

@algora-pbc /claim #1603