### PR TITLE
fix(drizzle-orm): don't nullify nested select object when a non-first field of the same table is not null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							value !== null
+							|| (typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table))
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/mapResultRow.test.ts
+++ b/drizzle-orm/tests/mapResultRow.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { integer, pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const orgTable = pgTable('org', {
+	id: integer('id').primaryKey(),
+	name: text('name').notNull(),
+	slug: text('slug').notNull(),
+});
+
+const orgBrandingTable = pgTable('org_branding', {
+	orgId: integer('org_id')
+		.notNull()
+		.references(() => orgTable.id),
+	logo: text('logo'),
+	panelBackground: text('panel_background').notNull(),
+});
+
+const otherTable = pgTable('other', {
+	orgId: integer('org_id')
+		.notNull()
+		.references(() => orgTable.id),
+	note: text('note'),
+});
+
+// columns for: select { name, slug, branding: { logo, panelBackground } }
+const brandingColumns = [
+	{ path: ['name'], field: orgTable.name },
+	{ path: ['slug'], field: orgTable.slug },
+	{ path: ['branding', 'logo'], field: orgBrandingTable.logo },
+	{ path: ['branding', 'panelBackground'], field: orgBrandingTable.panelBackground },
+];
+
+describe.concurrent('mapResultRow', () => {
+	// https://github.com/drizzle-team/drizzle-orm/issues/1603
+	it('does not nullify a nested object when a non-first field of the same table is not null', () => {
+		// joined row exists: logo is NULL, panelBackground is '#1a8cff'
+		const row = ['Test org 2', 'test-org-2', null, '#1a8cff'];
+
+		const result = mapResultRow<any>(
+			brandingColumns,
+			row,
+			{ org: true, org_branding: false },
+		);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			slug: 'test-org-2',
+			branding: {
+				logo: null,
+				panelBackground: '#1a8cff',
+			},
+		});
+	});
+
+	it('nullifies a nested object when every field of the joined table is null', () => {
+		// left join found no matching row: all joined columns are NULL
+		const row = ['Test org 2', 'test-org-2', null, null];
+
+		const result = mapResultRow<any>(
+			brandingColumns,
+			row,
+			{ org: true, org_branding: false },
+		);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			slug: 'test-org-2',
+			branding: null,
+		});
+	});
+
+	it('does not nullify a nested object when its fields come from different tables', () => {
+		const columns = [
+			{ path: ['name'], field: orgTable.name },
+			{ path: ['mixed', 'note'], field: otherTable.note },
+			{ path: ['mixed', 'panelBackground'], field: orgBrandingTable.panelBackground },
+		];
+
+		const result = mapResultRow<any>(
+			columns,
+			['Test org 2', null, '#1a8cff'],
+			{ org: true, org_branding: false, other: false },
+		);
+
+		expect(result).toEqual({
+			name: 'Test org 2',
+			mixed: {
+				note: null,
+				panelBackground: '#1a8cff',
+			},
+		});
+	});
+});


### PR DESCRIPTION
**Closes #1603**

## Problem

When a nested partial select contains a nullable column that is `null` in the database
followed by another column of the **same** table that is **not** null, the whole nested
object was returned as `null` even though the `leftJoin` found a matching row:

```ts
const org = await db
  .select({
    name: orgTable.name,
    slug: orgTable.slug,
    branding: {
      logo: orgBrandingTable.logo,             // null in database
      panelBackground: orgBrandingTable.panelBackground, // "#1a8cff" in database
    },
  })
  .from(orgTable)
  .leftJoin(orgBrandingTable, eq(orgTable.id, orgBrandingTable.orgId))
  .where(eq(orgTable.id, session.orgId));

console.log(org);
// { name: 'Test org 2', slug: 'test-org-2', branding: null }        <- before the fix
// { name: 'Test org 2', slug: 'test-org-2',
//   branding: { logo: null, panelBackground: '#1a8cff' } }          <- after the fix
```

Swapping the two fields "fixed" it — which pointed at the result-mapping logic rather
than at the generated SQL.

## Root cause

In `mapResultRow` (`drizzle-orm/src/utils.ts`) the `nullifyMap` remembers, per nested
object (`path.length === 2`), the table name of the first column whose value resolved to
`null`. The flag was supposed to mean "all fields of this object are null so far".
However, the only condition that cleared the flag was *a later field from a **different**
table*:

```ts
} else if (
  typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
) {
  nullifyMap[objectName] = false;
}
```

A later **non-null** field from the **same** table left the pending flag untouched, so at
the end of the row the object was still replaced with `null`.

## Fix

Any non-null column value now clears the pending nullify flag, regardless of which table
the field belongs to; the "different table" condition is kept for null values:

```ts
} else if (
  value !== null
  || (typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table))
) {
  nullifyMap[objectName] = false;
}
```

The object is now nullified only when **every** selected column of the nullable joined
table is `null` (i.e. a real "no match" left-join row).

## Test

`drizzle-orm/tests/mapResultRow.test.ts` — DB-free regression test that feeds rows and a
`joinsNotNullableMap` straight into `mapResultRow`:

1. joined row exists, first field of the joined table is `null`, second is not
   → object must be kept (fails on `main`, passes with the fix);
2. all fields of the joined table are `null` → object must be `null`;
3. fields of the nested object come from different tables → object must be kept.

## How to verify

```sh
pnpm install --frozen-lockfile --filter drizzle-orm
cd drizzle-orm
pnpm vitest run tests/mapResultRow.test.ts   # 3 passed
pnpm vitest run                              # full unit suite, 569 passed
```

All checks: unit suite green, `type-tests` (`tsc`) green, `dprint check` clean.