### PR TITLE
fix(relations): gracefully skip undefined where filter and fields in RQB v2

### DIFF
--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -345,13 +345,7 @@ export class One<
 		super(targetTable, targetTableName);
 		this.alias = config?.alias;
 		if (config && 'where' in config) {
-			if (config.where === undefined) {
-				throw new Error(
-					`Unexpected 'undefined' in filter value. Use 'EmptyFilter' if you want the filter field to be skipped.`,
-				);
-			}
-
-			this.where = config.where;
+			this.where = config.where ?? EmptyFilter;
 		} else {
 			this.where = EmptyFilter;
 		}
@@ -404,13 +398,7 @@ export class Many<TTargetTableName extends string> extends Relation<TTargetTable
 		super(targetTable, targetTableName);
 		this.alias = config?.alias;
 		if (config && 'where' in config) {
-			if (config.where === undefined) {
-				throw new Error(
-					`Unexpected 'undefined' in filter value. Use 'EmptyFilter' if you want the filter field to be skipped.`,
-				);
-			}
-
-			this.where = config.where;
+			this.where = config.where ?? EmptyFilter;
 		} else {
 			this.where = EmptyFilter;
 		}
@@ -1765,12 +1753,7 @@ function relationsFieldFilterToSQL(
 	column: SQLWrapper,
 	filter: RelationsFieldFilter<unknown> | EmptyFilter | undefined,
 ): SQL | undefined {
-	if (filter === EmptyFilter) return undefined;
-	if (filter === undefined) {
-		throw new Error(
-			`Unexpected 'undefined' in filter value. Use 'EmptyFilter' if you want the filter field to be skipped.`,
-		);
-	}
+	if (filter === EmptyFilter || filter === undefined) return undefined;
 	if (typeof filter !== 'object' || is(filter, Placeholder)) return eq(column, filter);
 
 	const entries = Object.entries(filter as RelationFieldsFilterInternals<unknown>);
@@ -1778,12 +1761,7 @@ function relationsFieldFilterToSQL(
 
 	const parts: (SQL | undefined)[] = [];
 	for (const [target, value] of entries) {
-		if (value === EmptyFilter) continue;
-		if (value === undefined) {
-			throw new Error(
-				`Unexpected 'undefined' in filter value. Use 'EmptyFilter' if you want the filter field to be skipped.`,
-			);
-		}
+		if (value === EmptyFilter || value === undefined) continue;
 
 		switch (target as keyof RelationFieldsFilterInternals<unknown>) {
 			case 'NOT': {
@@ -1884,23 +1862,13 @@ export function relationsFilterToSQL(
 	tablesRelations: TablesRelationalConfig = {},
 	depth: number = 0,
 ): SQL | undefined {
-	if (filter === EmptyFilter) return undefined;
-	if (filter === undefined) {
-		throw new Error(
-			`Unexpected 'undefined' in filter value. Use 'EmptyFilter' if you want the filter field to be skipped.`,
-		);
-	}
+	if (filter === EmptyFilter || filter === undefined) return undefined;
 	const entries = Object.entries(filter);
 	if (!entries.length) return undefined;
 
 	const parts: (SQL | undefined)[] = [];
 	for (const [target, value] of entries) {
-		if (value === EmptyFilter) continue;
-		if (value === undefined) {
-			throw new Error(
-				`Unexpected 'undefined' in filter value. Use 'EmptyFilter' if you want the filter field to be skipped.`,
-			);
-		}
+		if (value === EmptyFilter || value === undefined) continue;
 
 		switch (target) {
 			case 'RAW': {

--- a/drizzle-orm/tests/relation.test.ts
+++ b/drizzle-orm/tests/relation.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from 'vitest';
 
 import { createTableRelationsHelpers, extractTablesRelationalConfig } from '~/_relations.ts';
-import { pgSchema, pgTable } from '~/pg-core/index.ts';
+import { relationsFilterToSQL } from '~/relations.ts';
+import { pgSchema, pgTable, text } from '~/pg-core/index.ts';
 
 test('tables with same name in different schemas', () => {
 	const folder = pgSchema('folder');
@@ -33,4 +34,16 @@ test('tables with same name in different schemas', () => {
 	);
 
 	expect(Object.keys(relationsConfig)).toHaveLength(2);
+});
+
+test('relationsFilterToSQL skips undefined filter and undefined field values', () => {
+	const users = pgTable('users', {
+		name: text('name'),
+	});
+
+	// Undefined filter should return undefined
+	expect(relationsFilterToSQL(users as any, undefined)).toBeUndefined();
+
+	// Filter with undefined properties should skip them
+	expect(relationsFilterToSQL(users as any, { name: undefined } as any)).toBeUndefined();
 });


### PR DESCRIPTION
## Description
Gracefully skips \undefined\ filter objects and \undefined\ field values in relational queries (RQB v2), rather than throwing an unexpected error. This restores expected behavior when query filters contain conditionally undefined parameters without requiring explicit \EmptyFilter\ imports.

Fixes #6180