### PR TITLE
feat(orm): customType.selectFromDb for PostGIS-like SELECT wrapping

### DIFF
--- a/docs/custom-types.lite.md
+++ b/docs/custom-types.lite.md
@@ -295,3 +295,62 @@ export interface CustomTypeParams<T extends Partial<CustomTypeValues>> {
   fromDriver?: (value: T['driverData']) => T['data'];
 }
 ````
+
+## Selecting custom columns with SQL transforms (`selectFromDb`)
+
+Some database types cannot be read in their on-disk form. The classic example is
+PostGIS `geometry`: drivers often return EWKB hex that is awkward to parse, so
+you want every select to use `ST_AsText(column)` (or `ST_AsGeoJSON`) instead.
+
+Without framework support you must wrap the column at every call site, and
+relational queries (`db.query.*.findMany`) cannot express a custom SQL fragment
+in `columns`.
+
+Add an optional `selectFromDb` callback to `customType`. When present, Drizzle
+applies it automatically for `select`, `returning`, and relational queries, then
+aliases the expression back to the column name so `fromDriver` still runs.
+
+### PostGIS `geometry(Point)` example (PostgreSQL)
+
+```typescript
+import { customType, pgTable, integer, text } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+
+export type Point = { lat: number; lng: number };
+
+export const point = customType<{ data: Point; driverData: string }>({
+  dataType() {
+    return 'geometry(Point,4326)';
+  },
+  toDriver(value) {
+    return `SRID=4326;POINT(${value.lng} ${value.lat})`;
+  },
+  fromDriver(value) {
+    const match = value.match(/POINT\((?<lng>[-\d.]+)\s+(?<lat>[-\d.]+)\)/i);
+    const { lat, lng } = match?.groups ?? {};
+    return { lat: Number(lat), lng: Number(lng) };
+  },
+  // Always select ST_AsText(column) AS column — no per-query wrapper needed
+  selectFromDb(columnRef) {
+    return sql`st_astext(${columnRef})`;
+  },
+});
+
+export const location = pgTable('location', {
+  id: integer('id').primaryKey(),
+  name: text('name'),
+  coords: point('coords'),
+});
+
+// Works with default select, joins, returning(), and relational queries:
+// db.select().from(location)
+//   -> select "id", "name", st_astext("coords") as "coords" from "location"
+```
+
+`columnRef` is already table-/alias-qualified when needed (joins, aliases), so
+you should not re-wrap it with `sql.identifier(...)`. Return only the wrapping
+expression — do **not** call `.as()` or `.mapWith()`; the dialect aliases the
+result and `fromDriver` still decodes the driver value.
+
+The same `selectFromDb` hook is available on MySQL and SQLite `customType`
+factories (for example `lower(${columnRef})` or dialect-specific casts).

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private mapSelect?: (columnRef: SQL) => SQL;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -72,10 +73,19 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.mapSelect = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/**
+	 * @internal Apply optional `selectFromDb` wrap for SELECT / RETURNING.
+	 * Returns `undefined` when the custom type does not define a selector.
+	 */
+	sqlForSelect(columnRef: SQL): SQL | undefined {
+		return typeof this.mapSelect === 'function' ? this.mapSelect(columnRef) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +205,25 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL transform applied automatically whenever this column is selected
+	 * (`select`, `returning`, relational queries). Use for types whose on-disk form
+	 * cannot be read as-is (e.g. wrapping with a SQL function on every select).
+	 *
+	 * `columnRef` is already the correctly qualified column reference (including
+	 * table / alias qualification in joins). Return only the wrapping expression —
+	 * the dialect aliases it back to the column name so `mapResultRow` / `fromDriver`
+	 * keep working. Do not call `.as()` or `.mapWith()` here.
+	 *
+	 * @example
+	 * ```ts
+	 * selectFromDb(columnRef) {
+	 *   return sql`lower(${columnRef})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (columnRef: SQL) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -24,6 +24,7 @@ import { getTableName, getTableUniqueName, Table } from '~/table.ts';
 import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import { MySqlColumn } from './columns/common.ts';
+import { MySqlCustomColumn } from './columns/custom.ts';
 import type { MySqlDeleteConfig } from './query-builders/delete.ts';
 import type { MySqlInsertConfig } from './query-builders/insert.ts';
 import type {
@@ -245,8 +246,15 @@ export class MySqlDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+				const columnName = sql.identifier(this.casing.getColumnCasing(field));
+				const columnRef = isSingleTable ? sql`${columnName}` : sql`${field}`;
+				const customSelect = is(field, MySqlCustomColumn) ? field.sqlForSelect(columnRef) : undefined;
+
+				if (customSelect) {
+					chunk.push(customSelect);
+					chunk.push(sql` as ${columnName}`);
+				} else if (isSingleTable) {
+					chunk.push(columnName);
 				} else {
 					chunk.push(field);
 				}

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private mapSelect?: (columnRef: SQL) => SQL;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,10 +73,19 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.mapSelect = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/**
+	 * @internal Apply optional `selectFromDb` wrap for SELECT / RETURNING.
+	 * Returns `undefined` when the custom type does not define a selector.
+	 */
+	sqlForSelect(columnRef: SQL): SQL | undefined {
+		return typeof this.mapSelect === 'function' ? this.mapSelect(columnRef) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +205,25 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL transform applied automatically whenever this column is selected
+	 * (`select`, `returning`, relational queries). Use for types whose on-disk form
+	 * cannot be read as-is (e.g. PostGIS `geometry` via `ST_AsText`).
+	 *
+	 * `columnRef` is already the correctly qualified column reference (including
+	 * table / alias qualification in joins). Return only the wrapping expression —
+	 * the dialect aliases it back to the column name so `mapResultRow` / `fromDriver`
+	 * keep working. Do not call `.as()` or `.mapWith()` here.
+	 *
+	 * @example
+	 * ```ts
+	 * selectFromDb(columnRef) {
+	 *   return sql`st_astext(${columnRef})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (columnRef: SQL) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -6,6 +6,7 @@ import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
 import {
 	PgColumn,
+	PgCustomColumn,
 	PgDate,
 	PgDateString,
 	PgJson,
@@ -242,8 +243,17 @@ export class PgDialect {
 						chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 					}
 				} else if (is(field, Column)) {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+					const columnName = sql.identifier(this.casing.getColumnCasing(field));
+					const columnRef = isSingleTable ? sql`${columnName}` : sql`${field}`;
+					const customSelect = is(field, PgCustomColumn) ? field.sqlForSelect(columnRef) : undefined;
+
+					if (customSelect) {
+						// Alias back to the column name so mapResultRow + fromDriver keep working
+						// (e.g. st_astext("coords") as "coords").
+						chunk.push(customSelect);
+						chunk.push(sql` as ${columnName}`);
+					} else if (isSingleTable) {
+						chunk.push(columnName);
 					} else {
 						chunk.push(field);
 					}
@@ -1355,13 +1365,23 @@ export class PgDialect {
 		if (nestedQueryRelation) {
 			let field = sql`json_build_array(${
 				sql.join(
-					selection.map(({ field, tsKey, isJson }) =>
-						isJson
-							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
-							: is(field, SQL.Aliased)
-							? field.sql
-							: field
-					),
+					selection.map(({ field, tsKey, isJson }) => {
+						if (isJson) {
+							return sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`;
+						}
+						if (is(field, SQL.Aliased)) {
+							return field.sql;
+						}
+						// Relational json_build_array embeds columns directly (not via buildSelection),
+						// so apply customType.selectFromDb here as well.
+						if (is(field, PgCustomColumn)) {
+							const wrapped = field.sqlForSelect(sql`${field}`);
+							if (wrapped) {
+								return wrapped;
+							}
+						}
+						return field;
+					}),
 					sql`, `,
 				)
 			})`;

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -63,6 +63,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private mapSelect?: (columnRef: SQL) => SQL;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -72,10 +73,19 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.mapSelect = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/**
+	 * @internal Apply optional `selectFromDb` wrap for SELECT / RETURNING.
+	 * Returns `undefined` when the custom type does not define a selector.
+	 */
+	sqlForSelect(columnRef: SQL): SQL | undefined {
+		return typeof this.mapSelect === 'function' ? this.mapSelect(columnRef) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +205,25 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+
+	/**
+	 * Optional SQL transform applied automatically whenever this column is selected
+	 * (`select`, `returning`, relational queries). Use for types whose on-disk form
+	 * cannot be read as-is (e.g. wrapping with a SQL function on every select).
+	 *
+	 * `columnRef` is already the correctly qualified column reference (including
+	 * table / alias qualification in joins). Return only the wrapping expression —
+	 * the dialect aliases it back to the column name so `mapResultRow` / `fromDriver`
+	 * keep working. Do not call `.as()` or `.mapWith()` here.
+	 *
+	 * @example
+	 * ```ts
+	 * selectFromDb(columnRef) {
+	 *   return sql`lower(${columnRef})`;
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (columnRef: SQL) => SQL;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -20,7 +20,7 @@ import {
 import type { Name, Placeholder } from '~/sql/index.ts';
 import { and, eq } from '~/sql/index.ts';
 import { Param, type QueryWithTypings, SQL, sql, type SQLChunk } from '~/sql/sql.ts';
-import { SQLiteColumn } from '~/sqlite-core/columns/index.ts';
+import { SQLiteColumn, SQLiteCustomColumn } from '~/sqlite-core/columns/index.ts';
 import type {
 	AnySQLiteSelectQueryBuilder,
 	SQLiteDeleteConfig,
@@ -209,24 +209,21 @@ export abstract class SQLiteDialect {
 				}
 			} else if (is(field, Column)) {
 				const tableName = field.table[Table.Symbol.Name];
-				if (field.columnType === 'SQLiteNumericBigInt') {
-					if (isSingleTable) {
-						chunk.push(
-							sql`cast(${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
-						);
-					} else {
-						chunk.push(
-							sql`cast(${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
-						);
-					}
+				const columnName = sql.identifier(this.casing.getColumnCasing(field));
+				const columnRef = isSingleTable
+					? sql`${columnName}`
+					: sql`${sql.identifier(tableName)}.${columnName}`;
+				const customSelect = is(field, SQLiteCustomColumn) ? field.sqlForSelect(columnRef) : undefined;
+
+				if (customSelect) {
+					chunk.push(customSelect);
+					chunk.push(sql` as ${columnName}`);
+				} else if (field.columnType === 'SQLiteNumericBigInt') {
+					chunk.push(sql`cast(${columnRef} as text)`);
+				} else if (isSingleTable) {
+					chunk.push(columnName);
 				} else {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-					} else {
-						chunk.push(
-							sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
-						);
-					}
+					chunk.push(columnRef);
 				}
 			} else if (is(field, Subquery)) {
 				const entries = Object.entries(field._.selectedFields) as [

--- a/drizzle-orm/tests/custom-type-select-from-db.test.ts
+++ b/drizzle-orm/tests/custom-type-select-from-db.test.ts
@@ -1,0 +1,301 @@
+import Database from 'better-sqlite3';
+import mysql from 'mysql2';
+import postgres from 'postgres';
+import { describe, expect, test } from 'vitest';
+import { drizzle as drizzleSqlite } from '~/better-sqlite3';
+import { alias as mysqlAlias, customType as mysqlCustomType, int, mysqlTable, text as mysqlText } from '~/mysql-core';
+import { drizzle as drizzleMysql } from '~/mysql2';
+import { alias as pgAlias, customType as pgCustomType, integer, pgTable, text as pgText } from '~/pg-core';
+import { drizzle as drizzlePg } from '~/postgres-js';
+import { relations } from '~/relations';
+import { eq, sql } from '~/sql';
+import {
+	alias as sqliteAlias,
+	customType as sqliteCustomType,
+	integer as sqliteInteger,
+	sqliteTable,
+	text as sqliteText,
+} from '~/sqlite-core';
+
+/**
+ * PostGIS-like point custom type (#1083 / #554).
+ * Stored as geometry; always selected via ST_AsText so fromDriver gets WKT.
+ */
+type Point = { lat: number; lng: number };
+
+function parsePointWkt(value: string): Point {
+	const match = value.match(/POINT\((?<lng>[-\d.]+)\s+(?<lat>[-\d.]+)\)/i);
+	if (!match?.groups) {
+		throw new Error(`Unexpected geometry WKT: ${value}`);
+	}
+	return {
+		lat: Number(match.groups.lat),
+		lng: Number(match.groups.lng),
+	};
+}
+
+const pgPoint = pgCustomType<{ data: Point; driverData: string }>({
+	dataType() {
+		return 'geometry(Point,4326)';
+	},
+	toDriver(value) {
+		return `SRID=4326;POINT(${value.lng} ${value.lat})`;
+	},
+	fromDriver(value) {
+		return parsePointWkt(value);
+	},
+	selectFromDb(columnRef) {
+		return sql`st_astext(${columnRef})`;
+	},
+});
+
+const pgPlain = pgCustomType<{ data: string }>({
+	dataType() {
+		return 'text';
+	},
+});
+
+const location = pgTable('location', {
+	id: integer('id').primaryKey(),
+	name: pgText('name'),
+	coords: pgPoint('coords'),
+	notes: pgPlain('notes'),
+});
+
+const visit = pgTable('visit', {
+	id: integer('id').primaryKey(),
+	locationId: integer('location_id').notNull(),
+});
+
+const locationRelations = relations(location, ({ many }) => ({
+	visits: many(visit),
+}));
+
+const visitRelations = relations(visit, ({ one }) => ({
+	location: one(location, {
+		fields: [visit.locationId],
+		references: [location.id],
+	}),
+}));
+
+const pgSchema = { location, visit, locationRelations, visitRelations };
+const pgDb = drizzlePg(postgres(''), { schema: pgSchema });
+
+describe('pg customType.selectFromDb (PostGIS-like point)', () => {
+	test('full select wraps geometry and leaves plain custom untouched', () => {
+		const { sql: query } = pgDb.select().from(location).toSQL();
+		expect(query).toBe(
+			'select "id", "name", st_astext("coords") as "coords", "notes" from "location"',
+		);
+	});
+
+	test('partial select wraps only the geometry column', () => {
+		const { sql: query } = pgDb.select({ coords: location.coords }).from(location).toSQL();
+		expect(query).toBe('select st_astext("coords") as "coords" from "location"');
+	});
+
+	test('join keeps table-qualified refs inside the wrap', () => {
+		const { sql: query } = pgDb
+			.select()
+			.from(visit)
+			.innerJoin(location, eq(visit.locationId, location.id))
+			.toSQL();
+		expect(query).toContain('st_astext("location"."coords") as "coords"');
+		expect(query).toContain('"location"."notes"');
+	});
+
+	test('table alias is preserved inside the wrap', () => {
+		const l = pgAlias(location, 'l');
+		const { sql: query } = pgDb
+			.select({ coords: l.coords })
+			.from(visit)
+			.innerJoin(l, eq(visit.locationId, l.id))
+			.toSQL();
+		expect(query).toBe(
+			'select st_astext("l"."coords") as "coords" from "visit" inner join "location" "l" on "visit"."location_id" = "l"."id"',
+		);
+	});
+
+	test('insert/update/delete returning() apply the wrap', () => {
+		expect(
+			pgDb.insert(location).values({ id: 1, name: 'home', coords: { lat: 1, lng: 2 } }).returning().toSQL()
+				.sql,
+		).toContain('st_astext("coords") as "coords"');
+
+		expect(
+			pgDb.update(location).set({ name: 'work' }).returning({ coords: location.coords }).toSQL().sql,
+		).toBe('update "location" set "name" = $1 returning st_astext("coords") as "coords"');
+
+		expect(pgDb.delete(location).returning({ coords: location.coords }).toSQL().sql).toBe(
+			'delete from "location" returning st_astext("coords") as "coords"',
+		);
+	});
+
+	test('toDriver still serializes insert params (EWKT)', () => {
+		const { params } = pgDb
+			.insert(location)
+			.values({ id: 1, name: 'home', coords: { lat: 59.9, lng: 10.7 } })
+			.toSQL();
+		expect(params).toContain('SRID=4326;POINT(10.7 59.9)');
+	});
+
+	test('fromDriver still parses WKT after selection wrap', () => {
+		expect(location.coords.mapFromDriverValue('POINT(10.7 59.9)')).toEqual({ lat: 59.9, lng: 10.7 });
+	});
+
+	test('relational findMany applies the wrap', () => {
+		const { sql: query } = pgDb.query.location.findMany().toSQL();
+		expect(query).toContain('st_astext("coords") as "coords"');
+	});
+
+	test('relational findMany with nested relation still wraps the related geometry', () => {
+		const { sql: query } = pgDb.query.visit.findMany({
+			with: { location: true },
+		}).toSQL();
+		expect(query).toContain('st_astext(');
+		expect(query).toContain('coords');
+	});
+
+	test('casing: snake_case applies to both reference and alias', () => {
+		const camel = pgTable('camel', {
+			id: integer().primaryKey(),
+			homeCoords: pgPoint(),
+		});
+		const camelDb = drizzlePg(postgres(''), { casing: 'snake_case' });
+		const { sql: query } = camelDb.select({ homeCoords: camel.homeCoords }).from(camel).toSQL();
+		expect(query).toBe('select st_astext("home_coords") as "home_coords" from "camel"');
+	});
+});
+
+const mysqlLower = mysqlCustomType<{ data: string; driverData: string }>({
+	dataType() {
+		return 'varchar(255)';
+	},
+	selectFromDb(columnRef) {
+		return sql`lower(${columnRef})`;
+	},
+});
+
+const mysqlUsers = mysqlTable('users', {
+	id: int('id').primaryKey(),
+	name: mysqlLower('name'),
+	bio: mysqlText('bio'),
+});
+
+const mysqlDb = drizzleMysql(mysql.createPool({}));
+
+describe('mysql customType.selectFromDb', () => {
+	test('select wraps with lower() and aliases back', () => {
+		const { sql: query } = mysqlDb.select().from(mysqlUsers).toSQL();
+		expect(query).toBe('select `id`, lower(`name`) as `name`, `bio` from `users`');
+	});
+
+	test('join keeps qualified refs', () => {
+		const posts = mysqlTable('posts', {
+			id: int('id').primaryKey(),
+			userId: int('user_id'),
+		});
+		const { sql: query } = mysqlDb
+			.select({ name: mysqlUsers.name })
+			.from(posts)
+			.innerJoin(mysqlUsers, eq(posts.userId, mysqlUsers.id))
+			.toSQL();
+		expect(query).toBe(
+			'select lower(`users`.`name`) as `name` from `posts` inner join `users` on `posts`.`user_id` = `users`.`id`',
+		);
+	});
+
+	test('table alias is preserved inside joins', () => {
+		const posts = mysqlTable('posts_alias', {
+			id: int('id').primaryKey(),
+			userId: int('user_id'),
+		});
+		const u = mysqlAlias(mysqlUsers, 'u');
+		const { sql: query } = mysqlDb
+			.select({ name: u.name })
+			.from(posts)
+			.innerJoin(u, eq(posts.userId, u.id))
+			.toSQL();
+		expect(query).toBe(
+			'select lower(`u`.`name`) as `name` from `posts_alias` inner join `users` `u` on `posts_alias`.`user_id` = `u`.`id`',
+		);
+	});
+
+	test('single-table alias stays unqualified (isSingleTable)', () => {
+		const u = mysqlAlias(mysqlUsers, 'u');
+		const { sql: query } = mysqlDb.select({ name: u.name }).from(u).toSQL();
+		expect(query).toBe('select lower(`name`) as `name` from `users` `u`');
+	});
+});
+
+const sqliteLower = sqliteCustomType<{ data: string; driverData: string }>({
+	dataType() {
+		return 'text';
+	},
+	selectFromDb(columnRef) {
+		return sql`lower(${columnRef})`;
+	},
+});
+
+const sqliteUsers = sqliteTable('users', {
+	id: sqliteInteger('id').primaryKey(),
+	name: sqliteLower('name'),
+	bio: sqliteText('bio'),
+});
+
+const sqliteDb = drizzleSqlite(new Database(':memory:'));
+
+describe('sqlite customType.selectFromDb', () => {
+	test('select wraps with lower() and aliases back', () => {
+		const { sql: query } = sqliteDb.select().from(sqliteUsers).toSQL();
+		expect(query).toBe('select "id", lower("name") as "name", "bio" from "users"');
+	});
+
+	test('join keeps qualified refs', () => {
+		const posts = sqliteTable('posts', {
+			id: sqliteInteger('id').primaryKey(),
+			userId: sqliteInteger('user_id'),
+		});
+		const { sql: query } = sqliteDb
+			.select({ name: sqliteUsers.name })
+			.from(posts)
+			.innerJoin(sqliteUsers, eq(posts.userId, sqliteUsers.id))
+			.toSQL();
+		expect(query).toBe(
+			'select lower("users"."name") as "name" from "posts" inner join "users" on "posts"."user_id" = "users"."id"',
+		);
+	});
+
+	test('table alias is preserved inside joins', () => {
+		const posts = sqliteTable('posts_alias', {
+			id: sqliteInteger('id').primaryKey(),
+			userId: sqliteInteger('user_id'),
+		});
+		const u = sqliteAlias(sqliteUsers, 'u');
+		const { sql: query } = sqliteDb
+			.select({ name: u.name })
+			.from(posts)
+			.innerJoin(u, eq(posts.userId, u.id))
+			.toSQL();
+		expect(query).toBe(
+			'select lower("u"."name") as "name" from "posts_alias" inner join "users" "u" on "posts_alias"."user_id" = "u"."id"',
+		);
+	});
+
+	test('single-table alias stays unqualified (isSingleTable)', () => {
+		const u = sqliteAlias(sqliteUsers, 'u');
+		const { sql: query } = sqliteDb.select({ name: u.name }).from(u).toSQL();
+		expect(query).toBe('select lower("name") as "name" from "users" "u"');
+	});
+
+	test('returning() on insert applies the wrap', () => {
+		const { sql: query } = sqliteDb
+			.insert(sqliteUsers)
+			.values({ id: 1, name: 'Ada' })
+			.returning({ name: sqliteUsers.name })
+			.toSQL();
+		expect(query).toBe(
+			'insert into "users" ("id", "name", "bio") values (?, ?, null) returning lower("name") as "name"',
+		);
+	});
+});

--- a/drizzle-orm/type-tests/pg/tables.ts
+++ b/drizzle-orm/type-tests/pg/tables.ts
@@ -1474,3 +1474,30 @@ await db.refreshMaterializedView(newYorkers2).withNoData().concurrently();
 
 	Expect<Equal<{ enum: Role | null }[], typeof schemaRes>>;
 }
+
+{
+	type Point = { lat: number; lng: number };
+
+	const pointType = customType<{ data: Point; driverData: string }>({
+		dataType() {
+			return 'geometry(Point,4326)';
+		},
+		fromDriver(_value) {
+			return { lat: 0, lng: 0 };
+		},
+		selectFromDb(columnRef) {
+			return sql`st_astext(${columnRef})`;
+		},
+	});
+
+	const locations = pgTable('locations_select_from_db', {
+		id: integer('id').primaryKey(),
+		coords: pointType('coords'),
+	});
+
+	const result = await db.select().from(locations);
+	Expect<Equal<{ id: number; coords: Point | null }[], typeof result>>;
+
+	const partial = await db.select({ coords: locations.coords }).from(locations);
+	Expect<Equal<{ coords: Point | null }[], typeof partial>>;
+}


### PR DESCRIPTION
Closes #554
Closes #1083

## Problem

Custom types whose on-disk form is not what you want back (PostGIS `geometry`, forced casts, etc.) currently require a manual `sql\`fn(${col})\`` wrapper at every call site. That does not work with default `db.select().from(table)` or with relational `columns: true` / nested `with`.

## Solution

Optional `selectFromDb(columnRef)` on `customType` for **PostgreSQL, MySQL, and SQLite**:

```ts
const point = customType<{ data: Point; driverData: string }>({
  dataType() { return 'geometry(Point,4326)'; },
  toDriver(value) { return `SRID=4326;POINT(${value.lng} ${value.lat})`; },
  fromDriver(value) { /* parse WKT */ },
  selectFromDb(columnRef) {
    return sql`st_astext(${columnRef})`;
  },
});
// db.select().from(location)
//   -> select "id", "name", st_astext("coords") as "coords" from "location"
```

- `columnRef` is already table-/alias-qualified when needed (joins, aliases).
- Return only the wrapping expression — the dialect aliases it back to the column name so `mapResultRow` + `fromDriver` keep working.
- Fully backward compatible (option is optional).

## Wiring

| Path | Coverage |
|------|----------|
| `buildSelection` (select / returning) | pg + mysql + sqlite |
| Relational `json_build_array` embeds | pg (RQB nested One/Many) |
| Docs | `docs/custom-types.lite.md` PostGIS walkthrough |

## Tests (`drizzle-orm/tests/custom-type-select-from-db.test.ts`)

19 unit tests (`.toSQL()` / mapper only, no live DB):

- PostGIS-like point: full/partial select, joins, aliases, casing (`snake_case`)
- `insert` / `update` / `delete` `returning()`
- `toDriver` EWKT params + `fromDriver` WKT parse
- Relational `findMany` + nested `with: { location: true }` (json_build_array wrap)
- MySQL / SQLite `lower(${col})` select + join + alias + sqlite returning

Type coverage in `type-tests/pg/tables.ts`.

## Diff vs open PRs

Differentiates from #6153 / #6090 (pg-only), #5746 (thinner tests, no RQB json path / docs), and older forks by shipping **all three dialects**, **RQB nested `json_build_array` wrapping**, a **PostGIS-style point suite**, and **API docs**.

@algora-pbc /claim #554
@algora-pbc /claim #1083