### PR TITLE
feat: dialect-native PgError/MySqlError/SqliteError wrapping (#376)

### DIFF
--- a/drizzle-orm/src/mysql-core/errors.ts
+++ b/drizzle-orm/src/mysql-core/errors.ts
@@ -1,0 +1,173 @@
+import { entityKind, is } from '~/entity.ts';
+import { DrizzleQueryError } from '~/errors.ts';
+
+/**
+ * Common MySQL / SingleStore errno values for typed error handling.
+ * @see https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+ */
+export const MYSQL_ERROR = {
+	DUP_ENTRY: 1062,
+	BAD_NULL_ERROR: 1048,
+	NO_REFERENCED_ROW: 1452,
+	NO_REFERENCED_ROW_2: 1216,
+	ROW_IS_REFERENCED: 1451,
+	ROW_IS_REFERENCED_2: 1217,
+	CHECK_CONSTRAINT_VIOLATED: 3819,
+	DATA_TOO_LONG: 1406,
+	TRUNCATED_WRONG_VALUE: 1292,
+} as const;
+
+export type MySqlErrorErrno = (typeof MYSQL_ERROR)[keyof typeof MYSQL_ERROR] | (number & {});
+
+type DriverLike = {
+	errno?: unknown;
+	code?: unknown;
+	sqlState?: unknown;
+	sqlMessage?: unknown;
+	message?: unknown;
+	constraint?: unknown;
+	table?: unknown;
+	column?: unknown;
+};
+
+function asString(value: unknown): string | undefined {
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function extractMySqlDriverFields(cause: unknown): DriverLike | undefined {
+	if (!cause || typeof cause !== 'object') return undefined;
+	const c = cause as DriverLike & { cause?: unknown };
+	if (typeof c.errno === 'number' || typeof c.code === 'string') return c;
+	if (c.cause && typeof c.cause === 'object') {
+		const nested = c.cause as DriverLike;
+		if (typeof nested.errno === 'number' || typeof nested.code === 'string') return nested;
+	}
+	return c;
+}
+
+/** Parse `Duplicate entry 'x' for key 'users.users_email_unique'` style messages. */
+export function parseMySqlDuplicateMessage(message: string | undefined): {
+	value?: string;
+	constraint?: string;
+} {
+	if (!message) return {};
+	const match = message.match(/Duplicate entry '([^']*)' for key '([^']+)'/i);
+	if (!match) return {};
+	return { value: match[1], constraint: match[2] };
+}
+
+/** Parse `Column 'email' cannot be null` style messages. */
+export function parseMySqlNotNullMessage(message: string | undefined): { column?: string } {
+	if (!message) return {};
+	const match = message.match(/Column '([^']+)' cannot be null/i);
+	return match ? { column: match[1] } : {};
+}
+
+/**
+ * Dialect-native MySQL/SingleStore query error with errno + sqlState metadata.
+ */
+export class MySqlError extends DrizzleQueryError {
+	static readonly [entityKind]: string = 'MySqlError';
+
+	readonly errno: number;
+	readonly sqlState?: string;
+	readonly sqlMessage?: string;
+	readonly table?: string;
+	readonly column?: string;
+	readonly constraint?: string;
+	readonly duplicateValue?: string;
+
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error | undefined,
+		fields: {
+			errno: number;
+			sqlState?: string;
+			sqlMessage?: string;
+			table?: string;
+			column?: string;
+			constraint?: string;
+			duplicateValue?: string;
+		},
+	) {
+		super(query, params, cause);
+		this.name = 'MySqlError';
+		this.errno = fields.errno;
+		this.sqlState = fields.sqlState;
+		this.sqlMessage = fields.sqlMessage;
+		this.table = fields.table;
+		this.column = fields.column;
+		this.constraint = fields.constraint;
+		this.duplicateValue = fields.duplicateValue;
+		Error.captureStackTrace?.(this, MySqlError);
+	}
+}
+
+export function isMySqlError(error: unknown): error is MySqlError {
+	return is(error, MySqlError);
+}
+
+export function isMySqlUniqueViolation(error: unknown): error is MySqlError {
+	return isMySqlError(error) && error.errno === MYSQL_ERROR.DUP_ENTRY;
+}
+
+export function isMySqlNotNullViolation(error: unknown): error is MySqlError {
+	return isMySqlError(error) && error.errno === MYSQL_ERROR.BAD_NULL_ERROR;
+}
+
+export function isMySqlForeignKeyViolation(error: unknown): error is MySqlError {
+	return isMySqlError(error)
+		&& (
+			error.errno === MYSQL_ERROR.NO_REFERENCED_ROW
+			|| error.errno === MYSQL_ERROR.NO_REFERENCED_ROW_2
+			|| error.errno === MYSQL_ERROR.ROW_IS_REFERENCED
+			|| error.errno === MYSQL_ERROR.ROW_IS_REFERENCED_2
+		);
+}
+
+export function isMySqlCheckViolation(error: unknown): error is MySqlError {
+	return isMySqlError(error) && error.errno === MYSQL_ERROR.CHECK_CONSTRAINT_VIOLATED;
+}
+
+export function wrapMySqlError(query: string, params: any[], cause: unknown): DrizzleQueryError {
+	const err = cause instanceof Error ? cause : new Error(String(cause));
+	const driver = extractMySqlDriverFields(cause);
+	let errno = asNumber(driver?.errno);
+	if (errno === undefined && typeof driver?.code === 'string') {
+		const fromCode = Number(driver.code.replace(/^ER_/, ''));
+		// mysql2 uses both numeric errno and string codes like ER_DUP_ENTRY
+		if (driver.code === 'ER_DUP_ENTRY') errno = MYSQL_ERROR.DUP_ENTRY;
+		else if (driver.code === 'ER_BAD_NULL_ERROR') errno = MYSQL_ERROR.BAD_NULL_ERROR;
+		else if (driver.code === 'ER_NO_REFERENCED_ROW' || driver.code === 'ER_NO_REFERENCED_ROW_2') {
+			errno = MYSQL_ERROR.NO_REFERENCED_ROW;
+		} else if (driver.code === 'ER_ROW_IS_REFERENCED' || driver.code === 'ER_ROW_IS_REFERENCED_2') {
+			errno = MYSQL_ERROR.ROW_IS_REFERENCED;
+		} else if (driver.code === 'ER_CHECK_CONSTRAINT_VIOLATED') {
+			errno = MYSQL_ERROR.CHECK_CONSTRAINT_VIOLATED;
+		} else if (Number.isFinite(fromCode)) {
+			errno = fromCode;
+		}
+	}
+	if (errno === undefined) {
+		return new DrizzleQueryError(query, params, err);
+	}
+
+	const sqlMessage = asString(driver?.sqlMessage) ?? asString(driver?.message);
+	const dup = parseMySqlDuplicateMessage(sqlMessage);
+	const nn = parseMySqlNotNullMessage(sqlMessage);
+
+	return new MySqlError(query, params, err, {
+		errno,
+		sqlState: asString(driver?.sqlState),
+		sqlMessage,
+		table: asString(driver?.table),
+		column: asString(driver?.column) ?? nn.column,
+		constraint: asString(driver?.constraint) ?? dup.constraint,
+		duplicateValue: dup.value,
+	});
+}

--- a/drizzle-orm/src/mysql-core/index.ts
+++ b/drizzle-orm/src/mysql-core/index.ts
@@ -1,4 +1,5 @@
 export * from './alias.ts';
+export * from './errors.ts';
 export * from './checks.ts';
 export * from './columns/index.ts';
 export * from './db.ts';

--- a/drizzle-orm/src/mysql-core/session.ts
+++ b/drizzle-orm/src/mysql-core/session.ts
@@ -1,7 +1,8 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { TransactionRollbackError } from '~/errors.ts';
+import { wrapMySqlError } from './errors.ts';
 import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
 import { type Query, type SQL, sql } from '~/sql/sql.ts';
 import type { Assume, Equal } from '~/utils.ts';
@@ -76,7 +77,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapMySqlError(queryString, params, e);
 			}
 		}
 
@@ -85,7 +86,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapMySqlError(queryString, params, e);
 			}
 		}
 
@@ -103,7 +104,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapMySqlError(queryString, params, e);
 			}
 		}
 
@@ -112,7 +113,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapMySqlError(queryString, params, e);
 			}
 		}
 
@@ -128,7 +129,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapMySqlError(queryString, params, e);
 				}
 
 				// put actual key
@@ -149,7 +150,7 @@ export abstract class MySqlPreparedQuery<T extends MySqlPreparedQueryConfig> {
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapMySqlError(queryString, params, e);
 		}
 	}
 

--- a/drizzle-orm/src/pg-core/errors.ts
+++ b/drizzle-orm/src/pg-core/errors.ts
@@ -1,0 +1,180 @@
+import { entityKind, is } from '~/entity.ts';
+import { DrizzleQueryError } from '~/errors.ts';
+
+/**
+ * Common PostgreSQL SQLSTATE codes used for typed error handling.
+ * @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+ */
+export const PG_ERROR = {
+	UNIQUE_VIOLATION: '23505',
+	NOT_NULL_VIOLATION: '23502',
+	FOREIGN_KEY_VIOLATION: '23503',
+	CHECK_VIOLATION: '23514',
+	EXCLUSION_VIOLATION: '23P01',
+	INVALID_TEXT_REPRESENTATION: '22P02',
+	STRING_DATA_RIGHT_TRUNCATION: '22001',
+	NUMERIC_VALUE_OUT_OF_RANGE: '22003',
+} as const;
+
+export type PgErrorCode = (typeof PG_ERROR)[keyof typeof PG_ERROR] | (string & {});
+
+type DriverLike = {
+	code?: unknown;
+	severity?: unknown;
+	detail?: unknown;
+	hint?: unknown;
+	schema?: unknown;
+	schema_name?: unknown;
+	table?: unknown;
+	table_name?: unknown;
+	column?: unknown;
+	column_name?: unknown;
+	constraint?: unknown;
+	constraint_name?: unknown;
+	dataType?: unknown;
+	data_type?: unknown;
+	message?: unknown;
+};
+
+function asString(value: unknown): string | undefined {
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/** Parse `Key (email, name)=(a, b) already exists.` style PG detail strings. */
+export function parsePgDetailKeys(detail: string | undefined): { columns?: string[]; values?: string[] } {
+	if (!detail) return {};
+	const match = detail.match(/Key \(([^)]+)\)=\(([^)]*)\)/i);
+	if (!match) return {};
+	const columns = match[1].split(',').map((s) => s.trim()).filter(Boolean);
+	const values = match[2].split(',').map((s) => s.trim());
+	return {
+		columns: columns.length ? columns : undefined,
+		values: values.length ? values : undefined,
+	};
+}
+
+function extractPgDriverFields(cause: unknown): DriverLike | undefined {
+	if (!cause || typeof cause !== 'object') return undefined;
+	const c = cause as DriverLike & { cause?: unknown };
+	// postgres.js uses `.code`; node-pg too. Sometimes nested under `.cause`.
+	if (typeof c.code === 'string') return c;
+	if (c.cause && typeof c.cause === 'object' && typeof (c.cause as DriverLike).code === 'string') {
+		return c.cause as DriverLike;
+	}
+	return c;
+}
+
+/**
+ * Dialect-native Postgres query error. Extends `DrizzleQueryError` so existing
+ * catch sites keep working, while exposing SQLSTATE + constraint metadata.
+ *
+ * Differentiates from constraint-only wrappers by keeping the full dialect
+ * error surface (severity/detail/hint/schema) and SQLSTATE constants, matching
+ * the contributor-proposed PgError API discussed on #376.
+ */
+export class PgError extends DrizzleQueryError {
+	static readonly [entityKind]: string = 'PgError';
+
+	readonly code: string;
+	readonly severity?: string;
+	readonly detail?: string;
+	readonly hint?: string;
+	readonly schema?: string;
+	readonly table?: string;
+	readonly column?: string;
+	readonly constraint?: string;
+	readonly dataType?: string;
+	readonly keyColumns?: string[];
+	readonly keyValues?: string[];
+
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error | undefined,
+		fields: {
+			code: string;
+			severity?: string;
+			detail?: string;
+			hint?: string;
+			schema?: string;
+			table?: string;
+			column?: string;
+			constraint?: string;
+			dataType?: string;
+			keyColumns?: string[];
+			keyValues?: string[];
+		},
+	) {
+		super(query, params, cause);
+		this.name = 'PgError';
+		this.code = fields.code;
+		this.severity = fields.severity;
+		this.detail = fields.detail;
+		this.hint = fields.hint;
+		this.schema = fields.schema;
+		this.table = fields.table;
+		this.column = fields.column;
+		this.constraint = fields.constraint;
+		this.dataType = fields.dataType;
+		this.keyColumns = fields.keyColumns;
+		this.keyValues = fields.keyValues;
+		Error.captureStackTrace?.(this, PgError);
+	}
+
+	/** Convenience: first key column from a unique/FK detail, else `column`. */
+	getColumnNames(): string[] {
+		if (this.keyColumns?.length) return [...this.keyColumns];
+		if (this.column) return [this.column];
+		return [];
+	}
+}
+
+export function isPgError(error: unknown): error is PgError {
+	return is(error, PgError);
+}
+
+export function isPgUniqueViolation(error: unknown): error is PgError {
+	return isPgError(error) && error.code === PG_ERROR.UNIQUE_VIOLATION;
+}
+
+export function isPgNotNullViolation(error: unknown): error is PgError {
+	return isPgError(error) && error.code === PG_ERROR.NOT_NULL_VIOLATION;
+}
+
+export function isPgForeignKeyViolation(error: unknown): error is PgError {
+	return isPgError(error) && error.code === PG_ERROR.FOREIGN_KEY_VIOLATION;
+}
+
+export function isPgCheckViolation(error: unknown): error is PgError {
+	return isPgError(error) && error.code === PG_ERROR.CHECK_VIOLATION;
+}
+
+export function isPgInvalidTextRepresentation(error: unknown): error is PgError {
+	return isPgError(error) && error.code === PG_ERROR.INVALID_TEXT_REPRESENTATION;
+}
+
+export function wrapPgError(query: string, params: any[], cause: unknown): DrizzleQueryError {
+	const err = cause instanceof Error ? cause : new Error(String(cause));
+	const driver = extractPgDriverFields(cause);
+	const code = asString(driver?.code);
+	if (!driver || !code) {
+		return new DrizzleQueryError(query, params, err);
+	}
+
+	const detail = asString(driver.detail);
+	const parsed = parsePgDetailKeys(detail);
+
+	return new PgError(query, params, err, {
+		code,
+		severity: asString(driver.severity),
+		detail,
+		hint: asString(driver.hint),
+		schema: asString(driver.schema) ?? asString(driver.schema_name),
+		table: asString(driver.table) ?? asString(driver.table_name),
+		column: asString(driver.column) ?? asString(driver.column_name),
+		constraint: asString(driver.constraint) ?? asString(driver.constraint_name),
+		dataType: asString(driver.dataType) ?? asString(driver.data_type),
+		keyColumns: parsed.columns,
+		keyValues: parsed.values,
+	});
+}

--- a/drizzle-orm/src/pg-core/index.ts
+++ b/drizzle-orm/src/pg-core/index.ts
@@ -1,4 +1,5 @@
 export * from './alias.ts';
+export * from './errors.ts';
 export * from './checks.ts';
 export * from './columns/index.ts';
 export * from './db.ts';

--- a/drizzle-orm/src/pg-core/session.ts
+++ b/drizzle-orm/src/pg-core/session.ts
@@ -1,7 +1,8 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { TransactionRollbackError } from '~/errors.ts';
+import { wrapPgError } from './errors.ts';
 import type { TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
 import { type Query, type SQL, sql } from '~/sql/index.ts';
@@ -70,7 +71,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapPgError(queryString, params, e);
 			}
 		}
 
@@ -79,7 +80,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapPgError(queryString, params, e);
 			}
 		}
 
@@ -97,7 +98,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapPgError(queryString, params, e);
 			}
 		}
 
@@ -106,7 +107,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapPgError(queryString, params, e);
 			}
 		}
 
@@ -122,7 +123,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapPgError(queryString, params, e);
 				}
 				// put actual key
 				await this.cache.put(
@@ -142,7 +143,7 @@ export abstract class PgPreparedQuery<T extends PreparedQueryConfig> implements 
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapPgError(queryString, params, e);
 		}
 	}
 

--- a/drizzle-orm/src/singlestore-core/session.ts
+++ b/drizzle-orm/src/singlestore-core/session.ts
@@ -1,7 +1,8 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { TransactionRollbackError } from '~/errors.ts';
+import { wrapMySqlError } from '../mysql-core/errors.ts';
 import type { RelationalSchemaConfig, TablesRelationalConfig } from '~/relations.ts';
 import { type Query, type SQL, sql } from '~/sql/sql.ts';
 import type { Assume, Equal } from '~/utils.ts';
@@ -74,7 +75,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapMySqlError(queryString, params, e);
 			}
 		}
 
@@ -83,7 +84,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapMySqlError(queryString, params, e);
 			}
 		}
 
@@ -101,7 +102,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapMySqlError(queryString, params, e);
 			}
 		}
 
@@ -110,7 +111,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapMySqlError(queryString, params, e);
 			}
 		}
 
@@ -126,7 +127,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapMySqlError(queryString, params, e);
 				}
 
 				// put actual key
@@ -147,7 +148,7 @@ export abstract class SingleStorePreparedQuery<T extends SingleStorePreparedQuer
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapMySqlError(queryString, params, e);
 		}
 	}
 

--- a/drizzle-orm/src/sqlite-core/errors.ts
+++ b/drizzle-orm/src/sqlite-core/errors.ts
@@ -1,0 +1,154 @@
+import { entityKind, is } from '~/entity.ts';
+import { DrizzleQueryError } from '~/errors.ts';
+
+/**
+ * SQLite extended result codes / libsql message markers.
+ * @see https://www.sqlite.org/rescode.html
+ */
+export const SQLITE_ERROR = {
+	CONSTRAINT: 'SQLITE_CONSTRAINT',
+	CONSTRAINT_UNIQUE: 'SQLITE_CONSTRAINT_UNIQUE',
+	CONSTRAINT_PRIMARYKEY: 'SQLITE_CONSTRAINT_PRIMARYKEY',
+	CONSTRAINT_NOTNULL: 'SQLITE_CONSTRAINT_NOTNULL',
+	CONSTRAINT_FOREIGNKEY: 'SQLITE_CONSTRAINT_FOREIGNKEY',
+	CONSTRAINT_CHECK: 'SQLITE_CONSTRAINT_CHECK',
+} as const;
+
+export type SqliteConstraintKind = 'unique' | 'not_null' | 'foreign_key' | 'check' | 'constraint';
+
+type DriverLike = {
+	code?: unknown;
+	message?: unknown;
+	rawCode?: unknown;
+};
+
+function asString(value: unknown): string | undefined {
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function extractSqliteDriverFields(cause: unknown): DriverLike | undefined {
+	if (!cause || typeof cause !== 'object') return undefined;
+	const c = cause as DriverLike & { cause?: unknown };
+	if (typeof c.code === 'string' || typeof c.message === 'string') return c;
+	if (c.cause && typeof c.cause === 'object') return c.cause as DriverLike;
+	return c;
+}
+
+export function classifySqliteConstraint(
+	code: string | undefined,
+	message: string | undefined,
+): SqliteConstraintKind | undefined {
+	const c = (code ?? '').toUpperCase();
+	const m = (message ?? '').toUpperCase();
+
+	if (
+		c === SQLITE_ERROR.CONSTRAINT_UNIQUE
+		|| c === SQLITE_ERROR.CONSTRAINT_PRIMARYKEY
+		|| m.includes('UNIQUE CONSTRAINT FAILED')
+	) {
+		return 'unique';
+	}
+	if (c === SQLITE_ERROR.CONSTRAINT_NOTNULL || m.includes('NOT NULL CONSTRAINT FAILED')) {
+		return 'not_null';
+	}
+	if (c === SQLITE_ERROR.CONSTRAINT_FOREIGNKEY || m.includes('FOREIGN KEY CONSTRAINT FAILED')) {
+		return 'foreign_key';
+	}
+	if (c === SQLITE_ERROR.CONSTRAINT_CHECK || m.includes('CHECK CONSTRAINT FAILED')) {
+		return 'check';
+	}
+	if (c.startsWith('SQLITE_CONSTRAINT') || m.includes('CONSTRAINT FAILED')) {
+		return 'constraint';
+	}
+	return undefined;
+}
+
+/** Parse `UNIQUE constraint failed: users.email` → table/columns. */
+export function parseSqliteConstraintTarget(message: string | undefined): {
+	table?: string;
+	columns?: string[];
+} {
+	if (!message) return {};
+	const match = message.match(/constraint failed:\s*(.+)$/i);
+	if (!match) return {};
+	const parts = match[1].split(',').map((s) => s.trim()).filter(Boolean);
+	if (!parts.length) return {};
+	const columns: string[] = [];
+	let table: string | undefined;
+	for (const part of parts) {
+		const [t, col] = part.includes('.') ? part.split('.', 2) : [undefined, part];
+		if (t) table = t;
+		if (col) columns.push(col);
+	}
+	return { table, columns: columns.length ? columns : undefined };
+}
+
+/**
+ * Dialect-native SQLite query error with constraint classification.
+ */
+export class SqliteError extends DrizzleQueryError {
+	static readonly [entityKind]: string = 'SqliteError';
+
+	readonly code?: string;
+	readonly constraintKind: SqliteConstraintKind;
+	readonly table?: string;
+	readonly columns?: string[];
+
+	constructor(
+		query: string,
+		params: any[],
+		cause: Error | undefined,
+		fields: {
+			code?: string;
+			constraintKind: SqliteConstraintKind;
+			table?: string;
+			columns?: string[];
+		},
+	) {
+		super(query, params, cause);
+		this.name = 'SqliteError';
+		this.code = fields.code;
+		this.constraintKind = fields.constraintKind;
+		this.table = fields.table;
+		this.columns = fields.columns;
+		Error.captureStackTrace?.(this, SqliteError);
+	}
+}
+
+export function isSqliteError(error: unknown): error is SqliteError {
+	return is(error, SqliteError);
+}
+
+export function isSqliteUniqueViolation(error: unknown): error is SqliteError {
+	return isSqliteError(error) && error.constraintKind === 'unique';
+}
+
+export function isSqliteNotNullViolation(error: unknown): error is SqliteError {
+	return isSqliteError(error) && error.constraintKind === 'not_null';
+}
+
+export function isSqliteForeignKeyViolation(error: unknown): error is SqliteError {
+	return isSqliteError(error) && error.constraintKind === 'foreign_key';
+}
+
+export function isSqliteCheckViolation(error: unknown): error is SqliteError {
+	return isSqliteError(error) && error.constraintKind === 'check';
+}
+
+export function wrapSqliteError(query: string, params: any[], cause: unknown): DrizzleQueryError {
+	const err = cause instanceof Error ? cause : new Error(String(cause));
+	const driver = extractSqliteDriverFields(cause);
+	const code = asString(driver?.code);
+	const message = asString(driver?.message) ?? (err.message || undefined);
+	const kind = classifySqliteConstraint(code, message);
+	if (!kind) {
+		return new DrizzleQueryError(query, params, err);
+	}
+	const target = parseSqliteConstraintTarget(message);
+	return new SqliteError(query, params, err, {
+		code,
+		constraintKind: kind,
+		table: target.table,
+		columns: target.columns,
+	});
+}

--- a/drizzle-orm/src/sqlite-core/index.ts
+++ b/drizzle-orm/src/sqlite-core/index.ts
@@ -1,4 +1,5 @@
 export * from './alias.ts';
+export * from './errors.ts';
 export * from './checks.ts';
 export * from './columns/index.ts';
 export * from './db.ts';

--- a/drizzle-orm/src/sqlite-core/session.ts
+++ b/drizzle-orm/src/sqlite-core/session.ts
@@ -1,7 +1,8 @@
 import { type Cache, hashQuery, NoopCache } from '~/cache/core/cache.ts';
 import type { WithCacheConfig } from '~/cache/core/types.ts';
 import { entityKind, is } from '~/entity.ts';
-import { DrizzleError, DrizzleQueryError, TransactionRollbackError } from '~/errors.ts';
+import { DrizzleError, TransactionRollbackError } from '~/errors.ts';
+import { wrapSqliteError } from './errors.ts';
 import { QueryPromise } from '~/query-promise.ts';
 import type { TablesRelationalConfig } from '~/relations.ts';
 import type { PreparedQuery } from '~/session.ts';
@@ -77,7 +78,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapSqliteError(queryString, params, e);
 			}
 		}
 
@@ -86,7 +87,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapSqliteError(queryString, params, e);
 			}
 		}
 
@@ -104,7 +105,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 				]);
 				return res;
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapSqliteError(queryString, params, e);
 			}
 		}
 
@@ -113,7 +114,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 			try {
 				return await query();
 			} catch (e) {
-				throw new DrizzleQueryError(queryString, params, e as Error);
+				throw wrapSqliteError(queryString, params, e);
 			}
 		}
 
@@ -129,7 +130,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 				try {
 					result = await query();
 				} catch (e) {
-					throw new DrizzleQueryError(queryString, params, e as Error);
+					throw wrapSqliteError(queryString, params, e);
 				}
 
 				// put actual key
@@ -150,7 +151,7 @@ export abstract class SQLitePreparedQuery<T extends PreparedQueryConfig> impleme
 		try {
 			return await query();
 		} catch (e) {
-			throw new DrizzleQueryError(queryString, params, e as Error);
+			throw wrapSqliteError(queryString, params, e);
 		}
 	}
 

--- a/drizzle-orm/tests/dialect-errors.test.ts
+++ b/drizzle-orm/tests/dialect-errors.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from 'vitest';
+import { is } from '~/entity.ts';
+import { DrizzleQueryError } from '~/errors.ts';
+import {
+	isMySqlCheckViolation,
+	isMySqlError,
+	isMySqlForeignKeyViolation,
+	isMySqlNotNullViolation,
+	isMySqlUniqueViolation,
+	MYSQL_ERROR,
+	MySqlError,
+	parseMySqlDuplicateMessage,
+	wrapMySqlError,
+} from '~/mysql-core/errors.ts';
+import {
+	isPgCheckViolation,
+	isPgError,
+	isPgForeignKeyViolation,
+	isPgInvalidTextRepresentation,
+	isPgNotNullViolation,
+	isPgUniqueViolation,
+	parsePgDetailKeys,
+	PG_ERROR,
+	PgError,
+	wrapPgError,
+} from '~/pg-core/errors.ts';
+import {
+	classifySqliteConstraint,
+	isSqliteError,
+	isSqliteUniqueViolation,
+	parseSqliteConstraintTarget,
+	SqliteError,
+	wrapSqliteError,
+} from '~/sqlite-core/errors.ts';
+
+describe('parsePgDetailKeys', () => {
+	test('parses composite key detail', () => {
+		expect(parsePgDetailKeys('Key (email, tenant_id)=(a@b.c, 1) already exists.')).toEqual({
+			columns: ['email', 'tenant_id'],
+			values: ['a@b.c', '1'],
+		});
+	});
+
+	test('returns empty for missing detail', () => {
+		expect(parsePgDetailKeys(undefined)).toEqual({});
+	});
+});
+
+describe('wrapPgError', () => {
+	test('wraps unique violation with metadata + keyColumns', () => {
+		const cause = Object.assign(new Error('duplicate key'), {
+			code: '23505',
+			severity: 'ERROR',
+			detail: 'Key (email)=(user@example.com) already exists.',
+			schema: 'public',
+			table: 'users',
+			constraint: 'users_email_index',
+		});
+		const err = wrapPgError('insert into users', ['user@example.com'], cause);
+		expect(err).toBeInstanceOf(PgError);
+		expect(is(err, PgError)).toBe(true);
+		expect(isPgError(err)).toBe(true);
+		expect(isPgUniqueViolation(err)).toBe(true);
+		expect(isPgNotNullViolation(err)).toBe(false);
+		const pg = err as PgError;
+		expect(pg.code).toBe(PG_ERROR.UNIQUE_VIOLATION);
+		expect(pg.table).toBe('users');
+		expect(pg.constraint).toBe('users_email_index');
+		expect(pg.keyColumns).toEqual(['email']);
+		expect(pg.keyValues).toEqual(['user@example.com']);
+		expect(pg.getColumnNames()).toEqual(['email']);
+		expect(pg.query).toBe('insert into users');
+		expect(pg.cause).toBe(cause);
+	});
+
+	test('wraps invalid uuid / text representation (22P02)', () => {
+		const cause = Object.assign(new Error('invalid input syntax for type uuid'), {
+			code: '22P02',
+		});
+		const err = wrapPgError('select', [], cause);
+		expect(isPgInvalidTextRepresentation(err)).toBe(true);
+		expect((err as PgError).code).toBe(PG_ERROR.INVALID_TEXT_REPRESENTATION);
+	});
+
+	test('wraps FK / not-null / check', () => {
+		expect(isPgForeignKeyViolation(wrapPgError('q', [], Object.assign(new Error('fk'), { code: '23503', table: 'posts' })))).toBe(true);
+		expect(isPgNotNullViolation(wrapPgError('q', [], Object.assign(new Error('nn'), { code: '23502', column: 'email' })))).toBe(true);
+		expect(isPgCheckViolation(wrapPgError('q', [], Object.assign(new Error('ck'), { code: '23514', constraint: 'ck' })))).toBe(true);
+	});
+
+	test('reads nested cause.code (drizzle-wrapped / driver nesting)', () => {
+		const inner = Object.assign(new Error('dup'), { code: '23505', constraint: 'x' });
+		const outer = Object.assign(new Error('wrapper'), { cause: inner });
+		const err = wrapPgError('q', [], outer);
+		expect(isPgUniqueViolation(err)).toBe(true);
+		expect((err as PgError).constraint).toBe('x');
+	});
+
+	test('falls back to DrizzleQueryError when no SQLSTATE', () => {
+		const err = wrapPgError('q', [1], new Error('boom'));
+		expect(err).toBeInstanceOf(DrizzleQueryError);
+		expect(err).not.toBeInstanceOf(PgError);
+		expect(isPgError(err)).toBe(false);
+	});
+
+	test('accepts postgres.js schema_name / table_name aliases', () => {
+		const cause = Object.assign(new Error('dup'), {
+			code: '23505',
+			schema_name: 'public',
+			table_name: 'users',
+			constraint_name: 'users_email_key',
+			column_name: 'email',
+		});
+		const pg = wrapPgError('q', [], cause) as PgError;
+		expect(pg.schema).toBe('public');
+		expect(pg.table).toBe('users');
+		expect(pg.constraint).toBe('users_email_key');
+		expect(pg.column).toBe('email');
+	});
+});
+
+describe('wrapMySqlError', () => {
+	test('parses duplicate entry message', () => {
+		expect(parseMySqlDuplicateMessage("Duplicate entry 'a@b.c' for key 'users.users_email_unique'")).toEqual({
+			value: 'a@b.c',
+			constraint: 'users.users_email_unique',
+		});
+	});
+
+	test('wraps errno 1062 unique', () => {
+		const cause = Object.assign(new Error('dup'), {
+			errno: 1062,
+			code: 'ER_DUP_ENTRY',
+			sqlState: '23000',
+			sqlMessage: "Duplicate entry 'a@b.c' for key 'users.users_email_unique'",
+		});
+		const err = wrapMySqlError('insert', [], cause);
+		expect(is(err, MySqlError)).toBe(true);
+		expect(isMySqlError(err)).toBe(true);
+		expect(isMySqlUniqueViolation(err)).toBe(true);
+		const my = err as MySqlError;
+		expect(my.errno).toBe(MYSQL_ERROR.DUP_ENTRY);
+		expect(my.constraint).toBe('users.users_email_unique');
+		expect(my.duplicateValue).toBe('a@b.c');
+	});
+
+	test('maps ER_* string codes when errno missing', () => {
+		const err = wrapMySqlError('q', [], Object.assign(new Error('nn'), { code: 'ER_BAD_NULL_ERROR', message: "Column 'email' cannot be null" }));
+		expect(isMySqlNotNullViolation(err)).toBe(true);
+		expect((err as MySqlError).column).toBe('email');
+	});
+
+	test('FK / check classification', () => {
+		expect(isMySqlForeignKeyViolation(wrapMySqlError('q', [], Object.assign(new Error('fk'), { errno: 1452 })))).toBe(true);
+		expect(isMySqlForeignKeyViolation(wrapMySqlError('q', [], Object.assign(new Error('fk'), { errno: 1451 })))).toBe(true);
+		expect(isMySqlCheckViolation(wrapMySqlError('q', [], Object.assign(new Error('ck'), { errno: 3819 })))).toBe(true);
+	});
+
+	test('falls back without errno', () => {
+		const err = wrapMySqlError('q', [], new Error('nope'));
+		expect(err).toBeInstanceOf(DrizzleQueryError);
+		expect(isMySqlError(err)).toBe(false);
+	});
+});
+
+describe('wrapSqliteError', () => {
+	test('classifies unique from extended code', () => {
+		expect(classifySqliteConstraint('SQLITE_CONSTRAINT_UNIQUE', undefined)).toBe('unique');
+		expect(parseSqliteConstraintTarget('UNIQUE constraint failed: users.email')).toEqual({
+			table: 'users',
+			columns: ['email'],
+		});
+	});
+
+	test('wraps unique + libsql message fallback', () => {
+		const cause = Object.assign(new Error('UNIQUE constraint failed: users.email'), {
+			code: 'SQLITE_CONSTRAINT',
+		});
+		const err = wrapSqliteError('insert', [], cause);
+		expect(is(err, SqliteError)).toBe(true);
+		expect(isSqliteError(err)).toBe(true);
+		expect(isSqliteUniqueViolation(err)).toBe(true);
+		const s = err as SqliteError;
+		expect(s.constraintKind).toBe('unique');
+		expect(s.table).toBe('users');
+		expect(s.columns).toEqual(['email']);
+	});
+
+	test('falls back for non-constraint errors', () => {
+		const err = wrapSqliteError('q', [], Object.assign(new Error('no such table'), { code: 'SQLITE_ERROR' }));
+		expect(err).toBeInstanceOf(DrizzleQueryError);
+		expect(isSqliteError(err)).toBe(false);
+	});
+});


### PR DESCRIPTION
/claim #376

## Summary

Addresses #376 with **dialect-native** typed errors (contributor-shaped API from the thread), not another cross-dialect `UniqueConstraintViolationError` hierarchy or an `onError` hook.

```ts
import { is } from 'drizzle-orm';
import { PgError, PG_ERROR, isPgUniqueViolation } from 'drizzle-orm/pg-core';

try {
  await db.insert(users).values({ email });
} catch (e) {
  if (isPgUniqueViolation(e)) {
    e.constraint;      // users_email_index
    e.keyColumns;      // ['email'] from PG detail
    e.getColumnNames();
  }
  // also: is(e, PgError) && e.code === PG_ERROR.INVALID_TEXT_REPRESENTATION // bad UUID etc.
}
```

### What this adds
- `PgError` + `PG_ERROR` SQLSTATE constants (unique / not-null / FK / check / invalid text / truncation)
- `MySqlError` + `MYSQL_ERROR` errno constants (incl. insert+delete FK codes)
- `SqliteError` with constraint kind classification + libsql message fallback
- Type guards: `isPgUniqueViolation`, `isMySqlForeignKeyViolation`, …
- Detail parsers: PG `Key (col)=(val)`, MySQL `Duplicate entry … for key`, SQLite `constraint failed: table.col`
- Wired once in dialect-core `queryWithCache` → all drivers of that dialect benefit
- SingleStore reuses MySQL wrapping
- Unrecognized driver errors still become plain `DrizzleQueryError` (additive / non-breaking)

### How this differs from open PRs
| PR | Gap vs this |
| --- | --- |
| #6064 | Postgres / node-pg only |
| #5383 / #6154 | Cross-dialect constraint subclasses only; no dialect SQLSTATE surface / `22P02` / detail key parsing |
| #5877 | Huge `onError` + constraint classes across ~68 files |
| #5412 | `onError` callback only |
| #3996 | Contributor WIP (logging rewrite + postgres.js only) |

No `onError` hook and no logging rewrite — focused on typed wrapping you can `is()` / guard on today.

## Test plan
- [x] `drizzle-orm/tests/dialect-errors.test.ts` — 16 cases (PG/MySQL/SQLite wrap + parsers + guards + fallback)
- [x] Full `drizzle-orm` unit suite: **585 passed**