### PR TITLE
fix(orm): preserve nested partial select on left join when first column is null (#1603)

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}


### PR DESCRIPTION
Fixes #1603
/claim #1603

## Summary
Fixes an issue where `mapResultRow` improperly nullifies a nested partial-select object when the first selected field of a left-joined table evaluates to `null`, even if subsequent fields from the same table contain non-null values.

## Root Cause
In `mapResultRow` (`drizzle-orm/src/utils.ts`), `nullifyMap[objectName]` stored the table name when encountering the first null column, but only cleared the nullify flag when encountering a field from a different table. Non-null values from the same table failed to reset the flag.

## Changes
- Corrected the nullification guard in `mapResultRow` to ensure any non-null column value immediately clears the pending nullification.
- Preserves object structure when later fields in the same joined table have valid data.