### PR TITLE
[SQLite-kit] Read partial index predicates from the index DDL

### DIFF
--- a/drizzle-kit/src/dialects/sqlite/grammar.ts
+++ b/drizzle-kit/src/dialects/sqlite/grammar.ts
@@ -463,6 +463,74 @@ export const parseTableSQL = (rawSql: string) => {
 	};
 };
 
+const isIdentifierChar = (char: string | undefined): boolean => char !== undefined && /[\w$]/.test(char);
+
+/**
+ * Extracts the predicate of a partial index from its own `CREATE INDEX ... WHERE ...` DDL.
+ *
+ * The predicate is whatever follows the `WHERE` that sits outside of any parentheses and after
+ * the indexed-column list, so a `where` inside a quoted identifier, a string literal or a column
+ * expression is never mistaken for the keyword. Returns `null` when the DDL carries no predicate.
+ */
+export const parseIndexWhere = (rawDdl: string): string | null => {
+	const ddl = stripSqlComments(rawDdl);
+	const len = ddl.length;
+	let depth = 0;
+	let columnsClosed = false;
+	let i = 0;
+
+	while (i < len) {
+		const char = ddl[i];
+
+		// string / identifier literals cannot hold the keyword — skip them whole
+		if (char === "'" || char === '"' || char === '`' || char === '[') {
+			const close = char === '[' ? ']' : char;
+			i++;
+			while (i < len) {
+				if (ddl[i] === close) {
+					// doubled quote escaping (e.g. '' inside a '...' literal)
+					if (close !== ']' && ddl[i + 1] === close) {
+						i += 2;
+						continue;
+					}
+					i++;
+					break;
+				}
+				i++;
+			}
+			continue;
+		}
+
+		if (char === '(') {
+			depth++;
+			i++;
+			continue;
+		}
+
+		if (char === ')') {
+			depth--;
+			if (depth === 0) columnsClosed = true;
+			i++;
+			continue;
+		}
+
+		if (
+			columnsClosed
+			&& depth === 0
+			&& (char === 'w' || char === 'W')
+			&& ddl.slice(i, i + 5).toLowerCase() === 'where'
+			&& !isIdentifierChar(ddl[i - 1])
+			&& !isIdentifierChar(ddl[i + 5])
+		) {
+			return ddl.slice(i + 5).trim() || null;
+		}
+
+		i++;
+	}
+
+	return null;
+};
+
 export const parseViewSQL = (sql: string) => {
 	const match = sql.match(viewAsStatementRegex);
 	return match ? match[1] : null;

--- a/drizzle-kit/src/dialects/sqlite/introspect.ts
+++ b/drizzle-kit/src/dialects/sqlite/introspect.ts
@@ -21,6 +21,7 @@ import {
 	nameForPk,
 	nameForUnique,
 	parseDefault,
+	parseIndexWhere,
 	parseSqliteDdl,
 	parseSqliteFks,
 	parseTableSQL,
@@ -256,6 +257,8 @@ export const fromDatabase = async (
 	const dbIndexes = await db.query<{
 		table: string;
 		sql: string;
+		indexSql: string | null;
+		isPartial: number;
 		name: string;
 		column: string;
 		isUnique: number;
@@ -266,6 +269,11 @@ export const fromDatabase = async (
 		SELECT 
 			m.tbl_name as "table",
 			m.sql,
+			(
+				SELECT im.sql FROM sqlite_master AS im
+				WHERE im.type = 'index' AND im.name = il.name
+			) as "indexSql",
+			il.partial as "isPartial",
 			il.name as "name",
 			ii.name as "column",
 			il.[unique] as "isUnique",
@@ -332,8 +340,8 @@ export const fromDatabase = async (
 
 	const tableToIndexColumns = dbIndexes.reduce(
 		(acc, it) => {
-			const whereIdx = it.sql.toLowerCase().indexOf(' where ');
-			const where = whereIdx < 0 ? null : it.sql.slice(whereIdx + 7);
+			// `it.sql` is the table's CREATE TABLE — the predicate lives on the index's own DDL
+			const where = it.isPartial === 1 && it.indexSql ? parseIndexWhere(it.indexSql) : null;
 			const column = { value: it.column, isExpression: it.cid === -2 };
 			if (it.table in acc) {
 				if (it.name in acc[it.table]) {
@@ -634,7 +642,9 @@ export const fromDatabase = async (
 		for (const { columns, index } of Object.values(item).filter((it) => it.index.isUnique)) {
 			if (columns.length === 1) continue;
 			if (columns.some((it) => it.isExpression)) {
-				throw new Error(`unexpected unique index '${index.name}' with expression value: ${index.sql}`);
+				throw new Error(
+					`unexpected unique index '${index.name}' with expression value: ${index.indexSql ?? index.sql}`,
+				);
 			}
 
 			const origin = index.origin === 'u' || index.origin === 'pk' ? 'auto' : index.origin === 'c' ? 'manual' : null;

--- a/drizzle-kit/tests/sqlite/pull.test.ts
+++ b/drizzle-kit/tests/sqlite/pull.test.ts
@@ -803,3 +803,37 @@ test('Issue No6182', async () => {
 		},
 	]);
 });
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6223
+test('introspect partial index predicate', async () => {
+	const sqlite = new Database(':memory:');
+	const db = dbFrom(sqlite);
+
+	// the default holds " where " so a predicate read off the table's DDL leaks into the index
+	await db.run(
+		`CREATE TABLE t (
+			id INTEGER PRIMARY KEY,
+			code TEXT NOT NULL,
+			status TEXT,
+			note TEXT DEFAULT 'ask where it came from'
+		);`,
+	);
+	await db.run(`CREATE INDEX plain ON t (code);`);
+	await db.run(`CREATE UNIQUE INDEX partial ON t (code) WHERE status = 'active';`);
+	await db.run(`CREATE INDEX quoted ON t (note) WHERE note <> 'where';`);
+	await db.run(`CREATE INDEX expr ON t (lower(code), id) WHERE status = 'active';`);
+
+	const schema = await fromDatabaseForDrizzle(db, () => true, () => {}, {
+		table: '__drizzle_migrations',
+		schema: 'drizzle',
+	});
+	const { ddl, errors } = interimToDDL(schema);
+	expect(errors.length).toBe(0);
+
+	const whereOf = (name: string) => ddl.indexes.list().find((it) => it.name === name)?.where;
+
+	expect(whereOf('plain')).toBe(null);
+	expect(whereOf('partial')).toBe(`status = 'active'`);
+	expect(whereOf('quoted')).toBe(`note <> 'where'`);
+	expect(whereOf('expr')).toBe(`status = 'active'`);
+});


### PR DESCRIPTION
Fixes #6223.

## Problem

The index query in `fromDatabase` (`drizzle-kit/src/dialects/sqlite/introspect.ts`) selects `m.sql` under `WHERE m.type = 'table'`, so `m.sql` is the table's `CREATE TABLE`, not the index's `CREATE INDEX`. The predicate was then taken off that string:

```ts
const whereIdx = it.sql.toLowerCase().indexOf(' where ');
const where = whereIdx < 0 ? null : it.sql.slice(whereIdx + 7);
```

Two consequences:

**A real predicate is always lost.** `CREATE UNIQUE INDEX i ON t (code) WHERE status = 'active'` pulls as `uniqueIndex("i").on(table.code)`, and the baseline migration recreates it with no `WHERE`. Rows the original accepted — same `code`, `status = 'archived'` — then fail with `UNIQUE constraint failed`. This is the damaging half: it changes what the schema allows.

**A predicate is invented when the table DDL happens to contain `" where "`.** With a column default of `'ask where it came from'`, a plain non-partial index pulls as:

```json
{ "name": "i", "where": "it came from')", "isUnique": false, ... }
```

## Fix

The index's own DDL is fetched alongside the row with a correlated subquery on `sqlite_master`, and `pragma_index_list`'s `partial` flag gates the parse, so a non-partial index can never be given a predicate:

```ts
const where = it.isPartial === 1 && it.indexSql ? parseIndexWhere(it.indexSql) : null;
```

`parseIndexWhere` (added to `grammar.ts`) scans the index DDL for a `WHERE` that sits outside quotes and parentheses and after the indexed-column list, reusing the quote-skipping approach already used by `stripSqlComments`. A `where` inside a string literal, a quoted identifier or a column expression is therefore not mistaken for the keyword.

`m.sql` is deliberately left in place — the unique-constraint pass below still needs the table DDL for `parseSqliteDdl`. Only the expression-index error message was switched to report the index DDL, since it was printing the table's.

## Tests

Added `introspect partial index predicate` to `drizzle-kit/tests/sqlite/pull.test.ts`, covering the invented predicate, a real one, a predicate containing `'where'` as a string literal, and an expression index.

On `rc5` without the fix the new test fails on the first assertion:

```
AssertionError: expected 'it came from\'\n\t\t)' to be null
```

Full `tests/sqlite/` suite, before and after: `27 failed | 255 passed` → `26 failed | 256 passed`. The one test that flips is the new one; the remaining failures are pre-existing on `rc5` in this environment (`sqlite-defaults`/`sqlite-columns` shell out to `tsc`, which needs a built `drizzle-orm`, and `drizzle-orm`'s build requires `bun`). `dprint check` and `oxlint` pass on the changed files.

`parseIndexWhere` was also exercised directly against non-partial DDL, a literal `'where'`, a quoted `"my where idx"` identifier, a `somewhere` column, `[where]` in brackets, a `-- where` comment, lowercase `where`, and nested parentheses.
