### PR TITLE
Strip the remaining nominal members from the published declarations

### DIFF
--- a/drizzle-orm/src/cockroach-core/dialect.ts
+++ b/drizzle-orm/src/cockroach-core/dialect.ts
@@ -192,6 +192,7 @@ export class CockroachDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -311,6 +312,7 @@ export class CockroachDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -463,6 +465,7 @@ export class CockroachDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildJoins(
 		joins: CockroachSelectJoinConfig[] | undefined,
 	): SQL | undefined {
@@ -513,6 +516,7 @@ export class CockroachDialect {
 		return new SQL(joinsArray);
 	}
 
+	/** @internal */
 	private buildFromTable(
 		table: SQL | Subquery | CockroachViewBase | CockroachTable | undefined,
 	): SQL | Subquery | CockroachViewBase | CockroachTable | undefined {
@@ -897,6 +901,7 @@ export class CockroachDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -974,6 +979,7 @@ export class CockroachDialect {
 		return output;
 	}
 
+	/** @internal */
 	private getSelectedTableColumns = (
 		table: Table | View,
 		columns: Record<string, boolean | undefined>,
@@ -1009,6 +1015,7 @@ export class CockroachDialect {
 		return selectedColumns;
 	};
 
+	/** @internal */
 	private buildColumns = (
 		table: Table | View,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/cockroach-core/query-builders/query.ts
+++ b/drizzle-orm/src/cockroach-core/query-builders/query.ts
@@ -22,13 +22,34 @@ export class RelationalQueryBuilder<
 > {
 	static readonly [entityKind]: string = 'CockroachRelationalQueryBuilderV2';
 
+	/** @internal */
+	private schema: TSchema;
+
+	/** @internal */
+	private table: CockroachTable;
+
+	/** @internal */
+	private tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	private dialect: CockroachDialect;
+
+	/** @internal */
+	private session: CockroachSession;
+
 	constructor(
-		private schema: TSchema,
-		private table: CockroachTable,
-		private tableConfig: TableRelationalConfig,
-		private dialect: CockroachDialect,
-		private session: CockroachSession,
-	) {}
+		schema: TSchema,
+		table: CockroachTable,
+		tableConfig: TableRelationalConfig,
+		dialect: CockroachDialect,
+		session: CockroachSession,
+	) {
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+	}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
@@ -72,18 +93,47 @@ export class CockroachRelationalQuery<TResult> extends QueryPromise<TResult>
 		readonly result: TResult;
 	};
 
+	/** @internal */
+	protected schema: TablesRelationalConfig;
+
+	/** @internal */
+	protected table: CockroachTable;
+
+	/** @internal */
+	protected tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	protected dialect: CockroachDialect;
+
+	/** @internal */
+	protected session: CockroachSession;
+
+	/** @internal */
+	protected config: DBQueryConfig<'many' | 'one'> | true;
+
+	/** @internal */
+	protected mode: 'many' | 'first';
+
 	constructor(
-		protected schema: TablesRelationalConfig,
-		protected table: CockroachTable,
-		protected tableConfig: TableRelationalConfig,
-		protected dialect: CockroachDialect,
-		protected session: CockroachSession,
-		protected config: DBQueryConfig<'many' | 'one'> | true,
-		protected mode: 'many' | 'first',
+		schema: TablesRelationalConfig,
+		table: CockroachTable,
+		tableConfig: TableRelationalConfig,
+		dialect: CockroachDialect,
+		session: CockroachSession,
+		config: DBQueryConfig<'many' | 'one'> | true,
+		mode: 'many' | 'first',
 	) {
 		super();
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+		this.config = config;
+		this.mode = mode;
 	}
 
+	/** @internal */
 	protected _getQuery() {
 		return this.dialect.buildRelationalQuery({
 			schema: this.schema,
@@ -98,6 +148,7 @@ export class CockroachRelationalQuery<TResult> extends QueryPromise<TResult>
 		return this._getQuery().sql;
 	}
 
+	/** @internal */
 	protected _toSQL(): { query: BuildRelationalQueryResult; builtQuery: Query } {
 		const query = this._getQuery();
 

--- a/drizzle-orm/src/cockroach-core/view.ts
+++ b/drizzle-orm/src/cockroach-core/view.ts
@@ -18,10 +18,19 @@ export class DefaultViewBuilderCore<TConfig extends { name: string; columns?: un
 		readonly columns: TConfig['columns'];
 	};
 
+	/** @internal */
+	protected name: TConfig['name'];
+
+	/** @internal */
+	protected schema: string | undefined;
+
 	constructor(
-		protected name: TConfig['name'],
-		protected schema: string | undefined,
-	) {}
+		name: TConfig['name'],
+		schema: string | undefined,
+	) {
+		this.name = name;
+		this.schema = schema;
+	}
 }
 
 export class ViewBuilder<TName extends string = string> extends DefaultViewBuilderCore<{ name: TName }> {
@@ -60,6 +69,7 @@ export class ManualViewBuilder<
 > extends DefaultViewBuilderCore<{ name: TName; columns: TColumns }> {
 	static override readonly [entityKind]: string = 'CockroachManualViewBuilder';
 
+	/** @internal */
 	private columns: Record<string, CockroachColumn>;
 
 	constructor(
@@ -119,11 +129,21 @@ export class MaterializedViewBuilderCore<TConfig extends { name: string; columns
 		readonly columns: TConfig['columns'];
 	};
 
-	constructor(
-		protected name: TConfig['name'],
-		protected schema: string | undefined,
-	) {}
+	/** @internal */
+	protected name: TConfig['name'];
 
+	/** @internal */
+	protected schema: string | undefined;
+
+	constructor(
+		name: TConfig['name'],
+		schema: string | undefined,
+	) {
+		this.name = name;
+		this.schema = schema;
+	}
+
+	/** @internal */
 	protected config: {
 		withNoData?: boolean;
 	} = {};
@@ -183,6 +203,7 @@ export class ManualMaterializedViewBuilder<
 > extends MaterializedViewBuilderCore<{ name: TName; columns: TColumns }> {
 	static override readonly [entityKind]: string = 'CockroachManualMaterializedViewBuilder';
 
+	/** @internal */
 	private columns: Record<string, CockroachColumn>;
 
 	constructor(

--- a/drizzle-orm/src/cockroach-core/view.ts
+++ b/drizzle-orm/src/cockroach-core/view.ts
@@ -274,6 +274,7 @@ export class CockroachMaterializedView<
 > extends CockroachViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'CockroachMaterializedView';
 
+	/** @internal */
 	readonly [CockroachMaterializedViewConfig]: {
 		readonly withNoData?: boolean;
 	} | undefined;

--- a/drizzle-orm/src/codecs.ts
+++ b/drizzle-orm/src/codecs.ts
@@ -62,7 +62,15 @@ const itemToArrayTypeCodecNameMap = {
 export class CodecsCollection<TTypeSet extends string = string> {
 	static readonly [entityKind]: string = 'CodecsCollection';
 
-	constructor(protected resolveTypes: (type: string) => string, readonly codecs: Codecs<TTypeSet> = noopCodecs) {}
+	// Declared rather than left as a constructor parameter property so the `@internal`
+	// marker lands on the member itself; on a parameter it survives into the emitted
+	// constructor signature as a stray comment.
+	/** @internal */
+	protected resolveTypes: (type: string) => string;
+
+	constructor(resolveTypes: (type: string) => string, readonly codecs: Codecs<TTypeSet> = noopCodecs) {
+		this.resolveTypes = resolveTypes;
+	}
 
 	get<TCodecType extends keyof Codec>(
 		column: Column,

--- a/drizzle-orm/src/mssql-core/dialect.ts
+++ b/drizzle-orm/src/mssql-core/dialect.ts
@@ -304,6 +304,7 @@ export class MsSqlDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -456,6 +457,7 @@ export class MsSqlDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildSelectionOutput(
 		fields: SelectedFieldsOrdered,
 		{ type, ignoreCastCodecs = false }: { type: 'INSERTED' | 'DELETED'; ignoreCastCodecs?: boolean },
@@ -950,6 +952,7 @@ export class MsSqlDialect {
 		return res;
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -1025,6 +1028,7 @@ export class MsSqlDialect {
 		return output;
 	}
 
+	/** @internal */
 	private getSelectedTableColumns = (
 		table: Table | View,
 		columns: Record<string, boolean | undefined>,
@@ -1060,6 +1064,7 @@ export class MsSqlDialect {
 		return selectedColumns;
 	};
 
+	/** @internal */
 	private buildColumns = (
 		table: Table | View,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/mssql-core/query-builders/query.ts
+++ b/drizzle-orm/src/mssql-core/query-builders/query.ts
@@ -23,13 +23,34 @@ export class RelationalQueryBuilder<
 > {
 	static readonly [entityKind]: string = 'MsSqlRelationalQueryBuilderV2';
 
+	/** @internal */
+	private schema: TSchema;
+
+	/** @internal */
+	private table: MsSqlTable;
+
+	/** @internal */
+	private tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	private dialect: MsSqlDialect;
+
+	/** @internal */
+	private session: MsSqlSession;
+
 	constructor(
-		private schema: TSchema,
-		private table: MsSqlTable,
-		private tableConfig: TableRelationalConfig,
-		private dialect: MsSqlDialect,
-		private session: MsSqlSession,
-	) {}
+		schema: TSchema,
+		table: MsSqlTable,
+		tableConfig: TableRelationalConfig,
+		dialect: MsSqlDialect,
+		session: MsSqlSession,
+	) {
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+	}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
@@ -73,20 +94,50 @@ export class MsSqlRelationalQuery<TPreparedQueryHKT extends PreparedQueryHKTBase
 		readonly result: TResult;
 	};
 
+	/** @internal */
 	declare protected $brand: 'MsSqlRelationalQuery';
 
+	/** @internal */
+	protected schema: TablesRelationalConfig;
+
+	/** @internal */
+	protected table: MsSqlTable;
+
+	/** @internal */
+	protected tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	protected dialect: MsSqlDialect;
+
+	/** @internal */
+	protected session: MsSqlSession;
+
+	/** @internal */
+	protected config: DBQueryConfig<'many' | 'one'> | true;
+
+	/** @internal */
+	protected mode: 'many' | 'first';
+
 	constructor(
-		protected schema: TablesRelationalConfig,
-		protected table: MsSqlTable,
-		protected tableConfig: TableRelationalConfig,
-		protected dialect: MsSqlDialect,
-		protected session: MsSqlSession,
-		protected config: DBQueryConfig<'many' | 'one'> | true,
-		protected mode: 'many' | 'first',
+		schema: TablesRelationalConfig,
+		table: MsSqlTable,
+		tableConfig: TableRelationalConfig,
+		dialect: MsSqlDialect,
+		session: MsSqlSession,
+		config: DBQueryConfig<'many' | 'one'> | true,
+		mode: 'many' | 'first',
 	) {
 		super();
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+		this.config = config;
+		this.mode = mode;
 	}
 
+	/** @internal */
 	protected _getQuery() {
 		return this.dialect.buildRelationalQuery({
 			schema: this.schema,
@@ -101,6 +152,7 @@ export class MsSqlRelationalQuery<TPreparedQueryHKT extends PreparedQueryHKTBase
 		return this._getQuery().sql;
 	}
 
+	/** @internal */
 	protected _toSQL(): { query: BuildRelationalQueryResult; builtQuery: Query } {
 		const query = this._getQuery();
 

--- a/drizzle-orm/src/mssql-core/view.ts
+++ b/drizzle-orm/src/mssql-core/view.ts
@@ -28,11 +28,21 @@ export class ViewBuilderCore<TConfig extends { name: string; columns?: unknown }
 		readonly columns: TConfig['columns'];
 	};
 
-	constructor(
-		protected name: TConfig['name'],
-		protected schema: string | undefined,
-	) {}
+	/** @internal */
+	protected name: TConfig['name'];
 
+	/** @internal */
+	protected schema: string | undefined;
+
+	constructor(
+		name: TConfig['name'],
+		schema: string | undefined,
+	) {
+		this.name = name;
+		this.schema = schema;
+	}
+
+	/** @internal */
 	protected config: ViewBuilderConfig = {
 		encryption: false,
 		schemaBinding: false,
@@ -87,6 +97,7 @@ export class ManualViewBuilder<
 > extends ViewBuilderCore<{ name: TName; columns: TColumns }> {
 	static override readonly [entityKind]: string = 'MsSqlManualViewBuilder';
 
+	/** @internal */
 	private columns: Record<string, MsSqlColumn>;
 
 	constructor(

--- a/drizzle-orm/src/mssql-core/view.ts
+++ b/drizzle-orm/src/mssql-core/view.ts
@@ -149,8 +149,10 @@ export class MsSqlView<
 > extends MsSqlViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'MsSqlView';
 
+	/** @internal */
 	declare protected $MsSqlViewBrand: 'MsSqlView';
 
+	/** @internal */
 	[MsSqlViewConfig]: ViewBuilderConfig | undefined;
 
 	constructor({ mssqlConfig, config }: {

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -103,6 +103,7 @@ export class MySqlDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -206,6 +207,7 @@ export class MySqlDialect {
 	 * `select <selection> from`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -358,6 +360,7 @@ export class MySqlDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildLimit(limit: number | Placeholder | undefined): SQL | undefined {
 		return typeof limit === 'object'
 				|| (typeof limit === 'number' && limit >= 0)
@@ -366,6 +369,7 @@ export class MySqlDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildOrderBy(
 		orderBy: (MySqlColumn | SQL | SQL.Aliased)[] | undefined,
 	): SQL | undefined {
@@ -374,6 +378,7 @@ export class MySqlDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildIndex({
 		indexes,
 		indexFor,
@@ -823,6 +828,7 @@ export class MySqlDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -898,6 +904,7 @@ export class MySqlDialect {
 		return output;
 	}
 
+	/** @internal */
 	private buildColumns = (
 		table: Table | View,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/mysql-core/query-builders/query.ts
+++ b/drizzle-orm/src/mysql-core/query-builders/query.ts
@@ -35,14 +35,39 @@ export class RelationalQueryBuilder<
 > {
 	static readonly [entityKind]: string = 'MySqlRelationalQueryBuilderV2';
 
+	/** @internal */
+	private schema: TSchema;
+
+	/** @internal */
+	private table: MySqlTable | MySqlView;
+
+	/** @internal */
+	private tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	private dialect: MySqlDialect;
+
+	/** @internal */
+	private session: MySqlSession;
+
+	/** @internal */
+	private builder: MySqlRelationalQueryConstructor;
+
 	constructor(
-		private schema: TSchema,
-		private table: MySqlTable | MySqlView,
-		private tableConfig: TableRelationalConfig,
-		private dialect: MySqlDialect,
-		private session: MySqlSession,
-		private builder: MySqlRelationalQueryConstructor = MySqlRelationalQuery,
-	) {}
+		schema: TSchema,
+		table: MySqlTable | MySqlView,
+		tableConfig: TableRelationalConfig,
+		dialect: MySqlDialect,
+		session: MySqlSession,
+		builder: MySqlRelationalQueryConstructor = MySqlRelationalQuery,
+	) {
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+		this.builder = builder;
+	}
 
 	findMany<TConfig extends DBQueryConfigWithComment<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfigWithComment<'many', TSchema, TFields>>,
@@ -100,18 +125,49 @@ export class MySqlRelationalQuery<THKT extends MySqlRelationalQueryHKTBase, TRes
 		readonly result: TResult;
 	};
 
+	/** @internal */
 	declare protected $brand: 'MySqlRelationalQuery';
 
-	constructor(
-		protected schema: TablesRelationalConfig,
-		protected table: MySqlTable | MySqlView,
-		protected tableConfig: TableRelationalConfig,
-		protected dialect: MySqlDialect,
-		protected session: MySqlSession,
-		protected config: DBQueryConfigWithComment<'many' | 'one'> | true,
-		protected mode: 'many' | 'first',
-	) {}
+	/** @internal */
+	protected schema: TablesRelationalConfig;
 
+	/** @internal */
+	protected table: MySqlTable | MySqlView;
+
+	/** @internal */
+	protected tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	protected dialect: MySqlDialect;
+
+	/** @internal */
+	protected session: MySqlSession;
+
+	/** @internal */
+	protected config: DBQueryConfigWithComment<'many' | 'one'> | true;
+
+	/** @internal */
+	protected mode: 'many' | 'first';
+
+	constructor(
+		schema: TablesRelationalConfig,
+		table: MySqlTable | MySqlView,
+		tableConfig: TableRelationalConfig,
+		dialect: MySqlDialect,
+		session: MySqlSession,
+		config: DBQueryConfigWithComment<'many' | 'one'> | true,
+		mode: 'many' | 'first',
+	) {
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+		this.config = config;
+		this.mode = mode;
+	}
+
+	/** @internal */
 	protected _getQuery() {
 		return this.dialect.buildRelationalQuery({
 			schema: this.schema,
@@ -122,6 +178,7 @@ export class MySqlRelationalQuery<THKT extends MySqlRelationalQueryHKTBase, TRes
 		});
 	}
 
+	/** @internal */
 	protected _toSQL(): { query: BuildRelationalQueryResult; builtQuery: Query } {
 		const query = this._getQuery();
 

--- a/drizzle-orm/src/mysql-core/view.ts
+++ b/drizzle-orm/src/mysql-core/view.ts
@@ -26,11 +26,21 @@ export class ViewBuilderCore<TConfig extends { name: string; columns?: unknown }
 		readonly columns: TConfig['columns'];
 	};
 
-	constructor(
-		protected name: TConfig['name'],
-		protected schema: string | undefined,
-	) {}
+	/** @internal */
+	protected name: TConfig['name'];
 
+	/** @internal */
+	protected schema: string | undefined;
+
+	constructor(
+		name: TConfig['name'],
+		schema: string | undefined,
+	) {
+		this.name = name;
+		this.schema = schema;
+	}
+
+	/** @internal */
 	protected config: ViewBuilderConfig = {};
 
 	algorithm(
@@ -92,6 +102,7 @@ export class ManualViewBuilder<
 > extends ViewBuilderCore<{ name: TName; columns: TColumns }> {
 	static override readonly [entityKind]: string = 'MySqlManualViewBuilder';
 
+	/** @internal */
 	private columns: Record<string, MySqlColumn>;
 
 	constructor(

--- a/drizzle-orm/src/mysql-core/view.ts
+++ b/drizzle-orm/src/mysql-core/view.ts
@@ -156,8 +156,10 @@ export class MySqlView<
 > extends MySqlViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'MySqlView';
 
+	/** @internal */
 	declare protected $MySqlViewBrand: 'MySqlView';
 
+	/** @internal */
 	[MySqlViewConfig]: ViewBuilderConfig | undefined;
 
 	constructor({ mysqlConfig, config }: {

--- a/drizzle-orm/src/pg-core/async/query.ts
+++ b/drizzle-orm/src/pg-core/async/query.ts
@@ -19,6 +19,7 @@ export class PgAsyncRelationalQuery<TResult> extends PgRelationalQuery<PgAsyncRe
 {
 	static override readonly [entityKind]: string = 'PgAsyncRelationalQueryV2';
 
+	/** @internal */
 	declare protected session: PgAsyncSession;
 
 	/** @internal */

--- a/drizzle-orm/src/pg-core/async/session.ts
+++ b/drizzle-orm/src/pg-core/async/session.ts
@@ -26,25 +26,49 @@ export class PgAsyncPreparedQuery<T extends PreparedQueryConfig> extends PgBaseP
 		body?: string;
 	} | undefined;
 
+	/** @internal */
 	private fastPath: boolean;
 
+	/** @internal */
+	protected executor: (params?: unknown[]) => Promise<any>;
+
+	/** @internal */
+	protected logger: Logger;
+
+	/** @internal */
+	protected cache: Cache | undefined;
+
+	/** @internal */
+	protected queryMetadata: {
+		type: 'select' | 'update' | 'delete' | 'insert';
+		tables: string[];
+	} | undefined;
+
+	/** @internal */
+	protected cacheConfig: WithCacheConfig | undefined;
+
 	constructor(
-		protected executor: (params?: unknown[]) => Promise<any>,
+		executor: (params?: unknown[]) => Promise<any>,
 		query: Query,
 		mapper: ((rows: any[]) => any) | undefined,
 		readonly mode: 'arrays' | 'objects' | 'raw',
-		protected logger: Logger,
+		logger: Logger,
 		// cache instance
-		protected cache: Cache | undefined,
+		cache: Cache | undefined,
 		// per query related metadata
-		protected queryMetadata: {
+		queryMetadata: {
 			type: 'select' | 'update' | 'delete' | 'insert';
 			tables: string[];
 		} | undefined,
 		// config that was passed through $withCache
-		protected cacheConfig: WithCacheConfig | undefined,
+		cacheConfig: WithCacheConfig | undefined,
 	) {
 		super(query);
+		this.executor = executor;
+		this.logger = logger;
+		this.cache = cache;
+		this.queryMetadata = queryMetadata;
+		this.cacheConfig = cacheConfig;
 		this.mapper = mapper;
 		if (cache && cache.strategy() === 'all' && cacheConfig === undefined) {
 			this.cacheConfig = { enabled: true, autoInvalidate: true };
@@ -237,14 +261,18 @@ export abstract class PgAsyncTransaction<
 > extends PgAsyncDatabase<TQueryResult, TRelations> {
 	static override readonly [entityKind]: string = 'PgAsyncTransaction';
 
+	/** @internal */
+	protected readonly nestedIndex: number;
+
 	constructor(
 		dialect: PgDialect,
 		session: PgAsyncSession<any, any>,
 		relations: TRelations,
-		protected readonly nestedIndex = 0,
+		nestedIndex = 0,
 		parseRqbJson: boolean | undefined,
 	) {
 		super(dialect, session, relations, parseRqbJson);
+		this.nestedIndex = nestedIndex;
 	}
 
 	rollback(): never {

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -175,8 +175,10 @@ export abstract class PgColumnBuilder<
 
 	declare readonly _: T;
 
+	/** @internal */
 	private foreignKeyConfigs: ReferenceConfig[] = [];
 
+	/** @internal */
 	protected config: PgColumnBuilderRuntimeConfig<T['data']> & TRuntimeConfig;
 
 	constructor(name: string, dataType: ColumnType, columnType: string) {
@@ -502,6 +504,7 @@ type PgColumnConstructor = new(table: PgTable, config: any) => PgColumn;
 export class PgClonedColumnBuilder extends PgColumnBuilder {
 	static override readonly [entityKind]: string = 'PgClonedColumnBuilder';
 
+	/** @internal */
 	private readonly ColumnClass: PgColumnConstructor;
 
 	constructor(config: PgColumnBuilderRuntimeConfig<unknown>, ColumnClass: PgColumnConstructor) {

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -99,6 +99,7 @@ export class PgDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -224,6 +225,7 @@ export class PgDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -376,6 +378,7 @@ export class PgDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildJoins(joins: PgSelectJoinConfig[] | undefined): SQL | undefined {
 		if (!joins || joins.length === 0) {
 			return undefined;
@@ -424,6 +427,7 @@ export class PgDialect {
 		return new SQL(joinsArray);
 	}
 
+	/** @internal */
 	private buildFromTable(
 		table: SQL | Subquery | PgViewBase | PgTable | undefined,
 	): SQL | Subquery | PgViewBase | PgTable | undefined {
@@ -812,6 +816,7 @@ export class PgDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -888,6 +893,7 @@ export class PgDialect {
 		return output;
 	}
 
+	/** @internal */
 	private buildColumns = (
 		table: Table | View,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/pg-core/query-builders/query.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query.ts
@@ -35,15 +35,44 @@ export class RelationalQueryBuilder<
 > {
 	static readonly [entityKind]: string = 'PgRelationalQueryBuilderV2';
 
+	/** @internal */
+	private schema: TSchema;
+
+	/** @internal */
+	private table: PgTable;
+
+	/** @internal */
+	private tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	private dialect: PgDialect;
+
+	/** @internal */
+	private session: PgSession;
+
+	/** @internal */
+	private parseJson: boolean;
+
+	/** @internal */
+	private builder: PgRelationalQueryConstructor;
+
 	constructor(
-		private schema: TSchema,
-		private table: PgTable,
-		private tableConfig: TableRelationalConfig,
-		private dialect: PgDialect,
-		private session: PgSession,
-		private parseJson: boolean,
-		private builder: PgRelationalQueryConstructor = PgRelationalQuery,
-	) {}
+		schema: TSchema,
+		table: PgTable,
+		tableConfig: TableRelationalConfig,
+		dialect: PgDialect,
+		session: PgSession,
+		parseJson: boolean,
+		builder: PgRelationalQueryConstructor = PgRelationalQuery,
+	) {
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+		this.parseJson = parseJson;
+		this.builder = builder;
+	}
 
 	findMany<TConfig extends DBQueryConfigWithComment<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfigWithComment<'many', TSchema, TFields>>,
@@ -107,17 +136,51 @@ export class PgRelationalQuery<THKT extends PgRelationalQueryHKTBase, TResult> i
 		readonly result: TResult;
 	};
 
-	constructor(
-		protected schema: TablesRelationalConfig,
-		protected table: PgTable,
-		protected tableConfig: TableRelationalConfig,
-		protected dialect: PgDialect,
-		protected session: PgSession,
-		protected config: DBQueryConfigWithComment<'many' | 'one'> | true,
-		protected mode: 'many' | 'first',
-		protected parseJson: boolean,
-	) {}
+	/** @internal */
+	protected schema: TablesRelationalConfig;
 
+	/** @internal */
+	protected table: PgTable;
+
+	/** @internal */
+	protected tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	protected dialect: PgDialect;
+
+	/** @internal */
+	protected session: PgSession;
+
+	/** @internal */
+	protected config: DBQueryConfigWithComment<'many' | 'one'> | true;
+
+	/** @internal */
+	protected mode: 'many' | 'first';
+
+	/** @internal */
+	protected parseJson: boolean;
+
+	constructor(
+		schema: TablesRelationalConfig,
+		table: PgTable,
+		tableConfig: TableRelationalConfig,
+		dialect: PgDialect,
+		session: PgSession,
+		config: DBQueryConfigWithComment<'many' | 'one'> | true,
+		mode: 'many' | 'first',
+		parseJson: boolean,
+	) {
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+		this.config = config;
+		this.mode = mode;
+		this.parseJson = parseJson;
+	}
+
+	/** @internal */
 	protected _getQuery() {
 		return this.dialect.buildRelationalQuery({
 			schema: this.schema,
@@ -132,6 +195,7 @@ export class PgRelationalQuery<THKT extends PgRelationalQueryHKTBase, TResult> i
 		return this._getQuery().sql;
 	}
 
+	/** @internal */
 	protected _toSQL(): { query: BuildRelationalQueryResult; builtQuery: Query } {
 		const query = this._getQuery();
 

--- a/drizzle-orm/src/pg-core/session.ts
+++ b/drizzle-orm/src/pg-core/session.ts
@@ -11,9 +11,14 @@ export interface PreparedQueryConfig {
 export abstract class PgBasePreparedQuery implements PreparedQuery {
 	static readonly [entityKind]: string = 'PgBasePreparedQuery';
 
+	/** @internal */
+	protected query: Query;
+
 	constructor(
-		protected query: Query,
-	) {}
+		query: Query,
+	) {
+		this.query = query;
+	}
 
 	getQuery(): Query {
 		return this.query;
@@ -41,7 +46,12 @@ export type PgTransactionConfig =
 export abstract class PgSession {
 	static readonly [entityKind]: string = 'PgSession';
 
-	constructor(protected dialect: PgDialect) {}
+	/** @internal */
+	protected dialect: PgDialect;
+
+	constructor(dialect: PgDialect) {
+		this.dialect = dialect;
+	}
 
 	abstract prepareQuery(
 		query: Query,

--- a/drizzle-orm/src/pg-core/view.ts
+++ b/drizzle-orm/src/pg-core/view.ts
@@ -26,11 +26,21 @@ export class DefaultViewBuilderCore<TConfig extends { name: string; columns?: un
 		readonly columns: TConfig['columns'];
 	};
 
-	constructor(
-		protected name: TConfig['name'],
-		protected schema: string | undefined,
-	) {}
+	/** @internal */
+	protected name: TConfig['name'];
 
+	/** @internal */
+	protected schema: string | undefined;
+
+	constructor(
+		name: TConfig['name'],
+		schema: string | undefined,
+	) {
+		this.name = name;
+		this.schema = schema;
+	}
+
+	/** @internal */
 	protected config: {
 		with?: ViewWithConfig;
 	} = {};
@@ -78,6 +88,7 @@ export class ManualViewBuilder<
 > extends DefaultViewBuilderCore<{ name: TName; columns: TColumns }> {
 	static override readonly [entityKind]: string = 'PgManualViewBuilder';
 
+	/** @internal */
 	private columns: Record<string, PgColumn>;
 
 	constructor(
@@ -160,11 +171,21 @@ export class MaterializedViewBuilderCore<TConfig extends { name: string; columns
 		readonly columns: TConfig['columns'];
 	};
 
-	constructor(
-		protected name: TConfig['name'],
-		protected schema: string | undefined,
-	) {}
+	/** @internal */
+	protected name: TConfig['name'];
 
+	/** @internal */
+	protected schema: string | undefined;
+
+	constructor(
+		name: TConfig['name'],
+		schema: string | undefined,
+	) {
+		this.name = name;
+		this.schema = schema;
+	}
+
+	/** @internal */
 	protected config: {
 		with?: PgMaterializedViewWithConfig;
 		using?: string;
@@ -237,6 +258,7 @@ export class ManualMaterializedViewBuilder<
 > extends MaterializedViewBuilderCore<{ name: TName; columns: TColumns }> {
 	static override readonly [entityKind]: string = 'PgManualMaterializedViewBuilder';
 
+	/** @internal */
 	private columns: Record<string, PgColumn>;
 
 	constructor(

--- a/drizzle-orm/src/pg-core/view.ts
+++ b/drizzle-orm/src/pg-core/view.ts
@@ -307,6 +307,7 @@ export class PgView<
 > extends PgViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'PgView';
 
+	/** @internal */
 	[PgViewConfig]: {
 		with?: ViewWithConfig;
 	} | undefined;
@@ -344,6 +345,7 @@ export class PgMaterializedView<
 > extends PgViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'PgMaterializedView';
 
+	/** @internal */
 	readonly [PgMaterializedViewConfig]: {
 		readonly with?: PgMaterializedViewWithConfig;
 		readonly using?: string;

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -330,6 +330,7 @@ export class One<
 	TOptional extends boolean = boolean,
 > extends Relation<TTargetTableName> {
 	static override readonly [entityKind]: string = 'OneV2';
+	/** @internal */
 	declare protected $relationBrand: 'OneV2';
 
 	public override readonly relationType = 'one' as const;
@@ -391,6 +392,7 @@ export type AnyOne = One<string, boolean>;
 
 export class Many<TTargetTableName extends string> extends Relation<TTargetTableName> {
 	static override readonly [entityKind]: string = 'ManyV2';
+	/** @internal */
 	declare protected $relationBrand: 'ManyV2';
 
 	public override readonly relationType = 'many' as const;
@@ -455,6 +457,7 @@ export abstract class AggregatedField<T = unknown> implements SQLWrapper<T> {
 		readonly data: T;
 	};
 
+	/** @internal */
 	protected table: SchemaEntry | undefined;
 
 	onTable(table: SchemaEntry) {
@@ -469,8 +472,10 @@ export abstract class AggregatedField<T = unknown> implements SQLWrapper<T> {
 export class Count extends AggregatedField<number> {
 	static override readonly [entityKind]: string = 'AggregatedFieldCount';
 
+	/** @internal */
 	declare protected $aggregatedFieldBrand: 'Count';
 
+	/** @internal */
 	private query: SQL<number> | undefined;
 
 	getSQL(): SQL<number> {
@@ -1320,6 +1325,7 @@ export function makeJitRqbMapper<T = unknown>(
 export class RelationsBuilderTable<TTableName extends string = string> {
 	static readonly [entityKind]: string = 'RelationsBuilderTable';
 
+	/** @internal */
 	protected readonly _: {
 		readonly name: TTableName;
 		readonly table: SchemaEntry;

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -175,6 +175,7 @@ export class SingleStoreDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -290,6 +291,7 @@ export class SingleStoreDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -442,6 +444,7 @@ export class SingleStoreDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildLimit(limit: number | Placeholder | undefined): SQL | undefined {
 		return typeof limit === 'object'
 				|| (typeof limit === 'number' && limit >= 0)
@@ -449,6 +452,7 @@ export class SingleStoreDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildOrderBy(
 		orderBy: (SingleStoreColumn | SQL | SQL.Aliased)[] | undefined,
 	): SQL | undefined {
@@ -816,6 +820,7 @@ export class SingleStoreDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -891,6 +896,7 @@ export class SingleStoreDialect {
 		return output;
 	}
 
+	/** @internal */
 	private getSelectedTableColumns = (
 		table: Table | View,
 		columns: Record<string, boolean | undefined>,
@@ -928,6 +934,7 @@ export class SingleStoreDialect {
 		return selectedColumns;
 	};
 
+	/** @internal */
 	private buildColumns = (
 		table: SingleStoreTable | SingleStoreView,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/singlestore-core/query-builders/query.ts
+++ b/drizzle-orm/src/singlestore-core/query-builders/query.ts
@@ -27,13 +27,34 @@ export class RelationalQueryBuilder<
 > {
 	static readonly [entityKind]: string = 'SingleStoreRelationalQueryBuilderV2';
 
+	/** @internal */
+	private schema: TSchema;
+
+	/** @internal */
+	private table: SingleStoreTable | SingleStoreView;
+
+	/** @internal */
+	private tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	private dialect: SingleStoreDialect;
+
+	/** @internal */
+	private session: SingleStoreSession;
+
 	constructor(
-		private schema: TSchema,
-		private table: SingleStoreTable | SingleStoreView,
-		private tableConfig: TableRelationalConfig,
-		private dialect: SingleStoreDialect,
-		private session: SingleStoreSession,
-	) {}
+		schema: TSchema,
+		table: SingleStoreTable | SingleStoreView,
+		tableConfig: TableRelationalConfig,
+		dialect: SingleStoreDialect,
+		session: SingleStoreSession,
+	) {
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+	}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
@@ -73,18 +94,47 @@ export class SingleStoreRelationalQuery<
 	/** @internal */
 	protected mapper?: RelationalRowsMapper;
 
+	/** @internal */
 	declare protected $brand: 'SingleStoreRelationalQuery';
 
+	/** @internal */
+	private schema: TablesRelationalConfig;
+
+	/** @internal */
+	private table: SingleStoreTable | SingleStoreView;
+
+	/** @internal */
+	private tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	private dialect: SingleStoreDialect;
+
+	/** @internal */
+	private session: SingleStoreSession;
+
+	/** @internal */
+	private config: DBQueryConfig<'many' | 'one'> | true;
+
+	/** @internal */
+	private mode: 'many' | 'first';
+
 	constructor(
-		private schema: TablesRelationalConfig,
-		private table: SingleStoreTable | SingleStoreView,
-		private tableConfig: TableRelationalConfig,
-		private dialect: SingleStoreDialect,
-		private session: SingleStoreSession,
-		private config: DBQueryConfig<'many' | 'one'> | true,
-		private mode: 'many' | 'first',
+		schema: TablesRelationalConfig,
+		table: SingleStoreTable | SingleStoreView,
+		tableConfig: TableRelationalConfig,
+		dialect: SingleStoreDialect,
+		session: SingleStoreSession,
+		config: DBQueryConfig<'many' | 'one'> | true,
+		mode: 'many' | 'first',
 	) {
 		super();
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+		this.config = config;
+		this.mode = mode;
 	}
 
 	prepare() {
@@ -102,6 +152,7 @@ export class SingleStoreRelationalQuery<
 		) as PreparedQueryKind<TPreparedQueryHKT, SingleStorePreparedQueryConfig & { execute: TResult }, true>;
 	}
 
+	/** @internal */
 	private _getQuery() {
 		return this.dialect.buildRelationalQuery({
 			schema: this.schema,
@@ -112,6 +163,7 @@ export class SingleStoreRelationalQuery<
 		});
 	}
 
+	/** @internal */
 	private _toSQL(): { query: BuildRelationalQueryResult; builtQuery: Query } {
 		const query = this._getQuery();
 

--- a/drizzle-orm/src/singlestore-core/view.ts
+++ b/drizzle-orm/src/singlestore-core/view.ts
@@ -159,8 +159,10 @@ export class SingleStoreView<
 > extends SingleStoreViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'SingleStoreView';
 
+	/** @internal */
 	declare protected $SingleStoreViewBrand: 'SingleStoreView';
 
+	/** @internal */
 	[SingleStoreViewConfig]: ViewBuilderConfig | undefined;
 
 	constructor({ singlestoreConfig, config }: {

--- a/drizzle-orm/src/singlestore-core/view.ts
+++ b/drizzle-orm/src/singlestore-core/view.ts
@@ -27,11 +27,21 @@ export class ViewBuilderCore<TConfig extends { name: string; columns?: unknown }
 		readonly columns: TConfig['columns'];
 	};
 
-	constructor(
-		protected name: TConfig['name'],
-		protected schema: string | undefined,
-	) {}
+	/** @internal */
+	protected name: TConfig['name'];
 
+	/** @internal */
+	protected schema: string | undefined;
+
+	constructor(
+		name: TConfig['name'],
+		schema: string | undefined,
+	) {
+		this.name = name;
+		this.schema = schema;
+	}
+
+	/** @internal */
 	protected config: ViewBuilderConfig = {};
 
 	algorithm(
@@ -100,6 +110,7 @@ export class ManualViewBuilder<
 > extends ViewBuilderCore<{ name: TName; columns: TColumns }> {
 	static override readonly [entityKind]: string = 'SingleStoreManualViewBuilder';
 
+	/** @internal */
 	private columns: Record<string, SingleStoreColumn>;
 
 	constructor(

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -534,6 +534,7 @@ export type GetDecoderResult<T> = T extends { _: { data: infer TData } } ? TData
 export class Name implements SQLWrapper {
 	static readonly [entityKind]: string = 'Name';
 
+	/** @internal */
 	protected brand!: 'Name';
 
 	constructor(readonly value: string) {}
@@ -605,6 +606,7 @@ export const noopMapper: DriverValueMapper<any, any> = {
 export class Param<TDataType = any, TDriverParamType = TDataType> implements SQLWrapper {
 	static readonly [entityKind]: string = 'Param';
 
+	/** @internal */
 	protected brand!: 'BoundParamValue';
 
 	/**

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -33,6 +33,7 @@ export interface BuildQueryConfig {
 	escapeName(name: string): string;
 	escapeParam(num: number, value: unknown): string;
 	escapeString(str: string): string;
+	/** @internal */
 	codecs?: CodecsCollection;
 	paramStartIndex?: { value: number };
 	inlineParams?: boolean;
@@ -170,6 +171,7 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 		} as Query;
 	}
 
+	/** @internal */
 	private collectSQL(
 		chunks: SQLChunk[],
 		config: BuildQueryConfig,
@@ -439,6 +441,7 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 		}
 	}
 
+	/** @internal */
 	private mapInlineParam(
 		chunk: unknown,
 		{ escapeString }: BuildQueryConfig,
@@ -520,7 +523,7 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 	}
 }
 
-export type GetDecoderResult<T> = T extends Column ? T['_']['data'] : T extends
+export type GetDecoderResult<T> = T extends { _: { data: infer TData } } ? TData : T extends
 	| DriverValueDecoder<infer TData, any>
 	| DriverValueDecoder<infer TData, any>['mapFromDriverValue'] ? TData
 : never;

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -91,6 +91,7 @@ export class SQLiteDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -212,6 +213,7 @@ export class SQLiteDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -364,6 +366,7 @@ export class SQLiteDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildJoins(
 		joins: SQLiteSelectJoinConfig[] | undefined,
 	): SQL | undefined {
@@ -409,6 +412,7 @@ export class SQLiteDialect {
 		return new SQL(joinsArray);
 	}
 
+	/** @internal */
 	private buildLimit(limit: number | Placeholder | undefined): SQL | undefined {
 		return typeof limit === 'object'
 				|| (typeof limit === 'number')
@@ -416,6 +420,7 @@ export class SQLiteDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildOrderBy(
 		orderBy: (SQLiteColumn | SQL | SQL.Aliased)[] | undefined,
 	): SQL | undefined {
@@ -436,6 +441,7 @@ export class SQLiteDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildFromTable(
 		table: SQL | Subquery | SQLiteViewBase | SQLiteTable | undefined,
 	): SQL | Subquery | SQLiteViewBase | SQLiteTable | undefined {
@@ -789,6 +795,7 @@ export class SQLiteDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -864,6 +871,7 @@ export class SQLiteDialect {
 		return output;
 	}
 
+	/** @internal */
 	private getSelectedTableColumns = (
 		table: Table | View,
 		columns: Record<string, boolean | undefined>,
@@ -901,6 +909,7 @@ export class SQLiteDialect {
 		return selectedColumns;
 	};
 
+	/** @internal */
 	private buildColumns = (
 		table: SQLiteTable | SQLiteView,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/sqlite-core/query-builders/query.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/query.ts
@@ -56,16 +56,49 @@ export class RelationalQueryBuilder<
 > {
 	static readonly [entityKind]: string = 'SQLiteRelationalQueryBuilderV2';
 
+	/** @internal */
+	private mode: TMode;
+
+	/** @internal */
+	private schema: TSchema;
+
+	/** @internal */
+	private table: SQLiteTable;
+
+	/** @internal */
+	private tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	private dialect: SQLiteDialect;
+
+	/** @internal */
+	private session: SQLiteSession<any, any>;
+
+	/** @internal */
+	private forbidJsonb: boolean | undefined;
+
+	/** @internal */
+	private builder: SQLiteRelationalQueryConstructor;
+
 	constructor(
-		private mode: TMode,
-		private schema: TSchema,
-		private table: SQLiteTable,
-		private tableConfig: TableRelationalConfig,
-		private dialect: SQLiteDialect,
-		private session: SQLiteSession<any, any>,
-		private forbidJsonb: boolean | undefined,
-		private builder: SQLiteRelationalQueryConstructor = SQLiteRelationalQuery,
-	) {}
+		mode: TMode,
+		schema: TSchema,
+		table: SQLiteTable,
+		tableConfig: TableRelationalConfig,
+		dialect: SQLiteDialect,
+		session: SQLiteSession<any, any>,
+		forbidJsonb: boolean | undefined,
+		builder: SQLiteRelationalQueryConstructor = SQLiteRelationalQuery,
+	) {
+		this.mode = mode;
+		this.schema = schema;
+		this.table = table;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+		this.forbidJsonb = forbidJsonb;
+		this.builder = builder;
+	}
 
 	findMany<TConfig extends DBQueryConfig<'many', TSchema, TFields>>(
 		config?: KnownKeysOnly<TConfig, DBQueryConfig<'many', TSchema, TFields>>,
@@ -119,17 +152,41 @@ export class SQLiteRelationalQuery<THKT extends SQLiteRelationalQueryHKTBase, TR
 	/** @internal */
 	resultKind: unknown;
 
+	/** @internal */
+	protected schema: TablesRelationalConfig;
+
+	/** @internal */
+	protected tableConfig: TableRelationalConfig;
+
+	/** @internal */
+	protected dialect: SQLiteDialect;
+
+	/** @internal */
+	protected session: SQLiteSession<any, any>;
+
+	/** @internal */
+	protected config: DBQueryConfig<'many' | 'one'> | true;
+
+	/** @internal */
+	protected forbidJsonb?: boolean;
+
 	constructor(
 		resultKind: unknown,
-		protected schema: TablesRelationalConfig,
+		schema: TablesRelationalConfig,
 		table: SQLiteTable,
-		protected tableConfig: TableRelationalConfig,
-		protected dialect: SQLiteDialect,
-		protected session: SQLiteSession<any, any>,
-		protected config: DBQueryConfig<'many' | 'one'> | true,
+		tableConfig: TableRelationalConfig,
+		dialect: SQLiteDialect,
+		session: SQLiteSession<any, any>,
+		config: DBQueryConfig<'many' | 'one'> | true,
 		mode: 'many' | 'first',
-		protected forbidJsonb?: boolean,
+		forbidJsonb?: boolean,
 	) {
+		this.schema = schema;
+		this.tableConfig = tableConfig;
+		this.dialect = dialect;
+		this.session = session;
+		this.config = config;
+		this.forbidJsonb = forbidJsonb;
 		this.resultKind = resultKind;
 		this.mode = mode;
 		this.table = table;
@@ -139,6 +196,7 @@ export class SQLiteRelationalQuery<THKT extends SQLiteRelationalQueryHKTBase, TR
 		return this._getQuery().sql;
 	}
 
+	/** @internal */
 	protected _getQuery() {
 		const jsonb = this.forbidJsonb ? sql`json` : sql`jsonb`;
 
@@ -152,6 +210,7 @@ export class SQLiteRelationalQuery<THKT extends SQLiteRelationalQueryHKTBase, TR
 		});
 	}
 
+	/** @internal */
 	protected _toSQL(): { query: BuildRelationalQueryResult; builtQuery: Query } {
 		const query = this._getQuery();
 

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -115,40 +115,132 @@ describe.skipIf(!ARTIFACTS_PRESENT)('no public subpath is dropped', () => {
 	}, 120_000);
 });
 
+// Two physically distinct installs of the package produce two declaration sites for
+// every class. TypeScript compares classes carrying `private`/`protected` members
+// nominally, so any such member surviving into the emitted `.d.ts` makes that type
+// non-portable: a value from copy A is not assignable to the same type from copy B.
+// This is the failure a consumer hits whenever a transitive dep, a pnpm peer split
+// or a linked tarball puts two copies of drizzle-orm on disk.
+//
+// The matrix below is the current, measured state of the public surface. `portable:
+// false` entries are known leaks, not aspirations -- each is annotated with the member
+// responsible. Fixing one is expected to flip its flag here; that is the point of
+// asserting both directions.
+interface PortabilityProbe {
+	/** Exported type name. */
+	name: string;
+	/** Package subpath it is exported from. */
+	subpath: string;
+	/** Type arguments, when the type has no usable defaults. */
+	typeArgs?: string;
+	/** Whether a value of this type survives crossing between two installs. */
+	portable: boolean;
+	/** For known leaks: the member whose nominality blocks assignment. */
+	blockedBy?: string;
+}
+
+const PORTABILITY_MATRIX: PortabilityProbe[] = [
+	{ name: 'SQL', subpath: 'sql/sql', portable: true },
+	{ name: 'Column', subpath: 'column', portable: true },
+	{ name: 'Table', subpath: 'table', portable: true },
+	{ name: 'Subquery', subpath: 'subquery', portable: true },
+	{ name: 'View', subpath: 'sql/sql', portable: true },
+	{ name: 'Placeholder', subpath: 'sql/sql', portable: true },
+	{ name: 'QueryPromise', subpath: 'query-promise', typeArgs: '<number>', portable: true },
+	{ name: 'MySqlTable', subpath: 'mysql-core', portable: true },
+	{ name: 'MySqlColumn', subpath: 'mysql-core', portable: true },
+	{ name: 'SQLiteTable', subpath: 'sqlite-core', portable: true },
+	{ name: 'SQLiteColumn', subpath: 'sqlite-core', portable: true },
+
+	{ name: 'Param', subpath: 'sql/sql', portable: false, blockedBy: 'Param#brand (protected)' },
+	{ name: 'Name', subpath: 'sql/sql', portable: false, blockedBy: 'Name#brand (protected)' },
+	{
+		name: 'CodecsCollection',
+		subpath: 'codecs',
+		portable: false,
+		blockedBy: 'CodecsCollection#resolveTypes (protected)',
+	},
+	// The three dialects all embed a CodecsCollection, so they inherit its leak.
+	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: 'CodecsCollection#resolveTypes (protected)' },
+	{
+		name: 'MySqlDialect',
+		subpath: 'mysql-core',
+		portable: false,
+		blockedBy: 'CodecsCollection#resolveTypes (protected)',
+	},
+	{
+		name: 'SQLiteDialect',
+		subpath: 'sqlite-core',
+		portable: false,
+		blockedBy: 'CodecsCollection#resolveTypes (protected)',
+	},
+	// Only pg-core exposes `toBuilder()` in a public return type, which is why the
+	// identical `foreignKeyConfigs` field on the other dialects' builders is unreachable
+	// and their table/column types above are portable.
+	{
+		name: 'PgTable',
+		subpath: 'pg-core',
+		portable: false,
+		blockedBy: 'PgColumnBuilder#foreignKeyConfigs (private), via PgColumn#toBuilder',
+	},
+	{
+		name: 'PgColumn',
+		subpath: 'pg-core',
+		portable: false,
+		blockedBy: 'PgColumnBuilder#foreignKeyConfigs (private), via PgColumn#toBuilder',
+	},
+	{
+		name: 'NodePgDatabase',
+		subpath: 'node-postgres/driver',
+		typeArgs: '<Record<string, never>>',
+		portable: false,
+		blockedBy: 'PgAsyncPreparedQuery#executor (protected)',
+	},
+];
+
+// Unpacks the built tarball's declarations twice, under two different package names,
+// so the compiler sees two independent installs of the same types.
+function materializeTwoInstalls(outDir: string): void {
+	const sourcePrefix = `/node_modules/${pkg.packageName}/`;
+	for (const packageName of ['drizzle-a', 'drizzle-b']) {
+		for (const file of pkg.listFiles(sourcePrefix)) {
+			if (file !== `${sourcePrefix}package.json` && !file.endsWith('.d.ts')) continue;
+
+			const destination = join(outDir, 'node_modules', packageName, file.slice(sourcePrefix.length));
+			mkdirSync(dirname(destination), { recursive: true });
+			const contents = pkg.readFile(file);
+			writeFileSync(
+				destination,
+				file === `${sourcePrefix}package.json`
+					? JSON.stringify({ ...JSON.parse(contents), name: packageName })
+					: contents,
+			);
+		}
+	}
+}
+
 describe.skipIf(!ARTIFACTS_PRESENT)('types are portable across package instances', () => {
-	test('SQL types from separate installations are assignable', () => {
+	test('the published surface matches the recorded portability matrix', () => {
 		const outDir = mkdtempSync(join(tmpdir(), 'drizzle-duplicate-types-'));
 		try {
-			const sourcePrefix = `/node_modules/${pkg.packageName}/`;
-			for (const packageName of ['drizzle-a', 'drizzle-b']) {
-				for (const file of pkg.listFiles(sourcePrefix)) {
-					if (file !== `${sourcePrefix}package.json` && !file.endsWith('.d.ts')) continue;
+			materializeTwoInstalls(outDir);
 
-					const destination = join(outDir, 'node_modules', packageName, file.slice(sourcePrefix.length));
-					mkdirSync(dirname(destination), { recursive: true });
-					const contents = pkg.readFile(file);
-					writeFileSync(
-						destination,
-						file === `${sourcePrefix}package.json`
-							? JSON.stringify({ ...JSON.parse(contents), name: packageName })
-							: contents,
-					);
-				}
+			// One program covering every probe: each assignment gets its own line so a
+			// diagnostic's line number identifies which type failed.
+			const lines: string[] = [];
+			const lineToName = new Map<number, string>();
+			for (const { name, subpath } of PORTABILITY_MATRIX) {
+				lines.push(`import type { ${name} as ${name}_A } from 'drizzle-a/${subpath}';`);
+				lines.push(`import type { ${name} as ${name}_B } from 'drizzle-b/${subpath}';`);
+			}
+			for (const { name, typeArgs = '' } of PORTABILITY_MATRIX) {
+				lines.push(`declare const v_${name}: ${name}_B${typeArgs};`);
+				lineToName.set(lines.length + 1, name);
+				lines.push(`export const c_${name}: ${name}_A${typeArgs} = v_${name};`);
 			}
 
 			const entrypoint = join(outDir, 'index.mts');
-			writeFileSync(
-				entrypoint,
-				[
-					"import type { SQL as SQLA } from 'drizzle-a/sql/sql';",
-					"import type { SQL as SQLB } from 'drizzle-b/sql/sql';",
-					'declare const sqlA: SQLA;',
-					'declare const sqlB: SQLB;',
-					'const acceptsA: SQLA = sqlB;',
-					'const acceptsB: SQLB = sqlA;',
-					'void [acceptsA, acceptsB];',
-				].join('\n'),
-			);
+			writeFileSync(entrypoint, lines.join('\n') + '\n');
 
 			const program = ts.createProgram({
 				rootNames: [entrypoint],
@@ -161,15 +253,39 @@ describe.skipIf(!ARTIFACTS_PRESENT)('types are portable across package instances
 					target: ts.ScriptTarget.ESNext,
 				},
 			});
-			const diagnostics = ts.getPreEmitDiagnostics(program);
-			expect(
-				diagnostics,
-				ts.formatDiagnosticsWithColorAndContext(diagnostics, {
-					getCanonicalFileName: (fileName) => fileName,
-					getCurrentDirectory: () => outDir,
-					getNewLine: () => '\n',
-				}),
-			).toEqual([]);
+
+			const failed = new Map<string, string>();
+			const unattributed: string[] = [];
+			for (const diagnostic of ts.getPreEmitDiagnostics(program)) {
+				const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
+				if (!diagnostic.file || diagnostic.start === undefined) {
+					unattributed.push(message);
+					continue;
+				}
+				const line = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start).line + 1;
+				const name = lineToName.get(line);
+				// A diagnostic on a non-assignment line means the probe itself is malformed
+				// (bad subpath, wrong type arity) rather than a portability result.
+				if (name === undefined) {
+					unattributed.push(`line ${line}: ${message}`);
+					continue;
+				}
+				if (!failed.has(name)) failed.set(name, message);
+			}
+
+			expect(unattributed, `malformed probes:\n${unattributed.join('\n')}`).toEqual([]);
+
+			const actual = PORTABILITY_MATRIX.filter((p) => !failed.has(p.name)).map((p) => p.name).sort();
+			const expected = PORTABILITY_MATRIX.filter((p) => p.portable).map((p) => p.name).sort();
+
+			const regressed = expected.filter((n) => !actual.includes(n));
+			const fixed = actual.filter((n) => !expected.includes(n));
+			const hint = [
+				...regressed.map((n) => `REGRESSED ${n} is no longer portable: ${failed.get(n)}`),
+				...fixed.map((n) => `FIXED ${n} is now portable -- set portable: true in PORTABILITY_MATRIX`),
+			].join('\n');
+
+			expect(actual, hint).toEqual(expected);
 		} finally {
 			rmSync(outDir, { recursive: true, force: true });
 		}

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import { beforeAll, describe, expect, test } from 'vitest';
 import { checkPackage } from '../../attw-fork/src/checkPackage.ts';
 import { getExitCode } from '../../attw-fork/src/cli/getExitCode.ts';
@@ -112,6 +113,67 @@ describe.skipIf(!ARTIFACTS_PRESENT)('no public subpath is dropped', () => {
 			.map((p) => p.entrypoint);
 		expect(unresolved, `unresolved: ${unresolved.slice(0, 20).join(', ')}`).toEqual([]);
 	}, 120_000);
+});
+
+describe.skipIf(!ARTIFACTS_PRESENT)('types are portable across package instances', () => {
+	test('SQL types from separate installations are assignable', () => {
+		const outDir = mkdtempSync(join(tmpdir(), 'drizzle-duplicate-types-'));
+		try {
+			const sourcePrefix = `/node_modules/${pkg.packageName}/`;
+			for (const packageName of ['drizzle-a', 'drizzle-b']) {
+				for (const file of pkg.listFiles(sourcePrefix)) {
+					if (file !== `${sourcePrefix}package.json` && !file.endsWith('.d.ts')) continue;
+
+					const destination = join(outDir, 'node_modules', packageName, file.slice(sourcePrefix.length));
+					mkdirSync(dirname(destination), { recursive: true });
+					const contents = pkg.readFile(file);
+					writeFileSync(
+						destination,
+						file === `${sourcePrefix}package.json`
+							? JSON.stringify({ ...JSON.parse(contents), name: packageName })
+							: contents,
+					);
+				}
+			}
+
+			const entrypoint = join(outDir, 'index.mts');
+			writeFileSync(
+				entrypoint,
+				[
+					"import type { SQL as SQLA } from 'drizzle-a/sql/sql';",
+					"import type { SQL as SQLB } from 'drizzle-b/sql/sql';",
+					'declare const sqlA: SQLA;',
+					'declare const sqlB: SQLB;',
+					'const acceptsA: SQLA = sqlB;',
+					'const acceptsB: SQLB = sqlA;',
+					'void [acceptsA, acceptsB];',
+				].join('\n'),
+			);
+
+			const program = ts.createProgram({
+				rootNames: [entrypoint],
+				options: {
+					module: ts.ModuleKind.NodeNext,
+					moduleResolution: ts.ModuleResolutionKind.NodeNext,
+					noEmit: true,
+					skipLibCheck: true,
+					strict: true,
+					target: ts.ScriptTarget.ESNext,
+				},
+			});
+			const diagnostics = ts.getPreEmitDiagnostics(program);
+			expect(
+				diagnostics,
+				ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+					getCanonicalFileName: (fileName) => fileName,
+					getCurrentDirectory: () => outDir,
+					getNewLine: () => '\n',
+				}),
+			).toEqual([]);
+		} finally {
+			rmSync(outDir, { recursive: true, force: true });
+		}
+	});
 });
 
 describe('directory-index shim emitter refuses to shadow a source artifact', () => {

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -166,27 +166,20 @@ const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: DIALECT_BLOCKER },
 	{ name: 'MySqlDialect', subpath: 'mysql-core', portable: false, blockedBy: DIALECT_BLOCKER },
 	{ name: 'SQLiteDialect', subpath: 'sqlite-core', portable: false, blockedBy: DIALECT_BLOCKER },
-	// Only pg-core exposes `toBuilder()` in a public return type, which is why the
-	// identical `foreignKeyConfigs` field on the other dialects' builders is unreachable
-	// and their table/column types above are portable.
-	{
-		name: 'PgTable',
-		subpath: 'pg-core',
-		portable: false,
-		blockedBy: 'PgColumnBuilder#foreignKeyConfigs (private), via PgColumn#toBuilder',
-	},
-	{
-		name: 'PgColumn',
-		subpath: 'pg-core',
-		portable: false,
-		blockedBy: 'PgColumnBuilder#foreignKeyConfigs (private), via PgColumn#toBuilder',
-	},
+	{ name: 'PgTable', subpath: 'pg-core', portable: true },
+	{ name: 'PgColumn', subpath: 'pg-core', portable: true },
+	// The database object is reached through the session, and every prepared-query,
+	// transaction and relational-query-builder class along that path contributes its own
+	// nominal member: PgAsyncPreparedQuery#executor, then PgBasePreparedQuery#query, then
+	// PgAsyncTransaction#nestedIndex, then RelationalQueryBuilder#schema, and onward
+	// through ~70 more across pg-core/query-builders. Unlike the entries above it does
+	// not fall to a contained change, so it is left recorded rather than half-fixed.
 	{
 		name: 'NodePgDatabase',
 		subpath: 'node-postgres/driver',
 		typeArgs: '<Record<string, never>>',
 		portable: false,
-		blockedBy: 'PgAsyncPreparedQuery#executor (protected)',
+		blockedBy: 'a multi-layer chain rooted at PgAsyncPreparedQuery#executor (protected)',
 	},
 ];
 

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -139,13 +139,12 @@ interface PortabilityProbe {
 	blockedBy?: string;
 }
 
-// The dialects are blocked by something categorically different from a nominal member:
-// `BuildRelationalQueryResult['selection']`, an anonymous recursive intersection-of-union
-// reached via `mapperGenerators.relationalRows`. Having no named symbol, it misses the
-// compiler's relation cache, so each cross-instance comparison re-expands until the
-// recursion limiter gives up and reports a mismatch. Fixing it means naming that type,
-// not marking a member `@internal`.
-const DIALECT_BLOCKER = "BuildRelationalQueryResult['selection'] (anonymous recursive type)";
+// With every nominal member stripped, the dialects come to rest on `EmptyFilter`, which
+// is `Symbol.for('drizzle:EmptyFilter')`. `Symbol.for` returns the same symbol in every
+// copy on disk, so the value is portable at runtime -- but the inferred `unique symbol`
+// type is nominal per declaration site, so the types disagree with the runtime. Fixing
+// it is an API decision, not a marker, and is left to its own change.
+const DIALECT_BLOCKER = 'EmptyFilter (unique symbol)';
 
 const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'SQL', subpath: 'sql/sql', portable: true },
@@ -171,18 +170,18 @@ const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'SQLiteDialect', subpath: 'sqlite-core', portable: false, blockedBy: DIALECT_BLOCKER },
 	{ name: 'PgTable', subpath: 'pg-core', portable: true },
 	{ name: 'PgColumn', subpath: 'pg-core', portable: true },
-	// The database object is reached through the session, and every prepared-query,
-	// transaction and relational-query-builder class along that path contributes its own
-	// nominal member: PgAsyncPreparedQuery#executor, then PgBasePreparedQuery#query, then
-	// PgAsyncTransaction#nestedIndex, then RelationalQueryBuilder#schema, and onward
-	// through ~70 more across pg-core/query-builders. Unlike the entries above it does
-	// not fall to a contained change, so it is left recorded rather than half-fixed.
+	// The database object outlasts every marker. With the nominal members gone it fails on
+	// `BuildQueryResult<..., TConfig, ...>` -- a mapped type deferred on an unresolved type
+	// parameter from `findMany<TConfig>`. The compiler cannot relate `keyof X` from one
+	// declaration site to `keyof X` from the other while X stays deferred, so it widens to
+	// `string | number | symbol` and fails. That is a TypeScript comparison limit rather
+	// than anything drizzle emits, and no marker or contained type change reaches it.
 	{
 		name: 'NodePgDatabase',
 		subpath: 'node-postgres/driver',
 		typeArgs: '<Record<string, never>>',
 		portable: false,
-		blockedBy: 'a multi-layer chain rooted at PgAsyncPreparedQuery#executor (protected)',
+		blockedBy: 'BuildQueryResult (mapped type deferred on an unresolved type parameter)',
 	},
 ];
 

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -159,6 +159,9 @@ const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'MySqlColumn', subpath: 'mysql-core', portable: true },
 	{ name: 'SQLiteTable', subpath: 'sqlite-core', portable: true },
 	{ name: 'SQLiteColumn', subpath: 'sqlite-core', portable: true },
+	{ name: 'PgView', subpath: 'pg-core', portable: true },
+	{ name: 'MySqlView', subpath: 'mysql-core', portable: true },
+	{ name: 'SQLiteView', subpath: 'sqlite-core', portable: true },
 
 	{ name: 'Param', subpath: 'sql/sql', portable: true },
 	{ name: 'Name', subpath: 'sql/sql', portable: true },

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -139,6 +139,14 @@ interface PortabilityProbe {
 	blockedBy?: string;
 }
 
+// The dialects are blocked by something categorically different from a nominal member:
+// `BuildRelationalQueryResult['selection']`, an anonymous recursive intersection-of-union
+// reached via `mapperGenerators.relationalRows`. Having no named symbol, it misses the
+// compiler's relation cache, so each cross-instance comparison re-expands until the
+// recursion limiter gives up and reports a mismatch. Fixing it means naming that type,
+// not marking a member `@internal`.
+const DIALECT_BLOCKER = "BuildRelationalQueryResult['selection'] (anonymous recursive type)";
+
 const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'SQL', subpath: 'sql/sql', portable: true },
 	{ name: 'Column', subpath: 'column', portable: true },
@@ -152,28 +160,12 @@ const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'SQLiteTable', subpath: 'sqlite-core', portable: true },
 	{ name: 'SQLiteColumn', subpath: 'sqlite-core', portable: true },
 
-	{ name: 'Param', subpath: 'sql/sql', portable: false, blockedBy: 'Param#brand (protected)' },
-	{ name: 'Name', subpath: 'sql/sql', portable: false, blockedBy: 'Name#brand (protected)' },
-	{
-		name: 'CodecsCollection',
-		subpath: 'codecs',
-		portable: false,
-		blockedBy: 'CodecsCollection#resolveTypes (protected)',
-	},
-	// The three dialects all embed a CodecsCollection, so they inherit its leak.
-	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: 'CodecsCollection#resolveTypes (protected)' },
-	{
-		name: 'MySqlDialect',
-		subpath: 'mysql-core',
-		portable: false,
-		blockedBy: 'CodecsCollection#resolveTypes (protected)',
-	},
-	{
-		name: 'SQLiteDialect',
-		subpath: 'sqlite-core',
-		portable: false,
-		blockedBy: 'CodecsCollection#resolveTypes (protected)',
-	},
+	{ name: 'Param', subpath: 'sql/sql', portable: true },
+	{ name: 'Name', subpath: 'sql/sql', portable: true },
+	{ name: 'CodecsCollection', subpath: 'codecs', portable: true },
+	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: DIALECT_BLOCKER },
+	{ name: 'MySqlDialect', subpath: 'mysql-core', portable: false, blockedBy: DIALECT_BLOCKER },
+	{ name: 'SQLiteDialect', subpath: 'sqlite-core', portable: false, blockedBy: DIALECT_BLOCKER },
 	// Only pg-core exposes `toBuilder()` in a public return type, which is why the
 	// identical `foreignKeyConfigs` field on the other dialects' builders is unreachable
 	// and their table/column types above are portable.


### PR DESCRIPTION
> **Stacked on #6200, #6201, #6202, #6203 and #6206.** Review only the last commit.

## What

Sweeps the `private`/`protected` members that still reached the emitted `.d.ts` on the dialect, session, transaction, prepared-query and relational-query-builder classes.

Done with an AST codemod rather than by hand, since it spans ~20 files. Constructor parameter properties are desugared into declared fields: on a parameter the `@internal` marker strips the member but survives into the emitted constructor signature as a stray comment.

## This PR flips no row on its own

That is expected, and worth being upfront about. With these members gone the dialects come to rest on `EmptyFilter`'s `unique symbol`, which is an API decision handled separately in #6205. This change is the prerequisite: #6205 flips the three dialect rows only on top of it.

If #6205 is not wanted, this PR is largely inert and can be dropped too — the rows it would enable are the same three.

## And it re-records the database object

`NodePgDatabase` outlasts every marker. Its blocker is re-recorded in the matrix: `BuildQueryResult<..., TConfig, ...>` is a mapped type deferred on an unresolved type parameter from `findMany<TConfig>`, and the compiler cannot relate `keyof X` from one declaration site to `keyof X` from the other while `X` stays deferred — it widens to `string | number | symbol` and fails. That is a TypeScript comparison limit, not something drizzle emits, and no marker or contained type change reaches it.

## Verification

Full `drizzle-orm` suite green (27 files, 1344 tests); `test:types` clean. `drizzle-kit` and `drizzle-seed` — the in-repo consumers — also typecheck clean against the modified ORM.
