### PR TITLE
Generate dialect-valid SQL from the concat and substring helpers

### DIFF
--- a/drizzle-orm/src/mssql-core/expressions.ts
+++ b/drizzle-orm/src/mssql-core/expressions.ts
@@ -1,5 +1,5 @@
 import { bindIfParam } from '~/sql/expressions/index.ts';
-import type { Placeholder, SQL, SQLChunk, SQLWrapper } from '~/sql/sql.ts';
+import type { Placeholder, SQL, SQLWrapper } from '~/sql/sql.ts';
 import { sql } from '~/sql/sql.ts';
 import type { MsSqlColumn } from './columns/index.ts';
 
@@ -12,20 +12,19 @@ export * from '~/sql/expressions/index.ts';
 // }
 
 export function concat(column: MsSqlColumn | SQL.Aliased, value: string | Placeholder | SQLWrapper): SQL {
-	return sql`${column} || ${bindIfParam(value, column)}`;
+	// `||` is not an operator in T-SQL. SQL Server concatenates with `+` or with concat(),
+	// and concat() is the one that does not need the operands cast to a string type first.
+	return sql`concat(${column}, ${bindIfParam(value, column)})`;
 }
 
 export function substring(
 	column: MsSqlColumn | SQL.Aliased,
 	{ from, for: _for }: { from?: number | Placeholder | SQLWrapper; for?: number | Placeholder | SQLWrapper },
 ): SQL {
-	const chunks: SQLChunk[] = [sql`substring(`, column];
-	if (from !== undefined) {
-		chunks.push(sql` from `, bindIfParam(from, column));
-	}
-	if (_for !== undefined) {
-		chunks.push(sql` for `, bindIfParam(_for, column));
-	}
-	chunks.push(sql`)`);
-	return sql.join(chunks);
+	// T-SQL has no `substring(x from y for z)` form, only `substring(x, start, length)`,
+	// and all three arguments are required. `substring` counts from 1, which is what an
+	// omitted `from` means, and a length of `len(x)` runs to the end of the string.
+	const start = from === undefined ? sql`1` : bindIfParam(from, column);
+	const length = _for === undefined ? sql`len(${column})` : bindIfParam(_for, column);
+	return sql`substring(${column}, ${start}, ${length})`;
 }

--- a/drizzle-orm/src/mysql-core/expressions.ts
+++ b/drizzle-orm/src/mysql-core/expressions.ts
@@ -6,7 +6,9 @@ import type { MySqlColumn } from './columns/index.ts';
 export * from '~/sql/expressions/index.ts';
 
 export function concat(column: MySqlColumn | SQL.Aliased, value: string | Placeholder | SQLWrapper): SQL {
-	return sql`${column} || ${bindIfParam(value, column)}`;
+	// `||` is logical OR in MySQL unless PIPES_AS_CONCAT is in sql_mode, so string
+	// concatenation has to go through concat().
+	return sql`concat(${column}, ${bindIfParam(value, column)})`;
 }
 
 export function substring(

--- a/drizzle-orm/src/singlestore-core/expressions.ts
+++ b/drizzle-orm/src/singlestore-core/expressions.ts
@@ -6,7 +6,9 @@ import type { SingleStoreColumn } from './columns/index.ts';
 export * from '~/sql/expressions/index.ts';
 
 export function concat(column: SingleStoreColumn | SQL.Aliased, value: string | Placeholder | SQLWrapper): SQL {
-	return sql`${column} || ${bindIfParam(value, column)}`;
+	// SingleStore follows MySQL here: `||` is logical OR unless PIPES_AS_CONCAT is in
+	// sql_mode, so string concatenation has to go through concat().
+	return sql`concat(${column}, ${bindIfParam(value, column)})`;
 }
 
 export function substring(

--- a/drizzle-orm/src/sqlite-core/expressions.ts
+++ b/drizzle-orm/src/sqlite-core/expressions.ts
@@ -13,12 +13,18 @@ export function substring(
 	column: SQLiteColumn | SQL.Aliased,
 	{ from, for: _for }: { from?: number | SQLWrapper; for?: number | SQLWrapper },
 ): SQL {
-	const chunks: SQLChunk[] = [sql`substring(`, column];
-	if (from !== undefined) {
-		chunks.push(sql` from `, bindIfParam(from, column));
+	// SQLite has no `substring(x from y for z)` form, only `substr(x, start, length)`.
+	// `substr` counts from 1, which is what an omitted `from` means.
+	const chunks: SQLChunk[] = [sql`substr(`, column];
+	if (from === undefined) {
+		if (_for !== undefined) {
+			chunks.push(sql`, 1`);
+		}
+	} else {
+		chunks.push(sql`, `, bindIfParam(from, column));
 	}
 	if (_for !== undefined) {
-		chunks.push(sql` for `, bindIfParam(_for, column));
+		chunks.push(sql`, `, bindIfParam(_for, column));
 	}
 	chunks.push(sql`)`);
 	return sql.join(chunks);

--- a/drizzle-orm/tests/dialect-expressions.test.ts
+++ b/drizzle-orm/tests/dialect-expressions.test.ts
@@ -1,0 +1,124 @@
+import { describe, test } from 'vitest';
+import { CockroachDialect } from '~/cockroach-core/dialect.ts';
+import { concat as cockroachConcat, substring as cockroachSubstring } from '~/cockroach-core/expressions.ts';
+import { cockroachTable, text as cockroachText } from '~/cockroach-core/index.ts';
+import { MsSqlDialect } from '~/mssql-core/dialect.ts';
+import { concat as msSqlConcat, substring as msSqlSubstring } from '~/mssql-core/expressions.ts';
+import { mssqlTable, text as msSqlText } from '~/mssql-core/index.ts';
+import { MySqlDialect } from '~/mysql-core/dialect.ts';
+import { concat as mySqlConcat, substring as mySqlSubstring } from '~/mysql-core/expressions.ts';
+import { mysqlTable, text as mySqlText } from '~/mysql-core/index.ts';
+import { PgDialect } from '~/pg-core/dialect.ts';
+import { concat as pgConcat, substring as pgSubstring } from '~/pg-core/expressions.ts';
+import { pgTable, text as pgText } from '~/pg-core/index.ts';
+import { SingleStoreDialect } from '~/singlestore-core/dialect.ts';
+import { concat as singleStoreConcat, substring as singleStoreSubstring } from '~/singlestore-core/expressions.ts';
+import { singlestoreTable, text as singleStoreText } from '~/singlestore-core/index.ts';
+import { SQLiteDialect } from '~/sqlite-core/dialect.ts';
+import { concat as sqliteConcat, substring as sqliteSubstring } from '~/sqlite-core/expressions.ts';
+import { sqliteTable, text as sqliteText } from '~/sqlite-core/index.ts';
+
+const pgUsers = pgTable('users', { name: pgText('name') });
+const cockroachUsers = cockroachTable('users', { name: cockroachText('name') });
+const mySqlUsers = mysqlTable('users', { name: mySqlText('name') });
+const singleStoreUsers = singlestoreTable('users', { name: singleStoreText('name') });
+const sqliteUsers = sqliteTable('users', { name: sqliteText('name') });
+const msSqlUsers = mssqlTable('users', { name: msSqlText('name') });
+
+describe.concurrent('concat by dialect', () => {
+	test('Pg uses the || operator', ({ expect }) => {
+		expect(new PgDialect().sqlToQuery(pgConcat(pgUsers.name, '!')).sql).toBe('"users"."name" || $1');
+	});
+
+	test('Cockroach uses the || operator', ({ expect }) => {
+		expect(new CockroachDialect().sqlToQuery(cockroachConcat(cockroachUsers.name, '!')).sql).toBe(
+			'"users"."name" || $1',
+		);
+	});
+
+	test('SQLite uses the || operator', ({ expect }) => {
+		expect(new SQLiteDialect().sqlToQuery(sqliteConcat(sqliteUsers.name, '!')).sql).toBe(
+			'"users"."name" || ?',
+		);
+	});
+
+	test('MySQL calls concat() instead of the || operator', ({ expect }) => {
+		const query = new MySqlDialect().sqlToQuery(mySqlConcat(mySqlUsers.name, '!'));
+		expect(query.sql).toBe('concat(`users`.`name`, ?)');
+		expect(query.params).toEqual(['!']);
+	});
+
+	test('SingleStore calls concat() instead of the || operator', ({ expect }) => {
+		const query = new SingleStoreDialect().sqlToQuery(singleStoreConcat(singleStoreUsers.name, '!'));
+		expect(query.sql).toBe('concat(`users`.`name`, ?)');
+		expect(query.params).toEqual(['!']);
+	});
+
+	test('MsSQL calls concat() instead of the || operator', ({ expect }) => {
+		const query = new MsSqlDialect().sqlToQuery(msSqlConcat(msSqlUsers.name, '!'));
+		expect(query.sql).toBe('concat([users].[name], @par0)');
+		expect(query.params).toEqual(['!']);
+	});
+});
+
+describe.concurrent('substring by dialect', () => {
+	test('Pg uses the from/for form', ({ expect }) => {
+		expect(new PgDialect().sqlToQuery(pgSubstring(pgUsers.name, { from: 2, for: 3 })).sql).toBe(
+			'substring("users"."name" from $1 for $2)',
+		);
+	});
+
+	test('Cockroach uses the from/for form', ({ expect }) => {
+		expect(
+			new CockroachDialect().sqlToQuery(cockroachSubstring(cockroachUsers.name, { from: 2, for: 3 })).sql,
+		).toBe('substring("users"."name" from $1 for $2)');
+	});
+
+	test('MySQL uses the from/for form', ({ expect }) => {
+		expect(new MySqlDialect().sqlToQuery(mySqlSubstring(mySqlUsers.name, { from: 2, for: 3 })).sql).toBe(
+			'substring(`users`.`name` from ? for ?)',
+		);
+	});
+
+	test('SingleStore uses the from/for form', ({ expect }) => {
+		expect(
+			new SingleStoreDialect().sqlToQuery(singleStoreSubstring(singleStoreUsers.name, { from: 2, for: 3 })).sql,
+		).toBe('substring(`users`.`name` from ? for ?)');
+	});
+
+	test('SQLite calls substr() with positional arguments', ({ expect }) => {
+		const query = new SQLiteDialect().sqlToQuery(sqliteSubstring(sqliteUsers.name, { from: 2, for: 3 }));
+		expect(query.sql).toBe('substr("users"."name", ?, ?)');
+		expect(query.params).toEqual([2, 3]);
+	});
+
+	test('SQLite omits the length when only from is given', ({ expect }) => {
+		const query = new SQLiteDialect().sqlToQuery(sqliteSubstring(sqliteUsers.name, { from: 7 }));
+		expect(query.sql).toBe('substr("users"."name", ?)');
+		expect(query.params).toEqual([7]);
+	});
+
+	test('SQLite starts at 1 when only for is given', ({ expect }) => {
+		const query = new SQLiteDialect().sqlToQuery(sqliteSubstring(sqliteUsers.name, { for: 5 }));
+		expect(query.sql).toBe('substr("users"."name", 1, ?)');
+		expect(query.params).toEqual([5]);
+	});
+
+	test('MsSQL calls substring() with positional arguments', ({ expect }) => {
+		const query = new MsSqlDialect().sqlToQuery(msSqlSubstring(msSqlUsers.name, { from: 2, for: 3 }));
+		expect(query.sql).toBe('substring([users].[name], @par0, @par1)');
+		expect(query.params).toEqual([2, 3]);
+	});
+
+	test('MsSQL runs to the end of the string when only from is given', ({ expect }) => {
+		const query = new MsSqlDialect().sqlToQuery(msSqlSubstring(msSqlUsers.name, { from: 7 }));
+		expect(query.sql).toBe('substring([users].[name], @par0, len([users].[name]))');
+		expect(query.params).toEqual([7]);
+	});
+
+	test('MsSQL starts at 1 when only for is given', ({ expect }) => {
+		const query = new MsSqlDialect().sqlToQuery(msSqlSubstring(msSqlUsers.name, { for: 5 }));
+		expect(query.sql).toBe('substring([users].[name], 1, @par0)');
+		expect(query.params).toEqual([5]);
+	});
+});


### PR DESCRIPTION
Two of the per-dialect expression helpers generate SQL that the dialect they belong to cannot execute.

This now targets `rc5` rather than `main`, since `rc5` is where code has been landing. Everything below reproduces on `rc5` unchanged, and `rc5` also carries `mssql-core`, which `main` does not have and which has both problems at once.

## MySQL and SingleStore `concat()`

`drizzle-orm/src/mysql-core/expressions.ts:9` and `drizzle-orm/src/singlestore-core/expressions.ts:9` both build `concat()` as ``sql`${column} || ${bindIfParam(value, column)}` ``. In MySQL's default `sql_mode`, `||` is logical OR, not string concatenation: pipe concatenation only happens when `PIPES_AS_CONCAT` is enabled. So `concat(users.name, '!')` renders as `` `users`.`name` || ? ``, MySQL evaluates both sides as booleans, and the column comes back as `0` or `1` instead of the concatenated string. SingleStore inherits the same MySQL semantics. Both now render `` concat(`users`.`name`, ?) ``, which is correct under any `sql_mode`.

## SQLite `substring()`

`drizzle-orm/src/sqlite-core/expressions.ts:16-22` builds `substring()` as `substring(x from a for b)`. SQLite has no from/for form of `substring` at all, so that string is a parse error on every SQLite backend, not a wrong result. Running the generated statement against SQLite 3.51.3 gives `near "from": syntax error`, and the from-only and for-only variants fail the same way.

It now renders `substr(x, a, b)`. `substr` counts from 1, so `{ for: 5 }` with no `from` becomes `substr(x, 1, ?)`, and `{ from: 7 }` alone becomes `substr(x, ?)`. I used `substr` rather than `substring` because `substring` was only added as an alias in SQLite 3.34.0, while `substr` has always been there.

## SQL Server `concat()` and `substring()`

`drizzle-orm/src/mssql-core/expressions.ts:15` builds `concat()` with `||` and `drizzle-orm/src/mssql-core/expressions.ts:22-28` builds `substring()` with the from/for form. T-SQL has neither. `||` is not an operator in T-SQL, so the helper emits `[users].[name] || @par0`, which SQL Server cannot parse. `SUBSTRING` in T-SQL is `SUBSTRING(expression, start, length)` with all three arguments required and no from/for form, so `substring([users].[name] from @par0 for @par1)` cannot be parsed either.

`concat()` now renders `concat([users].[name], @par0)`. SQL Server does also concatenate with `+`, but `+` requires both operands to already be a string type and would need a cast added for anything else, while `CONCAT` converts its arguments itself. The commented-out variadic sketch at the top of that same file already assumes a comma-separated `CONCAT`, and `integration-tests/tests/mssql/mssql.test.ts:3912` hand-writes `concat(...)` in raw SQL against a real SQL Server, so this is the form the codebase already expects.

`substring()` now renders `substring([users].[name], @par0, @par1)`. Because all three arguments are required, a missing `from` becomes `1` and a missing `for` becomes `len([users].[name])`, which reaches the end of the string. One detail worth your eye: `len()` ignores trailing spaces, so `{ from: 1 }` on a value ending in spaces returns it without them. `datalength()` would keep them but returns bytes rather than characters, which reads oddly in generated SQL. Say the word and I will switch it.

## Sibling dialects

I checked all six dialects that have an `expressions.ts` on `rc5` before changing anything, and the new test file pins the rendering for each of them so the untouched ones stay untouched.

| dialect | `concat` | `substring` |
| --- | --- | --- |
| pg | `\|\|` is string concatenation in Postgres, unchanged | Postgres accepts from/for, unchanged |
| cockroach | same as pg, unchanged | same as pg, unchanged |
| sqlite | `\|\|` is string concatenation in SQLite, unchanged | **fixed**, from/for is not SQLite syntax |
| mysql | **fixed**, `\|\|` is logical OR | MySQL accepts `SUBSTRING(str FROM pos FOR len)`, unchanged |
| singlestore | **fixed**, same as MySQL | same as MySQL, unchanged |
| mssql | **fixed**, `\|\|` is not a T-SQL operator | **fixed**, T-SQL has no from/for form |

Nothing inside the repo calls these two helpers, so no existing test moves. `integration-tests/tests/singlestore/common-2.ts:71` imports `dotProduct` and `euclideanDistance` from `singlestore-core/expressions`, and neither is touched. `drizzle-orm/scripts/build.ts` generates an `exports` entry for every `src/**/*.ts`, so `drizzle-orm/mysql-core/expressions` and its siblings are published subpaths and these helpers are public API.

## Verification

`drizzle-orm/tests/dialect-expressions.test.ts`, 16 tests, no database needed. Reverting only the four `src/` files fails 9 of them: the three `concat` cases, the three SQLite `substr` cases and the three SQL Server `substring` cases. The other 7 pass either way, which is the point of including them.

`vitest run` in `drizzle-orm`: 28 files, 1377 passed and 7 skipped, all green with this change. The 7 skips are pre-existing and unrelated, 4 in `exports-resolution.test.ts` which want a built artifact and 3 in `sql-builder.test.ts`. `cd type-tests && tsc` exits 0. `dprint check --list-different` reports no differences on the five files, and `oxlint --max-warnings=0` is clean on them.

I ran the old and new SQLite output against a real SQLite 3.51.3 engine on a table holding the single row `drizzle`. The three old statements are all syntax errors, while `substr("users"."name", 2, 3)`, `substr("users"."name", 2)` and `substr("users"."name", 1, 3)` return `riz`, `rizzle` and `dri`.

The MySQL, SingleStore and SQL Server claims rest on documented behaviour rather than on a local engine run, since I have no instance of any of the three to hand. What I did check locally for those is the rendered SQL, which is what this change controls.

I left `changelogs/` alone since those look release-scoped. Happy to add an entry wherever you want it.
