### PR TITLE
[Sqlite-kit] Scaffold BOOLEAN columns as integer(mode: 'boolean'), not numeric()

### DIFF
--- a/drizzle-kit/src/introspect-sqlite.ts
+++ b/drizzle-kit/src/introspect-sqlite.ts
@@ -104,7 +104,9 @@ export const schemaToTypeScript = (
 
 			const columnImports = Object.values(it.columns)
 				.map((col) => {
-					return col.type;
+					// boolean columns are generated as integer(..., { mode: 'boolean' }) -
+					// sqlite-core has no separate boolean() builder to import.
+					return col.type === 'boolean' ? 'integer' : col.type;
 				})
 				.filter((type) => {
 					return sqliteImportsList.has(type);
@@ -277,6 +279,29 @@ const mapColumnDefault = (defaultValue: any) => {
 	return defaultValue;
 };
 
+// SQLite has no boolean storage class: a `BOOLEAN DEFAULT true/TRUE` column
+// stores that default as the keyword text "true"/"TRUE" (SQLite wraps the
+// all-caps form in parens - "(FALSE)" comes back from PRAGMA table_info for
+// `DEFAULT FALSE`, but "true" comes back bare for `DEFAULT true`). Either
+// way, mapColumnDefault (built for numeric/text defaults) passes it through
+// unchanged, or - for the parenthesized form - treats it as a raw SQL
+// expression. Spliced as-is into `.default(...)`, a bare "true" is a stray
+// boolean literal typed against a builder that expects `string |
+// SQL<unknown>`, and "TRUE"/"FALSE" is emitted as-is - an undeclared
+// identifier, since JS/TS boolean literals are lowercase.
+const mapColumnDefaultForBoolean = (defaultValue: any) => {
+	if (typeof defaultValue === 'string') {
+		const unwrapped = defaultValue.startsWith('(') && defaultValue.endsWith(')')
+			? defaultValue.slice(1, -1)
+			: defaultValue;
+		const lowered = unwrapped.toLowerCase();
+		if (lowered === 'true' || lowered === 'false') {
+			return lowered;
+		}
+	}
+	return mapColumnDefault(defaultValue);
+};
+
 const column = (
 	type: string,
 	name: string,
@@ -327,6 +352,14 @@ const column = (
 	if (lowered === 'numeric') {
 		let out = `${withCasing(name, casing)}: numeric(${dbColumnName({ name, casing })})`;
 		out += defaultValue ? `.default(${mapColumnDefault(defaultValue)})` : '';
+		return out;
+	}
+
+	if (lowered === 'boolean') {
+		let out = `${withCasing(name, casing)}: integer(${
+			dbColumnName({ name, casing, withMode: true })
+		}{ mode: 'boolean' })`;
+		out += defaultValue !== undefined ? `.default(${mapColumnDefaultForBoolean(defaultValue)})` : '';
 		return out;
 	}
 

--- a/drizzle-kit/src/serializer/sqliteSerializer.ts
+++ b/drizzle-kit/src/serializer/sqliteSerializer.ts
@@ -453,6 +453,8 @@ function mapSqlToSqliteType(sqlType: string): string {
 		['real', 'double', 'double precision', 'float'].some((it) => lowered.startsWith(it))
 	) {
 		return 'real';
+	} else if (lowered.startsWith('boolean')) {
+		return 'boolean';
 	} else {
 		return 'numeric';
 	}

--- a/drizzle-kit/tests/introspect/sqlite.test.ts
+++ b/drizzle-kit/tests/introspect/sqlite.test.ts
@@ -2,6 +2,9 @@ import Database from 'better-sqlite3';
 import { SQL, sql } from 'drizzle-orm';
 import { check, int, sqliteTable, sqliteView, text } from 'drizzle-orm/sqlite-core';
 import * as fs from 'fs';
+import { schemaToTypeScript } from 'src/introspect-sqlite';
+import { fromDatabase } from 'src/serializer/sqliteSerializer';
+import type { SQLiteDB } from 'src/utils';
 import { introspectSQLiteToFile } from 'tests/schemaDiffer';
 import { expect, test } from 'vitest';
 
@@ -119,4 +122,54 @@ test('view #1', async () => {
 
 	expect(statements.length).toBe(0);
 	expect(sqlStatements.length).toBe(0);
+});
+
+test('introspect boolean column with a literal true/false default', async () => {
+	// A hand-written DDL, not a drizzle push - BOOLEAN has no SQLite storage
+	// class, so a literal `DEFAULT true/TRUE/false/FALSE` is stored as that
+	// keyword text and comes back from PRAGMA table_info as either the bare
+	// text ("true", for the lowercase form) or wrapped in parens ("(FALSE)",
+	// observed for the all-caps form).
+	const sqlite = new Database(':memory:');
+	sqlite.exec(`
+		CREATE TABLE session_prompt (
+			id INTEGER PRIMARY KEY,
+			pending BOOLEAN NOT NULL DEFAULT true,
+			error BOOLEAN NOT NULL DEFAULT FALSE,
+			archived BOOLEAN NOT NULL DEFAULT TRUE,
+			seen BOOLEAN NOT NULL DEFAULT false
+		);
+	`);
+
+	const db: SQLiteDB = {
+		query: async <T>(sql: string, params: any[] = []) => {
+			return sqlite.prepare(sql).bind(params).all() as T[];
+		},
+		run: async (query: string) => {
+			sqlite.prepare(query).run();
+		},
+	};
+
+	const introspectedSchema = await fromDatabase(db, () => true);
+	const { file } = schemaToTypeScript(
+		{ id: '0', prevId: '0', ...introspectedSchema } as any,
+		'camel',
+	);
+
+	// Scaffolded as integer(..., { mode: 'boolean' }), not numeric() - SQLite
+	// has no boolean storage class, and numeric()'s .default() only accepts
+	// string | SQL<unknown>, not a raw boolean.
+	expect(file).toContain(`mode: 'boolean'`);
+	expect(file).not.toContain('numeric(');
+
+	// Every default must come through as a lowercase JS boolean literal,
+	// regardless of the case SQLite stored it in or whether PRAGMA returned
+	// it bare or parenthesized - never left as a bare "TRUE"/"FALSE" (not a
+	// valid, declared JS identifier) and never left attached to a
+	// numeric()-typed default.
+	expect(file).toMatch(/pending: integer\([^)]*\{ mode: 'boolean' \}\)\.default\(true\)/);
+	expect(file).toMatch(/error: integer\([^)]*\{ mode: 'boolean' \}\)\.default\(false\)/);
+	expect(file).toMatch(/archived: integer\([^)]*\{ mode: 'boolean' \}\)\.default\(true\)/);
+	expect(file).toMatch(/seen: integer\([^)]*\{ mode: 'boolean' \}\)\.default\(false\)/);
+	expect(file).not.toMatch(/\.default\((TRUE|FALSE)\)/);
 });


### PR DESCRIPTION
## What changed

Fixes #6182.

SQLite has no boolean storage class, so `mapSqlToSqliteType` (in `drizzle-kit/src/serializer/sqliteSerializer.ts`) had no case for it, and every `BOOLEAN` column fell through to the `numeric()` catch-all. A literal `DEFAULT true`/`DEFAULT FALSE` made this worse: `PRAGMA table_info` returns that default as the bare keyword text (`"true"`, or `"(FALSE)"` - SQLite parenthesizes the all-caps form, which I only found by actually running it, not by reading the report), and `introspect-sqlite.ts` spliced it unchanged into `.default(...)`. That produced either a raw JS boolean literal typed against `numeric()`'s `string | SQL<unknown>` default (`Argument of type 'boolean' is not assignable...`), or a bare `TRUE`/`FALSE` identifier TypeScript can't resolve at all, since JS/TS boolean literals are lowercase.

`BOOLEAN` now maps to its own `'boolean'` type and is scaffolded as `integer(name, { mode: 'boolean' })` - sqlite-core's idiomatic representation, since there's no separate `boolean()` builder. Its default is normalized to a lowercase `true`/`false` literal, unwrapping the parenthesized form before comparing. Column-import collection maps the new `'boolean'` type to `'integer'` for its import, since `sqlite-core` has no `boolean()` export.

## Testing

Added `tests/introspect/sqlite.test.ts` -> `introspect boolean column with a literal true/false default`, reproducing the exact reported DDL (both the lowercase and all-caps `true`/`false` default forms) plus unrelated `numeric`/`integer`/`text` columns in the same table, to guard against regressing what those already scaffold correctly.

I wasn't able to get a full `pnpm install` working in my environment (an unrelated, pre-existing `drizzle-kit@0.25.0-b1faa33` self-referential devDependency pin 404s against the registry), so I verified the fix standalone: built a minimal environment with just `better-sqlite3` + the runtime deps `introspect-sqlite.ts`/`sqliteSerializer.ts` actually import, ran the exact scenario from the issue plus the additional cases now in the test file, and confirmed the generated output end-to-end. Happy to re-verify against the real `vitest` suite if a maintainer can confirm that pin is a known issue.