### PR TITLE
Fix pg array parsing dropping backslashes in quoted elements

### DIFF
--- a/drizzle-orm/src/pg-core/utils/array.ts
+++ b/drizzle-orm/src/pg-core/utils/array.ts
@@ -8,7 +8,7 @@ function parsePgArrayValue(arrayString: string, startFrom: number, inQuotes: boo
 		}
 
 		if (char === '"') {
-			return [arrayString.slice(startFrom, i).replace(/\\/g, ''), i + 1];
+			return [arrayString.slice(startFrom, i).replace(/\\(.)/g, '$1'), i + 1];
 		}
 
 		if (inQuotes) {
@@ -16,11 +16,11 @@ function parsePgArrayValue(arrayString: string, startFrom: number, inQuotes: boo
 		}
 
 		if (char === ',' || char === '}') {
-			return [arrayString.slice(startFrom, i).replace(/\\/g, ''), i];
+			return [arrayString.slice(startFrom, i).replace(/\\(.)/g, '$1'), i];
 		}
 	}
 
-	return [arrayString.slice(startFrom).replace(/\\/g, ''), arrayString.length];
+	return [arrayString.slice(startFrom).replace(/\\(.)/g, '$1'), arrayString.length];
 }
 
 export function parsePgNestedArray(arrayString: string, startFrom = 0): [any[], number] {

--- a/drizzle-orm/tests/parsePgArray.test.ts
+++ b/drizzle-orm/tests/parsePgArray.test.ts
@@ -96,6 +96,22 @@ describe.concurrent('parsePgArray', () => {
 		expect(output).toEqual(['1', 'two "three", four', '5']);
 	});
 
+	it('parses escaped backslashes inside quotes', ({ expect }) => {
+		// Postgres doubles a backslash in its array output, so the wire value
+		// `{"a\\b","c:\\temp\\x"}` holds the single-backslash strings `a\b` and
+		// `c:\temp\x`. The backslash must survive rather than being stripped.
+		const input = '{"a\\\\b","c:\\\\temp\\\\x"}';
+		const output = table.a.mapFromDriverValue(input);
+		expect(output).toEqual(['a\\b', 'c:\\temp\\x']);
+	});
+
+	it('parses a value containing both an escaped backslash and an escaped quote', ({ expect }) => {
+		// Wire `{"a\\\"b"}` is the string `a\"b` (a backslash then a quote).
+		const input = '{"a\\\\\\"b"}';
+		const output = table.a.mapFromDriverValue(input);
+		expect(output).toEqual(['a\\"b']);
+	});
+
 	it('parses two-dimensional array with strings', ({ expect }) => {
 		const input = '{{"one","two",three},{"four",five,"six"},{seven,eight,"nine"}}';
 		const output = table.b.mapFromDriverValue(input);


### PR DESCRIPTION
## What / Why

`parsePgArrayValue` unescapes a quoted Postgres array element with `.replace(/\\/g, '')`, which strips **every** backslash. That is right for an escaped quote (`\"` → `"`) but wrong for an escaped backslash (`\\` should become a single `\`, not be removed). So a `text[]` / `varchar[]` value containing a backslash is corrupted on read.

Postgres doubles backslashes in its array output, so:

```
-- stored value is the string  a\b
select array['a\b']::text[];   -- wire format: {"a\\b"}
```

Reading that back through Drizzle today:

```ts
table.col.mapFromDriverValue('{"a\\\\b"}')            // => ['ab']            ❌ (should be ['a\b'])
table.col.mapFromDriverValue('{"c:\\\\temp\\\\x"}')   // => ['c:tempx']       ❌ (should be ['c:\temp\x'])
```

Any array value with a backslash is affected: Windows paths, regex patterns, LaTeX, escape sequences, etc.

## Fix

Unescape with `.replace(/\\(.)/g, '$1')` so a backslash escapes the following character. This is the inverse of what `makePgArray` produces (it escapes `\` → `\\` and `"` → `\"`) and matches how Postgres formats array output.

- Escaped backslashes now round-trip: `{"a\\b"}` → `['a\b']`.
- Escaped quotes are unchanged: `{"a\"b"}` → `['a"b']` (already covered by existing tests, still green).

Added tests for escaped backslashes and for a value containing both an escaped backslash and an escaped quote.

## Testing

I verified the fixed `parsePgArrayValue`/`parsePgNestedArray` against every existing `parsePgArray` test input (all still pass) plus the new backslash cases. I wasn't able to spin up the full monorepo test run locally (slow dependency install in my environment), so I'd appreciate CI running the `parsePgArray` suite.
