### PR TITLE
[SQLite-kit]: Order table drops by foreign key dependencies

### DIFF
--- a/drizzle-kit/src/snapshotsDiffer.ts
+++ b/drizzle-kit/src/snapshotsDiffer.ts
@@ -550,6 +550,53 @@ const columnChangeFor = (
 	return column;
 };
 
+// SQLite and libSQL enforce foreign keys by default (unlike the drop-and-recreate
+// __new_ table rebuild path, plain DROP TABLE statements aren't wrapped in
+// `PRAGMA foreign_keys=OFF`), so dropping a table that's still referenced by
+// another table also being dropped fails with `FOREIGN KEY constraint failed`.
+// Order the tables so a table is dropped before any table it references.
+const orderSqliteTableDeletionsByForeignKeys = <T extends Table>(tables: T[]): T[] => {
+	const byName = new Map(tables.map((table) => [table.name, table]));
+
+	// tables in `tables` that reference a given table name via a foreign key -
+	// these must be dropped before that table
+	const dependents = new Map<string, Set<string>>();
+	for (const table of tables) {
+		for (const fkStr of Object.values(table.foreignKeys)) {
+			const { tableTo } = SQLiteSquasher.unsquashFK(fkStr);
+			if (!byName.has(tableTo)) continue;
+			const set = dependents.get(tableTo) ?? new Set<string>();
+			set.add(table.name);
+			dependents.set(tableTo, set);
+		}
+	}
+
+	const sorted: T[] = [];
+	const visited = new Set<string>();
+	const visiting = new Set<string>();
+
+	const visit = (name: string) => {
+		if (visited.has(name) || visiting.has(name)) return;
+		visiting.add(name);
+
+		for (const dependent of dependents.get(name) ?? []) {
+			visit(dependent);
+		}
+
+		visiting.delete(name);
+		visited.add(name);
+
+		const table = byName.get(name);
+		if (table) sorted.push(table);
+	};
+
+	for (const table of tables) {
+		visit(table.name);
+	}
+
+	return sorted;
+};
+
 // resolve roles same as enums
 // create new json statements
 // sql generators
@@ -3266,12 +3313,13 @@ export const applySqliteSnapshotsDiff = async (
 
 	const {
 		created: createdTables,
-		deleted: deletedTables,
+		deleted: unorderedDeletedTables,
 		renamed: renamedTables,
 	} = await tablesResolver({
 		created: tablesDiff.added,
 		deleted: tablesDiff.deleted,
 	});
+	const deletedTables = orderSqliteTableDeletionsByForeignKeys(unorderedDeletedTables);
 
 	const tablesPatchedSnap1 = copy(json1);
 	tablesPatchedSnap1.tables = mapEntries(tablesPatchedSnap1.tables, (_, it) => {
@@ -3820,12 +3868,13 @@ export const applyLibSQLSnapshotsDiff = async (
 	const tablesDiff = diffSchemasOrTables(json1.tables, json2.tables);
 	const {
 		created: createdTables,
-		deleted: deletedTables,
+		deleted: unorderedDeletedTables,
 		renamed: renamedTables,
 	} = await tablesResolver({
 		created: tablesDiff.added,
 		deleted: tablesDiff.deleted,
 	});
+	const deletedTables = orderSqliteTableDeletionsByForeignKeys(unorderedDeletedTables);
 
 	const tablesPatchedSnap1 = copy(json1);
 	tablesPatchedSnap1.tables = mapEntries(tablesPatchedSnap1.tables, (_, it) => {

--- a/drizzle-kit/tests/sqlite-tables.test.ts
+++ b/drizzle-kit/tests/sqlite-tables.test.ts
@@ -635,3 +635,57 @@ test('optional db aliases (camel case)', async () => {
 
 	expect(sqlStatements).toStrictEqual([st1, st2, st3, st4, st5, st6]);
 });
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6251
+test('drop tables respects foreign key dependencies (child name sorts after parent)', async () => {
+	const aaaParent = sqliteTable('aaa_parent', {
+		id: int('id').primaryKey(),
+		code: text('code'),
+	});
+
+	const zzzChild = sqliteTable('zzz_child', {
+		id: int('id').primaryKey(),
+		p: int('p').references(() => aaaParent.id),
+	});
+
+	const from = {
+		aaaParent,
+		zzzChild,
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite(from, {}, []);
+
+	const childDropIndex = sqlStatements.findIndex((it) => it.includes('DROP TABLE `zzz_child`'));
+	const parentDropIndex = sqlStatements.findIndex((it) => it.includes('DROP TABLE `aaa_parent`'));
+
+	expect(childDropIndex).toBeGreaterThanOrEqual(0);
+	expect(parentDropIndex).toBeGreaterThanOrEqual(0);
+	expect(childDropIndex).toBeLessThan(parentDropIndex);
+});
+
+// https://github.com/drizzle-team/drizzle-orm/issues/6251
+test('drop tables respects foreign key dependencies (child name sorts before parent)', async () => {
+	const zzzParent = sqliteTable('zzz_parent', {
+		id: int('id').primaryKey(),
+		code: text('code'),
+	});
+
+	const aaaChild = sqliteTable('aaa_child', {
+		id: int('id').primaryKey(),
+		p: int('p').references(() => zzzParent.id),
+	});
+
+	const from = {
+		zzzParent,
+		aaaChild,
+	};
+
+	const { sqlStatements } = await diffTestSchemasSqlite(from, {}, []);
+
+	const childDropIndex = sqlStatements.findIndex((it) => it.includes('DROP TABLE `aaa_child`'));
+	const parentDropIndex = sqlStatements.findIndex((it) => it.includes('DROP TABLE `zzz_parent`'));
+
+	expect(childDropIndex).toBeGreaterThanOrEqual(0);
+	expect(parentDropIndex).toBeGreaterThanOrEqual(0);
+	expect(childDropIndex).toBeLessThan(parentDropIndex);
+});


### PR DESCRIPTION
## Description

Fixes #6251. `generate` on SQLite (and libSQL) orders `DROP TABLE`
statements by whatever order the `json-diff`-based schema differ
happens to return (effectively alphabetical by table name), with no
awareness of foreign keys between the tables being dropped.

SQLite enforces foreign keys by default in both `better-sqlite3` and
`node:sqlite`. Dropping a parent table before a child that still
references it fires `FOREIGN KEY constraint failed` against a
database with rows in both tables — but succeeds against an empty
database, which is what makes this pass in local/CI testing and fail
in production.

### Root cause

- `drizzle-kit/src/jsonDiffer.js`'s `diffSchemasOrTables` returns
  `deleted` tables in whatever order the diff library's own key
  iteration gives (alphabetical), no dependency awareness.
- `drizzle-kit/src/snapshotsDiffer.ts`'s `applySqliteSnapshotsDiff`
  and `applyLibSQLSnapshotsDiff` fed that unordered list straight into
  `prepareDropTableJson`, with no re-sort.
- `drizzle-kit/src/sqlgenerator.ts` emits `DROP TABLE` in whatever
  order it receives — no safety net downstream either.

### Fix

Added `orderSqliteTableDeletionsByForeignKeys`, a small DFS-based
topological sort (cycle-safe via visited/visiting sets, same shape as
the dependents-first approach in the still-open #5388 for views) that
reorders the deleted-tables list so a table is always dropped before
any table it references. Applied at both the SQLite and libSQL call
sites in `snapshotsDiffer.ts` — they share identical FK-enforcement
semantics. Postgres/MySQL/SingleStore are untouched: different FK
models, not reported or reproduced as broken.

### Tests

Two new tests in `drizzle-kit/tests/sqlite-tables.test.ts`, mirroring
the issue's own A/B repro (child name sorting after the parent's,
and before it), so the fix isn't just accidentally reversing
alphabetical order in one direction. Both fail on unpatched `main`
("expected 1 to be less than 0") and pass with the fix.

Full non-Docker-dependent `drizzle-kit` suite: 646 passed (was 644 on
baseline + 2 new), same 4 pre-existing unrelated CLI/push-config
failures on both baseline and this branch (confirmed by diffing
against unmodified main). `dprint check` clean on changed files;
`tsc --noEmit` has one pre-existing, unrelated error in a test helper
(confirmed identical on baseline).
