### PR TITLE
Drop expo-sqlite from peerDependencies

### DIFF
--- a/drizzle-orm/package.json
+++ b/drizzle-orm/package.json
@@ -64,7 +64,6 @@
 		"@xata.io/client": "*",
 		"better-sqlite3": ">=7",
 		"bun-types": "*",
-		"expo-sqlite": ">=14.0.0",
 		"gel": ">=2",
 		"knex": "*",
 		"kysely": "*",
@@ -140,9 +139,6 @@
 			"optional": true
 		},
 		"@opentelemetry/api": {
-			"optional": true
-		},
-		"expo-sqlite": {
 			"optional": true
 		},
 		"gel": {


### PR DESCRIPTION
From #6115. Same shape as #6116, for the peer with the widest blast radius.

### Why

`expo-sqlite` is an optional peer, so the entry only gives a version warning. But pnpm resolves optional peers workspace-wide and shares one variant, so a single Expo app using `drizzle-orm/expo-sqlite` makes every other consumer resolve `drizzle-orm(...)(expo-sqlite(expo)(react-native))`. `expo` → `@expo/cli` pulls the whole SDK toolchain in.

In our monorepo that put 76 Expo/RN packages into Node server images: `node_modules` 1.3 GB → 867 MB once the entry is dropped.

Unlike #6116 this peer *is* used — `src/expo-sqlite/query.ts` imports `addDatabaseChangeListener` at runtime. But anyone importing the subpath installs `expo-sqlite` themselves, since it's a native module that has to be autolinked. The declaration isn't what makes the driver resolve; it just makes unrelated consumers pay for it.

### What changed

Removed `expo-sqlite` from `peerDependencies` and `peerDependenciesMeta`. Kept the `devDependencies` entry, so build-time types are unchanged — `peerDependencies` doesn't participate in TypeScript resolution.

No tests: package metadata, no runtime or type surface. Verified the driver still resolves and typechecks in an Expo app with the entry removed.

Related: #6115, #6116, pnpm/pnpm#10046.

cc @AndriiSherman @AlexBlokh @dankochetov @Sukairo-02 @candrewlee14
