### PR TITLE
fix: preserve nested left join object when later field is non-null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/integration-tests/tests/pg/pg-common.ts
+++ b/integration-tests/tests/pg/pg-common.ts
@@ -1679,6 +1679,7 @@ export function tests() {
 						nameUpper: sql<string>`upper(${users2Table.name})`,
 					},
 					city: {
+						state: citiesTable.state,
 						id: citiesTable.id,
 						name: citiesTable.name,
 						nameUpper: sql<string>`upper(${citiesTable.name})`,
@@ -1691,7 +1692,7 @@ export function tests() {
 				{
 					id: 1,
 					user: { name: 'John', nameUpper: 'JOHN' },
-					city: { id: cityId, name: 'Paris', nameUpper: 'PARIS' },
+					city: { state: null, id: cityId, name: 'Paris', nameUpper: 'PARIS' },
 				},
 				{
 					id: 2,


### PR DESCRIPTION
Fixes #1603

/claim #1603

## Summary
- stop treating a nullable joined object as absent when its first selected column is null but a later column from the same joined table is non-null
- extend the existing grouped left-join regression test so the nullable `state` field is selected first

## Why
`mapResultRow` recorded the table name when the first nested field was null, but never cleared that nullification marker when a later field from the same table proved the joined row existed. This made the result depend on selected-field order.

## Verification
The updated existing PostgreSQL grouped left-join test directly covers the reported ordering case: `state` is null while `id`, `name`, and the SQL-derived uppercase name are non-null. CI should exercise the integration suite.