### PR TITLE
fix(kit): recreate PostgreSQL views before referenced column type changes

### DIFF
--- a/drizzle-kit/src/dialects/postgres/aws-introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/aws-introspect.ts
@@ -12,6 +12,7 @@ import type {
 	InterimSchema,
 	Policy,
 	PostgresEntities,
+	PostgresViewDependency,
 	PrimaryKey,
 	Privilege,
 	Role,
@@ -21,6 +22,7 @@ import type {
 	View,
 	ViewColumn,
 } from './ddl';
+import { setViewDependencies } from './ddl';
 import {
 	defaultForColumn,
 	isSerialExpression,
@@ -1160,7 +1162,88 @@ export const fromDatabase = async (
 	progressCallback('checks', checksCount, 'done');
 	progressCallback('views', viewsCount, 'done');
 
-	return {
+	type ViewDependencyRow = {
+		viewSchema: string;
+		viewName: string;
+		relationSchema: string;
+		relationName: string;
+		columnOrdinality: number | string;
+		columnName: string | null;
+	};
+
+	const resultViewKeys = new Set(views.map((it) => `${it.schema}\0${it.name}`));
+	const resultViewIds = viewsList
+		.filter((it) => resultViewKeys.has(`${it.schema}\0${it.name}`))
+		.map((it) => it.oid);
+	const viewDependencyRows = resultViewIds.length > 0
+		? await db.query<ViewDependencyRow>(`
+			SELECT
+				view_namespace.nspname AS "viewSchema",
+				view_class.relname AS "viewName",
+				relation_namespace.nspname AS "relationSchema",
+				relation_class.relname AS "relationName",
+				dependency.refobjsubid AS "columnOrdinality",
+				attribute.attname AS "columnName"
+			FROM pg_catalog.pg_rewrite AS rewrite
+			JOIN pg_catalog.pg_class AS view_class
+				ON view_class.oid OPERATOR(pg_catalog.=) rewrite.ev_class
+			JOIN pg_catalog.pg_namespace AS view_namespace
+				ON view_namespace.oid OPERATOR(pg_catalog.=) view_class.relnamespace
+			JOIN pg_catalog.pg_depend AS dependency
+				ON dependency.classid OPERATOR(pg_catalog.=) 'pg_catalog.pg_rewrite'::pg_catalog.regclass
+				AND dependency.objid OPERATOR(pg_catalog.=) rewrite.oid
+				AND dependency.refclassid OPERATOR(pg_catalog.=) 'pg_catalog.pg_class'::pg_catalog.regclass
+				AND dependency.deptype OPERATOR(pg_catalog.=) 'n'
+			JOIN pg_catalog.pg_class AS relation_class
+				ON relation_class.oid OPERATOR(pg_catalog.=) dependency.refobjid
+			JOIN pg_catalog.pg_namespace AS relation_namespace
+				ON relation_namespace.oid OPERATOR(pg_catalog.=) relation_class.relnamespace
+			LEFT JOIN pg_catalog.pg_attribute AS attribute
+				ON attribute.attrelid OPERATOR(pg_catalog.=) dependency.refobjid
+				AND attribute.attnum OPERATOR(pg_catalog.=) dependency.refobjsubid
+			WHERE rewrite.rulename OPERATOR(pg_catalog.=) '_RETURN'
+				AND view_class.relkind IN ('v', 'm')
+				AND rewrite.ev_class IN (${resultViewIds.join(',')})
+			ORDER BY
+				pg_catalog.lower(view_namespace.nspname),
+				pg_catalog.lower(view_class.relname),
+				pg_catalog.lower(relation_namespace.nspname),
+				pg_catalog.lower(relation_class.relname),
+				dependency.refobjsubid;
+		`).then((rows) => {
+			queryCallback('viewDependencies', rows, null);
+			return rows;
+		}).catch((error) => {
+			queryCallback('viewDependencies', [], error);
+			throw error;
+		})
+		: [];
+
+	const dependenciesByRelation = new Map<string, PostgresViewDependency>();
+	for (const row of viewDependencyRows) {
+		if (!resultViewKeys.has(`${row.viewSchema}\0${row.viewName}`)) continue;
+
+		const key = `${row.viewSchema}\0${row.viewName}\0${row.relationSchema}\0${row.relationName}`;
+		let dependency = dependenciesByRelation.get(key);
+		if (!dependency) {
+			dependency = {
+				view: { schema: row.viewSchema, name: row.viewName },
+				relation: { schema: row.relationSchema, name: row.relationName },
+				columns: [],
+			};
+			dependenciesByRelation.set(key, dependency);
+		}
+
+		if (
+			Number(row.columnOrdinality) !== 0
+			&& row.columnName !== null
+			&& !dependency.columns.includes(row.columnName)
+		) {
+			dependency.columns.push(row.columnName);
+		}
+	}
+
+	const result = {
 		schemas,
 		tables,
 		enums,
@@ -1177,6 +1260,8 @@ export const fromDatabase = async (
 		views,
 		viewColumns,
 	} satisfies InterimSchema;
+	setViewDependencies(result, [...dependenciesByRelation.values()]);
+	return result;
 };
 
 export const fromDatabaseForDrizzle = async (

--- a/drizzle-kit/src/dialects/postgres/ddl.ts
+++ b/drizzle-kit/src/dialects/postgres/ddl.ts
@@ -235,6 +235,37 @@ export interface InterimSchema {
 	viewColumns: ViewColumn[];
 }
 
+export type PostgresViewDependency = {
+	view: {
+		schema: string;
+		name: string;
+	};
+	relation: {
+		schema: string;
+		name: string;
+	};
+	columns: string[];
+};
+
+// Keep dependencies outside DDL entities so metadata never produces SQL on its own.
+const viewDependencies = new WeakMap<object, PostgresViewDependency[]>();
+
+export const setViewDependencies = (
+	target: object,
+	dependencies: PostgresViewDependency[],
+) => {
+	viewDependencies.set(target, dependencies);
+};
+
+export const getViewDependencies = (target: object) => {
+	return viewDependencies.get(target) ?? [];
+};
+
+export const copyViewDependencies = (from: object, to: object) => {
+	const dependencies = viewDependencies.get(from);
+	if (dependencies) viewDependencies.set(to, dependencies);
+};
+
 export function postgresToRelationsPull(schema: PostgresDDL): SchemaForPull {
 	return Object.values(schema.tables.list()).map((table) => {
 		const rawTable = tableFromDDL(table, schema);
@@ -604,6 +635,8 @@ export const interimToDDL = (
 			throw new Error(`Invalid entity: ${JSON.stringify(it)}`);
 		}
 	}
+
+	copyViewDependencies(schema, ddl);
 
 	return { ddl, errors };
 };

--- a/drizzle-kit/src/dialects/postgres/diff.ts
+++ b/drizzle-kit/src/dialects/postgres/diff.ts
@@ -18,6 +18,7 @@ import type {
 	Policy,
 	PostgresDDL,
 	PostgresEntities,
+	PostgresViewDependency,
 	PrimaryKey,
 	Privilege,
 	Role,
@@ -26,7 +27,7 @@ import type {
 	UniqueConstraint,
 	View,
 } from './ddl';
-import { createDDL, tableFromDDL } from './ddl';
+import { createDDL, getViewDependencies, tableFromDDL } from './ddl';
 import { defaults, defaultsCommutative, isSerialType } from './grammar';
 import type { JsonAlterPrimaryKey, JsonRecreateIndex, JsonStatement } from './statements';
 import { prepareStatement } from './statements';
@@ -1156,31 +1157,128 @@ export const ddlDiff = async (
 		});
 	});
 
+	const relationKey = (it: { schema: string; name: string }) => `${it.schema}\0${it.name}`;
+	const sourceViewDependencies = getViewDependencies(ddl1);
+	const viewDependencies = getViewDependencies(ddl2);
+	const viewsWithChangedDefinitions = new Set(
+		viewsAlters.filter((it) => it.diff.definition || it.diff.materialized)
+			.map((it) => relationKey(it.view)),
+	);
+	const forwardSchema = (schema: string) => {
+		return renamedSchemas.find((it) => it.from.name === schema)?.to.name ?? schema;
+	};
+	const inverseSchema = (schema: string) => {
+		return renamedSchemas.find((it) => it.to.name === schema)?.from.name ?? schema;
+	};
+
+	const recreatedViewKeys = new Set<string>();
+	const recreatedDropTargets = new Map<JsonStatement, string>();
+	const recreatedDropSources = new Map<JsonStatement, string>();
+	const sourceViewFor = (target: View) => {
+		const rename = renamedOrMovedViews.find((it) => it.to.schema === target.schema && it.to.name === target.name);
+		const currentSource = rename
+			? { schema: rename.from.schema, name: rename.from.name }
+			: { schema: target.schema, name: target.name };
+		return ddl1Copy.views.one({
+			schema: inverseSchema(currentSource.schema),
+			name: currentSource.name,
+		});
+	};
+	const recreateView = (target: View, source: View) => {
+		const targetKey = relationKey(target);
+		if (recreatedViewKeys.has(targetKey)) return;
+
+		const drop = prepareStatement('drop_view', {
+			view: { ...source, schema: forwardSchema(source.schema) },
+			cause: source,
+		});
+		jsonDropViews.push(drop);
+		createViews.push(prepareStatement('create_view', { view: target }));
+		recreatedViewKeys.add(targetKey);
+		recreatedDropTargets.set(drop, targetKey);
+		recreatedDropSources.set(drop, relationKey(source));
+	};
+
 	// recreate views
 	viewsAlters.filter((it) => it.diff.definition || it.diff.materialized).forEach((entry) => {
 		const it = entry.view;
-		const schemaRename = renamedSchemas.find((r) => r.to.name === it.schema);
-		const schema = schemaRename ? schemaRename.from.name : it.schema;
-		const viewRename = renamedViews.find((r) => r.to.schema === it.schema && r.to.name === it.name);
-		const name = viewRename ? viewRename.from.name : it.name;
-		const from = ddl1Copy.views.one({ schema, name });
+		const from = sourceViewFor(it);
 
 		if (!from) {
 			throw new Error(`
 				Missing view in original ddl:
 				${it.schema}:${it.name}
-				${schema}:${name}
 				`);
 		}
 
-		jsonDropViews.push(prepareStatement('drop_view', { view: entry.diff.$left, cause: from }));
-		createViews.push(prepareStatement('create_view', { view: it }));
+		recreateView(it, from);
 	});
 
 	const columnsToRecreate = columnAlters.filter((it) => it.generated && it.generated.to !== null).filter((it) => {
 		// if push and definition changed
 		return !(it.generated?.to && it.generated.from && mode === 'push');
 	});
+	const changedColumnKeys = new Set(
+		columnAlters.filter((it) => it.type)
+			.map((it) => `${it.schema}\0${it.table}\0${it.name}`),
+	);
+	const affectedViewKeys = changedColumnKeys.size > 0 ? new Set(recreatedViewKeys) : new Set<string>();
+	for (const dependency of viewDependencies) {
+		const view = ddl2.views.one(dependency.view);
+		if (
+			view !== null
+			&& !view.materialized
+			&& dependency.columns.some((column) => changedColumnKeys.has(`${relationKey(dependency.relation)}\0${column}`))
+		) {
+			affectedViewKeys.add(relationKey(dependency.view));
+		}
+	}
+
+	let affectedCount = -1;
+	while (affectedCount !== affectedViewKeys.size) {
+		affectedCount = affectedViewKeys.size;
+		for (const dependency of viewDependencies) {
+			const view = ddl2.views.one(dependency.view);
+			if (view !== null && !view.materialized && affectedViewKeys.has(relationKey(dependency.relation))) {
+				affectedViewKeys.add(relationKey(dependency.view));
+			}
+		}
+	}
+
+	for (const key of affectedViewKeys) {
+		const separator = key.indexOf('\0');
+		const target = ddl2.views.one({ schema: key.slice(0, separator), name: key.slice(separator + 1) });
+		if (!target || target.materialized) continue;
+		const source = sourceViewFor(target);
+		if (source) recreateView(target, source);
+	}
+
+	const topologicallySortViews = <T extends { view: View }>(
+		statements: T[],
+		dependencies: PostgresViewDependency[],
+		keyOf: (statement: T) => string = (it) => relationKey(it.view),
+	) => {
+		const byKey = new Map(statements.map((it) => [keyOf(it), it]));
+		const permanent = new Set<string>();
+		const temporary = new Set<string>();
+		const sorted: T[] = [];
+		const visit = (key: string) => {
+			if (permanent.has(key)) return;
+			if (temporary.has(key)) return;
+			temporary.add(key);
+			for (const dependency of dependencies) {
+				if (relationKey(dependency.view) === key) {
+					const dependencyKey = relationKey(dependency.relation);
+					if (byKey.has(dependencyKey)) visit(dependencyKey);
+				}
+			}
+			temporary.delete(key);
+			permanent.add(key);
+			sorted.push(byKey.get(key)!);
+		};
+		for (const key of byKey.keys()) visit(key);
+		return sorted;
+	};
 
 	const jsonRecreateColumns = columnsToRecreate.map((it) => {
 		const indexes = ddl2.indexes.list({ table: it.table, schema: it.schema }).filter((index) =>
@@ -1212,6 +1310,27 @@ export const ddlDiff = async (
 		});
 	});
 
+	const structuredDrops = jsonDropViews.filter((it) => recreatedDropTargets.has(it));
+	const dropViewDependencies = sourceViewDependencies.length > 0 ? sourceViewDependencies : viewDependencies;
+	const safeDropViewDependencies = sourceViewDependencies.length > 0
+		? dropViewDependencies
+		: dropViewDependencies.filter((it) => !viewsWithChangedDefinitions.has(relationKey(it.view)));
+	const orderedStructuredDrops = topologicallySortViews(
+		[...structuredDrops].reverse(),
+		safeDropViewDependencies,
+		(it) =>
+			sourceViewDependencies.length > 0
+				? recreatedDropSources.get(it)!
+				: recreatedDropTargets.get(it)!,
+	).reverse();
+	const structuredDropSet = new Set(structuredDrops);
+	let structuredDropIndex = 0;
+	for (let i = 0; i < jsonDropViews.length; i++) {
+		if (structuredDropSet.has(jsonDropViews[i])) {
+			jsonDropViews[i] = orderedStructuredDrops[structuredDropIndex++];
+		}
+	}
+
 	jsonStatements.push(...createSchemas);
 	jsonStatements.push(...renameSchemas);
 	jsonStatements.push(...jsonCreateEnums);
@@ -1236,9 +1355,9 @@ export const ddlDiff = async (
 	jsonStatements.push(...createTables);
 
 	jsonStatements.push(...jsonDropViews);
-	jsonStatements.push(...jsonRenameViews);
-	jsonStatements.push(...jsonMoveViews);
-	jsonStatements.push(...jsonAlterViews);
+	jsonStatements.push(...jsonRenameViews.filter((it) => !recreatedViewKeys.has(relationKey(it.to))));
+	jsonStatements.push(...jsonMoveViews.filter((it) => !recreatedViewKeys.has(relationKey(it.view))));
+	jsonStatements.push(...jsonAlterViews.filter((it) => !recreatedViewKeys.has(relationKey(it.view))));
 
 	jsonStatements.push(...jsonRenameTables);
 	jsonStatements.push(...jsonDropPoliciesStatements); // before drop tables
@@ -1284,7 +1403,7 @@ export const ddlDiff = async (
 
 	jsonStatements.push(...jsonAlterCheckConstraints);
 
-	const sortedCreateViews = createViews.sort((a, b) => {
+	const legacySortedCreateViews = createViews.sort((a, b) => {
 		// this sort fixes this issue: https://github.com/drizzle-team/drizzle-orm/issues/4520 and https://github.com/drizzle-team/drizzle-orm/issues/6176
 		// When using `prepareFromSchemaFiles` to read schema files, views were returned in an unpredictable order
 		// (not in order that is was declared in schema.ts).
@@ -1299,6 +1418,10 @@ export const ddlDiff = async (
 
 		return 0;
 	});
+	const sortedCreateViews = topologicallySortViews(
+		legacySortedCreateViews,
+		viewDependencies,
+	);
 	jsonStatements.push(...sortedCreateViews);
 
 	jsonStatements.push(...jsonRenamePoliciesStatements);

--- a/drizzle-kit/src/dialects/postgres/drizzle.ts
+++ b/drizzle-kit/src/dialects/postgres/drizzle.ts
@@ -50,12 +50,14 @@ import type {
 	InterimSchema,
 	Policy,
 	PostgresEntities,
+	PostgresViewDependency,
 	PrimaryKey,
 	Schema,
 	SchemaError,
 	SchemaWarning,
 	UniqueConstraint,
 } from './ddl';
+import { setViewDependencies } from './ddl';
 import {
 	defaultNameForFK,
 	defaultNameForPK,
@@ -70,6 +72,8 @@ import {
 	trimDefaultValueSuffix,
 	typeFor,
 } from './grammar';
+
+const PgViewDependencies = Symbol.for('drizzle:PgViewDependencies');
 
 export const policyFrom = (policy: PgPolicy, dialect: PgDialect) => {
 	const mappedTo = !policy.to
@@ -641,18 +645,23 @@ export const fromDrizzleSchema = (
 	}
 
 	const combinedViews = [...schema.views, ...schema.matViews].map((it) => {
+		const dependencies = (it as unknown as Record<symbol, unknown>)[PgViewDependencies] as
+			| { schema: string | undefined; name: string; columns: string[] }[]
+			| undefined;
 		if (is(it, PgView)) {
 			return {
 				...getViewConfig(it),
+				dependencies,
 				materialized: false,
 				tablespace: undefined,
 				using: undefined,
 				withNoData: undefined,
 			};
 		} else {
-			return { ...getMaterializedViewConfig(it), materialized: true };
+			return { ...getMaterializedViewConfig(it), dependencies, materialized: true };
 		}
 	});
+	const viewDependencies: PostgresViewDependency[] = [];
 
 	for (const view of combinedViews) {
 		if (view.isExisting || !filter({ type: 'table', schema: view.schema ?? 'public', name: view.name })) continue;
@@ -668,6 +677,12 @@ export const fromDrizzleSchema = (
 		} = view;
 
 		const viewSchema = schema ?? 'public';
+		const dependencies = view.dependencies ?? [];
+		viewDependencies.push(...dependencies.map((dependency): PostgresViewDependency => ({
+			view: { schema: viewSchema, name: viewName },
+			relation: { schema: dependency.schema ?? 'public', name: dependency.name },
+			columns: dependency.columns,
+		})));
 
 		type MergerWithConfig = keyof (
 			& ViewWithConfig
@@ -749,6 +764,7 @@ export const fromDrizzleSchema = (
 			using: using ?? null,
 		});
 	}
+	setViewDependencies(res, viewDependencies);
 
 	res.enums = schema.enums.map<Enum>((e) => {
 		return {

--- a/drizzle-kit/src/dialects/postgres/introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/introspect.ts
@@ -13,6 +13,7 @@ import type {
 	InterimSchema,
 	Policy,
 	PostgresEntities,
+	PostgresViewDependency,
 	PrimaryKey,
 	Privilege,
 	Role,
@@ -22,6 +23,7 @@ import type {
 	View,
 	ViewColumn,
 } from './ddl';
+import { setViewDependencies } from './ddl';
 import {
 	defaultForColumn,
 	isSerialExpression,
@@ -1188,7 +1190,88 @@ export const fromDatabase = async (
 		resultViews.some((v) => v.schema === x.schema && v.name === x.view)
 	);
 
-	return {
+	type ViewDependencyRow = {
+		viewSchema: string;
+		viewName: string;
+		relationSchema: string;
+		relationName: string;
+		columnOrdinality: number | string;
+		columnName: string | null;
+	};
+
+	const resultViewKeys = new Set(resultViews.map((it) => `${it.schema}\0${it.name}`));
+	const resultViewIds = viewsList
+		.filter((it) => resultViewKeys.has(`${it.schema}\0${it.name}`))
+		.map((it) => it.oid);
+	const viewDependencyRows = resultViewIds.length > 0
+		? await db.query<ViewDependencyRow>(`
+			SELECT
+				view_namespace.nspname AS "viewSchema",
+				view_class.relname AS "viewName",
+				relation_namespace.nspname AS "relationSchema",
+				relation_class.relname AS "relationName",
+				dependency.refobjsubid AS "columnOrdinality",
+				attribute.attname AS "columnName"
+			FROM pg_catalog.pg_rewrite AS rewrite
+			JOIN pg_catalog.pg_class AS view_class
+				ON view_class.oid OPERATOR(pg_catalog.=) rewrite.ev_class
+			JOIN pg_catalog.pg_namespace AS view_namespace
+				ON view_namespace.oid OPERATOR(pg_catalog.=) view_class.relnamespace
+			JOIN pg_catalog.pg_depend AS dependency
+				ON dependency.classid OPERATOR(pg_catalog.=) 'pg_catalog.pg_rewrite'::pg_catalog.regclass
+				AND dependency.objid OPERATOR(pg_catalog.=) rewrite.oid
+				AND dependency.refclassid OPERATOR(pg_catalog.=) 'pg_catalog.pg_class'::pg_catalog.regclass
+				AND dependency.deptype OPERATOR(pg_catalog.=) 'n'
+			JOIN pg_catalog.pg_class AS relation_class
+				ON relation_class.oid OPERATOR(pg_catalog.=) dependency.refobjid
+			JOIN pg_catalog.pg_namespace AS relation_namespace
+				ON relation_namespace.oid OPERATOR(pg_catalog.=) relation_class.relnamespace
+			LEFT JOIN pg_catalog.pg_attribute AS attribute
+				ON attribute.attrelid OPERATOR(pg_catalog.=) dependency.refobjid
+				AND attribute.attnum OPERATOR(pg_catalog.=) dependency.refobjsubid
+			WHERE rewrite.rulename OPERATOR(pg_catalog.=) '_RETURN'
+				AND view_class.relkind IN ('v', 'm')
+				AND rewrite.ev_class IN (${resultViewIds.join(',')})
+			ORDER BY
+				pg_catalog.lower(view_namespace.nspname),
+				pg_catalog.lower(view_class.relname),
+				pg_catalog.lower(relation_namespace.nspname),
+				pg_catalog.lower(relation_class.relname),
+				dependency.refobjsubid;
+		`).then((rows) => {
+			queryCallback('viewDependencies', rows, null);
+			return rows;
+		}).catch((error) => {
+			queryCallback('viewDependencies', [], error);
+			throw error;
+		})
+		: [];
+
+	const dependenciesByRelation = new Map<string, PostgresViewDependency>();
+	for (const row of viewDependencyRows) {
+		if (!resultViewKeys.has(`${row.viewSchema}\0${row.viewName}`)) continue;
+
+		const key = `${row.viewSchema}\0${row.viewName}\0${row.relationSchema}\0${row.relationName}`;
+		let dependency = dependenciesByRelation.get(key);
+		if (!dependency) {
+			dependency = {
+				view: { schema: row.viewSchema, name: row.viewName },
+				relation: { schema: row.relationSchema, name: row.relationName },
+				columns: [],
+			};
+			dependenciesByRelation.set(key, dependency);
+		}
+
+		if (
+			Number(row.columnOrdinality) !== 0
+			&& row.columnName !== null
+			&& !dependency.columns.includes(row.columnName)
+		) {
+			dependency.columns.push(row.columnName);
+		}
+	}
+
+	const result = {
 		schemas: resultSchemas,
 		tables: resultTables,
 		enums: resultEnums,
@@ -1205,6 +1288,8 @@ export const fromDatabase = async (
 		views: resultViews,
 		viewColumns: resultViewColumns,
 	} satisfies InterimSchema;
+	setViewDependencies(result, [...dependenciesByRelation.values()]);
+	return result;
 };
 
 export const fromDatabaseForDrizzle = async (

--- a/drizzle-kit/tests/postgres/pg-views.test.ts
+++ b/drizzle-kit/tests/postgres/pg-views.test.ts
@@ -1,5 +1,6 @@
 import { and, eq, gt, or, sql } from 'drizzle-orm';
 import {
+	alias,
 	camelCase,
 	integer,
 	pgMaterializedView,
@@ -9,6 +10,7 @@ import {
 	serial,
 	snakeCase,
 	text,
+	timestamp,
 } from 'drizzle-orm/pg-core';
 import { generate } from 'src/cli/schema';
 import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
@@ -2237,6 +2239,273 @@ test('rename column referenced in view', async () => {
 		'ALTER TABLE "users" RENAME COLUMN "name" TO "name2";',
 		'ALTER TABLE "users" RENAME COLUMN "id" TO "id2";',
 		'CREATE VIEW "users_view" AS (select "id2", "name2" from "users");',
+	]);
+});
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6194
+test('alter column type referenced by a view', async () => {
+	const accessLogs = pgTable('access_logs', {
+		id: integer('id').primaryKey(),
+		accessedAt: timestamp('accessed_at', { mode: 'string' }).notNull(),
+	});
+	const evenAccessLogs = pgView('even_access_logs').as((qb) =>
+		qb.select().from(accessLogs).where(sql`${accessLogs.id} % 2 = 0`)
+	);
+	const from = { accessLogs, evenAccessLogs };
+
+	const accessLogsWithTimezone = pgTable('access_logs', {
+		id: integer('id').primaryKey(),
+		accessedAt: timestamp('accessed_at', {
+			mode: 'string',
+			withTimezone: true,
+		}).notNull(),
+	});
+	const evenAccessLogsWithTimezone = pgView('even_access_logs').as((qb) =>
+		qb.select().from(accessLogsWithTimezone).where(sql`${accessLogsWithTimezone.id} % 2 = 0`)
+	);
+	const to = { accessLogsWithTimezone, evenAccessLogsWithTimezone };
+
+	const { sqlStatements: generated } = await diff(from, to, []);
+	await push({ db, to: from });
+	const { sqlStatements: pushed } = await push({ db, to });
+
+	const expected = [
+		'DROP VIEW "even_access_logs";',
+		'ALTER TABLE "access_logs" ALTER COLUMN "accessed_at" SET DATA TYPE timestamp with time zone USING "accessed_at"::timestamp with time zone;',
+		'CREATE VIEW "even_access_logs" AS (select "id", "accessed_at" from "access_logs" where "access_logs"."id" % 2 = 0);',
+	];
+	expect(generated).toStrictEqual(expected);
+	expect(pushed).toStrictEqual(expected);
+});
+
+test('does not recreate a view when an unrelated column changes type', async () => {
+	const accessLogs = pgTable('access_logs', {
+		id: integer('id').primaryKey(),
+		accessedAt: timestamp('accessed_at', { mode: 'string' }).notNull(),
+	});
+	const accessLogIds = pgView('access_log_ids').as((qb) => qb.select({ id: accessLogs.id }).from(accessLogs));
+	const from = { accessLogs, accessLogIds };
+
+	const accessLogsWithTimezone = pgTable('access_logs', {
+		id: integer('id').primaryKey(),
+		accessedAt: timestamp('accessed_at', {
+			mode: 'string',
+			withTimezone: true,
+		}).notNull(),
+	});
+	const accessLogIdsWithTimezone = pgView('access_log_ids').as((qb) =>
+		qb.select({ id: accessLogsWithTimezone.id }).from(accessLogsWithTimezone)
+	);
+	const to = { accessLogsWithTimezone, accessLogIdsWithTimezone };
+
+	const { sqlStatements: generated } = await diff(from, to, []);
+	await push({ db, to: from });
+	const { sqlStatements: pushed } = await push({ db, to });
+
+	const expected = [
+		'ALTER TABLE "access_logs" ALTER COLUMN "accessed_at" SET DATA TYPE timestamp with time zone USING "accessed_at"::timestamp with time zone;',
+	];
+	expect(generated).toStrictEqual(expected);
+	expect(pushed).toStrictEqual(expected);
+});
+
+test('does not recreate a relation-only dependent view when a column changes type', async () => {
+	const accessLogs = pgTable('access_logs', {
+		accessedAt: timestamp('accessed_at', { mode: 'string' }).notNull(),
+	});
+	const accessLogCount = pgView('access_log_count').as((qb) =>
+		qb.select({ count: sql<number>`count(*)::integer` }).from(accessLogs)
+	);
+	const from = { accessLogs, accessLogCount };
+
+	const accessLogsWithTimezone = pgTable('access_logs', {
+		accessedAt: timestamp('accessed_at', {
+			mode: 'string',
+			withTimezone: true,
+		}).notNull(),
+	});
+	const accessLogCountWithTimezone = pgView('access_log_count').as((qb) =>
+		qb.select({ count: sql<number>`count(*)::integer` }).from(accessLogsWithTimezone)
+	);
+	const to = { accessLogsWithTimezone, accessLogCountWithTimezone };
+
+	const { sqlStatements: generated } = await diff(from, to, []);
+	await push({ db, to: from });
+	const { sqlStatements: pushed } = await push({ db, to });
+
+	const expected = [
+		'ALTER TABLE "access_logs" ALTER COLUMN "accessed_at" SET DATA TYPE timestamp with time zone USING "accessed_at"::timestamp with time zone;',
+	];
+	expect(generated).toStrictEqual(expected);
+	expect(pushed).toStrictEqual(expected);
+});
+
+test('recreates relation-only dependents of an affected view', async () => {
+	const accessLogs = pgTable('access_logs', {
+		accessedAt: timestamp('accessed_at', { mode: 'string' }).notNull(),
+	});
+	const base = pgView('access_logs_base').as((qb) => qb.select({ accessedAt: accessLogs.accessedAt }).from(accessLogs));
+	const top = pgView('access_logs_top').as((qb) => {
+		const nested = qb
+			.select({ count: sql<number>`count(*)::integer`.as('count') })
+			.from(alias(base, 'base'))
+			.as('nested');
+		const counts = qb.$with('counts').as(qb.select().from(nested));
+		return qb.with(counts).select().from(counts);
+	});
+	const from = { top, accessLogs, base };
+
+	const accessLogsWithTimezone = pgTable('access_logs', {
+		accessedAt: timestamp('accessed_at', {
+			mode: 'string',
+			withTimezone: true,
+		}).notNull(),
+	});
+	const baseWithTimezone = pgView('access_logs_base').as((qb) =>
+		qb.select({ accessedAt: accessLogsWithTimezone.accessedAt }).from(accessLogsWithTimezone)
+	);
+	const topWithTimezone = pgView('access_logs_top').as((qb) => {
+		const nested = qb
+			.select({ count: sql<number>`count(*)::integer`.as('count') })
+			.from(alias(baseWithTimezone, 'base'))
+			.as('nested');
+		const counts = qb.$with('counts').as(qb.select().from(nested));
+		return qb.with(counts).select().from(counts);
+	});
+	const to = { topWithTimezone, accessLogsWithTimezone, baseWithTimezone };
+
+	const { sqlStatements: generated } = await diff(from, to, []);
+	await push({ db, to: from });
+	const { sqlStatements: pushed } = await push({ db, to });
+
+	const expected = [
+		'DROP VIEW "access_logs_top";',
+		'DROP VIEW "access_logs_base";',
+		'ALTER TABLE "access_logs" ALTER COLUMN "accessed_at" SET DATA TYPE timestamp with time zone USING "accessed_at"::timestamp with time zone;',
+		'CREATE VIEW "access_logs_base" AS (select "accessed_at" from "access_logs");',
+		'CREATE VIEW "access_logs_top" AS (with "counts" as (select "count" from (select count(*)::integer as "count" from "access_logs_base" "base") "nested") select "count" from "counts");',
+	];
+	expect(generated).toStrictEqual(expected);
+	expect(pushed).toStrictEqual(expected);
+});
+
+test('recreates a view when the changed column is referenced in a captured predicate', async () => {
+	const accessLogs = pgTable('access_logs', {
+		id: integer('id').primaryKey(),
+		accessedAt: timestamp('accessed_at', { mode: 'string' }).notNull(),
+	});
+	const filteredAccessLogIds = pgView('filtered_access_log_ids').as((qb) => {
+		const query = qb
+			.select({ id: accessLogs.id })
+			.from(accessLogs)
+			.where(sql`${accessLogs.accessedAt} is not null`)
+			.$dynamic();
+		const nested = query.as('nested');
+		query.where(sql`${accessLogs.id} > 0`);
+		return qb.select().from(nested);
+	});
+	const from = { accessLogs, filteredAccessLogIds };
+
+	const accessLogsWithTimezone = pgTable('access_logs', {
+		id: integer('id').primaryKey(),
+		accessedAt: timestamp('accessed_at', {
+			mode: 'string',
+			withTimezone: true,
+		}).notNull(),
+	});
+	const filteredAccessLogIdsWithTimezone = pgView('filtered_access_log_ids').as((qb) => {
+		const query = qb
+			.select({ id: accessLogsWithTimezone.id })
+			.from(accessLogsWithTimezone)
+			.where(sql`${accessLogsWithTimezone.accessedAt} is not null`)
+			.$dynamic();
+		const nested = query.as('nested');
+		query.where(sql`${accessLogsWithTimezone.id} > 0`);
+		return qb.select().from(nested);
+	});
+	const to = { accessLogsWithTimezone, filteredAccessLogIdsWithTimezone };
+
+	const { sqlStatements: generated } = await diff(from, to, []);
+	await push({ db, to: from });
+	const { sqlStatements: pushed } = await push({ db, to });
+
+	const expected = [
+		'DROP VIEW "filtered_access_log_ids";',
+		'ALTER TABLE "access_logs" ALTER COLUMN "accessed_at" SET DATA TYPE timestamp with time zone USING "accessed_at"::timestamp with time zone;',
+		'CREATE VIEW "filtered_access_log_ids" AS (select "id" from (select "id" from "access_logs" where "access_logs"."accessed_at" is not null) "nested");',
+	];
+	expect(generated).toStrictEqual(expected);
+	expect(pushed).toStrictEqual(expected);
+});
+
+test('recreates a dependent view after its schema is renamed', async () => {
+	const oldSchema = pgSchema('old');
+	const accessLogs = oldSchema.table('access_logs', {
+		accessedAt: timestamp('accessed_at', { mode: 'string' }).notNull(),
+	});
+	const accessLogsView = oldSchema.view('access_logs_view').as((qb) => qb.select().from(accessLogs));
+	const from = { oldSchema, accessLogs, accessLogsView };
+
+	const newSchema = pgSchema('new');
+	const accessLogsWithTimezone = newSchema.table('access_logs', {
+		accessedAt: timestamp('accessed_at', {
+			mode: 'string',
+			withTimezone: true,
+		}).notNull(),
+	});
+	const accessLogsViewWithTimezone = newSchema.view('access_logs_view').as((qb) =>
+		qb.select().from(accessLogsWithTimezone)
+	);
+	const to = { newSchema, accessLogsWithTimezone, accessLogsViewWithTimezone };
+	const renames = ['old->new'];
+
+	const { sqlStatements: generated } = await diff(from, to, renames);
+	await push({ db, to: from });
+	const { sqlStatements: pushed } = await push({ db, to, renames });
+
+	const expected = [
+		'ALTER SCHEMA "old" RENAME TO "new";\n',
+		'DROP VIEW "new"."access_logs_view";',
+		'ALTER TABLE "new"."access_logs" ALTER COLUMN "accessed_at" SET DATA TYPE timestamp with time zone USING "accessed_at"::timestamp with time zone;',
+		'CREATE VIEW "new"."access_logs_view" AS (select "accessed_at" from "new"."access_logs");',
+	];
+	expect(generated).toStrictEqual(expected);
+	expect(pushed).toStrictEqual(expected);
+});
+
+test('drops views in source dependency order when the target dependency is removed', async () => {
+	const accessLogs = pgTable('access_logs', {
+		accessedAt: timestamp('accessed_at', { mode: 'string' }).notNull(),
+	});
+	const base = pgView('access_logs_base').as((qb) => qb.select({ accessedAt: accessLogs.accessedAt }).from(accessLogs));
+	const top = pgView('access_logs_top').as((qb) => qb.select().from(base));
+
+	await push({ db, to: { accessLogs, base, top } });
+
+	const accessLogsWithTimezone = pgTable('access_logs', {
+		accessedAt: timestamp('accessed_at', {
+			mode: 'string',
+			withTimezone: true,
+		}).notNull(),
+	});
+	const baseWithTimezone = pgView('access_logs_base').as((qb) =>
+		qb.select({ accessedAt: accessLogsWithTimezone.accessedAt }).from(accessLogsWithTimezone)
+	);
+	const topWithTimezone = pgView('access_logs_top').as((qb) =>
+		qb.select({ accessedAt: accessLogsWithTimezone.accessedAt }).from(accessLogsWithTimezone)
+	);
+
+	const { sqlStatements } = await push({
+		db,
+		to: { accessLogsWithTimezone, baseWithTimezone, topWithTimezone },
+	});
+
+	expect(sqlStatements).toStrictEqual([
+		'DROP VIEW "access_logs_top";',
+		'DROP VIEW "access_logs_base";',
+		'ALTER TABLE "access_logs" ALTER COLUMN "accessed_at" SET DATA TYPE timestamp with time zone USING "accessed_at"::timestamp with time zone;',
+		'CREATE VIEW "access_logs_base" AS (select "accessed_at" from "access_logs");',
+		'CREATE VIEW "access_logs_top" AS (select "accessed_at" from "access_logs");',
 	]);
 });
 

--- a/drizzle-orm/src/pg-core/async/db.ts
+++ b/drizzle-orm/src/pg-core/async/db.ts
@@ -24,6 +24,7 @@ import type { SelectedFields } from '../query-builders/select.types.ts';
 import type { PreparedQueryConfig } from '../session.ts';
 import type { WithBuilder } from '../subquery.ts';
 import type { PgViewBase } from '../view-base.ts';
+import { setPgViewDependencyConfig } from '../view-dependencies.ts';
 import type { PgMaterializedView } from '../view.ts';
 import { PgAsyncCountBuilder } from './count.ts';
 import { PgAsyncDeleteBase } from './delete.ts';
@@ -132,12 +133,15 @@ export class PgAsyncDatabase<
 
 			const sql = ('withoutSelectionCastCodecs' in qb ? qb.withoutSelectionCastCodecs() : qb).getSQL();
 			return new Proxy(
-				new WithSubquery(
-					sql,
-					selection ?? ('getSelectedFields' in qb ? qb.getSelectedFields() ?? {} : {}) as SelectedFields,
-					alias,
-					true,
-					sql.usedTables ?? [],
+				setPgViewDependencyConfig(
+					new WithSubquery(
+						sql,
+						selection ?? ('getSelectedFields' in qb ? qb.getSelectedFields() ?? {} : {}) as SelectedFields,
+						alias,
+						true,
+						sql.usedTables ?? [],
+					),
+					qb,
 				),
 				new SelectionProxyHandler({ alias, sqlAliasedBehavior: 'alias', sqlBehavior: 'error' }),
 			);

--- a/drizzle-orm/src/pg-core/effect/db.ts
+++ b/drizzle-orm/src/pg-core/effect/db.ts
@@ -26,6 +26,7 @@ import type { SelectedFields } from '../query-builders/select.types.ts';
 import { PgUpdateBuilder } from '../query-builders/update.ts';
 import type { PgQueryResultHKT, PgQueryResultKind, PgTransactionConfig, PreparedQueryConfig } from '../session.ts';
 import type { WithBuilder } from '../subquery.ts';
+import { setPgViewDependencyConfig } from '../view-dependencies.ts';
 import type { PgMaterializedView } from '../view.ts';
 import { PgEffectDeleteBase } from './delete.ts';
 import { PgEffectRelationalQuery, type PgEffectRelationalQueryHKT } from './query.ts';
@@ -135,12 +136,15 @@ export class PgEffectDatabase<
 
 			const sql = ('withoutSelectionCastCodecs' in qb ? qb.withoutSelectionCastCodecs() : qb).getSQL();
 			return new Proxy(
-				new WithSubquery(
-					sql,
-					selection ?? ('getSelectedFields' in qb ? qb.getSelectedFields() ?? {} : {}) as SelectedFields,
-					alias,
-					true,
-					sql.usedTables ?? [],
+				setPgViewDependencyConfig(
+					new WithSubquery(
+						sql,
+						selection ?? ('getSelectedFields' in qb ? qb.getSelectedFields() ?? {} : {}) as SelectedFields,
+						alias,
+						true,
+						sql.usedTables ?? [],
+					),
+					qb,
 				),
 				new SelectionProxyHandler({ alias, sqlAliasedBehavior: 'alias', sqlBehavior: 'error' }),
 			);

--- a/drizzle-orm/src/pg-core/query-builders/query-builder.ts
+++ b/drizzle-orm/src/pg-core/query-builders/query-builder.ts
@@ -7,6 +7,7 @@ import type { ColumnsSelection, SQL, SQLWrapper } from '~/sql/sql.ts';
 import { WithSubquery } from '~/subquery.ts';
 import type { PgColumn } from '../columns/index.ts';
 import type { WithBuilder } from '../subquery.ts';
+import { setPgViewDependencyConfig } from '../view-dependencies.ts';
 import { PgSelectBuilder } from './select.ts';
 import type { SelectedFields } from './select.types.ts';
 
@@ -35,12 +36,15 @@ export class QueryBuilder {
 
 			const sql = ('withoutSelectionCastCodecs' in qb ? qb.withoutSelectionCastCodecs() : qb).getSQL();
 			return new Proxy(
-				new WithSubquery(
-					sql,
-					selection ?? ('getSelectedFields' in qb ? qb.getSelectedFields() ?? {} : {}) as SelectedFields,
-					alias,
-					true,
-					sql.usedTables ?? [],
+				setPgViewDependencyConfig(
+					new WithSubquery(
+						sql,
+						selection ?? ('getSelectedFields' in qb ? qb.getSelectedFields() ?? {} : {}) as SelectedFields,
+						alias,
+						true,
+						sql.usedTables ?? [],
+					),
+					qb,
 				),
 				new SelectionProxyHandler({ alias, sqlAliasedBehavior: 'alias', sqlBehavior: 'error' }),
 			) as any;

--- a/drizzle-orm/src/pg-core/query-builders/select.ts
+++ b/drizzle-orm/src/pg-core/query-builders/select.ts
@@ -33,6 +33,7 @@ import {
 import { ViewBaseConfig } from '~/view-common.ts';
 import { type PostgresType, unionsTypeTable } from '../codecs.ts';
 import { extractUsedTable } from '../utils.ts';
+import { setPgViewDependencyConfig } from '../view-dependencies.ts';
 import type {
 	AnyPgSelectQueryBuilder,
 	CheckTableLikeSelection,
@@ -1151,9 +1152,12 @@ export class PgSelectBase<
 		if (this.config.joins) { for (const it of this.config.joins) usedTables.push(...extractUsedTable(it.table)); }
 
 		return new Proxy(
-			new Subquery(this.withoutSelectionCastCodecs().getSQL(), this.config.fields, alias, false, [
-				...new Set(usedTables),
-			]),
+			setPgViewDependencyConfig(
+				new Subquery(this.withoutSelectionCastCodecs().getSQL(), this.config.fields, alias, false, [
+					...new Set(usedTables),
+				]),
+				this,
+			),
 			new SelectionProxyHandler({ alias, sqlAliasedBehavior: 'alias', sqlBehavior: 'error' }),
 		) as SubqueryWithSelection<this['_']['selectedFields'], TAlias>;
 	}

--- a/drizzle-orm/src/pg-core/view-dependencies.ts
+++ b/drizzle-orm/src/pg-core/view-dependencies.ts
@@ -1,0 +1,213 @@
+import { getOriginalColumnFromAlias } from '~/alias.ts';
+import { Column } from '~/column.ts';
+import { is } from '~/entity.ts';
+import type { TypedQueryBuilder } from '~/query-builders/query-builder.ts';
+import { isSQLWrapper, Param, SQL, View } from '~/sql/sql.ts';
+import type { ColumnsSelection } from '~/sql/sql.ts';
+import { Subquery } from '~/subquery.ts';
+import { Table } from '~/table.ts';
+import { ViewBaseConfig } from '~/view-common.ts';
+
+type PgViewDependency = {
+	schema: string | undefined;
+	name: string;
+	columns: string[];
+};
+
+type PgViewQueryConfig = {
+	fields?: unknown;
+	table?: unknown;
+	joins?: readonly { table?: unknown; on?: unknown }[];
+	where?: unknown;
+	having?: unknown;
+	groupBy?: readonly unknown[];
+	orderBy?: readonly unknown[];
+	withList?: readonly unknown[];
+	distinct?: boolean | { on?: readonly unknown[] };
+	setOperators?: readonly {
+		rightSelect?: unknown;
+		rightConfig?: PgViewQueryConfig;
+		orderBy?: readonly unknown[];
+	}[];
+};
+
+// Internal handoff to Drizzle Kit without exposing dependency metadata in the view API.
+const PgViewDependencies = Symbol.for('drizzle:PgViewDependencies');
+const PgViewDependencyConfig = Symbol.for('drizzle:PgViewDependencyConfig');
+
+function isObject(value: unknown): value is Record<PropertyKey, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function getQueryConfig(value: unknown): PgViewQueryConfig | undefined {
+	if (!isObject(value)) return undefined;
+	const state = value['_'];
+	if (!isObject(state)) return undefined;
+	const config = state['config'];
+	return isObject(config) ? config : undefined;
+}
+
+function snapshotQueryConfig(config: PgViewQueryConfig): PgViewQueryConfig {
+	// A dynamic query builder can be mutated after `.as()`, while the subquery SQL
+	// has already been captured. Keep dependency metadata tied to that same state.
+	return {
+		...config,
+		joins: config.joins?.map((join) => ({ ...join })),
+		groupBy: config.groupBy && [...config.groupBy],
+		orderBy: config.orderBy && [...config.orderBy],
+		withList: config.withList && [...config.withList],
+		distinct: typeof config.distinct === 'object'
+			? { on: config.distinct.on && [...config.distinct.on] }
+			: config.distinct,
+		setOperators: config.setOperators?.map((operator) => {
+			const rightConfig = getQueryConfig(operator.rightSelect);
+			return {
+				...operator,
+				rightConfig: rightConfig && snapshotQueryConfig(rightConfig),
+				orderBy: operator.orderBy && [...operator.orderBy],
+			};
+		}),
+	};
+}
+
+/** @internal */
+export function collectPgViewDependencies(
+	queryBuilder: TypedQueryBuilder<ColumnsSelection | undefined>,
+): PgViewDependency[] {
+	const dependencies = new Map<string, {
+		schema: string | undefined;
+		name: string;
+		columns: Set<string>;
+	}>();
+	const visited = new WeakSet<object>();
+	const visitedConfigs = new WeakSet<object>();
+	let visitConfig: (config: PgViewQueryConfig) => void;
+
+	const addRelation = (schema: string | undefined, name: string) => {
+		const key = `${schema ?? ''}\0${name}`;
+		let dependency = dependencies.get(key);
+		if (!dependency) {
+			dependency = { schema, name, columns: new Set() };
+			dependencies.set(key, dependency);
+		}
+		return dependency;
+	};
+
+	const addColumn = (column: Column) => {
+		let original = column;
+		for (;;) {
+			const next = getOriginalColumnFromAlias(original);
+			if (next === original) break;
+			original = next;
+		}
+
+		const relation = original.table as unknown;
+		if (is(relation, View)) {
+			const config = relation[ViewBaseConfig];
+			addRelation(config.schema, config.originalName).columns.add(original.name);
+		} else if (is(relation, Table)) {
+			addRelation(relation[Table.Symbol.Schema], relation[Table.Symbol.OriginalName]).columns.add(original.name);
+		}
+	};
+
+	const visit = (value: unknown, selection: boolean): void => {
+		if (!isObject(value)) return;
+
+		if (is(value, Column)) {
+			addColumn(value);
+			return;
+		}
+		if (is(value, View)) {
+			const config = value[ViewBaseConfig];
+			addRelation(config.schema, config.originalName);
+			return;
+		}
+		if (is(value, Table)) {
+			addRelation(value[Table.Symbol.Schema], value[Table.Symbol.OriginalName]);
+			if (selection) visit(value[Table.Symbol.Columns], true);
+			return;
+		}
+
+		if (visited.has(value)) return;
+		visited.add(value);
+
+		if (is(value, Subquery)) {
+			const config = (value as unknown as Record<symbol, unknown>)[PgViewDependencyConfig];
+			if (isObject(config)) visitConfig(config);
+			else {
+				visit(value._.selectedFields, true);
+				visit(value._.sql, false);
+			}
+			return;
+		}
+		if (is(value, Param)) {
+			if (is(value.value, SQL)) visit(value.value, false);
+			return;
+		}
+		if (is(value, SQL.Aliased)) {
+			if (!value.isSelectionField) visit(value.sql, false);
+			return;
+		}
+		if (is(value, SQL)) {
+			for (const chunk of value.queryChunks) visit(chunk, false);
+			return;
+		}
+		if (Array.isArray(value)) {
+			for (const item of value) visit(item, selection);
+			return;
+		}
+		if (isSQLWrapper(value)) {
+			visit(value.getSQL(), false);
+			return;
+		}
+		if (selection) {
+			for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(value))) {
+				if ('value' in descriptor) visit(descriptor.value, true);
+			}
+		}
+	};
+
+	visitConfig = (config) => {
+		if (visitedConfigs.has(config)) return;
+		visitedConfigs.add(config);
+		visit(config.fields, true);
+		visit(config.table, false);
+		for (const join of config.joins ?? []) {
+			visit(join.table, false);
+			visit(join.on, false);
+		}
+		visit(config.where, false);
+		visit(config.having, false);
+		visit(config.groupBy, false);
+		visit(config.orderBy, false);
+		visit(config.withList, false);
+		if (typeof config.distinct === 'object') visit(config.distinct.on, false);
+		for (const operator of config.setOperators ?? []) {
+			const rightConfig = operator.rightConfig ?? getQueryConfig(operator.rightSelect);
+			if (rightConfig) visitConfig(rightConfig);
+			visit(operator.orderBy, false);
+		}
+	};
+
+	const config = getQueryConfig(queryBuilder);
+	if (config) visitConfig(config);
+
+	return [...dependencies.values()].map(({ schema, name, columns }) => ({
+		schema,
+		name,
+		columns: [...columns].sort(),
+	}));
+}
+
+/** @internal */
+export function setPgViewDependencies<T extends object>(view: T, dependencies: PgViewDependency[]): T {
+	Object.defineProperty(view, PgViewDependencies, { value: dependencies });
+	return view;
+}
+
+/** @internal */
+export function setPgViewDependencyConfig<T extends object>(target: T, queryBuilder: unknown): T {
+	const config = getQueryConfig(queryBuilder);
+	if (config) Object.defineProperty(target, PgViewDependencyConfig, { value: snapshotQueryConfig(config) });
+	return target;
+}

--- a/drizzle-orm/src/pg-core/view.ts
+++ b/drizzle-orm/src/pg-core/view.ts
@@ -11,6 +11,7 @@ import { QueryBuilder } from './query-builders/query-builder.ts';
 import { pgTableWithSchema } from './table.ts';
 import { PgViewBase } from './view-base.ts';
 import { PgMaterializedViewConfig, PgViewConfig } from './view-common.ts';
+import { collectPgViewDependencies, setPgViewDependencies } from './view-dependencies.ts';
 
 export type ViewWithConfig = RequireAtLeastOne<{
 	checkOption: 'local' | 'cascaded';
@@ -50,23 +51,28 @@ export class ViewBuilder<TName extends string = string> extends DefaultViewBuild
 		if (typeof qb === 'function') {
 			qb = qb(new QueryBuilder());
 		}
+		const selectedFields = qb.getSelectedFields();
+		const query = qb.withoutSelectionCastCodecs().getSQL().inlineParams();
 		const selectionProxy = new SelectionProxyHandler<TSelectedFields>({
 			alias: this.name,
 			sqlBehavior: 'error',
 			sqlAliasedBehavior: 'alias',
 			replaceOriginalName: true,
 		});
-		const aliasedSelection = new Proxy(qb.getSelectedFields(), selectionProxy);
+		const aliasedSelection = new Proxy(selectedFields, selectionProxy);
 		return new Proxy(
-			new PgView({
-				pgConfig: this.config,
-				config: {
-					name: this.name,
-					schema: this.schema,
-					selectedFields: aliasedSelection,
-					query: qb.withoutSelectionCastCodecs().getSQL().inlineParams(),
-				},
-			}),
+			setPgViewDependencies(
+				new PgView({
+					pgConfig: this.config,
+					config: {
+						name: this.name,
+						schema: this.schema,
+						selectedFields: aliasedSelection,
+						query,
+					},
+				}),
+				collectPgViewDependencies(qb),
+			),
 			selectionProxy as any,
 		) as PgViewWithSelection<TName, false, AddAliasToSelection<TSelectedFields, TName, 'pg'>>;
 	}


### PR DESCRIPTION
PostgreSQL rejects ALTER COLUMN TYPE while a regular view references the affected column. Capture column-level dependencies from query-builder views before SQL rendering, then order DROP, ALTER, and CREATE statements for drizzle-kit generate and push.

For push, read PostgreSQL pg_rewrite and pg_depend catalogs so drops follow the authoritative source dependency graph even when the target graph changes.

Fixes #6194