### PR TITLE
fix(orm): nullify nested objects deeper than one level (fixes #6246)

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -45,11 +45,16 @@ export function mapResultRow<TResult>(
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;
-						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
-						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
-						) {
+						const tableName = getTableName(field.table);
+
+						if (value !== null) {
+							// A column that came back with a value proves the joined row exists,
+							// so this object must never be nullified - regardless of which of its
+							// columns happened to be read first.
+							nullifyMap[objectName] = false;
+						} else if (!(objectName in nullifyMap)) {
+							nullifyMap[objectName] = tableName;
+						} else if (typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== tableName) {
 							nullifyMap[objectName] = false;
 						}
 					}

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -17,7 +17,8 @@ export function mapResultRow<TResult>(
 	row: unknown[],
 	joinsNotNullableMap: Record<string, boolean> | undefined,
 ): TResult {
-	// Key -> nested object key, value -> table name if all fields in the nested object are from the same table, false otherwise
+	// Key -> JSON-encoded path of the nested object, value -> table name if all fields
+	// in that object are from the same table, false otherwise
 	const nullifyMap: Record<string, string | false> = {};
 
 	const result = columns.reduce<Record<string, any>>(
@@ -43,19 +44,21 @@ export function mapResultRow<TResult>(
 					const rawValue = row[columnIndex]!;
 					const value = node[pathChunk] = rawValue === null ? null : decoder.mapFromDriverValue(rawValue);
 
-					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
-						const objectName = path[0]!;
+					if (joinsNotNullableMap && is(field, Column) && path.length >= 2) {
+						// Key on the object's own path, not just path[0], so objects nested
+						// deeper than one level are tracked too.
+						const objectKey = JSON.stringify(path.slice(0, -1));
 						const tableName = getTableName(field.table);
 
 						if (value !== null) {
 							// A column that came back with a value proves the joined row exists,
 							// so this object must never be nullified - regardless of which of its
 							// columns happened to be read first.
-							nullifyMap[objectName] = false;
-						} else if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = tableName;
-						} else if (typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== tableName) {
-							nullifyMap[objectName] = false;
+							nullifyMap[objectKey] = false;
+						} else if (!(objectKey in nullifyMap)) {
+							nullifyMap[objectKey] = tableName;
+						} else if (typeof nullifyMap[objectKey] === 'string' && nullifyMap[objectKey] !== tableName) {
+							nullifyMap[objectKey] = false;
 						}
 					}
 				}
@@ -67,9 +70,19 @@ export function mapResultRow<TResult>(
 
 	// Nullify all nested objects from nullifyMap that are nullable
 	if (joinsNotNullableMap && Object.keys(nullifyMap).length > 0) {
-		for (const [objectName, tableName] of Object.entries(nullifyMap)) {
-			if (typeof tableName === 'string' && !joinsNotNullableMap[tableName]) {
-				result[objectName] = null;
+		for (const [objectKey, tableName] of Object.entries(nullifyMap)) {
+			if (typeof tableName !== 'string' || joinsNotNullableMap[tableName]) {
+				continue;
+			}
+
+			const objectPath: string[] = JSON.parse(objectKey);
+			let node = result;
+			for (const pathChunk of objectPath.slice(0, -1)) {
+				node = node?.[pathChunk];
+			}
+
+			if (node) {
+				node[objectPath[objectPath.length - 1]!] = null;
 			}
 		}
 	}

--- a/drizzle-orm/tests/map-result-row.test.ts
+++ b/drizzle-orm/tests/map-result-row.test.ts
@@ -63,3 +63,46 @@ describe.concurrent('mapResultRow nested partial select', () => {
 		});
 	});
 });
+
+describe.concurrent('mapResultRow nesting depth', () => {
+	const deepSelection = [
+		{ path: ['name'], field: orgs.name },
+		{ path: ['theme', 'branding', 'logo'], field: orgBranding.logo },
+		{ path: ['theme', 'branding', 'panelBackground'], field: orgBranding.panelBackground },
+	];
+
+	it('nullifies an object nested more than one level deep', ({ expect }) => {
+		const result = mapResultRow(deepSelection, ['Test org', null, null], leftJoined);
+
+		expect(result).toEqual({ name: 'Test org', theme: { branding: null } });
+	});
+
+	it('keeps a deeply nested object when one of its columns has a value', ({ expect }) => {
+		const result = mapResultRow(deepSelection, ['Test org', null, '#1a8cff'], leftJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			theme: { branding: { logo: null, panelBackground: '#1a8cff' } },
+		});
+	});
+
+	it('leaves a parent that holds no columns of its own with its shape', ({ expect }) => {
+		// `theme` has no direct columns, so there is nothing to decide about it -
+		// only the object that actually owns the null columns is nullified.
+		const result = mapResultRow(deepSelection, ['Test org', null, null], leftJoined) as {
+			theme: unknown;
+		};
+
+		expect(result.theme).toEqual({ branding: null });
+	});
+
+	it('keeps a deeply nested object from a non-nullable join', ({ expect }) => {
+		const innerJoined = { orgs: true, org_branding: true };
+		const result = mapResultRow(deepSelection, ['Test org', null, null], innerJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			theme: { branding: { logo: null, panelBackground: null } },
+		});
+	});
+});

--- a/drizzle-orm/tests/map-result-row.test.ts
+++ b/drizzle-orm/tests/map-result-row.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from 'vitest';
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const orgs = pgTable('orgs', {
+	id: text('id'),
+	name: text('name'),
+});
+
+const orgBranding = pgTable('org_branding', {
+	orgId: text('org_id'),
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+const selection = [
+	{ path: ['name'], field: orgs.name },
+	{ path: ['branding', 'logo'], field: orgBranding.logo },
+	{ path: ['branding', 'panelBackground'], field: orgBranding.panelBackground },
+];
+
+// `orgs` is the base table; `org_branding` is left joined, so it is nullable.
+const leftJoined = { orgs: true, org_branding: false };
+
+describe.concurrent('mapResultRow nested partial select', () => {
+	it('keeps the joined object when a later column has a value', ({ expect }) => {
+		const result = mapResultRow(selection, ['Test org', null, '#1a8cff'], leftJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { logo: null, panelBackground: '#1a8cff' },
+		});
+	});
+
+	it('does not depend on which column of the object is selected first', ({ expect }) => {
+		const swapped = [
+			{ path: ['name'], field: orgs.name },
+			{ path: ['branding', 'panelBackground'], field: orgBranding.panelBackground },
+			{ path: ['branding', 'logo'], field: orgBranding.logo },
+		];
+
+		const result = mapResultRow(swapped, ['Test org', '#1a8cff', null], leftJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { panelBackground: '#1a8cff', logo: null },
+		});
+	});
+
+	it('still nullifies the object when the join matched no row', ({ expect }) => {
+		const result = mapResultRow(selection, ['Test org', null, null], leftJoined);
+
+		expect(result).toEqual({ name: 'Test org', branding: null });
+	});
+
+	it('keeps an object from a non-nullable join even when every column is null', ({ expect }) => {
+		const innerJoined = { orgs: true, org_branding: true };
+		const result = mapResultRow(selection, ['Test org', null, null], innerJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { logo: null, panelBackground: null },
+		});
+	});
+});


### PR DESCRIPTION
Fixes #6246

**Stacked on #6245.** That PR is the first commit here, so the diff below shows both changes. If #6245 merges first I'll rebase this down to just the depth commit; if you'd rather have one PR, say so and I'll fold them together.

### The problem

`mapResultRow` only tracked an object for nullification when its selection path was exactly two segments long, and keyed the entry on `path[0]`:

```ts
if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
	const objectName = path[0]!;
```

`orderSelectedFields` recurses through plain objects, so a selection can nest arbitrarily deep. Anything past the first level never got an entry in `nullifyMap` and so survived a left join that matched no row:

```ts
// one level - nullified today
{ branding: { logo: orgBranding.logo } }          -> { branding: null }        ✅

// two levels - not nullified
{ theme: { branding: { logo: orgBranding.logo } } }
                          -> { theme: { branding: { logo: null } } }
              expected       { theme: { branding: null } }
```

Same join, same absent row, different result — decided by how deeply the caller happened to nest the selection. Code doing `if (row.theme.branding)` to test whether the join matched takes the wrong branch.

### The change

Key `nullifyMap` on the object's own path (`path.slice(0, -1)`, JSON-encoded so segments can't collide) and walk that path in the nullify pass instead of assigning to `result[objectName]`.

Depth-2 selections are unaffected by construction: the parent path of `['branding', 'logo']` is `['branding']`, which is exactly what the old code used as the key and the assignment target.

A parent that holds no columns of its own — `theme` above — keeps its shape and just holds `branding: null`. Only the object that actually owns the null columns is nullified. I've deliberately not made nullification cascade upward, because that's a judgement call about what an empty parent should mean and I'd rather you make it than have me guess. Happy to change it if you want the cascade.

### Tests

Four cases added to `drizzle-orm/tests/map-result-row.test.ts`, in the existing database-free vitest suite:

- a two-level-deep object is nullified when the join matched nothing
- it survives when one of its columns has a value
- a column-less parent keeps its shape
- a deeply nested object from a non-nullable join is never nullified

Together with the four cases from #6245 that pin the ordering behaviour, the depth-2 path stays covered, so this can't quietly regress what #6245 fixes.
