### PR TITLE
Type EmptyFilter as a string literal instead of a unique symbol

### DIFF
--- a/drizzle-orm/src/cockroach-core/dialect.ts
+++ b/drizzle-orm/src/cockroach-core/dialect.ts
@@ -192,6 +192,7 @@ export class CockroachDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -311,6 +312,7 @@ export class CockroachDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -463,6 +465,7 @@ export class CockroachDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildJoins(
 		joins: CockroachSelectJoinConfig[] | undefined,
 	): SQL | undefined {
@@ -513,6 +516,7 @@ export class CockroachDialect {
 		return new SQL(joinsArray);
 	}
 
+	/** @internal */
 	private buildFromTable(
 		table: SQL | Subquery | CockroachViewBase | CockroachTable | undefined,
 	): SQL | Subquery | CockroachViewBase | CockroachTable | undefined {
@@ -897,6 +901,7 @@ export class CockroachDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -974,6 +979,7 @@ export class CockroachDialect {
 		return output;
 	}
 
+	/** @internal */
 	private getSelectedTableColumns = (
 		table: Table | View,
 		columns: Record<string, boolean | undefined>,
@@ -1009,6 +1015,7 @@ export class CockroachDialect {
 		return selectedColumns;
 	};
 
+	/** @internal */
 	private buildColumns = (
 		table: Table | View,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/cockroach-core/view.ts
+++ b/drizzle-orm/src/cockroach-core/view.ts
@@ -274,6 +274,7 @@ export class CockroachMaterializedView<
 > extends CockroachViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'CockroachMaterializedView';
 
+	/** @internal */
 	readonly [CockroachMaterializedViewConfig]: {
 		readonly withNoData?: boolean;
 	} | undefined;

--- a/drizzle-orm/src/codecs.ts
+++ b/drizzle-orm/src/codecs.ts
@@ -62,7 +62,15 @@ const itemToArrayTypeCodecNameMap = {
 export class CodecsCollection<TTypeSet extends string = string> {
 	static readonly [entityKind]: string = 'CodecsCollection';
 
-	constructor(protected resolveTypes: (type: string) => string, readonly codecs: Codecs<TTypeSet> = noopCodecs) {}
+	// Declared rather than left as a constructor parameter property so the `@internal`
+	// marker lands on the member itself; on a parameter it survives into the emitted
+	// constructor signature as a stray comment.
+	/** @internal */
+	protected resolveTypes: (type: string) => string;
+
+	constructor(resolveTypes: (type: string) => string, readonly codecs: Codecs<TTypeSet> = noopCodecs) {
+		this.resolveTypes = resolveTypes;
+	}
 
 	get<TCodecType extends keyof Codec>(
 		column: Column,

--- a/drizzle-orm/src/mssql-core/dialect.ts
+++ b/drizzle-orm/src/mssql-core/dialect.ts
@@ -304,6 +304,7 @@ export class MsSqlDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -456,6 +457,7 @@ export class MsSqlDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildSelectionOutput(
 		fields: SelectedFieldsOrdered,
 		{ type, ignoreCastCodecs = false }: { type: 'INSERTED' | 'DELETED'; ignoreCastCodecs?: boolean },
@@ -950,6 +952,7 @@ export class MsSqlDialect {
 		return res;
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -1025,6 +1028,7 @@ export class MsSqlDialect {
 		return output;
 	}
 
+	/** @internal */
 	private getSelectedTableColumns = (
 		table: Table | View,
 		columns: Record<string, boolean | undefined>,
@@ -1060,6 +1064,7 @@ export class MsSqlDialect {
 		return selectedColumns;
 	};
 
+	/** @internal */
 	private buildColumns = (
 		table: Table | View,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/mssql-core/view.ts
+++ b/drizzle-orm/src/mssql-core/view.ts
@@ -149,8 +149,10 @@ export class MsSqlView<
 > extends MsSqlViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'MsSqlView';
 
+	/** @internal */
 	declare protected $MsSqlViewBrand: 'MsSqlView';
 
+	/** @internal */
 	[MsSqlViewConfig]: ViewBuilderConfig | undefined;
 
 	constructor({ mssqlConfig, config }: {

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -103,6 +103,7 @@ export class MySqlDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -206,6 +207,7 @@ export class MySqlDialect {
 	 * `select <selection> from`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -358,6 +360,7 @@ export class MySqlDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildLimit(limit: number | Placeholder | undefined): SQL | undefined {
 		return typeof limit === 'object'
 				|| (typeof limit === 'number' && limit >= 0)
@@ -366,6 +369,7 @@ export class MySqlDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildOrderBy(
 		orderBy: (MySqlColumn | SQL | SQL.Aliased)[] | undefined,
 	): SQL | undefined {
@@ -374,6 +378,7 @@ export class MySqlDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildIndex({
 		indexes,
 		indexFor,
@@ -823,6 +828,7 @@ export class MySqlDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -898,6 +904,7 @@ export class MySqlDialect {
 		return output;
 	}
 
+	/** @internal */
 	private buildColumns = (
 		table: Table | View,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/mysql-core/view.ts
+++ b/drizzle-orm/src/mysql-core/view.ts
@@ -156,8 +156,10 @@ export class MySqlView<
 > extends MySqlViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'MySqlView';
 
+	/** @internal */
 	declare protected $MySqlViewBrand: 'MySqlView';
 
+	/** @internal */
 	[MySqlViewConfig]: ViewBuilderConfig | undefined;
 
 	constructor({ mysqlConfig, config }: {

--- a/drizzle-orm/src/pg-core/columns/common.ts
+++ b/drizzle-orm/src/pg-core/columns/common.ts
@@ -175,8 +175,10 @@ export abstract class PgColumnBuilder<
 
 	declare readonly _: T;
 
+	/** @internal */
 	private foreignKeyConfigs: ReferenceConfig[] = [];
 
+	/** @internal */
 	protected config: PgColumnBuilderRuntimeConfig<T['data']> & TRuntimeConfig;
 
 	constructor(name: string, dataType: ColumnType, columnType: string) {
@@ -502,6 +504,7 @@ type PgColumnConstructor = new(table: PgTable, config: any) => PgColumn;
 export class PgClonedColumnBuilder extends PgColumnBuilder {
 	static override readonly [entityKind]: string = 'PgClonedColumnBuilder';
 
+	/** @internal */
 	private readonly ColumnClass: PgColumnConstructor;
 
 	constructor(config: PgColumnBuilderRuntimeConfig<unknown>, ColumnClass: PgColumnConstructor) {

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -99,6 +99,7 @@ export class PgDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -224,6 +225,7 @@ export class PgDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -376,6 +378,7 @@ export class PgDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildJoins(joins: PgSelectJoinConfig[] | undefined): SQL | undefined {
 		if (!joins || joins.length === 0) {
 			return undefined;
@@ -424,6 +427,7 @@ export class PgDialect {
 		return new SQL(joinsArray);
 	}
 
+	/** @internal */
 	private buildFromTable(
 		table: SQL | Subquery | PgViewBase | PgTable | undefined,
 	): SQL | Subquery | PgViewBase | PgTable | undefined {
@@ -812,6 +816,7 @@ export class PgDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -888,6 +893,7 @@ export class PgDialect {
 		return output;
 	}
 
+	/** @internal */
 	private buildColumns = (
 		table: Table | View,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/pg-core/view.ts
+++ b/drizzle-orm/src/pg-core/view.ts
@@ -307,6 +307,7 @@ export class PgView<
 > extends PgViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'PgView';
 
+	/** @internal */
 	[PgViewConfig]: {
 		with?: ViewWithConfig;
 	} | undefined;
@@ -344,6 +345,7 @@ export class PgMaterializedView<
 > extends PgViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'PgMaterializedView';
 
+	/** @internal */
 	readonly [PgMaterializedViewConfig]: {
 		readonly with?: PgMaterializedViewWithConfig;
 		readonly using?: string;

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -455,6 +455,12 @@ export abstract class AggregatedField<T = unknown> implements SQLWrapper<T> {
 		readonly data: T;
 	};
 
+	// Reached from `BuildRelationalQueryResult['selection']`, whose element union names
+	// AggregatedField directly. A protected member here makes that class nominal, which
+	// makes the whole recursive selection type non-portable, which propagates out through
+	// the dialects' mapperGenerators. The resulting diagnostic points at the recursive
+	// type rather than at this member, which makes it easy to misread as a compiler limit.
+	/** @internal */
 	protected table: SchemaEntry | undefined;
 
 	onTable(table: SchemaEntry) {

--- a/drizzle-orm/src/relations.ts
+++ b/drizzle-orm/src/relations.ts
@@ -2168,5 +2168,14 @@ export function getTableAsAliasSQL(table: SchemaEntry) {
 	}`;
 }
 
-export const EmptyFilter = Symbol.for('drizzle:EmptyFilter');
+// A string literal rather than `Symbol.for`. Both are unit types, so both narrow under
+// `===`, which the filter builder relies on. The difference is that a `unique symbol` is
+// nominal per declaration site: with two copies of the package on disk, copy A's
+// EmptyFilter and copy B's are unrelated types, and every public type mentioning it
+// stops being assignable across the boundary. A literal type is structural and compares
+// equal across installs.
+//
+// The runtime sentinel keeps the same identity semantics: `Symbol.for` already returned
+// the same symbol in every copy, and the literal is likewise shared by value.
+export const EmptyFilter = 'drizzle:EmptyFilter';
 export type EmptyFilter = typeof EmptyFilter;

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -175,6 +175,7 @@ export class SingleStoreDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -290,6 +291,7 @@ export class SingleStoreDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -442,6 +444,7 @@ export class SingleStoreDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildLimit(limit: number | Placeholder | undefined): SQL | undefined {
 		return typeof limit === 'object'
 				|| (typeof limit === 'number' && limit >= 0)
@@ -449,6 +452,7 @@ export class SingleStoreDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildOrderBy(
 		orderBy: (SingleStoreColumn | SQL | SQL.Aliased)[] | undefined,
 	): SQL | undefined {
@@ -816,6 +820,7 @@ export class SingleStoreDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -891,6 +896,7 @@ export class SingleStoreDialect {
 		return output;
 	}
 
+	/** @internal */
 	private getSelectedTableColumns = (
 		table: Table | View,
 		columns: Record<string, boolean | undefined>,
@@ -928,6 +934,7 @@ export class SingleStoreDialect {
 		return selectedColumns;
 	};
 
+	/** @internal */
 	private buildColumns = (
 		table: SingleStoreTable | SingleStoreView,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/src/singlestore-core/view.ts
+++ b/drizzle-orm/src/singlestore-core/view.ts
@@ -159,8 +159,10 @@ export class SingleStoreView<
 > extends SingleStoreViewBase<TName, TExisting, TSelectedFields> {
 	static override readonly [entityKind]: string = 'SingleStoreView';
 
+	/** @internal */
 	declare protected $SingleStoreViewBrand: 'SingleStoreView';
 
+	/** @internal */
 	[SingleStoreViewConfig]: ViewBuilderConfig | undefined;
 
 	constructor({ singlestoreConfig, config }: {

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -33,6 +33,10 @@ export interface BuildQueryConfig {
 	escapeName(name: string): string;
 	escapeParam(num: number, value: unknown): string;
 	escapeString(str: string): string;
+	// Stripped so `SQL` does not reach `CodecsCollection`, which is nominal until its
+	// own protected member is marked. Once that happens this marker is belt-and-braces,
+	// but it is what makes `SQL` portable on its own.
+	/** @internal */
 	codecs?: CodecsCollection;
 	paramStartIndex?: { value: number };
 	inlineParams?: boolean;
@@ -170,6 +174,7 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 		} as Query;
 	}
 
+	/** @internal */
 	private collectSQL(
 		chunks: SQLChunk[],
 		config: BuildQueryConfig,
@@ -439,6 +444,7 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 		}
 	}
 
+	/** @internal */
 	private mapInlineParam(
 		chunk: unknown,
 		{ escapeString }: BuildQueryConfig,
@@ -520,7 +526,13 @@ export class SQL<T = unknown> implements SQLWrapper<T> {
 	}
 }
 
-export type GetDecoderResult<T> = T extends Column ? T['_']['data'] : T extends
+// Structural rather than `T extends Column`. Naming the class here makes the conditional
+// depend on relating one install's `Column` to another's, and that dependency propagates
+// out through `mapWith` to `Column`, `CodecsCollection`, and the mysql table/column/dialect
+// types. Matching on the shape instead resolves identically for `Column` -- its `_` is its
+// `ColumnBaseConfig`, whose `data` is exactly what the indexed access read -- while naming
+// nothing. `SQL`, `SQL.Aliased` and `View` brand as `_: { brand; type }` and so do not match.
+export type GetDecoderResult<T> = T extends { _: { data: infer TData } } ? TData : T extends
 	| DriverValueDecoder<infer TData, any>
 	| DriverValueDecoder<infer TData, any>['mapFromDriverValue'] ? TData
 : never;

--- a/drizzle-orm/src/sql/sql.ts
+++ b/drizzle-orm/src/sql/sql.ts
@@ -543,6 +543,7 @@ export type GetDecoderResult<T> = T extends { _: { data: infer TData } } ? TData
 export class Name implements SQLWrapper {
 	static readonly [entityKind]: string = 'Name';
 
+	/** @internal */
 	protected brand!: 'Name';
 
 	constructor(readonly value: string) {}
@@ -614,6 +615,7 @@ export const noopMapper: DriverValueMapper<any, any> = {
 export class Param<TDataType = any, TDriverParamType = TDataType> implements SQLWrapper {
 	static readonly [entityKind]: string = 'Param';
 
+	/** @internal */
 	protected brand!: 'BoundParamValue';
 
 	/**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -91,6 +91,7 @@ export class SQLiteDialect {
 		return `'${str.replace(/'/g, "''")}'`;
 	}
 
+	/** @internal */
 	private buildWithCTE(queries: Subquery[] | undefined): SQL | undefined {
 		if (!queries?.length) return undefined;
 
@@ -212,6 +213,7 @@ export class SQLiteDialect {
 	 * `insert ... returning <selection>`
 	 *
 	 * If `isSingleTable` is true, then columns won't be prefixed with table name
+	 * @internal
 	 */
 	private buildSelection(
 		fields: SelectedFieldsOrdered,
@@ -364,6 +366,7 @@ export class SQLiteDialect {
 		return new SQL(chunks);
 	}
 
+	/** @internal */
 	private buildJoins(
 		joins: SQLiteSelectJoinConfig[] | undefined,
 	): SQL | undefined {
@@ -409,6 +412,7 @@ export class SQLiteDialect {
 		return new SQL(joinsArray);
 	}
 
+	/** @internal */
 	private buildLimit(limit: number | Placeholder | undefined): SQL | undefined {
 		return typeof limit === 'object'
 				|| (typeof limit === 'number')
@@ -416,6 +420,7 @@ export class SQLiteDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildOrderBy(
 		orderBy: (SQLiteColumn | SQL | SQL.Aliased)[] | undefined,
 	): SQL | undefined {
@@ -436,6 +441,7 @@ export class SQLiteDialect {
 			: undefined;
 	}
 
+	/** @internal */
 	private buildFromTable(
 		table: SQL | Subquery | SQLiteViewBase | SQLiteTable | undefined,
 	): SQL | Subquery | SQLiteViewBase | SQLiteTable | undefined {
@@ -789,6 +795,7 @@ export class SQLiteDialect {
 		});
 	}
 
+	/** @internal */
 	private buildRqbColumn(
 		table: Table | View,
 		field: unknown,
@@ -864,6 +871,7 @@ export class SQLiteDialect {
 		return output;
 	}
 
+	/** @internal */
 	private getSelectedTableColumns = (
 		table: Table | View,
 		columns: Record<string, boolean | undefined>,
@@ -901,6 +909,7 @@ export class SQLiteDialect {
 		return selectedColumns;
 	};
 
+	/** @internal */
 	private buildColumns = (
 		table: SQLiteTable | SQLiteView,
 		selection: BuildRelationalQueryResult['selection'],

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -115,40 +115,132 @@ describe.skipIf(!ARTIFACTS_PRESENT)('no public subpath is dropped', () => {
 	}, 120_000);
 });
 
+// Two physically distinct installs of the package produce two declaration sites for
+// every class. TypeScript compares classes carrying `private`/`protected` members
+// nominally, so any such member surviving into the emitted `.d.ts` makes that type
+// non-portable: a value from copy A is not assignable to the same type from copy B.
+// This is the failure a consumer hits whenever a transitive dep, a pnpm peer split
+// or a linked tarball puts two copies of drizzle-orm on disk.
+//
+// The matrix below is the current, measured state of the public surface. `portable:
+// false` entries are known leaks, not aspirations -- each is annotated with the member
+// responsible. Fixing one is expected to flip its flag here; that is the point of
+// asserting both directions.
+interface PortabilityProbe {
+	/** Exported type name. */
+	name: string;
+	/** Package subpath it is exported from. */
+	subpath: string;
+	/** Type arguments, when the type has no usable defaults. */
+	typeArgs?: string;
+	/** Whether a value of this type survives crossing between two installs. */
+	portable: boolean;
+	/** For known leaks: the member whose nominality blocks assignment. */
+	blockedBy?: string;
+}
+
+const PORTABILITY_MATRIX: PortabilityProbe[] = [
+	{ name: 'SQL', subpath: 'sql/sql', portable: true },
+	{ name: 'Column', subpath: 'column', portable: true },
+	{ name: 'Table', subpath: 'table', portable: true },
+	{ name: 'Subquery', subpath: 'subquery', portable: true },
+	{ name: 'View', subpath: 'sql/sql', portable: true },
+	{ name: 'Placeholder', subpath: 'sql/sql', portable: true },
+	{ name: 'QueryPromise', subpath: 'query-promise', typeArgs: '<number>', portable: true },
+	{ name: 'MySqlTable', subpath: 'mysql-core', portable: true },
+	{ name: 'MySqlColumn', subpath: 'mysql-core', portable: true },
+	{ name: 'SQLiteTable', subpath: 'sqlite-core', portable: true },
+	{ name: 'SQLiteColumn', subpath: 'sqlite-core', portable: true },
+
+	{ name: 'Param', subpath: 'sql/sql', portable: false, blockedBy: 'Param#brand (protected)' },
+	{ name: 'Name', subpath: 'sql/sql', portable: false, blockedBy: 'Name#brand (protected)' },
+	{
+		name: 'CodecsCollection',
+		subpath: 'codecs',
+		portable: false,
+		blockedBy: 'CodecsCollection#resolveTypes (protected)',
+	},
+	// The three dialects all embed a CodecsCollection, so they inherit its leak.
+	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: 'CodecsCollection#resolveTypes (protected)' },
+	{
+		name: 'MySqlDialect',
+		subpath: 'mysql-core',
+		portable: false,
+		blockedBy: 'CodecsCollection#resolveTypes (protected)',
+	},
+	{
+		name: 'SQLiteDialect',
+		subpath: 'sqlite-core',
+		portable: false,
+		blockedBy: 'CodecsCollection#resolveTypes (protected)',
+	},
+	// Only pg-core exposes `toBuilder()` in a public return type, which is why the
+	// identical `foreignKeyConfigs` field on the other dialects' builders is unreachable
+	// and their table/column types above are portable.
+	{
+		name: 'PgTable',
+		subpath: 'pg-core',
+		portable: false,
+		blockedBy: 'PgColumnBuilder#foreignKeyConfigs (private), via PgColumn#toBuilder',
+	},
+	{
+		name: 'PgColumn',
+		subpath: 'pg-core',
+		portable: false,
+		blockedBy: 'PgColumnBuilder#foreignKeyConfigs (private), via PgColumn#toBuilder',
+	},
+	{
+		name: 'NodePgDatabase',
+		subpath: 'node-postgres/driver',
+		typeArgs: '<Record<string, never>>',
+		portable: false,
+		blockedBy: 'PgAsyncPreparedQuery#executor (protected)',
+	},
+];
+
+// Unpacks the built tarball's declarations twice, under two different package names,
+// so the compiler sees two independent installs of the same types.
+function materializeTwoInstalls(outDir: string): void {
+	const sourcePrefix = `/node_modules/${pkg.packageName}/`;
+	for (const packageName of ['drizzle-a', 'drizzle-b']) {
+		for (const file of pkg.listFiles(sourcePrefix)) {
+			if (file !== `${sourcePrefix}package.json` && !file.endsWith('.d.ts')) continue;
+
+			const destination = join(outDir, 'node_modules', packageName, file.slice(sourcePrefix.length));
+			mkdirSync(dirname(destination), { recursive: true });
+			const contents = pkg.readFile(file);
+			writeFileSync(
+				destination,
+				file === `${sourcePrefix}package.json`
+					? JSON.stringify({ ...JSON.parse(contents), name: packageName })
+					: contents,
+			);
+		}
+	}
+}
+
 describe.skipIf(!ARTIFACTS_PRESENT)('types are portable across package instances', () => {
-	test('SQL types from separate installations are assignable', () => {
+	test('the published surface matches the recorded portability matrix', () => {
 		const outDir = mkdtempSync(join(tmpdir(), 'drizzle-duplicate-types-'));
 		try {
-			const sourcePrefix = `/node_modules/${pkg.packageName}/`;
-			for (const packageName of ['drizzle-a', 'drizzle-b']) {
-				for (const file of pkg.listFiles(sourcePrefix)) {
-					if (file !== `${sourcePrefix}package.json` && !file.endsWith('.d.ts')) continue;
+			materializeTwoInstalls(outDir);
 
-					const destination = join(outDir, 'node_modules', packageName, file.slice(sourcePrefix.length));
-					mkdirSync(dirname(destination), { recursive: true });
-					const contents = pkg.readFile(file);
-					writeFileSync(
-						destination,
-						file === `${sourcePrefix}package.json`
-							? JSON.stringify({ ...JSON.parse(contents), name: packageName })
-							: contents,
-					);
-				}
+			// One program covering every probe: each assignment gets its own line so a
+			// diagnostic's line number identifies which type failed.
+			const lines: string[] = [];
+			const lineToName = new Map<number, string>();
+			for (const { name, subpath } of PORTABILITY_MATRIX) {
+				lines.push(`import type { ${name} as ${name}_A } from 'drizzle-a/${subpath}';`);
+				lines.push(`import type { ${name} as ${name}_B } from 'drizzle-b/${subpath}';`);
+			}
+			for (const { name, typeArgs = '' } of PORTABILITY_MATRIX) {
+				lines.push(`declare const v_${name}: ${name}_B${typeArgs};`);
+				lineToName.set(lines.length + 1, name);
+				lines.push(`export const c_${name}: ${name}_A${typeArgs} = v_${name};`);
 			}
 
 			const entrypoint = join(outDir, 'index.mts');
-			writeFileSync(
-				entrypoint,
-				[
-					"import type { SQL as SQLA } from 'drizzle-a/sql/sql';",
-					"import type { SQL as SQLB } from 'drizzle-b/sql/sql';",
-					'declare const sqlA: SQLA;',
-					'declare const sqlB: SQLB;',
-					'const acceptsA: SQLA = sqlB;',
-					'const acceptsB: SQLB = sqlA;',
-					'void [acceptsA, acceptsB];',
-				].join('\n'),
-			);
+			writeFileSync(entrypoint, lines.join('\n') + '\n');
 
 			const program = ts.createProgram({
 				rootNames: [entrypoint],
@@ -161,15 +253,39 @@ describe.skipIf(!ARTIFACTS_PRESENT)('types are portable across package instances
 					target: ts.ScriptTarget.ESNext,
 				},
 			});
-			const diagnostics = ts.getPreEmitDiagnostics(program);
-			expect(
-				diagnostics,
-				ts.formatDiagnosticsWithColorAndContext(diagnostics, {
-					getCanonicalFileName: (fileName) => fileName,
-					getCurrentDirectory: () => outDir,
-					getNewLine: () => '\n',
-				}),
-			).toEqual([]);
+
+			const failed = new Map<string, string>();
+			const unattributed: string[] = [];
+			for (const diagnostic of ts.getPreEmitDiagnostics(program)) {
+				const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
+				if (!diagnostic.file || diagnostic.start === undefined) {
+					unattributed.push(message);
+					continue;
+				}
+				const line = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start).line + 1;
+				const name = lineToName.get(line);
+				// A diagnostic on a non-assignment line means the probe itself is malformed
+				// (bad subpath, wrong type arity) rather than a portability result.
+				if (name === undefined) {
+					unattributed.push(`line ${line}: ${message}`);
+					continue;
+				}
+				if (!failed.has(name)) failed.set(name, message);
+			}
+
+			expect(unattributed, `malformed probes:\n${unattributed.join('\n')}`).toEqual([]);
+
+			const actual = PORTABILITY_MATRIX.filter((p) => !failed.has(p.name)).map((p) => p.name).sort();
+			const expected = PORTABILITY_MATRIX.filter((p) => p.portable).map((p) => p.name).sort();
+
+			const regressed = expected.filter((n) => !actual.includes(n));
+			const fixed = actual.filter((n) => !expected.includes(n));
+			const hint = [
+				...regressed.map((n) => `REGRESSED ${n} is no longer portable: ${failed.get(n)}`),
+				...fixed.map((n) => `FIXED ${n} is now portable -- set portable: true in PORTABILITY_MATRIX`),
+			].join('\n');
+
+			expect(actual, hint).toEqual(expected);
 		} finally {
 			rmSync(outDir, { recursive: true, force: true });
 		}

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import { beforeAll, describe, expect, test } from 'vitest';
 import { checkPackage } from '../../attw-fork/src/checkPackage.ts';
 import { getExitCode } from '../../attw-fork/src/cli/getExitCode.ts';
@@ -112,6 +113,67 @@ describe.skipIf(!ARTIFACTS_PRESENT)('no public subpath is dropped', () => {
 			.map((p) => p.entrypoint);
 		expect(unresolved, `unresolved: ${unresolved.slice(0, 20).join(', ')}`).toEqual([]);
 	}, 120_000);
+});
+
+describe.skipIf(!ARTIFACTS_PRESENT)('types are portable across package instances', () => {
+	test('SQL types from separate installations are assignable', () => {
+		const outDir = mkdtempSync(join(tmpdir(), 'drizzle-duplicate-types-'));
+		try {
+			const sourcePrefix = `/node_modules/${pkg.packageName}/`;
+			for (const packageName of ['drizzle-a', 'drizzle-b']) {
+				for (const file of pkg.listFiles(sourcePrefix)) {
+					if (file !== `${sourcePrefix}package.json` && !file.endsWith('.d.ts')) continue;
+
+					const destination = join(outDir, 'node_modules', packageName, file.slice(sourcePrefix.length));
+					mkdirSync(dirname(destination), { recursive: true });
+					const contents = pkg.readFile(file);
+					writeFileSync(
+						destination,
+						file === `${sourcePrefix}package.json`
+							? JSON.stringify({ ...JSON.parse(contents), name: packageName })
+							: contents,
+					);
+				}
+			}
+
+			const entrypoint = join(outDir, 'index.mts');
+			writeFileSync(
+				entrypoint,
+				[
+					"import type { SQL as SQLA } from 'drizzle-a/sql/sql';",
+					"import type { SQL as SQLB } from 'drizzle-b/sql/sql';",
+					'declare const sqlA: SQLA;',
+					'declare const sqlB: SQLB;',
+					'const acceptsA: SQLA = sqlB;',
+					'const acceptsB: SQLB = sqlA;',
+					'void [acceptsA, acceptsB];',
+				].join('\n'),
+			);
+
+			const program = ts.createProgram({
+				rootNames: [entrypoint],
+				options: {
+					module: ts.ModuleKind.NodeNext,
+					moduleResolution: ts.ModuleResolutionKind.NodeNext,
+					noEmit: true,
+					skipLibCheck: true,
+					strict: true,
+					target: ts.ScriptTarget.ESNext,
+				},
+			});
+			const diagnostics = ts.getPreEmitDiagnostics(program);
+			expect(
+				diagnostics,
+				ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+					getCanonicalFileName: (fileName) => fileName,
+					getCurrentDirectory: () => outDir,
+					getNewLine: () => '\n',
+				}),
+			).toEqual([]);
+		} finally {
+			rmSync(outDir, { recursive: true, force: true });
+		}
+	});
 });
 
 describe('directory-index shim emitter refuses to shadow a source artifact', () => {

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -139,13 +139,7 @@ interface PortabilityProbe {
 	blockedBy?: string;
 }
 
-// The dialects are blocked by something categorically different from a nominal member:
-// `BuildRelationalQueryResult['selection']`, an anonymous recursive intersection-of-union
-// reached via `mapperGenerators.relationalRows`. Having no named symbol, it misses the
-// compiler's relation cache, so each cross-instance comparison re-expands until the
-// recursion limiter gives up and reports a mismatch. Fixing it means naming that type,
-// not marking a member `@internal`.
-const DIALECT_BLOCKER = "BuildRelationalQueryResult['selection'] (anonymous recursive type)";
+const EMPTY_FILTER = 'EmptyFilter (unique symbol)';
 
 const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'SQL', subpath: 'sql/sql', portable: true },
@@ -162,21 +156,61 @@ const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'PgView', subpath: 'pg-core', portable: true },
 	{ name: 'MySqlView', subpath: 'mysql-core', portable: true },
 	{ name: 'SQLiteView', subpath: 'sqlite-core', portable: true },
+	{ name: 'CockroachView', subpath: 'cockroach-core', portable: true },
+	{ name: 'MsSqlView', subpath: 'mssql-core', portable: true },
+	{ name: 'SingleStoreView', subpath: 'singlestore-core/view', portable: true },
 
 	{ name: 'Param', subpath: 'sql/sql', portable: true },
 	{ name: 'Name', subpath: 'sql/sql', portable: true },
 	{ name: 'CodecsCollection', subpath: 'codecs', portable: true },
-	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: DIALECT_BLOCKER },
-	{ name: 'MySqlDialect', subpath: 'mysql-core', portable: false, blockedBy: DIALECT_BLOCKER },
-	{ name: 'SQLiteDialect', subpath: 'sqlite-core', portable: false, blockedBy: DIALECT_BLOCKER },
+	// Their nominal members are stripped; what remains is `EmptyFilter`, whose
+	// `unique symbol` type is nominal per declaration site. That is an API decision
+	// rather than a marker, so it is made separately.
+	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: EMPTY_FILTER },
+	{ name: 'MySqlDialect', subpath: 'mysql-core', portable: false, blockedBy: EMPTY_FILTER },
+	{ name: 'SQLiteDialect', subpath: 'sqlite-core', portable: false, blockedBy: EMPTY_FILTER },
+	// These three reach their session class, and so inherit a chain of nominal members
+	// -- Session#dialect, then the prepared-query and transaction classes behind it --
+	// on top of EmptyFilter. The chain does not fall to a contained change, so unlike
+	// their pg/mysql/sqlite counterparts they stay recorded rather than fixed here.
+	{
+		name: 'CockroachDialect',
+		subpath: 'cockroach-core',
+		portable: false,
+		blockedBy: 'CockroachSession#dialect (protected), and a chain behind it',
+	},
+	{
+		name: 'MsSqlDialect',
+		subpath: 'mssql-core',
+		portable: false,
+		blockedBy: 'MsSqlSession#dialect (protected), and a chain behind it',
+	},
+	{
+		name: 'SingleStoreDialect',
+		subpath: 'singlestore-core',
+		portable: false,
+		blockedBy: 'SingleStoreSession#dialect (protected), and a chain behind it',
+	},
 	{ name: 'PgTable', subpath: 'pg-core', portable: true },
 	{ name: 'PgColumn', subpath: 'pg-core', portable: true },
+	// Query builders are non-portable for the same reason, and stop at the same kind of
+	// wall: stripping PgSelectBase's nominal members only reveals `CheckTableLikeSelection`,
+	// a conditional deferred on an unresolved type parameter, behind them. Recorded so
+	// `function withPagination(qb: PgSelect)` is known not to survive the boundary.
+	{
+		name: 'PgSelect',
+		subpath: 'pg-core',
+		portable: false,
+		blockedBy: 'PgSelectBase#config (protected), and a deferred conditional behind it',
+	},
 	// The database object is reached through the session, and every prepared-query,
-	// transaction and relational-query-builder class along that path contributes its own
-	// nominal member: PgAsyncPreparedQuery#executor, then PgBasePreparedQuery#query, then
-	// PgAsyncTransaction#nestedIndex, then RelationalQueryBuilder#schema, and onward
-	// through ~70 more across pg-core/query-builders. Unlike the entries above it does
-	// not fall to a contained change, so it is left recorded rather than half-fixed.
+	// transaction and relational-query-builder class on that path contributes its own
+	// nominal member. Peeling them is not worth attempting: past the last of them the
+	// type comes to rest on `BuildQueryResult<..., TConfig, ...>`, a mapped type deferred
+	// on the unresolved parameter of `findMany<TConfig>`. The compiler cannot relate
+	// `keyof X` from one declaration site to `keyof X` from the other while X stays
+	// deferred, so it widens to `string | number | symbol` and fails -- a comparison
+	// limit in TypeScript rather than anything drizzle emits. Recorded, not chased.
 	{
 		name: 'NodePgDatabase',
 		subpath: 'node-postgres/driver',

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -166,27 +166,20 @@ const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: DIALECT_BLOCKER },
 	{ name: 'MySqlDialect', subpath: 'mysql-core', portable: false, blockedBy: DIALECT_BLOCKER },
 	{ name: 'SQLiteDialect', subpath: 'sqlite-core', portable: false, blockedBy: DIALECT_BLOCKER },
-	// Only pg-core exposes `toBuilder()` in a public return type, which is why the
-	// identical `foreignKeyConfigs` field on the other dialects' builders is unreachable
-	// and their table/column types above are portable.
-	{
-		name: 'PgTable',
-		subpath: 'pg-core',
-		portable: false,
-		blockedBy: 'PgColumnBuilder#foreignKeyConfigs (private), via PgColumn#toBuilder',
-	},
-	{
-		name: 'PgColumn',
-		subpath: 'pg-core',
-		portable: false,
-		blockedBy: 'PgColumnBuilder#foreignKeyConfigs (private), via PgColumn#toBuilder',
-	},
+	{ name: 'PgTable', subpath: 'pg-core', portable: true },
+	{ name: 'PgColumn', subpath: 'pg-core', portable: true },
+	// The database object is reached through the session, and every prepared-query,
+	// transaction and relational-query-builder class along that path contributes its own
+	// nominal member: PgAsyncPreparedQuery#executor, then PgBasePreparedQuery#query, then
+	// PgAsyncTransaction#nestedIndex, then RelationalQueryBuilder#schema, and onward
+	// through ~70 more across pg-core/query-builders. Unlike the entries above it does
+	// not fall to a contained change, so it is left recorded rather than half-fixed.
 	{
 		name: 'NodePgDatabase',
 		subpath: 'node-postgres/driver',
 		typeArgs: '<Record<string, never>>',
 		portable: false,
-		blockedBy: 'PgAsyncPreparedQuery#executor (protected)',
+		blockedBy: 'a multi-layer chain rooted at PgAsyncPreparedQuery#executor (protected)',
 	},
 ];
 

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -159,6 +159,9 @@ const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'MySqlColumn', subpath: 'mysql-core', portable: true },
 	{ name: 'SQLiteTable', subpath: 'sqlite-core', portable: true },
 	{ name: 'SQLiteColumn', subpath: 'sqlite-core', portable: true },
+	{ name: 'PgView', subpath: 'pg-core', portable: true },
+	{ name: 'MySqlView', subpath: 'mysql-core', portable: true },
+	{ name: 'SQLiteView', subpath: 'sqlite-core', portable: true },
 
 	{ name: 'Param', subpath: 'sql/sql', portable: true },
 	{ name: 'Name', subpath: 'sql/sql', portable: true },

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -139,6 +139,14 @@ interface PortabilityProbe {
 	blockedBy?: string;
 }
 
+// The dialects are blocked by something categorically different from a nominal member:
+// `BuildRelationalQueryResult['selection']`, an anonymous recursive intersection-of-union
+// reached via `mapperGenerators.relationalRows`. Having no named symbol, it misses the
+// compiler's relation cache, so each cross-instance comparison re-expands until the
+// recursion limiter gives up and reports a mismatch. Fixing it means naming that type,
+// not marking a member `@internal`.
+const DIALECT_BLOCKER = "BuildRelationalQueryResult['selection'] (anonymous recursive type)";
+
 const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'SQL', subpath: 'sql/sql', portable: true },
 	{ name: 'Column', subpath: 'column', portable: true },
@@ -152,28 +160,12 @@ const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'SQLiteTable', subpath: 'sqlite-core', portable: true },
 	{ name: 'SQLiteColumn', subpath: 'sqlite-core', portable: true },
 
-	{ name: 'Param', subpath: 'sql/sql', portable: false, blockedBy: 'Param#brand (protected)' },
-	{ name: 'Name', subpath: 'sql/sql', portable: false, blockedBy: 'Name#brand (protected)' },
-	{
-		name: 'CodecsCollection',
-		subpath: 'codecs',
-		portable: false,
-		blockedBy: 'CodecsCollection#resolveTypes (protected)',
-	},
-	// The three dialects all embed a CodecsCollection, so they inherit its leak.
-	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: 'CodecsCollection#resolveTypes (protected)' },
-	{
-		name: 'MySqlDialect',
-		subpath: 'mysql-core',
-		portable: false,
-		blockedBy: 'CodecsCollection#resolveTypes (protected)',
-	},
-	{
-		name: 'SQLiteDialect',
-		subpath: 'sqlite-core',
-		portable: false,
-		blockedBy: 'CodecsCollection#resolveTypes (protected)',
-	},
+	{ name: 'Param', subpath: 'sql/sql', portable: true },
+	{ name: 'Name', subpath: 'sql/sql', portable: true },
+	{ name: 'CodecsCollection', subpath: 'codecs', portable: true },
+	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: DIALECT_BLOCKER },
+	{ name: 'MySqlDialect', subpath: 'mysql-core', portable: false, blockedBy: DIALECT_BLOCKER },
+	{ name: 'SQLiteDialect', subpath: 'sqlite-core', portable: false, blockedBy: DIALECT_BLOCKER },
 	// Only pg-core exposes `toBuilder()` in a public return type, which is why the
 	// identical `foreignKeyConfigs` field on the other dialects' builders is unreachable
 	// and their table/column types above are portable.

--- a/drizzle-orm/tests/exports-resolution.test.ts
+++ b/drizzle-orm/tests/exports-resolution.test.ts
@@ -139,8 +139,6 @@ interface PortabilityProbe {
 	blockedBy?: string;
 }
 
-const EMPTY_FILTER = 'EmptyFilter (unique symbol)';
-
 const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'SQL', subpath: 'sql/sql', portable: true },
 	{ name: 'Column', subpath: 'column', portable: true },
@@ -163,12 +161,9 @@ const PORTABILITY_MATRIX: PortabilityProbe[] = [
 	{ name: 'Param', subpath: 'sql/sql', portable: true },
 	{ name: 'Name', subpath: 'sql/sql', portable: true },
 	{ name: 'CodecsCollection', subpath: 'codecs', portable: true },
-	// Their nominal members are stripped; what remains is `EmptyFilter`, whose
-	// `unique symbol` type is nominal per declaration site. That is an API decision
-	// rather than a marker, so it is made separately.
-	{ name: 'PgDialect', subpath: 'pg-core', portable: false, blockedBy: EMPTY_FILTER },
-	{ name: 'MySqlDialect', subpath: 'mysql-core', portable: false, blockedBy: EMPTY_FILTER },
-	{ name: 'SQLiteDialect', subpath: 'sqlite-core', portable: false, blockedBy: EMPTY_FILTER },
+	{ name: 'PgDialect', subpath: 'pg-core', portable: true },
+	{ name: 'MySqlDialect', subpath: 'mysql-core', portable: true },
+	{ name: 'SQLiteDialect', subpath: 'sqlite-core', portable: true },
 	// These three reach their session class, and so inherit a chain of nominal members
 	// -- Session#dialect, then the prepared-query and transaction classes behind it --
 	// on top of EmptyFilter. The chain does not fall to a contained change, so unlike


### PR DESCRIPTION
> **Stacked on #6200** — it contains that PR's commits until it lands. Review only the last commit, `Type EmptyFilter as a string literal`.
>
> Separate from #6200 because it is the one change that touches observable API. That call is yours; #6200 stands on its own without it.

## What

```diff
-export const EmptyFilter = Symbol.for('drizzle:EmptyFilter');
+export const EmptyFilter = 'drizzle:EmptyFilter';
 export type EmptyFilter = typeof EmptyFilter;
```

## Why

#6200 strips every nominal member from the dialects — including `AggregatedField#table`, which is what the recursive `selection` type was actually tripping over — and all three then come to rest here. I verified this is still load-bearing after that: with #6200 applied and this change reverted, all three dialects fail again on `Type 'unique symbol' is not assignable to type 'AnyTableFilter | unique symbol'`.

`Symbol.for` returns the *same* symbol in every copy of the package on disk, so the value was already portable at runtime — but its inferred type is `unique symbol`, which is nominal per declaration site. The type contradicted the runtime, and every public type mentioning `EmptyFilter` stopped being assignable across installs.

## Why a string literal specifically

The filter builder relies on unit-ness:

```ts
if (processed === EmptyFilter) continue;
parts.push(processed);   // <- requires EmptyFilter to be narrowed out of the union
```

Only **unit types** narrow under `===`. I tried the obvious structural alternative first — a branded `symbol & { readonly [Brand]: true }` — and it fails to compile at exactly that line: structural, but not a unit type, so the guard stops narrowing. A string literal is the only type that is both, so it is the only option that keeps the narrowing *and* gains the portability.

## Trade-off, explicitly

This changes an exported runtime value from a symbol to a string. Identity comparison (`where === EmptyFilter`, `where: EmptyFilter`) is unaffected, and `EmptyFilter` is confined to `relations.ts` internally — but it is observable: `typeof EmptyFilter === 'symbol'`, or reliance on symbol non-enumerability when serialising a filter, would notice.

If that is unacceptable, drop this PR. It costs the three dialect rows and nothing else.

## Result

`PgDialect`, `MySqlDialect` and `SQLiteDialect` flip to portable — **22 of 30 to 25 of 30** on the matrix.

The cockroach, mssql and singlestore dialects need this change too, but do not flip: they reach their session class and are blocked behind a further chain of nominal members. They stay recorded rather than half-fixed.

## Verification

Full `drizzle-orm` suite green (27 files, 1344 tests); `test:types` clean, including the narrowing site above.
