### PR TITLE
fix(drizzle-zod): validate Gel temporal columns instead of emitting z.any()

### DIFF
--- a/drizzle-zod/src/column.ts
+++ b/drizzle-zod/src/column.ts
@@ -1,5 +1,13 @@
 import type { Column, ColumnBaseConfig } from 'drizzle-orm';
 import type {
+	GelDateDuration,
+	GelDuration,
+	GelLocalDateString,
+	GelLocalTime,
+	GelRelDuration,
+	GelTimestamp,
+} from 'drizzle-orm/gel-core';
+import type {
 	MySqlBigInt53,
 	MySqlChar,
 	MySqlDouble,
@@ -124,6 +132,31 @@ export function columnToSchema(
 			schema = z.any();
 		} else if (column.dataType === 'buffer') {
 			schema = bufferSchema;
+		} else if (
+			isColumnType<
+				| GelDateDuration<any>
+				| GelDuration<any>
+				| GelRelDuration<any>
+				| GelLocalTime<any>
+				| GelLocalDateString<any>
+				| GelTimestamp<any>
+			>(column, [
+				'GelDateDuration',
+				'GelDuration',
+				'GelRelDuration',
+				'GelLocalTime',
+				'GelLocalDateString',
+				'GelTimestamp',
+			])
+		) {
+			// Gel-only ColumnDataType variants (dateDuration, duration, relDuration,
+			// localTime, localDate, localDateTime). Their runtime values are opaque driver
+			// class instances from the `gel` package (Duration, RelativeDuration,
+			// DateDuration, LocalTime, LocalDate, LocalDateTime). drizzle-zod has no `gel`
+			// dependency, so rather than an `instanceof` check we validate that the value
+			// is a non-null object instead of letting it fall through to the `z.any()`
+			// catch-all, which validated nothing (#6027).
+			schema = z.custom<object>((value) => typeof value === 'object' && value !== null);
 		}
 	}
 

--- a/drizzle-zod/tests/gel.test.ts
+++ b/drizzle-zod/tests/gel.test.ts
@@ -1,0 +1,44 @@
+import { dateDuration, duration, gelTable, localDate, localTime, relDuration, timestamp } from 'drizzle-orm/gel-core';
+import { expect, test } from 'vitest';
+import { createInsertSchema, createSelectSchema } from '../src';
+
+// Regression test for #6027: the 6 Gel-only ColumnDataType variants
+// (dateDuration, duration, relDuration, localTime, localDate, localDateTime)
+// were falling through columnToSchema()'s if/else chain to the `z.any()`
+// catch-all, so the generated schema validated nothing.
+const gelTemporalColumns = {
+	dateDuration: dateDuration().notNull(),
+	duration: duration().notNull(),
+	relDuration: relDuration().notNull(),
+	localTime: localTime().notNull(),
+	localDate: localDate().notNull(),
+	localDateTime: timestamp().notNull(),
+} as const;
+
+const columnKeys = Object.keys(gelTemporalColumns) as (keyof typeof gelTemporalColumns)[];
+
+test('gel temporal columns do not produce z.any() - select', () => {
+	const table = gelTable('test', gelTemporalColumns);
+	const result = createSelectSchema(table);
+
+	for (const key of columnKeys) {
+		const columnSchema = result.shape[key];
+		expect(columnSchema, `${key} should have a schema`).toBeDefined();
+		// z.any() reports `._zod.def.type === 'any'` and validates nothing.
+		expect(columnSchema!._zod.def.type, `${key} should not be z.any()`).not.toBe('any');
+		// A real schema rejects primitives that z.any() would happily accept.
+		expect(columnSchema!.safeParse(123).success, `${key} should reject a number`).toBe(false);
+		expect(columnSchema!.safeParse('not-a-temporal').success, `${key} should reject a string`).toBe(false);
+	}
+});
+
+test('gel temporal columns do not produce z.any() - insert', () => {
+	const table = gelTable('test', gelTemporalColumns);
+	const result = createInsertSchema(table);
+
+	for (const key of columnKeys) {
+		const columnSchema = result.shape[key];
+		expect(columnSchema, `${key} should have a schema`).toBeDefined();
+		expect(columnSchema!._zod.def.type, `${key} should not be z.any()`).not.toBe('any');
+	}
+});


### PR DESCRIPTION
For a Gel table, `drizzle-zod` generates a schema that validates nothing for the six Gel-only column types added in #4172 (`dateDuration`, `duration`, `relDuration`, `localTime`, `localDate`, `localDateTime`). `columnToSchema()` dispatches on `column.dataType` and none of those strings has a branch, so each falls through to the `z.any()` catch-all and any value — a number, a string, `null` — passes.

This adds a branch that detects those columns by `entityKind` via the existing `isColumnType` helper (the same mechanism already used for `PgGeometry`/`PgVector`) and emits `z.custom<object>(v => typeof v === 'object' && v !== null)` — strictly better than `z.any()` without making `drizzle-zod` depend on the `gel` package just to `z.instanceof` its classes. It's placed last in the chain because the loose `GelXxx<any>` guard union would otherwise narrow `column` to `never` for any following branch.

Scoped to `drizzle-zod`; `drizzle-arktype`/`-valibot`/`-typebox` have the same gap and can follow. One open question: I kept the schema minimal ("a non-null object"); the type-level mapping in `column.types.ts` is more specific, so if you'd rather the runtime match it (per-class `z.object`, or `z.instanceof` with a `gel` peer dep) I'm happy to change it.

New `tests/gel.test.ts` asserts all six columns produce a non-`any` schema that rejects primitives — it fails on `master` and passes here; `pnpm --filter drizzle-zod test` is green.

Ref #6027
