### PR TITLE
fix: brand PrimaryKeyBuilder to close empty structural type hole

### DIFF
--- a/drizzle-orm/src/cockroach-core/primary-keys.ts
+++ b/drizzle-orm/src/cockroach-core/primary-keys.ts
@@ -13,6 +13,10 @@ export function primaryKey<
 export class PrimaryKeyBuilder {
 	static readonly [entityKind]: string = 'CockroachPrimaryKeyBuilder';
 
+	declare _: {
+		brand: 'CockroachPrimaryKeyBuilder';
+	};
+
 	/** @internal */
 	columns: CockroachColumn[];
 

--- a/drizzle-orm/src/mssql-core/primary-keys.ts
+++ b/drizzle-orm/src/mssql-core/primary-keys.ts
@@ -13,6 +13,10 @@ export function primaryKey<
 export class PrimaryKeyBuilder {
 	static readonly [entityKind]: string = 'MsSqlPrimaryKeyBuilder';
 
+	declare _: {
+		brand: 'MsSqlPrimaryKeyBuilder';
+	};
+
 	/** @internal */
 	columns: MsSqlColumn[];
 

--- a/drizzle-orm/src/mysql-core/primary-keys.ts
+++ b/drizzle-orm/src/mysql-core/primary-keys.ts
@@ -25,6 +25,10 @@ export function primaryKey(...config: any) {
 export class PrimaryKeyBuilder {
 	static readonly [entityKind]: string = 'MySqlPrimaryKeyBuilder';
 
+	declare _: {
+		brand: 'MySqlPrimaryKeyBuilder';
+	};
+
 	/** @internal */
 	columns: MySqlColumn[];
 

--- a/drizzle-orm/src/pg-core/primary-keys.ts
+++ b/drizzle-orm/src/pg-core/primary-keys.ts
@@ -25,6 +25,10 @@ export function primaryKey(...config: any) {
 export class PrimaryKeyBuilder {
 	static readonly [entityKind]: string = 'PgPrimaryKeyBuilder';
 
+	declare _: {
+		brand: 'PgPrimaryKeyBuilder';
+	};
+
 	/** @internal */
 	columns: PgColumn[];
 

--- a/drizzle-orm/src/singlestore-core/primary-keys.ts
+++ b/drizzle-orm/src/singlestore-core/primary-keys.ts
@@ -25,6 +25,10 @@ export function primaryKey(...config: any) {
 export class PrimaryKeyBuilder {
 	static readonly [entityKind]: string = 'SingleStorePrimaryKeyBuilder';
 
+	declare _: {
+		brand: 'SingleStorePrimaryKeyBuilder';
+	};
+
 	/** @internal */
 	columns: SingleStoreColumn[];
 

--- a/drizzle-orm/tests/primary-keys.test.ts
+++ b/drizzle-orm/tests/primary-keys.test.ts
@@ -1,0 +1,17 @@
+import { describe, test } from 'vitest';
+import { pgTable, uuid, primaryKey, getTableConfig } from '~/pg-core/index.ts';
+
+describe('primary keys branding', () => {
+	test('primaryKey builder builds correctly and configures table', ({ expect }) => {
+		const table = pgTable('users', {
+			id: uuid('id').notNull(),
+			orgId: uuid('org_id').notNull(),
+		}, (t) => [
+			primaryKey({ columns: [t.id, t.orgId], name: 'users_pk' }),
+		]);
+
+		const config = getTableConfig(table);
+		expect(config.primaryKeys.length).toBe(1);
+		expect(config.primaryKeys[0]?.name).toBe('users_pk');
+	});
+});


### PR DESCRIPTION
Fixes #6140

## Summary

In published type definitions, PrimaryKeyBuilder had its instance properties stripped due to /** @internal */ comments, leaving it structurally empty ({}).

Consequently, arbitrary plain objects or object-wrapped builders (such as [{ myIndex: uniqueIndex(...) }] when migrating from legacy object syntax) satisfied TableExtraConfigValue without TypeScript reporting any diagnostic, which caused indexes to be silently ignored at runtime.

## Changes

- Added declare _: { brand: '<Dialect>PrimaryKeyBuilder' } to PrimaryKeyBuilder in pg-core, mysql-core, singlestore-core, cockroach-core, and mssql-core (matching sqlite-core).
- Added unit test in drizzle-orm/tests/primary-keys.test.ts.
