### PR TITLE
fix(orm): keep a left-joined object when a later column has a value (fixes #1603)

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -45,11 +45,16 @@ export function mapResultRow<TResult>(
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;
-						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
-						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
-						) {
+						const tableName = getTableName(field.table);
+
+						if (value !== null) {
+							// A column that came back with a value proves the joined row exists,
+							// so this object must never be nullified - regardless of which of its
+							// columns happened to be read first.
+							nullifyMap[objectName] = false;
+						} else if (!(objectName in nullifyMap)) {
+							nullifyMap[objectName] = tableName;
+						} else if (typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== tableName) {
 							nullifyMap[objectName] = false;
 						}
 					}

--- a/drizzle-orm/tests/map-result-row.test.ts
+++ b/drizzle-orm/tests/map-result-row.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from 'vitest';
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const orgs = pgTable('orgs', {
+	id: text('id'),
+	name: text('name'),
+});
+
+const orgBranding = pgTable('org_branding', {
+	orgId: text('org_id'),
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+const selection = [
+	{ path: ['name'], field: orgs.name },
+	{ path: ['branding', 'logo'], field: orgBranding.logo },
+	{ path: ['branding', 'panelBackground'], field: orgBranding.panelBackground },
+];
+
+// `orgs` is the base table; `org_branding` is left joined, so it is nullable.
+const leftJoined = { orgs: true, org_branding: false };
+
+describe.concurrent('mapResultRow nested partial select', () => {
+	it('keeps the joined object when a later column has a value', ({ expect }) => {
+		const result = mapResultRow(selection, ['Test org', null, '#1a8cff'], leftJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { logo: null, panelBackground: '#1a8cff' },
+		});
+	});
+
+	it('does not depend on which column of the object is selected first', ({ expect }) => {
+		const swapped = [
+			{ path: ['name'], field: orgs.name },
+			{ path: ['branding', 'panelBackground'], field: orgBranding.panelBackground },
+			{ path: ['branding', 'logo'], field: orgBranding.logo },
+		];
+
+		const result = mapResultRow(swapped, ['Test org', '#1a8cff', null], leftJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { panelBackground: '#1a8cff', logo: null },
+		});
+	});
+
+	it('still nullifies the object when the join matched no row', ({ expect }) => {
+		const result = mapResultRow(selection, ['Test org', null, null], leftJoined);
+
+		expect(result).toEqual({ name: 'Test org', branding: null });
+	});
+
+	it('keeps an object from a non-nullable join even when every column is null', ({ expect }) => {
+		const innerJoined = { orgs: true, org_branding: true };
+		const result = mapResultRow(selection, ['Test org', null, null], innerJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { logo: null, panelBackground: null },
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1603

### Root cause

`mapResultRow` builds `nullifyMap` while walking the selected columns in order. For a nested object it decides from **the first column of that object it happens to read**:

```ts
if (!(objectName in nullifyMap)) {
	nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
} else if (
	typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
) {
	nullifyMap[objectName] = false;
}
```

If that first column is null, the entry is set to the table name — "candidate for nullification". A later **non-null** column from the *same* table never clears it, because the `else if` only resets the entry when the table name differs. So the object gets nullified even though the join matched and other columns had values.

That's exactly the reported behaviour, and it explains why reordering the two fields fixes it: put a non-null column first and the entry is set to `false` immediately, so it's never nullified.

The comment right above `nullifyMap` already describes the intended rule — "table name if all fields in the nested object are from the same table" — and nullification is only supposed to happen when the joined row is absent, i.e. when *every* column is null.

### The change

Treat any non-null column as proof that the joined row exists and clear the candidacy outright:

```ts
if (value !== null) {
	nullifyMap[objectName] = false;
} else if (!(objectName in nullifyMap)) {
	nullifyMap[objectName] = tableName;
} else if (typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== tableName) {
	nullifyMap[objectName] = false;
}
```

Once an entry is `false` it stays `false`, so column order no longer matters. `getTableName(field.table)` is now computed once instead of twice per column.

Behaviour that does not change: an object whose columns are all null on a nullable join is still nullified, and an object from a non-nullable join is never nullified.

### Tests

`drizzle-orm/tests/map-result-row.test.ts` — a new unit test in the existing DB-free vitest suite, so it runs with `pnpm test` without needing a database:

- a later column with a value keeps the object (the reported case)
- the result is the same whichever column of the object is selected first
- an object whose columns are all null on a left join is still nullified
- an object from a non-nullable join survives even when every column is null

### Note

There are already several open PRs against this issue (#6178, #6228, #6227, #6018, #6080). I've kept this one to the minimal change in `mapResultRow` plus unit coverage that pins the ordering behaviour, so it's quick to review — but if one of the others is further along, close this in favour of it, no hard feelings. Flagging it rather than quietly adding to the pile.
