### PR TITLE
fix(kit): correctly parse check constraint modifiers

### DIFF
--- a/drizzle-kit/src/dialects/cockroach/grammar.ts
+++ b/drizzle-kit/src/dialects/cockroach/grammar.ts
@@ -94,15 +94,14 @@ export const isSystemRole = (name: string) => {
 };
 
 /*
-	CHECK (((email)::text <> 'test@gmail.com'::text))
-	Where (email) is column in table
+	pg_get_constraintdef returns:
+	CHECK (expression) [NO INHERIT] [NOT VALID | NOT ENFORCED]
 */
 export const parseCheckDefinition = (value: string): string => {
-	const clean = value.replace(/(?:\s+(?:NOT\s+VALID|NO\s+INHERIT))+\s*$/i, '').trim();
-	if (clean.startsWith('CHECK (') && clean.endsWith(')')) {
-		return clean.slice(7, -1);
-	}
-	return clean;
+	return value.replace(
+		/^CHECK\s*\(([\s\S]*)\)(?:\s+NO\s+INHERIT)?(?:\s+NOT\s+(?:VALID|ENFORCED))?\s*$/i,
+		'$1',
+	);
 };
 
 export const parseViewDefinition = (value: string | null | undefined): string | null => {

--- a/drizzle-kit/src/dialects/cockroach/grammar.ts
+++ b/drizzle-kit/src/dialects/cockroach/grammar.ts
@@ -98,7 +98,11 @@ export const isSystemRole = (name: string) => {
 	Where (email) is column in table
 */
 export const parseCheckDefinition = (value: string): string => {
-	return value.replace(/^CHECK\s*\(\(/, '').replace(/\)\)\s*$/, '');
+	const clean = value.replace(/(?:\s+(?:NOT\s+VALID|NO\s+INHERIT))+\s*$/i, '').trim();
+	if (clean.startsWith('CHECK (') && clean.endsWith(')')) {
+		return clean.slice(7, -1);
+	}
+	return clean;
 };
 
 export const parseViewDefinition = (value: string | null | undefined): string | null => {

--- a/drizzle-kit/src/dialects/cockroach/introspect.ts
+++ b/drizzle-kit/src/dialects/cockroach/introspect.ts
@@ -22,6 +22,7 @@ import type {
 import {
 	defaultForColumn,
 	isSystemNamespace,
+	parseCheckDefinition,
 	parseOnType,
 	parseViewDefinition,
 	stringFromDatabaseIdentityProperty as parseIdentityProperty,
@@ -860,7 +861,7 @@ export const fromDatabase = async (
 			schema: schema.name,
 			table: table.name,
 			name: check.name,
-			value: check.definition.startsWith('CHECK (') ? check.definition.slice(7, -1) : check.definition,
+			value: parseCheckDefinition(check.definition),
 		});
 	}
 

--- a/drizzle-kit/src/dialects/postgres/aws-introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/aws-introspect.ts
@@ -25,6 +25,7 @@ import {
 	defaultForColumn,
 	isSerialExpression,
 	isSystemNamespace,
+	parseCheckDefinition,
 	parseOnType,
 	parseViewDefinition,
 	stringFromDatabaseIdentityProperty as parseIdentityProperty,
@@ -876,7 +877,7 @@ export const fromDatabase = async (
 			schema: schema.name,
 			table: table.name,
 			name: check.name,
-			value: check.definition,
+			value: parseCheckDefinition(check.definition),
 		});
 	}
 

--- a/drizzle-kit/src/dialects/postgres/grammar.ts
+++ b/drizzle-kit/src/dialects/postgres/grammar.ts
@@ -1942,15 +1942,14 @@ export const wrapRecord = (it: Record<string, string>) => {
 };
 
 /*
-	CHECK (((email)::text <> 'test@gmail.com'::text))
-	Where (email) is column in table
+	pg_get_constraintdef returns:
+	CHECK (expression) [NO INHERIT] [NOT VALID | NOT ENFORCED]
 */
 export const parseCheckDefinition = (value: string): string => {
-	const clean = value.replace(/(?:\s+(?:NOT\s+VALID|NO\s+INHERIT))+\s*$/i, '').trim();
-	if (clean.startsWith('CHECK (') && clean.endsWith(')')) {
-		return clean.slice(7, -1);
-	}
-	return clean;
+	return value.replace(
+		/^CHECK\s*\(([\s\S]*)\)(?:\s+NO\s+INHERIT)?(?:\s+NOT\s+(?:VALID|ENFORCED))?\s*$/i,
+		'$1',
+	);
 };
 
 export const parseViewDefinition = (value: string | null | undefined): string | null => {

--- a/drizzle-kit/src/dialects/postgres/grammar.ts
+++ b/drizzle-kit/src/dialects/postgres/grammar.ts
@@ -1946,7 +1946,11 @@ export const wrapRecord = (it: Record<string, string>) => {
 	Where (email) is column in table
 */
 export const parseCheckDefinition = (value: string): string => {
-	return value.replace(/^CHECK\s*\(\(/, '').replace(/\)\)\s*$/, '');
+	const clean = value.replace(/(?:\s+(?:NOT\s+VALID|NO\s+INHERIT))+\s*$/i, '').trim();
+	if (clean.startsWith('CHECK (') && clean.endsWith(')')) {
+		return clean.slice(7, -1);
+	}
+	return clean;
 };
 
 export const parseViewDefinition = (value: string | null | undefined): string | null => {

--- a/drizzle-kit/src/dialects/postgres/introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/introspect.ts
@@ -26,6 +26,7 @@ import {
 	defaultForColumn,
 	isSerialExpression,
 	isSystemNamespace,
+	parseCheckDefinition,
 	parseOnType,
 	parseViewDefinition,
 	stringFromDatabaseIdentityProperty as parseIdentityProperty,
@@ -890,7 +891,7 @@ export const fromDatabase = async (
 			schema: schema.name,
 			table: table.name,
 			name: check.name,
-			value: check.definition.startsWith('CHECK (') ? check.definition.slice(7, -1) : check.definition,
+			value: parseCheckDefinition(check.definition),
 		});
 	}
 	progressCallback('checks', checks.length, 'done');

--- a/drizzle-kit/tests/cockroach/grammar.test.ts
+++ b/drizzle-kit/tests/cockroach/grammar.test.ts
@@ -1,4 +1,4 @@
-import { splitSqlType, trimDefaultValueSuffix } from 'src/dialects/cockroach/grammar';
+import { parseCheckDefinition, splitSqlType, trimDefaultValueSuffix } from 'src/dialects/cockroach/grammar';
 import { expect, test } from 'vitest';
 
 test.each([
@@ -73,4 +73,17 @@ test('split sql type', () => {
 	expect.soft(splitSqlType('numeric(10)[][]')).toStrictEqual({ type: 'numeric', options: '10' });
 	expect.soft(splitSqlType('numeric(10,0)[][]')).toStrictEqual({ type: 'numeric', options: '10,0' });
 	expect.soft(splitSqlType('numeric(10,2)[][]')).toStrictEqual({ type: 'numeric', options: '10,2' });
+});
+
+test.each([
+	['CHECK ((version >= 0))', '(version >= 0)'],
+	['CHECK((version >= 0)) NOT VALID', '(version >= 0)'],
+	['check ((version >= 0)) not valid', '(version >= 0)'],
+	['CHECK ((version >= 0)) NO INHERIT', '(version >= 0)'],
+	['CHECK ((version >= 0)) NO INHERIT NOT VALID', '(version >= 0)'],
+	["CHECK (status <> 'NOT VALID')", "status <> 'NOT VALID'"],
+	["CHECK (status <> 'NOT VALID') NOT VALID", "status <> 'NOT VALID'"],
+	['version >= 0 NOT VALID', 'version >= 0 NOT VALID'],
+])('parse check definition %#: %s', (it, expected) => {
+	expect(parseCheckDefinition(it)).toBe(expected);
 });

--- a/drizzle-kit/tests/postgres/grammar.test.ts
+++ b/drizzle-kit/tests/postgres/grammar.test.ts
@@ -85,19 +85,17 @@ test('to default array', () => {
 
 test.each([
 	['CHECK ((version >= 0))', '(version >= 0)'],
-	['CHECK ((version >= 0)) NOT VALID', '(version >= 0)'],
-	['CHECK ((version >= 0)) not valid', '(version >= 0)'],
+	['CHECK((version >= 0)) NOT VALID', '(version >= 0)'],
+	['check ((version >= 0)) not valid', '(version >= 0)'],
 	['CHECK ((version >= 0)) NO INHERIT', '(version >= 0)'],
 	['CHECK ((version >= 0)) NO INHERIT NOT VALID', '(version >= 0)'],
-	['CHECK ((version >= 0)) NOT VALID NO INHERIT', '(version >= 0)'],
+	['CHECK ((version >= 0)) NOT ENFORCED', '(version >= 0)'],
 	['CHECK (version >= 0)', 'version >= 0'],
-	['CHECK (version >= 0) NOT VALID', 'version >= 0'],
 	["CHECK (status <> 'NOT VALID')", "status <> 'NOT VALID'"],
 	["CHECK (status <> 'NOT VALID') NOT VALID", "status <> 'NOT VALID'"],
 	["CHECK (status <> 'NO INHERIT') NO INHERIT", "status <> 'NO INHERIT'"],
-	['CHECK (a > 0 AND b < 10)', 'a > 0 AND b < 10'],
-	['CHECK (a > 0 AND b < 10) NOT VALID', 'a > 0 AND b < 10'],
+	['version >= 0 NOT VALID', 'version >= 0 NOT VALID'],
+	['CHECK ((version >= 0)) NOT VALID NO INHERIT', 'CHECK ((version >= 0)) NOT VALID NO INHERIT'],
 ])('parse check definition %#: %s', (it, expected) => {
 	expect(parseCheckDefinition(it)).toBe(expected);
 });
-

--- a/drizzle-kit/tests/postgres/grammar.test.ts
+++ b/drizzle-kit/tests/postgres/grammar.test.ts
@@ -1,4 +1,4 @@
-import { splitSqlType, trimDefaultValueSuffix } from 'src/dialects/postgres/grammar';
+import { parseCheckDefinition, splitSqlType, trimDefaultValueSuffix } from 'src/dialects/postgres/grammar';
 import { expect, test } from 'vitest';
 
 test.each([
@@ -82,3 +82,22 @@ test('to default array', () => {
 	// 	`{{"key":"one"},{"key":"two"}}`,
 	// );
 });
+
+test.each([
+	['CHECK ((version >= 0))', '(version >= 0)'],
+	['CHECK ((version >= 0)) NOT VALID', '(version >= 0)'],
+	['CHECK ((version >= 0)) not valid', '(version >= 0)'],
+	['CHECK ((version >= 0)) NO INHERIT', '(version >= 0)'],
+	['CHECK ((version >= 0)) NO INHERIT NOT VALID', '(version >= 0)'],
+	['CHECK ((version >= 0)) NOT VALID NO INHERIT', '(version >= 0)'],
+	['CHECK (version >= 0)', 'version >= 0'],
+	['CHECK (version >= 0) NOT VALID', 'version >= 0'],
+	["CHECK (status <> 'NOT VALID')", "status <> 'NOT VALID'"],
+	["CHECK (status <> 'NOT VALID') NOT VALID", "status <> 'NOT VALID'"],
+	["CHECK (status <> 'NO INHERIT') NO INHERIT", "status <> 'NO INHERIT'"],
+	['CHECK (a > 0 AND b < 10)', 'a > 0 AND b < 10'],
+	['CHECK (a > 0 AND b < 10) NOT VALID', 'a > 0 AND b < 10'],
+])('parse check definition %#: %s', (it, expected) => {
+	expect(parseCheckDefinition(it)).toBe(expected);
+});
+

--- a/drizzle-kit/tests/postgres/pull.test.ts
+++ b/drizzle-kit/tests/postgres/pull.test.ts
@@ -2187,6 +2187,46 @@ test('check definition', async () => {
 	]);
 });
 
+// https://github.com/drizzle-team/drizzle-orm/issues/6214
+test('check definition ending in NOT VALID', async () => {
+	await db.query(`
+		CREATE TABLE documents (
+			id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+			version integer NOT NULL
+		);
+	`);
+	await db.query(`
+		ALTER TABLE documents
+			ADD CONSTRAINT documents_version_check
+			CHECK (version >= 0) NOT VALID;
+	`);
+
+	const filter = prepareEntityFilter(
+		'postgresql',
+		{
+			tables: undefined,
+			schemas: undefined,
+			entities: undefined,
+			extensions: undefined,
+		},
+		[],
+	);
+	const { checks } = await fromDatabaseForDrizzle(db, filter, () => {}, {
+		table: '__drizzle_migrations',
+		schema: 'drizzle',
+	});
+
+	expect(checks).toStrictEqual([
+		{
+			entityType: 'checks',
+			schema: 'public',
+			name: 'documents_version_check',
+			table: 'documents',
+			value: '(version >= 0)',
+		},
+	]);
+});
+
 // other tables in migration schema
 test('pull after migrate with custom migrations table #1', async () => {
 	await db.query(`CREATE SCHEMA drizzle;`);


### PR DESCRIPTION
Fixes #6214

## Problem

`drizzle-kit pull` assumes PostgreSQL check definitions always end with `)` and removes the first 7 and final characters.

For definitions returned as:

```sql
CHECK ((version >= 0)) NOT VALID
 ```                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                              
 this produced the invalid expression:                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                              
 ```sql                                                                                                                                                                                                                                                                       
(version >= 0)) NOT VALI
 ```                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                              
 Changes                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                              
 - Parse the complete CHECK (...) definition before extracting its expression.                                                                                                                                                                                                
 - Handle trailing NO INHERIT, NOT VALID, and NOT ENFORCED modifiers.                                                                                                                                                                                                         
 - Preserve unmatched definitions unchanged.                                                                                                                                                                                                                                  
 - Apply the parser to PostgreSQL, AWS PostgreSQL, and CockroachDB introspection.                                                                                                                                                                                             
 - Add PostgreSQL and CockroachDB parser tests.                                                                                                                                                                                                                               
 - Add an end-to-end PostgreSQL pull regression test for NOT VALID.                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                              
 The modifiers are removed because the current snapshot model only stores the check expression and does not model constraint validation or inheritance state.                                                                                                                 
                                                                                                                                                                                                                                                                              
 Verification                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                              
 - PostgreSQL and CockroachDB grammar tests: 97 passed                                                                                                                                                                                                                        
 - PostgreSQL NOT VALID pull regression test: passed                                                                                                                                                                                                                          
 - TypeScript check: passed                                                                                                                                                                                                                                                   
 - Oxlint: 0 warnings and 0 errors 