### PR TITLE
Fix/sqlite check regex

### DIFF
--- a/drizzle-kit/src/dialects/sqlite/grammar.ts
+++ b/drizzle-kit/src/dialects/sqlite/grammar.ts
@@ -4,8 +4,55 @@ import { escapeForTsLiteral } from '../utils';
 import type { Column, DiffEntities, ForeignKey } from './ddl';
 import type { Import } from './typescript';
 
-const namedCheckPattern = /CONSTRAINT\s+["'`[]?(\w+)["'`\]]?\s+CHECK\s*\((.*)\)/gi;
-const unnamedCheckPattern = /CHECK\s+\((.*)\)/gi;
+function extractCheckConstraints(sql: string) {
+	const checks: { name: string | null; value: string }[] = [];
+	const checkStartRegex = /(?:CONSTRAINT\s+["'`\[]?(\w+)["'`\]]?\s+)?CHECK\s*\(/gi;
+	
+	let match;
+	while ((match = checkStartRegex.exec(sql)) !== null) {
+		const name = match[1] || null;
+		const startIdx = match.index + match[0].length;
+		
+		let depth = 1;
+		let inString = false;
+		let stringChar = '';
+		let endIdx = -1;
+		
+		for (let i = startIdx; i < sql.length; i++) {
+			const char = sql[i];
+			if (inString) {
+				if (char === stringChar) {
+					if (i + 1 < sql.length && sql[i+1] === stringChar) {
+						i++;
+					} else {
+						inString = false;
+					}
+				}
+			} else {
+				if (char === "'" || char === '"' || char === '`' || char === '[') {
+					inString = true;
+					stringChar = char === '[' ? ']' : char;
+				} else if (char === '(') {
+					depth++;
+				} else if (char === ')') {
+					depth--;
+					if (depth === 0) {
+						endIdx = i;
+						break;
+					}
+				}
+			}
+		}
+		
+		if (endIdx !== -1) {
+			const value = sql.substring(startIdx, endIdx).trim();
+			checks.push({ name, value });
+			checkStartRegex.lastIndex = endIdx + 1;
+		}
+	}
+	
+	return checks;
+}
 const viewAsStatementRegex = new RegExp(`\\bAS\\b\\s+(WITH.+|SELECT.+)$`, 'is'); // 'i' for case-insensitive, 's' for dotall mode
 
 /**
@@ -449,17 +496,10 @@ export const parseDefault = (type: string, it: string): Column['default'] => {
 
 export const parseTableSQL = (rawSql: string) => {
 	const sql = stripSqlComments(rawSql);
-	const namedChecks = [...sql.matchAll(namedCheckPattern)].map((it) => {
-		const [_, name, value] = it;
-		return { name, value: value.trim() };
-	});
-	const unnamedChecks = [...sql.matchAll(unnamedCheckPattern)].map((it) => {
-		const [_, value] = it;
-		return { name: null, value: value.trim() };
-	}).filter((it) => !namedChecks.some((x) => x.value === it.value));
+	const checks = extractCheckConstraints(sql);
 
 	return {
-		checks: [...namedChecks, ...unnamedChecks],
+		checks,
 	};
 };
 

--- a/drizzle-kit/src/dialects/sqlite/grammar.ts
+++ b/drizzle-kit/src/dialects/sqlite/grammar.ts
@@ -4,53 +4,147 @@ import { escapeForTsLiteral } from '../utils';
 import type { Column, DiffEntities, ForeignKey } from './ddl';
 import type { Import } from './typescript';
 
-function extractCheckConstraints(sql: string) {
-	const checks: { name: string | null; value: string }[] = [];
-	const checkStartRegex = /(?:CONSTRAINT\s+["'`\[]?(\w+)["'`\]]?\s+)?CHECK\s*\(/gi;
-	
-	let match;
-	while ((match = checkStartRegex.exec(sql)) !== null) {
-		const name = match[1] || null;
-		const startIdx = match.index + match[0].length;
-		
-		let depth = 1;
-		let inString = false;
-		let stringChar = '';
-		let endIdx = -1;
-		
-		for (let i = startIdx; i < sql.length; i++) {
-			const char = sql[i];
-			if (inString) {
-				if (char === stringChar) {
-					if (i + 1 < sql.length && sql[i+1] === stringChar) {
-						i++;
-					} else {
-						inString = false;
-					}
-				}
-			} else {
-				if (char === "'" || char === '"' || char === '`' || char === '[') {
-					inString = true;
-					stringChar = char === '[' ? ']' : char;
-				} else if (char === '(') {
-					depth++;
-				} else if (char === ')') {
-					depth--;
-					if (depth === 0) {
-						endIdx = i;
-						break;
-					}
-				}
-			}
+type CheckConstraint = { name: string | null; value: string };
+type CheckStart = { name: string | null; openParenthesisIndex: number };
+
+const quotePairs = {
+	"'": "'",
+	'"': '"',
+	'`': '`',
+	'[': ']',
+} as const;
+
+const closingQuoteFor = (char: string): string | undefined => {
+	return quotePairs[char as keyof typeof quotePairs];
+};
+
+const findQuotedEnd = (sql: string, startIndex: number, closingQuote: string): number | null => {
+	for (let index = startIndex + 1; index < sql.length; index++) {
+		if (sql[index] !== closingQuote) continue;
+		if (sql[index + 1] === closingQuote) {
+			index++;
+			continue;
 		}
-		
-		if (endIdx !== -1) {
-			const value = sql.substring(startIdx, endIdx).trim();
-			checks.push({ name, value });
-			checkStartRegex.lastIndex = endIdx + 1;
-		}
+		return index;
 	}
-	
+	return null;
+};
+
+const skipWhitespace = (sql: string, startIndex: number): number => {
+	let index = startIndex;
+	while (index < sql.length && /\s/.test(sql[index])) index++;
+	return index;
+};
+
+const isIdentifierCharacter = (char: string | undefined): boolean => {
+	if (char === undefined) return false;
+	const code = char.charCodeAt(0);
+	return code >= 0x80
+		|| code >= 48 && code <= 57
+		|| code >= 65 && code <= 90
+		|| code >= 97 && code <= 122
+		|| char === '_'
+		|| char === '$';
+};
+
+const matchesKeyword = (sql: string, index: number, keyword: string): boolean => {
+	if (isIdentifierCharacter(sql[index - 1])) return false;
+	if (isIdentifierCharacter(sql[index + keyword.length])) return false;
+
+	for (let offset = 0; offset < keyword.length; offset++) {
+		let code = sql.charCodeAt(index + offset);
+		if (code >= 97 && code <= 122) code -= 32;
+		if (code !== keyword.charCodeAt(offset)) return false;
+	}
+	return true;
+};
+
+const readIdentifier = (sql: string, startIndex: number): { name: string; endIndex: number } | null => {
+	const closingQuote = closingQuoteFor(sql[startIndex]);
+	if (closingQuote !== undefined) {
+		const endIndex = findQuotedEnd(sql, startIndex, closingQuote);
+		if (endIndex === null) return null;
+		const escapedQuote = closingQuote + closingQuote;
+		const name = sql.slice(startIndex + 1, endIndex).replaceAll(escapedQuote, closingQuote);
+		return { name, endIndex: endIndex + 1 };
+	}
+
+	let endIndex = startIndex;
+	while (isIdentifierCharacter(sql[endIndex])) endIndex++;
+	if (endIndex === startIndex) return null;
+	return { name: sql.slice(startIndex, endIndex), endIndex };
+};
+
+const readCheckStart = (sql: string, index: number, name: string | null): CheckStart | null => {
+	if (!matchesKeyword(sql, index, 'CHECK')) return null;
+	const openParenthesisIndex = skipWhitespace(sql, index + 'CHECK'.length);
+	if (sql[openParenthesisIndex] !== '(') return null;
+	return { name, openParenthesisIndex };
+};
+
+const readNamedCheckStart = (sql: string, index: number): CheckStart | null => {
+	if (!matchesKeyword(sql, index, 'CONSTRAINT')) return null;
+	const nameStartIndex = skipWhitespace(sql, index + 'CONSTRAINT'.length);
+	const identifier = readIdentifier(sql, nameStartIndex);
+	if (identifier === null) return null;
+	const checkStartIndex = skipWhitespace(sql, identifier.endIndex);
+	return readCheckStart(sql, checkStartIndex, identifier.name);
+};
+
+const findClosingParenthesis = (sql: string, openParenthesisIndex: number): number | null => {
+	let depth = 1;
+	for (let index = openParenthesisIndex + 1; index < sql.length; index++) {
+		const closingQuote = closingQuoteFor(sql[index]);
+		if (closingQuote !== undefined) {
+			const quotedEnd = findQuotedEnd(sql, index, closingQuote);
+			if (quotedEnd === null) return null;
+			index = quotedEnd;
+			continue;
+		}
+		if (sql[index] === '(') {
+			depth++;
+			continue;
+		}
+		if (sql[index] !== ')') continue;
+		depth--;
+		if (depth === 0) return index;
+	}
+	return null;
+};
+
+const readCheckConstraint = (
+	sql: string,
+	index: number,
+): { check: CheckConstraint; endIndex: number } | null => {
+	const start = readNamedCheckStart(sql, index) ?? readCheckStart(sql, index, null);
+	if (start === null) return null;
+	const endIndex = findClosingParenthesis(sql, start.openParenthesisIndex);
+	if (endIndex === null) return null;
+	const value = sql.slice(start.openParenthesisIndex + 1, endIndex).trim();
+	return { check: { name: start.name, value }, endIndex };
+};
+
+function extractCheckConstraints(sql: string): CheckConstraint[] {
+	const checks: CheckConstraint[] = [];
+	let index = 0;
+
+	while (index < sql.length) {
+		const closingQuote = closingQuoteFor(sql[index]);
+		if (closingQuote !== undefined) {
+			const quotedEnd = findQuotedEnd(sql, index, closingQuote);
+			index = quotedEnd === null ? sql.length : quotedEnd + 1;
+			continue;
+		}
+
+		const result = readCheckConstraint(sql, index);
+		if (result !== null) {
+			checks.push(result.check);
+			index = result.endIndex + 1;
+			continue;
+		}
+		index++;
+	}
+
 	return checks;
 }
 const viewAsStatementRegex = new RegExp(`\\bAS\\b\\s+(WITH.+|SELECT.+)$`, 'is'); // 'i' for case-insensitive, 's' for dotall mode

--- a/drizzle-kit/tests/sqlite/check-constraints.test.ts
+++ b/drizzle-kit/tests/sqlite/check-constraints.test.ts
@@ -1,0 +1,59 @@
+import { parseTableSQL } from 'src/dialects/sqlite/grammar';
+import { describe, expect, test } from 'vitest';
+
+describe('parseTableSQL CHECK constraints', () => {
+	test.each(
+		[
+			[
+				'CHECK without whitespace',
+				"CREATE TABLE t (a TEXT CHECK(a <> ''), b INTEGER, CHECK (b > 0));",
+				[
+					{ name: null, value: "a <> ''" },
+					{ name: null, value: 'b > 0' },
+				],
+			],
+			[
+				'multiple CHECK constraints on one line',
+				'CREATE TABLE two (a INTEGER, CHECK (a > 0), CHECK (a < 10));',
+				[
+					{ name: null, value: 'a > 0' },
+					{ name: null, value: 'a < 10' },
+				],
+			],
+			[
+				'multiline CHECK constraint',
+				'CREATE TABLE multi (b INTEGER, CHECK (\n  b > 0\n));',
+				[{ name: null, value: 'b > 0' }],
+			],
+		] as const,
+	)('parses %s', (_, sql, expected) => {
+		expect(parseTableSQL(sql).checks).toStrictEqual(expected);
+	});
+
+	test('balances nested parentheses without counting quoted parentheses', () => {
+		const sql =
+			"CREATE TABLE nested (a TEXT, CONSTRAINT [validity check] CHECK (length(a) > 0 AND coalesce(a, ')') <> 'it''s (empty)'));";
+
+		expect(parseTableSQL(sql).checks).toStrictEqual([
+			{
+				name: 'validity check',
+				value: "length(a) > 0 AND coalesce(a, ')') <> 'it''s (empty)'",
+			},
+		]);
+	});
+
+	test('ignores CHECK-like text inside literals and quoted identifiers', () => {
+		const sql =
+			"CREATE TABLE literals (\"CHECK(fake)\" TEXT DEFAULT 'RECHECK (fake)', note TEXT DEFAULT 'CHECK(other)');";
+
+		expect(parseTableSQL(sql).checks).toStrictEqual([]);
+	});
+
+	test('recognizes keywords case-insensitively and unescapes quoted names', () => {
+		const sql = 'CREATE TABLE named (a INTEGER, cOnStRaInT "positive ""value" ChEcK(a > 0));';
+
+		expect(parseTableSQL(sql).checks).toStrictEqual([
+			{ name: 'positive "value', value: 'a > 0' },
+		]);
+	});
+});


### PR DESCRIPTION
Fixes #6195

## What changed

- replaced regex-only CHECK extraction with balanced-parenthesis parsing
- recognizes CHECK only as a complete SQL keyword
- ignores CHECK-like text inside strings and quoted identifiers
- supports nested parentheses and parentheses inside quoted values
- preserves quoted constraint names
- adds regression coverage for the reported formatting cases and false positives

## Verification

- `vitest run tests/sqlite/check-constraints.test.ts` — 6 passed
- `oxlint` — 0 warnings, 0 errors
- `dprint check` — passed
- verified against SQL returned by SQLite's `sqlite_master`
