### PR TITLE
fix(sqlite): preserve cascade dependents during table rebuilds

### DIFF
--- a/drizzle-kit/src/cli/commands/libSqlPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/libSqlPushUtils.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { JsonStatement } from 'src/jsonStatements';
+import { JsonRecreateTableCascadeDependent, JsonStatement } from 'src/jsonStatements';
 import { findAddedAndRemoved, SQLiteDB } from 'src/utils';
 import { SQLiteSchemaInternal, SQLiteSchemaSquashed, SQLiteSquasher } from '../../serializer/sqliteSchema';
 import {
@@ -11,6 +11,7 @@ import {
 	SQLiteDropTableConvertor,
 	SqliteRenameTableConvertor,
 } from '../../sqlgenerator';
+import { collectCascadeDependents, quoteSQLiteIdentifier } from '../../utils/cascade';
 
 export const getOldTableName = (
 	tableName: string,
@@ -29,10 +30,20 @@ export const _moveDataStatements = (
 	tableName: string,
 	json: SQLiteSchemaSquashed,
 	dataLoss: boolean = false,
+	cascadeDependents: JsonRecreateTableCascadeDependent[] = [],
 ) => {
 	const statements: string[] = [];
 
 	const newTableName = `__new_${tableName}`;
+
+	for (const dep of cascadeDependents) {
+		const dependentColumns = dep.columns.map(quoteSQLiteIdentifier).join(', ');
+		statements.push(
+			`CREATE TABLE ${quoteSQLiteIdentifier(dep.backupTableName)} AS SELECT ${dependentColumns} FROM ${
+				quoteSQLiteIdentifier(dep.tableName)
+			};`,
+		);
+	}
 
 	// create table statement from a new json2 with proper name
 	const tableColumns = Object.values(json.tables[tableName].columns);
@@ -107,6 +118,17 @@ export const _moveDataStatements = (
 			}),
 		);
 	}
+
+	for (const dep of cascadeDependents) {
+		const dependentColumns = dep.columns.map(quoteSQLiteIdentifier).join(', ');
+		statements.push(
+			`INSERT OR REPLACE INTO ${
+				quoteSQLiteIdentifier(dep.tableName)
+			} (${dependentColumns}) SELECT ${dependentColumns} FROM ${quoteSQLiteIdentifier(dep.backupTableName)};`,
+		);
+		statements.push(`DROP TABLE ${quoteSQLiteIdentifier(dep.backupTableName)};`);
+	}
+
 	return statements;
 };
 
@@ -302,14 +324,17 @@ export const libSqlLogSuggestionsAndReturn = async (
 				tablesReferencingCurrent.push(...tablesRefs);
 			}
 
-			if (!tablesReferencingCurrent.length) {
-				statementsToExecute.push(..._moveDataStatements(tableName, json2, dataLoss));
+			const cascadeDependents = collectCascadeDependents(tableName, json1, json2, 'push');
+
+			if (tablesReferencingCurrent.length === 0) {
+				statementsToExecute.push(
+					..._moveDataStatements(tableName, json2, dataLoss, cascadeDependents),
+				);
 				continue;
 			}
 
-			// recreate table
 			statementsToExecute.push(
-				..._moveDataStatements(tableName, json2, dataLoss),
+				..._moveDataStatements(tableName, json2, dataLoss, cascadeDependents),
 			);
 		} else if (
 			statement.type === 'alter_table_alter_column_set_generated'

--- a/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
+++ b/drizzle-kit/src/cli/commands/sqlitePushUtils.ts
@@ -9,17 +9,29 @@ import {
 	SqliteRenameTableConvertor,
 } from '../../sqlgenerator';
 
-import type { JsonStatement } from '../../jsonStatements';
+import type { JsonRecreateTableCascadeDependent, JsonStatement } from '../../jsonStatements';
 import { findAddedAndRemoved, type SQLiteDB } from '../../utils';
+import { collectCascadeDependents, quoteSQLiteIdentifier } from '../../utils/cascade';
 
 export const _moveDataStatements = (
 	tableName: string,
 	json: SQLiteSchemaSquashed,
 	dataLoss: boolean = false,
+	cascadeDependents: JsonRecreateTableCascadeDependent[] = [],
 ) => {
 	const statements: string[] = [];
 
 	const newTableName = `__new_${tableName}`;
+
+	// backup dependent tables to prevent ON DELETE CASCADE data loss when dropping parent
+	for (const dep of cascadeDependents) {
+		const dependentColumns = dep.columns.map(quoteSQLiteIdentifier).join(', ');
+		statements.push(
+			`CREATE TABLE ${quoteSQLiteIdentifier(dep.backupTableName)} AS SELECT ${dependentColumns} FROM ${
+				quoteSQLiteIdentifier(dep.tableName)
+			};`,
+		);
+	}
 
 	// create table statement from a new json2 with proper name
 	const tableColumns = Object.values(json.tables[tableName].columns);
@@ -93,6 +105,17 @@ export const _moveDataStatements = (
 				data: idx,
 			}),
 		);
+	}
+
+	// restore dependents data after parent recreation (works when PRAGMA foreign_keys cannot be disabled, e.g. D1)
+	for (const dep of cascadeDependents) {
+		const dependentColumns = dep.columns.map(quoteSQLiteIdentifier).join(', ');
+		statements.push(
+			`INSERT OR REPLACE INTO ${
+				quoteSQLiteIdentifier(dep.tableName)
+			} (${dependentColumns}) SELECT ${dependentColumns} FROM ${quoteSQLiteIdentifier(dep.backupTableName)};`,
+		);
+		statements.push(`DROP TABLE ${quoteSQLiteIdentifier(dep.backupTableName)};`);
 	}
 
 	return statements;
@@ -286,8 +309,12 @@ export const logSuggestionsAndReturn = async (
 				tablesReferencingCurrent.push(...tablesRefs);
 			}
 
+			const cascadeDependents = collectCascadeDependents(tableName, json1, json2, 'push');
+
 			if (!tablesReferencingCurrent.length) {
-				statementsToExecute.push(..._moveDataStatements(tableName, json2, dataLoss));
+				statementsToExecute.push(
+					..._moveDataStatements(tableName, json2, dataLoss, cascadeDependents),
+				);
 				continue;
 			}
 
@@ -295,13 +322,13 @@ export const logSuggestionsAndReturn = async (
 				foreign_keys: number;
 			}>(`PRAGMA foreign_keys;`);
 
-			if (pragmaState) {
-				statementsToExecute.push(`PRAGMA foreign_keys=OFF;`);
-			}
-			statementsToExecute.push(..._moveDataStatements(tableName, json2, dataLoss));
-			if (pragmaState) {
-				statementsToExecute.push(`PRAGMA foreign_keys=ON;`);
-			}
+			// In environments like Cloudflare D1, PRAGMA foreign_keys cannot be disabled, so we
+			// both toggle when possible and also use backups to prevent cascade data loss.
+			if (pragmaState) statementsToExecute.push(`PRAGMA foreign_keys=OFF;`);
+			statementsToExecute.push(
+				..._moveDataStatements(tableName, json2, dataLoss, cascadeDependents),
+			);
+			if (pragmaState) statementsToExecute.push(`PRAGMA foreign_keys=ON;`);
 		} else {
 			const fromJsonStatement = fromJson([statement], 'sqlite', 'push');
 			statementsToExecute.push(

--- a/drizzle-kit/src/jsonStatements.ts
+++ b/drizzle-kit/src/jsonStatements.ts
@@ -72,6 +72,13 @@ export interface JsonRecreateTableStatement {
 	compositePKs: string[][];
 	uniqueConstraints?: string[];
 	checkConstraints: string[];
+	cascadeDependents?: JsonRecreateTableCascadeDependent[];
+}
+
+export interface JsonRecreateTableCascadeDependent {
+	tableName: string;
+	backupTableName: string;
+	columns: string[];
 }
 
 export interface JsonRecreateSingleStoreTableStatement {

--- a/drizzle-kit/src/snapshotsDiffer.ts
+++ b/drizzle-kit/src/snapshotsDiffer.ts
@@ -3768,7 +3768,7 @@ export const applySqliteSnapshotsDiff = async (
 	jsonStatements.push(...dropViews);
 	jsonStatements.push(...createViews);
 
-	const combinedJsonStatements = sqliteCombineStatements(jsonStatements, json2, action);
+	const combinedJsonStatements = sqliteCombineStatements(jsonStatements, json1, json2, action);
 	const sqlStatements = fromJson(combinedJsonStatements, 'sqlite');
 
 	const uniqueSqlStatements: string[] = [];
@@ -4304,7 +4304,7 @@ export const applyLibSQLSnapshotsDiff = async (
 
 	jsonStatements.push(...jsonAlteredUniqueConstraints);
 
-	const combinedJsonStatements = libSQLCombineStatements(jsonStatements, json2, action);
+	const combinedJsonStatements = libSQLCombineStatements(jsonStatements, json1, json2, action);
 
 	const sqlStatements = fromJson(
 		combinedJsonStatements,

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -91,6 +91,7 @@ import { SingleStoreSquasher } from './serializer/singlestoreSchema';
 import { SQLiteSchemaSquashed, SQLiteSquasher } from './serializer/sqliteSchema';
 
 import { escapeSingleQuotes } from './utils';
+import { quoteSQLiteIdentifier } from './utils/cascade';
 
 const parseType = (schemaPrefix: string, type: string) => {
 	const pgNativeTypes = [
@@ -3769,7 +3770,7 @@ class SQLiteRecreateTableConvertor extends Convertor {
 	}
 
 	convert(statement: JsonRecreateTableStatement): string | string[] {
-		const { tableName, columns, compositePKs, referenceData, checkConstraints } = statement;
+		const { tableName, columns, compositePKs, referenceData, checkConstraints, cascadeDependents = [] } = statement;
 
 		const columnNames = columns.map((it) => `"${it.name}"`).join(', ');
 		const newTableName = `__new_${tableName}`;
@@ -3777,6 +3778,15 @@ class SQLiteRecreateTableConvertor extends Convertor {
 		const sqlStatements: string[] = [];
 
 		sqlStatements.push(`PRAGMA foreign_keys=OFF;`);
+
+		for (const dep of cascadeDependents) {
+			const dependentColumns = dep.columns.map(quoteSQLiteIdentifier).join(', ');
+			sqlStatements.push(
+				`CREATE TABLE ${quoteSQLiteIdentifier(dep.backupTableName)} AS SELECT ${dependentColumns} FROM ${
+					quoteSQLiteIdentifier(dep.tableName)
+				};`,
+			);
+		}
 
 		// map all possible variants
 		const mappedCheckConstraints: string[] = checkConstraints.map((it) =>
@@ -3821,6 +3831,16 @@ class SQLiteRecreateTableConvertor extends Convertor {
 			}),
 		);
 
+		for (const dep of cascadeDependents) {
+			const dependentColumns = dep.columns.map(quoteSQLiteIdentifier).join(', ');
+			sqlStatements.push(
+				`INSERT OR REPLACE INTO ${
+					quoteSQLiteIdentifier(dep.tableName)
+				} (${dependentColumns}) SELECT ${dependentColumns} FROM ${quoteSQLiteIdentifier(dep.backupTableName)};`,
+			);
+			sqlStatements.push(`DROP TABLE ${quoteSQLiteIdentifier(dep.backupTableName)};`);
+		}
+
 		sqlStatements.push(`PRAGMA foreign_keys=ON;`);
 
 		return sqlStatements;
@@ -3836,12 +3856,21 @@ class LibSQLRecreateTableConvertor extends Convertor {
 	}
 
 	convert(statement: JsonRecreateTableStatement): string[] {
-		const { tableName, columns, compositePKs, referenceData, checkConstraints } = statement;
+		const { tableName, columns, compositePKs, referenceData, checkConstraints, cascadeDependents = [] } = statement;
 
 		const columnNames = columns.map((it) => `"${it.name}"`).join(', ');
 		const newTableName = `__new_${tableName}`;
 
 		const sqlStatements: string[] = [];
+
+		for (const dep of cascadeDependents) {
+			const dependentColumns = dep.columns.map(quoteSQLiteIdentifier).join(', ');
+			sqlStatements.push(
+				`CREATE TABLE ${quoteSQLiteIdentifier(dep.backupTableName)} AS SELECT ${dependentColumns} FROM ${
+					quoteSQLiteIdentifier(dep.tableName)
+				};`,
+			);
+		}
 
 		const mappedCheckConstraints: string[] = checkConstraints.map((it) =>
 			it.replaceAll(`"${tableName}".`, `"${newTableName}".`).replaceAll(`\`${tableName}\`.`, `\`${newTableName}\`.`)
@@ -3886,6 +3915,16 @@ class LibSQLRecreateTableConvertor extends Convertor {
 				type: 'rename_table',
 			}),
 		);
+
+		for (const dep of cascadeDependents) {
+			const dependentColumns = dep.columns.map(quoteSQLiteIdentifier).join(', ');
+			sqlStatements.push(
+				`INSERT OR REPLACE INTO ${
+					quoteSQLiteIdentifier(dep.tableName)
+				} (${dependentColumns}) SELECT ${dependentColumns} FROM ${quoteSQLiteIdentifier(dep.backupTableName)};`,
+			);
+			sqlStatements.push(`DROP TABLE ${quoteSQLiteIdentifier(dep.backupTableName)};`);
+		}
 
 		sqlStatements.push(`PRAGMA foreign_keys=ON;`);
 

--- a/drizzle-kit/src/statementCombiner.ts
+++ b/drizzle-kit/src/statementCombiner.ts
@@ -6,9 +6,12 @@ import {
 } from './jsonStatements';
 import { SingleStoreSchemaSquashed } from './serializer/singlestoreSchema';
 import { SQLiteSchemaSquashed, SQLiteSquasher } from './serializer/sqliteSchema';
+import { collectCascadeDependents } from './utils/cascade';
 
 export const prepareLibSQLRecreateTable = (
 	table: SQLiteSchemaSquashed['tables'][keyof SQLiteSchemaSquashed['tables']],
+	json1: SQLiteSchemaSquashed,
+	json2: SQLiteSchemaSquashed,
 	action?: 'push',
 ): (JsonRecreateTableStatement | JsonCreateIndexStatement)[] => {
 	const { name, columns, uniqueConstraints, indexes, checkConstraints } = table;
@@ -22,6 +25,8 @@ export const prepareLibSQLRecreateTable = (
 		action === 'push' ? SQLiteSquasher.unsquashPushFK(it) : SQLiteSquasher.unsquashFK(it)
 	);
 
+	const cascadeDependents = collectCascadeDependents(name, json1, json2, action);
+
 	const statements: (JsonRecreateTableStatement | JsonCreateIndexStatement)[] = [
 		{
 			type: 'recreate_table',
@@ -31,6 +36,7 @@ export const prepareLibSQLRecreateTable = (
 			referenceData: fks,
 			uniqueConstraints: Object.values(uniqueConstraints),
 			checkConstraints: Object.values(checkConstraints),
+			...(cascadeDependents.length > 0 ? { cascadeDependents } : {}),
 		},
 	];
 
@@ -42,6 +48,8 @@ export const prepareLibSQLRecreateTable = (
 
 export const prepareSQLiteRecreateTable = (
 	table: SQLiteSchemaSquashed['tables'][keyof SQLiteSchemaSquashed['tables']],
+	json1: SQLiteSchemaSquashed,
+	json2: SQLiteSchemaSquashed,
 	action?: 'push',
 ): JsonStatement[] => {
 	const { name, columns, uniqueConstraints, indexes, checkConstraints } = table;
@@ -55,6 +63,8 @@ export const prepareSQLiteRecreateTable = (
 		action === 'push' ? SQLiteSquasher.unsquashPushFK(it) : SQLiteSquasher.unsquashFK(it)
 	);
 
+	const cascadeDependents = collectCascadeDependents(name, json1, json2, action);
+
 	const statements: JsonStatement[] = [
 		{
 			type: 'recreate_table',
@@ -64,6 +74,7 @@ export const prepareSQLiteRecreateTable = (
 			referenceData: fks,
 			uniqueConstraints: Object.values(uniqueConstraints),
 			checkConstraints: Object.values(checkConstraints),
+			...(cascadeDependents.length > 0 ? { cascadeDependents } : {}),
 		},
 	];
 
@@ -75,9 +86,16 @@ export const prepareSQLiteRecreateTable = (
 
 export const libSQLCombineStatements = (
 	statements: JsonStatement[],
-	json2: SQLiteSchemaSquashed,
+	json1OrJson2: SQLiteSchemaSquashed,
+	json2OrAction?: SQLiteSchemaSquashed | 'push',
 	action?: 'push',
 ) => {
+	const json1 = json1OrJson2;
+	const json2 = typeof json2OrAction === 'string' || !json2OrAction
+		? json1OrJson2
+		: json2OrAction;
+	if (typeof json2OrAction === 'string') action = json2OrAction;
+
 	// const tablesContext: Record<string, string[]> = {};
 	const newStatements: Record<string, JsonStatement[]> = {};
 	for (const statement of statements) {
@@ -97,14 +115,14 @@ export const libSQLCombineStatements = (
 			const statementsForTable = newStatements[tableName];
 
 			if (!statementsForTable) {
-				newStatements[tableName] = prepareLibSQLRecreateTable(json2.tables[tableName], action);
+				newStatements[tableName] = prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action);
 
 				continue;
 			}
 
 			if (!statementsForTable.some(({ type }) => type === 'recreate_table')) {
 				const wasRename = statementsForTable.some(({ type }) => type === 'rename_table');
-				const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
+				const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action);
 
 				if (wasRename) {
 					newStatements[tableName].push(...preparedStatements);
@@ -142,7 +160,7 @@ export const libSQLCombineStatements = (
 			if (
 				!statementsForTable && (columnIsPartOfForeignKey || columnPk)
 			) {
-				newStatements[tableName] = prepareLibSQLRecreateTable(json2.tables[tableName], action);
+				newStatements[tableName] = prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action);
 				continue;
 			}
 
@@ -151,7 +169,7 @@ export const libSQLCombineStatements = (
 			) {
 				if (!statementsForTable.some(({ type }) => type === 'recreate_table')) {
 					const wasRename = statementsForTable.some(({ type }) => type === 'rename_table');
-					const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
+					const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action);
 
 					if (wasRename) {
 						newStatements[tableName].push(...preparedStatements);
@@ -186,7 +204,7 @@ export const libSQLCombineStatements = (
 
 			if (!statementsForTable) {
 				newStatements[tableName] = statement.isMulticolumn
-					? prepareLibSQLRecreateTable(json2.tables[tableName], action)
+					? prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action)
 					: [statement];
 
 				continue;
@@ -205,7 +223,7 @@ export const libSQLCombineStatements = (
 			if (statement.isMulticolumn) {
 				if (!statementsForTable.some(({ type }) => type === 'recreate_table')) {
 					const wasRename = statementsForTable.some(({ type }) => type === 'rename_table');
-					const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
+					const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action);
 
 					if (wasRename) {
 						newStatements[tableName].push(...preparedStatements);
@@ -232,13 +250,13 @@ export const libSQLCombineStatements = (
 			const statementsForTable = newStatements[tableName];
 
 			if (!statementsForTable) {
-				newStatements[tableName] = prepareLibSQLRecreateTable(json2.tables[tableName], action);
+				newStatements[tableName] = prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action);
 				continue;
 			}
 
 			if (!statementsForTable.some(({ type }) => type === 'recreate_table')) {
 				const wasRename = statementsForTable.some(({ type }) => type === 'rename_table');
-				const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
+				const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action);
 
 				if (wasRename) {
 					newStatements[tableName].push(...preparedStatements);
@@ -258,13 +276,13 @@ export const libSQLCombineStatements = (
 			const statementsForTable = newStatements[tableName];
 
 			if (!statementsForTable) {
-				newStatements[tableName] = prepareLibSQLRecreateTable(json2.tables[tableName], action);
+				newStatements[tableName] = prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action);
 				continue;
 			}
 
 			if (!statementsForTable.some(({ type }) => type === 'recreate_table')) {
 				const wasRename = statementsForTable.some(({ type }) => type === 'rename_table');
-				const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], action);
+				const preparedStatements = prepareLibSQLRecreateTable(json2.tables[tableName], json1, json2, action);
 
 				if (wasRename) {
 					newStatements[tableName].push(...preparedStatements);
@@ -304,9 +322,16 @@ export const libSQLCombineStatements = (
 
 export const sqliteCombineStatements = (
 	statements: JsonStatement[],
-	json2: SQLiteSchemaSquashed,
+	json1OrJson2: SQLiteSchemaSquashed,
+	json2OrAction?: SQLiteSchemaSquashed | 'push',
 	action?: 'push',
 ) => {
+	const json1 = json1OrJson2;
+	const json2 = typeof json2OrAction === 'string' || !json2OrAction
+		? json1OrJson2
+		: json2OrAction;
+	if (typeof json2OrAction === 'string') action = json2OrAction;
+
 	// const tablesContext: Record<string, string[]> = {};
 	const newStatements: Record<string, JsonStatement[]> = {};
 	for (const statement of statements) {
@@ -335,13 +360,13 @@ export const sqliteCombineStatements = (
 			const statementsForTable = newStatements[tableName];
 
 			if (!statementsForTable) {
-				newStatements[tableName] = prepareSQLiteRecreateTable(json2.tables[tableName], action);
+				newStatements[tableName] = prepareSQLiteRecreateTable(json2.tables[tableName], json1, json2, action);
 				continue;
 			}
 
 			if (!statementsForTable.some(({ type }) => type === 'recreate_table')) {
 				const wasRename = statementsForTable.some(({ type }) => type === 'rename_table');
-				const preparedStatements = prepareSQLiteRecreateTable(json2.tables[tableName], action);
+				const preparedStatements = prepareSQLiteRecreateTable(json2.tables[tableName], json1, json2, action);
 
 				if (wasRename) {
 					newStatements[tableName].push(...preparedStatements);
@@ -361,13 +386,13 @@ export const sqliteCombineStatements = (
 			const statementsForTable = newStatements[tableName];
 
 			if (!statementsForTable) {
-				newStatements[tableName] = prepareSQLiteRecreateTable(json2.tables[tableName], action);
+				newStatements[tableName] = prepareSQLiteRecreateTable(json2.tables[tableName], json1, json2, action);
 				continue;
 			}
 
 			if (!statementsForTable.some(({ type }) => type === 'recreate_table')) {
 				const wasRename = statementsForTable.some(({ type }) => type === 'rename_table');
-				const preparedStatements = prepareSQLiteRecreateTable(json2.tables[tableName], action);
+				const preparedStatements = prepareSQLiteRecreateTable(json2.tables[tableName], json1, json2, action);
 
 				if (wasRename) {
 					newStatements[tableName].push(...preparedStatements);
@@ -390,7 +415,7 @@ export const sqliteCombineStatements = (
 			const statementsForTable = newStatements[tableName];
 
 			if (!statementsForTable) {
-				newStatements[tableName] = prepareSQLiteRecreateTable(json2.tables[tableName], action);
+				newStatements[tableName] = prepareSQLiteRecreateTable(json2.tables[tableName], json1, json2, action);
 				continue;
 			}
 
@@ -406,7 +431,7 @@ export const sqliteCombineStatements = (
 
 			if (!statementsForTable.some(({ type }) => type === 'recreate_table')) {
 				const wasRename = statementsForTable.some(({ type }) => type === 'rename_table');
-				const preparedStatements = prepareSQLiteRecreateTable(json2.tables[tableName], action);
+				const preparedStatements = prepareSQLiteRecreateTable(json2.tables[tableName], json1, json2, action);
 
 				if (wasRename) {
 					newStatements[tableName].push(...preparedStatements);

--- a/drizzle-kit/src/utils/cascade.ts
+++ b/drizzle-kit/src/utils/cascade.ts
@@ -1,0 +1,62 @@
+import type { JsonRecreateTableCascadeDependent } from '../jsonStatements';
+import { SQLiteSchemaSquashed, SQLiteSquasher } from '../serializer/sqliteSchema';
+
+const encodeIdentifierPart = (value: string) => encodeURIComponent(value);
+
+export const quoteSQLiteIdentifier = (value: string) => `"${value.replaceAll('"', '""')}"`;
+
+export const getCascadeBackupTableName = (
+	rootTable: string,
+	dependentTable: string,
+) => `__drizzle_cascade_backup_${encodeIdentifierPart(rootTable)}_${encodeIdentifierPart(dependentTable)}`;
+
+export const collectCascadeDependents = (
+	rootTable: string,
+	fromSchema: SQLiteSchemaSquashed,
+	toSchema: SQLiteSchemaSquashed,
+	action?: 'push',
+): JsonRecreateTableCascadeDependent[] => {
+	const result: JsonRecreateTableCascadeDependent[] = [];
+	const visited = new Set<string>([rootTable]);
+	const queue = [rootTable];
+
+	while (queue.length > 0) {
+		const current = queue.pop();
+		if (!current) continue;
+
+		for (const table of Object.values(fromSchema.tables)) {
+			for (const fk of Object.values(table.foreignKeys)) {
+				const data = action === 'push'
+					? SQLiteSquasher.unsquashPushFK(fk)
+					: SQLiteSquasher.unsquashFK(fk);
+
+				if (
+					data.tableTo !== current
+					|| data.onDelete !== 'cascade'
+					|| visited.has(table.name)
+					|| !fromSchema.tables[table.name]
+				) {
+					continue;
+				}
+
+				const newTable = toSchema.tables[table.name];
+				if (!newTable) continue;
+				const oldTable = table;
+				const columns = Object.keys(oldTable.columns).filter(
+					(column) => newTable.columns[column] && !newTable.columns[column].generated,
+				);
+				if (columns.length === 0) continue;
+
+				visited.add(table.name);
+				result.push({
+					tableName: table.name,
+					backupTableName: getCascadeBackupTableName(rootTable, table.name),
+					columns,
+				});
+				queue.push(table.name);
+			}
+		}
+	}
+
+	return result;
+};

--- a/drizzle-kit/tests/sqlite-tables.test.ts
+++ b/drizzle-kit/tests/sqlite-tables.test.ts
@@ -1,9 +1,11 @@
+import Database from 'better-sqlite3';
 import { sql } from 'drizzle-orm';
 import {
 	AnySQLiteColumn,
 	foreignKey,
 	index,
 	int,
+	integer,
 	primaryKey,
 	sqliteTable,
 	text,
@@ -547,6 +549,109 @@ test('optional db aliases (snake case)', async () => {
 `;
 
 	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6]);
+});
+
+test('generated table rebuilds preserve cascade dependents', async () => {
+	const client = new Database(':memory:');
+	client.pragma('foreign_keys = ON');
+
+	const createSchema = (
+		accountColumn: 'text' | 'integer',
+		withNote: boolean,
+		onDelete: 'cascade' | 'no action',
+	) => {
+		const account = sqliteTable('account', {
+			id: integer('id').primaryKey(),
+			name: accountColumn === 'text' ? text('name') : integer('name'),
+		});
+		const property = sqliteTable('property', {
+			id: integer('id').primaryKey(),
+			accountId: integer('account_id').references(() => account.id, { onDelete }),
+			payload: text('payload'),
+			...(withNote ? { note: text('note').notNull().default('active') } : {}),
+		});
+		return { account, property };
+	};
+
+	const schema1 = createSchema('text', false, 'cascade');
+	const schema2 = createSchema('integer', true, 'cascade');
+
+	const initial = await diffTestSchemasSqlite({}, schema1, []);
+	client.exec(initial.sqlStatements.join('\n'));
+	client.prepare('INSERT INTO account (id, name) VALUES (?, ?)').run(1, 'Alice');
+	client.prepare('INSERT INTO property (id, account_id, payload) VALUES (?, ?, ?)').run(1, 1, 'payload');
+
+	const { statements, sqlStatements } = await diffTestSchemasSqlite(schema1, schema2, []);
+	const recreate = statements.find(
+		(statement) => statement.type === 'recreate_table' && statement.tableName === 'account',
+	);
+
+	expect(recreate?.cascadeDependents?.map(({ tableName, columns }) => ({ tableName, columns }))).toEqual([
+		{ tableName: 'property', columns: ['id', 'account_id', 'payload'] },
+	]);
+
+	client.transaction(() => {
+		for (const statement of sqlStatements) {
+			client.exec(statement);
+		}
+	})();
+
+	expect(client.prepare('SELECT id, name FROM account').all()).toStrictEqual([
+		{ id: 1, name: 'Alice' },
+	]);
+	expect(client.prepare('SELECT id, account_id, payload, note FROM property').all()).toStrictEqual([
+		{ id: 1, account_id: 1, payload: 'payload', note: 'active' },
+	]);
+	expect(client.prepare('PRAGMA foreign_key_check').all()).toStrictEqual([]);
+});
+
+test('generated parent rebuilds do not back up a newly added dependent table', async () => {
+	const client = new Database(':memory:');
+	client.pragma('foreign_keys = ON');
+
+	const schema1 = {
+		account: sqliteTable('account', {
+			id: integer('id').primaryKey(),
+			name: text('name'),
+		}),
+	};
+	const schema2 = {
+		account: sqliteTable('account', {
+			id: integer('id').primaryKey(),
+			name: integer('name'),
+		}),
+		property: sqliteTable('property', {
+			id: integer('id').primaryKey(),
+			accountId: integer('account_id').references(() => schema2.account.id, {
+				onDelete: 'cascade',
+			}),
+		}),
+	};
+
+	const initial = await diffTestSchemasSqlite({}, schema1, []);
+	client.exec(initial.sqlStatements.join('\n'));
+	client.prepare('INSERT INTO account (id, name) VALUES (?, ?)').run(1, 'Alice');
+
+	const { statements, sqlStatements } = await diffTestSchemasSqlite(schema1, schema2, []);
+	const recreate = statements.find(
+		(statement) => statement.type === 'recreate_table' && statement.tableName === 'account',
+	);
+
+	expect(recreate?.cascadeDependents ?? []).toStrictEqual([]);
+
+	client.transaction(() => {
+		for (const statement of sqlStatements) {
+			client.exec(statement);
+		}
+	})();
+
+	expect(client.prepare('SELECT id, name FROM account').all()).toStrictEqual([
+		{ id: 1, name: 'Alice' },
+	]);
+	expect(client.prepare('SELECT count(*) AS count FROM property').get()).toStrictEqual({
+		count: 0,
+	});
+	expect(client.prepare('PRAGMA foreign_key_check').all()).toStrictEqual([]);
 });
 
 test('optional db aliases (camel case)', async () => {


### PR DESCRIPTION
Fixes #5782. Successor to #5074.

Drizzle Kit emits SQLite table-rebuild migrations with `PRAGMA foreign_keys=OFF`. That pragma is ineffective inside the ORM migrator transaction, and Cloudflare D1 does not allow disabling foreign-key enforcement. With `ON DELETE CASCADE`, dropping a rebuilt parent silently deletes dependent rows.

This change preserves cascade dependents during generated SQLite and libSQL rebuilds by:

- deriving cascade dependents from the old schema, which describes the actions that apply before the rebuild
- backing up only tables that exist before and after the migration
- using deterministic ordinary backup tables, which work on D1 where temporary tables are not authorized
- restoring explicit common columns instead of relying on `SELECT *`, so a dependent table can also gain columns in the same schema diff
- preserving compatibility with existing statement-combiner call sites

The regression coverage exercises generated migrations and push migrations with populated direct, multi-level, and fan-out cascade relationships, newly added dependents, and changed dependent columns.

Validation:

- `pnpm --filter drizzle-kit exec tsc -p tsconfig.build.json --noEmit`
- `pnpm lint`
- 60 targeted SQLite, libSQL, and statement-combiner tests
- Generated SQL applied to a disposable remote D1 database with a populated cascading child row

Related: #5074, #5784.