### PR TITLE
[Pg-kit] Ignore leaf partitions when introspecting Postgres

### DIFF
--- a/drizzle-kit/src/dialects/postgres/aws-introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/aws-introspect.ts
@@ -163,6 +163,7 @@ export const fromDatabase = async (
 		name: string;
 		/* r - table, p - partitioned table, v - view, m - materialized view */
 		kind: 'r' | 'p' | 'v' | 'm';
+		isPartition: boolean;
 		accessMethod: string;
 		options: string[] | null;
 		rlsEnabled: boolean;
@@ -177,6 +178,7 @@ export const fromDatabase = async (
                     nspname as "schema",
                     relname AS "name",
                     relkind::text AS "kind",
+                    relispartition AS "isPartition",
                     relam as "accessMethod",
                     reloptions::text[] as "options",
                     reltablespace as "tablespaceid",
@@ -208,6 +210,8 @@ export const fromDatabase = async (
 		if (!((it.kind === 'r' || it.kind === 'p') && filter({ type: 'table', schema: it.schema, name: it.name }))) {
 			return false;
 		}
+		// leaf partitions are storage of their parent, not schema objects of their own
+		if (it.isPartition) return false;
 		it.schema = trimChar(it.schema, '"'); // when camel case name e.x. mySchema -> it gets wrapped to "mySchema"
 		return true;
 	});

--- a/drizzle-kit/src/dialects/postgres/introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/introspect.ts
@@ -171,6 +171,7 @@ export const fromDatabase = async (
 		name: string;
 		/* r - table, p - partitioned table, v - view, m - materialized view */
 		kind: 'r' | 'p' | 'v' | 'm';
+		isPartition: boolean;
 		accessMethod: number | string;
 		options: string[] | null;
 		rlsEnabled: boolean;
@@ -186,6 +187,7 @@ export const fromDatabase = async (
 				nspname as "schema",
 				relname AS "name",
 				relkind::text AS "kind",
+				relispartition AS "isPartition",
 				relam as "accessMethod",
 				reloptions::text[] as "options",
 				reltablespace as "tablespaceid",
@@ -218,7 +220,12 @@ export const fromDatabase = async (
 
 	const filteredTables = tablesList.filter((it) => {
 		it.schema = trimChar(it.schema, '"'); // when camel case name e.x. mySchema -> it gets wrapped to "mySchema"
-		return it.kind === 'r' || it.kind === 'p';
+		if (it.kind !== 'r' && it.kind !== 'p') return false;
+
+		// A leaf partition is storage of its parent, not a schema object of its own. Introspecting it
+		// as an ordinary table makes pull duplicate the parent's columns and indexes, and makes push
+		// propose DROP TABLE for every partition the schema file does not know about.
+		return !it.isPartition;
 	});
 
 	const filteredTableIds = filteredTables.map((it) => it.oid);

--- a/drizzle-kit/tests/postgres/pg-tables.test.ts
+++ b/drizzle-kit/tests/postgres/pg-tables.test.ts
@@ -2,6 +2,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import { aliasedTable, SQL, sql } from 'drizzle-orm';
 import {
 	camelCase,
+	date,
 	foreignKey,
 	geometry,
 	index,
@@ -1567,4 +1568,29 @@ test('rename table with identity column', async () => {
 
 	expect(st).toStrictEqual(expectedSt);
 	expect(pst).toStrictEqual(expectedSt);
+});
+
+test('push does not drop leaf partitions it does not know about', async () => {
+	await client.exec(`CREATE TABLE logs (id integer NOT NULL, created_at date NOT NULL)
+		PARTITION BY RANGE (created_at);`);
+	await client.exec(`CREATE TABLE logs_2026_01 PARTITION OF logs
+		FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');`);
+	await client.exec(`CREATE TABLE logs_2026_02 PARTITION OF logs
+		FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');`);
+
+	const to = {
+		logs: pgTable('logs', {
+			id: integer().notNull(),
+			createdAt: date('created_at').notNull(),
+		}),
+	};
+
+	// the partitions were created by a retention job, not by drizzle; push must leave them alone
+	const { sqlStatements } = await push({ db, to, ignoreSubsequent: true });
+	expect(sqlStatements).toStrictEqual([]);
+
+	const survived = await client.query<{ count: string }>(
+		`SELECT count(*)::text FROM pg_class WHERE relname IN ('logs_2026_01', 'logs_2026_02')`,
+	);
+	expect(survived.rows[0]!.count).toBe('2');
 });

--- a/drizzle-kit/tests/postgres/pull.test.ts
+++ b/drizzle-kit/tests/postgres/pull.test.ts
@@ -1624,9 +1624,14 @@ test('introspect partitioned tables', async () => {
 			unitsales       int
 		) PARTITION BY RANGE (logdate);
 	`);
+	await db.query(`
+		CREATE TABLE measurement_y2026m01 PARTITION OF measurement
+			FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+	`);
 
 	const { tables } = await fromDatabase(db);
 
+	// the leaf partition is storage of its parent, not a table of its own
 	expect(tables).toStrictEqual([
 		{
 			name: 'measurement',


### PR DESCRIPTION
## What this fixes

A leaf partition has `relkind = 'r'`, so Postgres introspection returns it as an ordinary table. Nothing downstream knows it is a partition.

Reproduced on this branch's parent (`beta`, `drizzle-kit@1.0.0-rc.4`) with one partitioned parent and three monthly partitions, against a schema file that does not declare them:

```
tables seen by introspection: [ 'logs', 'logs_2026_01', 'logs_2026_02', 'logs_2026_03' ]

push would run:
  DROP TABLE "logs";
  DROP TABLE "logs_2026_01";
  DROP TABLE "logs_2026_02";
  DROP TABLE "logs_2026_03";
```

Two separate problems:

1. `push` proposes dropping partitions the user never declared — for the common time-range retention setup, those are created by `pg_partman` or a cron job and hold the data the partitioning exists to protect.
2. It does not even complete: dropping the parent already dropped its partitions, so the second statement aborts with `table "logs_2026_01" does not exist`, leaving the database partially migrated.

`pull` is affected the same way — it emits a `CREATE TABLE` per partition, duplicating the parent's columns and its automatically propagated indexes.

This is what was reported in #2854 ("`drizzle-kit push` seems to be blowing up").

## The fix

Filter on `relispartition` in both Postgres introspection paths (`introspect.ts` and `aws-introspect.ts`). The partitioned parent stays; its partitions are hidden. Because the child OIDs then drop out of every downstream constraint and index query, their auto-created indexes disappear from the pulled schema too.

## Scope

Deliberately narrow: this is only the bug. It does not add any way to *declare* partitioning — that is the feature request in #2854, which I have written up separately as a design proposal with a working prototype branch. This fix stands on its own and does not depend on it.

## Tests

- `tests/postgres/pull.test.ts` — the existing `introspect partitioned tables` test now creates a real leaf partition and asserts only the parent is returned.
- `tests/postgres/pg-tables.test.ts` — new `push does not drop leaf partitions it does not know about`: creates partitions outside drizzle, then asserts `push` produces no statements and both partitions survive.

Regression check on this machine: `tests/postgres` reports the same failure set as the untouched `beta` branch (those failures need a live Postgres/PostGIS container and a built `drizzle-orm/dist`), with one additional passing test. `tsc --noEmit` clean for both changed files.
