### PR TITLE
fix(pg,gel): forward the selection argument through withReplicas $with

### DIFF
--- a/drizzle-orm/src/gel-core/db.ts
+++ b/drizzle-orm/src/gel-core/db.ts
@@ -642,7 +642,7 @@ export const withReplicas = <
 	const selectDistinct: Q['selectDistinct'] = (...args: []) => getReplica(replicas).selectDistinct(...args);
 	const selectDistinctOn: Q['selectDistinctOn'] = (...args: [any]) => getReplica(replicas).selectDistinctOn(...args);
 	const _with: Q['with'] = (...args: any) => getReplica(replicas).with(...args);
-	const $with: Q['$with'] = (arg: any) => getReplica(replicas).$with(arg);
+	const $with: Q['$with'] = (...args: [any, any?]) => getReplica(replicas).$with(...args);
 
 	const update: Q['update'] = (...args: [any]) => primary.update(...args);
 	const insert: Q['insert'] = (...args: [any]) => primary.insert(...args);

--- a/drizzle-orm/src/pg-core/db.ts
+++ b/drizzle-orm/src/pg-core/db.ts
@@ -662,7 +662,7 @@ export const withReplicas = <
 	const selectDistinctOn: Q['selectDistinctOn'] = (...args: [any]) => getReplica(replicas).selectDistinctOn(...args);
 	const $count: Q['$count'] = (...args: [any]) => getReplica(replicas).$count(...args);
 	const _with: Q['with'] = (...args: any) => getReplica(replicas).with(...args);
-	const $with: Q['$with'] = (arg: any) => getReplica(replicas).$with(arg) as any;
+	const $with: Q['$with'] = (...args: [any, any?]) => getReplica(replicas).$with(...args) as any;
 
 	const update: Q['update'] = (...args: [any]) => primary.update(...args);
 	const insert: Q['insert'] = (...args: [any]) => primary.insert(...args);

--- a/integration-tests/tests/replicas/postgres.test.ts
+++ b/integration-tests/tests/replicas/postgres.test.ts
@@ -933,3 +933,31 @@ describe('[$count] read replicas postgres', () => {
 		expect(spyRead2).toHaveBeenCalledTimes(0);
 	});
 });
+
+describe('[$with] read replicas postgres', () => {
+	it('$with forwards the declared selection', () => {
+		const primaryDb = drizzle.mock();
+		const read1 = drizzle.mock();
+		const read2 = drizzle.mock();
+
+		const db = withReplicas(primaryDb, [read1, read2], () => read1);
+
+		const spyRead1 = vi.spyOn(read1, '$with');
+
+		const sq = db.$with('sq', {
+			userId: usersTable.id,
+		}).as(sql`select id from ${usersTable}`);
+
+		expect(spyRead1).toHaveBeenCalledWith('sq', { userId: usersTable.id });
+
+		// without the selection reaching the replica, every field of the CTE
+		// comes back undefined
+		expect(sq.userId).toBeDefined();
+
+		const query = db.with(sq).select({ userId: sq.userId }).from(sq);
+
+		expect(query.toSQL().sql).toEqual(
+			'with "sq" as (select id from "users") select "id" from "sq"',
+		);
+	});
+});


### PR DESCRIPTION
### What this fixes

`$with` takes `(alias, selection?)`, but the `withReplicas` wrapper forwarded only the first argument:

```ts
const $with: Q['$with'] = (arg: any) => getReplica(replicas).$with(arg) as any;
```

Every other method on that wrapper spreads its arguments — `select`, `selectDistinct`, `$count`, `with` — `$with` alone did not. So the documented "CTE from raw SQL with a declared selection" pattern silently lost its selection under `withReplicas`, and every field read off the CTE came back `undefined`.

This is the first of the three problems @shadoworion reported in #6187. I have deliberately left the other two alone — `with recursive` support and array parsing for unbound `sql` fields are separate concerns with their own design questions, and folding them in here would make a one-line fix hard to review. Happy to look at either separately.

### Scope

`pg-core` is where it was reported. `gel-core` carries the identical line and is fixed alongside it. The `mysql`, `sqlite` and `singlestore` wrappers name a `$with` variable but forward `with`, so they are a different shape and untouched here.

### Test

`integration-tests/tests/replicas/postgres.test.ts` gains a test in the existing `drizzle.mock()` style, so it needs no database. It asserts three things: that the replica's `$with` is called with **both** arguments, that a field on the resulting CTE is defined rather than `undefined`, and that the generated SQL is right.

I confirmed it actually catches the bug rather than merely passing — with the fix reverted it fails with:

```
expected "$with" to be called with arguments: [ 'sq', { userId: PgSerial{ … } } ]
Received: 'sq'
```

and the file is 36/36 green with the fix.

One note on how I ran it: `drizzle-orm`'s build script does not complete on my machine (Windows — `scripts/build.ts` exits during the zx-driven steps), and `pnpm install` at the root fails on a `drizzle-kit@0.25.0-b1faa33` devDependency that is no longer published. I installed with `--filter drizzle-orm --filter integration-tests` and ran the replica tests against `drizzle-orm/src` through a local-only vitest alias, which is not part of this PR. So the test is verified, but by that route rather than the standard one — worth a second pair of eyes on CI.
