### PR TITLE
[Pg-kit] Exclude NOT VALID check constraints from Postgres introspection

### DIFF
--- a/drizzle-kit/src/dialects/postgres/introspect.ts
+++ b/drizzle-kit/src/dialects/postgres/introspect.ts
@@ -881,7 +881,9 @@ export const fromDatabase = async (
 	}
 	progressCallback('fks', fks.length, 'done');
 
-	for (const check of constraintsList.filter((it) => it.type === 'c')) {
+	for (
+		const check of constraintsList.filter((it) => it.type === 'c' && !it.definition.endsWith(' NOT VALID'))
+	) {
 		const table = tablesList.find((it) => Number(it.oid) === Number(check.tableId))!;
 		const schema = namespaces.find((it) => Number(it.oid) === Number(check.schemaId))!;
 


### PR DESCRIPTION
Fixes #6214.

`drizzle-kit pull` was mangling any check constraint defined with
NOT VALID. The introspector assumed the definition always looked
like `CHECK (...)` and pulled out the expression with a fixed slice,
which works fine normally but chops the last letter off "NOT VALID"
when it's there, e.g.

CHECK ((version >= 0)) NOT VALID  ->  sql`(version >= 0)) NOT VALI`

which is just invalid SQL once it lands in the generated migration.

My first pass just stripped the NOT VALID suffix and kept the
constraint, but I switched to excluding it entirely instead. There's
nowhere in drizzle-kit that tracks whether a check constraint is
validated, so keeping a "fixed" version around means a future push
could quietly re-create it as validated - that's a real behavior
change nobody asked for, on top of just fixing corrupted SQL.

I noticed there's already a test for this exact issue in the repo
(`Issue No6214` in pull.test.ts, date-gated to turn on today) that
expects exactly this - NOT VALID checks excluded from introspection.
This PR is written to make that pass.

Couldn't run it end to end locally though - it goes through a tsc
check that needs the built drizzle-orm package, and building
drizzle-orm on rc5 right now hits an unrelated rolldown error
(MISSING_EXPORT on sql/expressions/index.ts) even on a clean
checkout with nothing changed. I checked the actual behavior works
directly against a real Postgres instance instead - a NOT VALID
constraint gets excluded, a normal one on the same table comes
through untouched.
