### PR TITLE
fix(kit): propagate push execution errors

### DIFF
--- a/drizzle-kit/src/cli/commands/push.ts
+++ b/drizzle-kit/src/cli/commands/push.ts
@@ -160,6 +160,7 @@ export const mysqlPush = async (
 		}
 	} catch (e) {
 		console.log(e);
+		process.exitCode = 1;
 	}
 };
 
@@ -283,6 +284,7 @@ export const singlestorePush = async (
 		}
 	} catch (e) {
 		console.log(e);
+		process.exitCode = 1;
 	}
 };
 
@@ -407,6 +409,7 @@ export const pgPush = async (
 		}
 	} catch (e) {
 		console.error(e);
+		process.exitCode = 1;
 	}
 };
 

--- a/drizzle-kit/src/cli/schema.ts
+++ b/drizzle-kit/src/cli/schema.ts
@@ -398,8 +398,9 @@ export const push = command({
 			}
 		} catch (e) {
 			console.error(e);
+			process.exitCode = 1;
 		}
-		process.exit(0);
+		process.exit(process.exitCode ?? 0);
 	},
 });
 

--- a/drizzle-kit/tests/cli-push-execution.test.ts
+++ b/drizzle-kit/tests/cli-push-execution.test.ts
@@ -1,0 +1,62 @@
+import { PGlite } from '@electric-sql/pglite';
+import { spawnSync } from 'child_process';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { expect, test } from 'vitest';
+
+test('push exits non-zero and stops at the first failed statement', async () => {
+	const tempDir = await mkdtemp(join(tmpdir(), 'drizzle-kit-push-'));
+	const databasePath = join(tempDir, 'pglite');
+
+	try {
+		const setup = new PGlite(databasePath);
+		try {
+			await setup.exec('CREATE TABLE "issue_6192" ("id" integer NOT NULL);');
+		} finally {
+			await setup.close();
+		}
+
+		const result = spawnSync(
+			process.execPath,
+			[
+				require.resolve('tsx/cli'),
+				resolve('src/cli/index.ts'),
+				'push',
+				'--config=push-error.config.ts',
+				'--force',
+				'--verbose',
+			],
+			{
+				cwd: resolve('.'),
+				encoding: 'utf8',
+				timeout: 60_000,
+				env: {
+					...process.env,
+					TEST_CONFIG_PATH_PREFIX: './tests/cli/',
+					PGLITE_DATABASE_PATH: databasePath,
+					NO_COLOR: '1',
+				},
+			},
+		);
+
+		if (result.error) throw result.error;
+
+		expect(result.status).toBe(1);
+		expect(result.stdout.indexOf('a_fails')).toBeGreaterThanOrEqual(0);
+		expect(result.stdout.indexOf('z_after_failure')).toBeGreaterThan(result.stdout.indexOf('a_fails'));
+		expect(result.stdout).not.toContain('Changes applied');
+
+		const verify = new PGlite(databasePath);
+		try {
+			const { rows } = await verify.query<{ conname: string }>(
+				`select conname from pg_constraint where conrelid = 'issue_6192'::regclass`,
+			);
+			expect(rows.map(({ conname }) => conname)).not.toContain('z_after_failure');
+		} finally {
+			await verify.close();
+		}
+	} finally {
+		await rm(tempDir, { recursive: true, force: true });
+	}
+});

--- a/drizzle-kit/tests/cli/push-error.config.ts
+++ b/drizzle-kit/tests/cli/push-error.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '../../src';
+
+export default defineConfig({
+	schema: './push-error.schema.ts',
+	dialect: 'postgresql',
+	driver: 'pglite',
+	dbCredentials: {
+		url: process.env.PGLITE_DATABASE_PATH!,
+	},
+});

--- a/drizzle-kit/tests/cli/push-error.schema.ts
+++ b/drizzle-kit/tests/cli/push-error.schema.ts
@@ -1,0 +1,9 @@
+import { sql } from 'drizzle-orm';
+import { check, integer, pgTable } from 'drizzle-orm/pg-core';
+
+export const issue6192 = pgTable('issue_6192', {
+	id: integer('id').notNull(),
+}, (table) => ({
+	aFails: check('a_fails', sql`drizzle_issue_6192_missing(${table.id})`),
+	zAfterFailure: check('z_after_failure', sql`${table.id} > 0`),
+}));


### PR DESCRIPTION
`drizzle-kit push` currently logs execution failures and then exits with status 0. Preserve a non-zero exit status across the affected push paths, with a PGlite regression test confirming that later statements are not executed after a failure.

Fixes #6192
