### PR TITLE
fix(drizzle-kit): exit non-zero and name the failing statement when push fails

### DIFF
--- a/drizzle-kit/src/cli/commands/push.ts
+++ b/drizzle-kit/src/cli/commands/push.ts
@@ -146,11 +146,21 @@ export const mysqlPush = async (
 			}
 
 			for (const dStmnt of uniqueSqlStatementsToExecute) {
-				await db.query(dStmnt);
+				try {
+					await db.query(dStmnt);
+				} catch (e) {
+					console.error(`Failed to execute statement:\n${dStmnt}`);
+					throw e;
+				}
 			}
 
 			for (const statement of uniqueFilteredSqlStatements) {
-				await db.query(statement);
+				try {
+					await db.query(statement);
+				} catch (e) {
+					console.error(`Failed to execute statement:\n${statement}`);
+					throw e;
+				}
 			}
 			if (filteredStatements.length > 0) {
 				render(`[${chalk.green('✓')}] Changes applied`);
@@ -160,6 +170,7 @@ export const mysqlPush = async (
 		}
 	} catch (e) {
 		console.log(e);
+		process.exit(1);
 	}
 };
 
@@ -396,7 +407,12 @@ export const pgPush = async (
 			}
 
 			for (const dStmnt of statementsToExecute) {
-				await db.query(dStmnt);
+				try {
+					await db.query(dStmnt);
+				} catch (e) {
+					console.error(`Failed to execute statement:\n${dStmnt}`);
+					throw e;
+				}
 			}
 
 			if (statements.statements.length > 0) {
@@ -407,6 +423,7 @@ export const pgPush = async (
 		}
 	} catch (e) {
 		console.error(e);
+		process.exit(1);
 	}
 };
 


### PR DESCRIPTION
> **Disclosure:** this pull request was researched, written, and tested by breken, an AI engineer that investigates production issues and proposes fixes. A human directed the run and reviewed this body. We label our work so you never have to guess.

## The problem in plain words

When `drizzle-kit push` hits a database error, it prints the error and then exits with code 0, as if everything went fine.

CI pipelines trust exit codes - it is the only contract they have. So a failed deploy looks green: the pipeline passes, the release ships, and the database is left behind, part of the migration applied and part of it not. The first sign anything went wrong is a production bug, hours later.

## Root cause

`drizzle-kit push` executes migration statements sequentially, per dialect. The three dialects have three different failure behaviors:

- `sqlitePush` (push.ts:524): the catch block calls `process.exit(1)`. Correct.
- `pgPush` (push.ts:408): the catch block logs the driver error and falls through. The process exits 0.
- `mysqlPush` (push.ts:161): same as pg - logs and falls through to exit 0.

So on Postgres and MySQL, a failed push is indistinguishable from a successful one at the only layer CI can observe.

There is a second gap. When statement N of M fails, the loop rethrows the raw driver exception. Statements 1..N-1 have already been applied; statements N+1..M never run. The database matches neither the old schema nor the new one, and the log never says which statement stopped the run. In a long migration, the bare driver error leaves you guessing where it died.

## The fix

One file, 20 insertions, 3 deletions.

1. `pgPush` and `mysqlPush` catch blocks now call `process.exit(1)` after logging, matching the existing `sqlitePush` behavior. A failed push fails the pipeline.
2. The pg and mysql statement loops wrap each `db.query(...)`: on error they print `Failed to execute statement:` followed by the exact SQL, then rethrow. The log now names the migration step that failed.

```diff
 for (const statement of uniqueFilteredSqlStatements) {
-	await db.query(statement);
+	try {
+		await db.query(statement);
+	} catch (e) {
+		console.error(`Failed to execute statement:\n${statement}`);
+		throw e;
+	}
 }
```

## Behavior change worth knowing about

Pipelines that were silently broken will now fail loudly. Any CI job that has been "successfully" deploying failed pushes turns red the first time it hits one after this lands. That is the point, but it will surprise teams whose deploys have been quietly partial - arguably the most valuable red their pipeline has ever shown.

## Reproduction and evidence

Setup: Postgres via PGlite. Schema v1 is `users(id, name, age)`, seeded with a row where `age = -5`. Schema v2 adds CHECK constraints `age_positive` and `name_nonempty` plus a `posts` table. Pushing v2 must fail, because existing data violates the new constraint. The question is what the caller learns.

**Before (0.31.10)** - error printed, exit code 0:

```
error: check constraint "age_positive" of relation "users" is violated by some row
    at async pgPush (drizzle-kit/bin.cjs:82768:13)
    ...

$ echo $?
0        <- CI reads this as a successful deploy
```

Note the half-migrated state: in this run the `posts` table was created (statements before the failing one applied), the constraints were not, and the pipeline still reported success.

**After (this branch)** - failing statement named, exit code 1:

```
Failed to execute statement:
ALTER TABLE "users" ADD CONSTRAINT "age_positive" CHECK ("users"."age" >= 0);
error: check constraint "age_positive" of relation "users" is violated by some row
    ...

$ echo $?
1        <- CI correctly fails the deploy
```

Happy path: a valid push with no violating rows still succeeds exactly as before (`[✓] Changes applied`, exit 0), verified on the same setup. Failure semantics are unchanged - statements after a failure still do not run. Only the reporting becomes honest.

## Verified vs. not verified

- ✅ Bug and fix reproduced end-to-end against Postgres (PGlite): exit code and statement naming behave exactly as shown above.
- ✅ Happy-path push with a valid schema still succeeds; the before/after artifacts are real captured output, not mockups.
- ⚠️ Not yet run against this repo's own test suite, or against a live external Postgres/MySQL server. The MySQL path received the same change by symmetry and was exercised less than the pg path - worth a maintainer CI pass.

Happy to iterate - if you want the statement log formatted differently, tests added in-repo, or the change scoped to pg only, say the word and I will adjust.

Fixes #6192.