### PR TITLE
[Pg] Release the pool client when BEGIN fails in pooled transactions

### DIFF
--- a/changelogs/drizzle-orm/0.45.3.md
+++ b/changelogs/drizzle-orm/0.45.3.md
@@ -33,3 +33,7 @@ const db = drizzle({ client: netlifyDbClient });
 
 const result = await db.execute('select 1');
 ```
+
+## Bug fixes
+
+- Fixed pooled transactions in `node-postgres`, `neon-serverless` and `vercel-postgres` leaking the pool client when `BEGIN` fails ([#6241](https://github.com/drizzle-team/drizzle-orm/issues/6241))

--- a/drizzle-orm/src/neon-serverless/session.ts
+++ b/drizzle-orm/src/neon-serverless/session.ts
@@ -265,8 +265,8 @@ export class NeonSession<
 			? new NeonSession(await this.client.connect(), this.dialect, this.schema, this.options)
 			: this;
 		const tx = new NeonTransaction<TFullSchema, TSchema>(this.dialect, session, this.schema);
-		await tx.execute(sql`begin ${tx.getTransactionConfigSQL(config)}`);
 		try {
+			await tx.execute(sql`begin ${tx.getTransactionConfigSQL(config)}`);
 			const result = await transaction(tx);
 			await tx.execute(sql`commit`);
 			return result;

--- a/drizzle-orm/src/node-postgres/session.ts
+++ b/drizzle-orm/src/node-postgres/session.ts
@@ -254,8 +254,8 @@ export class NodePgSession<
 			? new NodePgSession(await (<pg.Pool> this.client).connect(), this.dialect, this.schema, this.options)
 			: this;
 		const tx = new NodePgTransaction<TFullSchema, TSchema>(this.dialect, session, this.schema);
-		await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
 		try {
+			await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
 			const result = await transaction(tx);
 			await tx.execute(sql`commit`);
 			return result;

--- a/drizzle-orm/src/vercel-postgres/session.ts
+++ b/drizzle-orm/src/vercel-postgres/session.ts
@@ -263,8 +263,8 @@ export class VercelPgSession<
 			? new VercelPgSession(await this.client.connect(), this.dialect, this.schema, this.options)
 			: this;
 		const tx = new VercelPgTransaction<TFullSchema, TSchema>(this.dialect, session, this.schema);
-		await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
 		try {
+			await tx.execute(sql`begin${config ? sql` ${tx.getTransactionConfigSQL(config)}` : undefined}`);
 			const result = await transaction(tx);
 			await tx.execute(sql`commit`);
 			return result;

--- a/drizzle-orm/tests/pg-transaction-begin-failure.test.ts
+++ b/drizzle-orm/tests/pg-transaction-begin-failure.test.ts
@@ -1,0 +1,108 @@
+import { Pool as NeonPool } from '@neondatabase/serverless';
+import { VercelPool } from '@vercel/postgres';
+import pg from 'pg';
+import { describe, expect, test } from 'vitest';
+import { drizzle as drizzleNeon } from '~/neon-serverless/index.ts';
+import { drizzle as drizzleNodePg } from '~/node-postgres/index.ts';
+import { drizzle as drizzleVercel } from '~/vercel-postgres/index.ts';
+
+// Regression test for pooled transactions: when `BEGIN` itself fails (statement
+// timeout, connection dropped while connecting, ...), the client acquired from
+// the pool must still be released. Before the fix `begin` ran outside the
+// try/finally, so the client leaked and the pool eventually ran dry.
+
+interface FakePoolStats {
+	acquired: number;
+	released: number;
+	queries: string[];
+}
+
+function fakeClient(stats: FakePoolStats, failOn: (text: string) => Error | undefined) {
+	return {
+		query: async (query: string | { text: string }) => {
+			const text = typeof query === 'string' ? query : query.text;
+			stats.queries.push(text);
+			const error = failOn(text.toLowerCase());
+			if (error) throw error;
+			return { rows: [], rowCount: 0, command: '', oid: 0, fields: [] };
+		},
+		release: () => {
+			stats.released++;
+		},
+	};
+}
+
+function beginFailure(): Error {
+	return Object.assign(new Error('canceling statement due to statement timeout'), { code: '57014' });
+}
+
+const connectionString = 'postgres://user:password@localhost:5432/db';
+
+const drivers = [
+	{
+		name: 'node-postgres',
+		make(stats: FakePoolStats, failOn: (text: string) => Error | undefined) {
+			class FailingPool extends pg.Pool {
+				override connect(): any {
+					stats.acquired++;
+					return Promise.resolve(fakeClient(stats, failOn));
+				}
+			}
+			return drizzleNodePg({ client: new FailingPool({ connectionString }) });
+		},
+	},
+	{
+		name: 'neon-serverless',
+		make(stats: FakePoolStats, failOn: (text: string) => Error | undefined) {
+			class FailingPool extends NeonPool {
+				override connect(): any {
+					stats.acquired++;
+					return Promise.resolve(fakeClient(stats, failOn));
+				}
+			}
+			return drizzleNeon({ client: new FailingPool({ connectionString }) });
+		},
+	},
+	{
+		name: 'vercel-postgres',
+		make(stats: FakePoolStats, failOn: (text: string) => Error | undefined) {
+			class FailingPool extends VercelPool {
+				override connect(): any {
+					stats.acquired++;
+					return Promise.resolve(fakeClient(stats, failOn));
+				}
+			}
+			return drizzleVercel({ client: new FailingPool({ connectionString }) });
+		},
+	},
+];
+
+describe.each(drivers)('$name pooled transaction', ({ make }) => {
+	test('releases the pool client when BEGIN fails', async () => {
+		const stats: FakePoolStats = { acquired: 0, released: 0, queries: [] };
+		const db = make(stats, (text) => (text.startsWith('begin') ? beginFailure() : undefined));
+		let callbackRan = false;
+
+		const error = await db
+			.transaction(async () => {
+				callbackRan = true;
+			})
+			.then(() => undefined, (e: unknown) => e as Error & { cause?: { code?: string } });
+
+		expect(error?.cause?.code).toBe('57014');
+		expect(callbackRan).toBe(false);
+		expect(stats.acquired).toBe(1);
+		expect(stats.released).toBe(1);
+	});
+
+	test('still commits and releases on the happy path', async () => {
+		const stats: FakePoolStats = { acquired: 0, released: 0, queries: [] };
+		const db = make(stats, () => undefined);
+
+		const result = await db.transaction(async () => 'ok');
+
+		expect(result).toBe('ok');
+		expect(stats.queries.map((q) => q.split(' ')[0])).toEqual(['begin', 'commit']);
+		expect(stats.released).toBe(1);
+	});
+});


### PR DESCRIPTION
Fixes #6241

### What changed

`transaction()` in the `node-postgres`, `neon-serverless` and `vercel-postgres` sessions ran `begin` before the `try/finally` that releases the pool client. When `BEGIN` threw (statement timeout, connection dropped right after connect, admin shutdown), `finally` never ran and the `PoolClient` leaked — one client per failure until `connect()` hung on an empty pool.

This moves the `begin` statement inside the `try` in all three sessions. That's the whole code change (3 lines).

- The existing `catch` still runs `rollback` and rethrows. Outside a transaction `ROLLBACK` is a WARNING, not an error.
- The error the caller gets is unchanged (`DrizzleQueryError` wrapping the driver error).
- Non-pooled clients never went through `release()`, so nothing changes for them.
- `pglite` and `aws-data-api` don't acquire a pooled client and aren't touched.

### Tests

`drizzle-orm/tests/pg-transaction-begin-failure.test.ts` — vitest, no database or Docker. It subclasses each driver's `Pool`, overrides `connect()` to return a fake client whose `BEGIN` throws `57014`, and runs two cases per driver via `describe.each`:

1. `BEGIN` fails → error propagates with `cause.code === '57014'`, the callback never runs, the client is acquired once and released once.
2. Happy path → `begin`, `commit`, released once. Guards the normal flow.

On `main` case 1 fails for all three drivers (`released` is 0). With this change all 6 pass. `dprint check` is clean and `tsc -p tests/tsconfig.json` has no errors.

### Changelog

One line under a new "Bug fixes" heading in `changelogs/drizzle-orm/0.45.3.md` (the unreleased version on `main`). No version bump.

### Notes

`beta` (1.0.0-rc.4) has the same three lines; happy to open the same change there if you want it ported.

Found this while moving a service from raw `pg` to drizzle — the raw code had `finally { client.release() }` around `BEGIN`, so every `db.transaction()` in the migration silently picked up the leak.

This was created with the help of AI (Claude), reviewed and tested by me.
