### PR TITLE
[mysql]: add buffer mode to binary and varbinary columns

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -2,6 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
+import type { Equal } from '~/utils.ts';
 import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
@@ -58,19 +59,72 @@ export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> ex
 	}
 }
 
-export interface MySqlBinaryConfig {
+export type MySqlBinaryBufferBuilderInitial<TName extends string> = MySqlBinaryBufferBuilder<{
+	name: TName;
+	dataType: 'buffer';
+	columnType: 'MySqlBinaryBuffer';
+	data: Buffer;
+	driverParam: Buffer;
+	enumValues: undefined;
+}>;
+
+export class MySqlBinaryBufferBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinaryBuffer'>>
+	extends MySqlColumnBuilder<T, MySqlBinaryConfig>
+{
+	static override readonly [entityKind]: string = 'MySqlBinaryBufferBuilder';
+
+	constructor(name: T['name'], length: number | undefined) {
+		super(name, 'buffer', 'MySqlBinaryBuffer');
+		this.config.length = length;
+	}
+
+	/** @internal */
+	override build<TTableName extends string>(
+		table: AnyMySqlTable<{ name: TTableName }>,
+	): MySqlBinaryBuffer<MakeColumnConfig<T, TTableName>> {
+		return new MySqlBinaryBuffer<MakeColumnConfig<T, TTableName>>(
+			table,
+			this.config as ColumnBuilderRuntimeConfig<any, any>,
+		);
+	}
+}
+
+export class MySqlBinaryBuffer<T extends ColumnBaseConfig<'buffer', 'MySqlBinaryBuffer'>> extends MySqlColumn<
+	T,
+	MySqlBinaryConfig
+> {
+	static override readonly [entityKind]: string = 'MySqlBinaryBuffer';
+
+	length: number | undefined = this.config.length;
+
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'binary');
+		return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+	}
+
+	getSQLType(): string {
+		return this.length === undefined ? `binary` : `binary(${this.length})`;
+	}
+}
+
+export interface MySqlBinaryConfig<TMode extends 'string' | 'buffer' = 'string' | 'buffer'> {
 	length?: number;
+	mode?: TMode;
 }
 
 export function binary(): MySqlBinaryBuilderInitial<''>;
-export function binary(
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<''>;
-export function binary<TName extends string>(
+export function binary<TMode extends 'string' | 'buffer' = 'string'>(
+	config?: MySqlBinaryConfig<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<''> : MySqlBinaryBuilderInitial<''>;
+export function binary<TName extends string, TMode extends 'string' | 'buffer' = 'string'>(
 	name: TName,
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<TName>;
+	config?: MySqlBinaryConfig<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<TName> : MySqlBinaryBuilderInitial<TName>;
 export function binary(a?: string | MySqlBinaryConfig, b: MySqlBinaryConfig = {}) {
 	const { name, config } = getColumnNameAndConfig<MySqlBinaryConfig>(a, b);
+	if (config.mode === 'buffer') {
+		return new MySqlBinaryBufferBuilder(name, config.length);
+	}
 	return new MySqlBinaryBuilder(name, config.length);
 }

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -2,6 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
+import type { Equal } from '~/utils.ts';
 import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
@@ -60,18 +61,71 @@ export class MySqlVarBinary<
 	}
 }
 
-export interface MySqlVarbinaryOptions {
-	length: number;
+export type MySqlVarBinaryBufferBuilderInitial<TName extends string> = MySqlVarBinaryBufferBuilder<{
+	name: TName;
+	dataType: 'buffer';
+	columnType: 'MySqlVarBinaryBuffer';
+	data: Buffer;
+	driverParam: Buffer;
+	enumValues: undefined;
+}>;
+
+export class MySqlVarBinaryBufferBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarBinaryBuffer'>>
+	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
+{
+	static override readonly [entityKind]: string = 'MySqlVarBinaryBufferBuilder';
+
+	/** @internal */
+	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
+		super(name, 'buffer', 'MySqlVarBinaryBuffer');
+		this.config.length = config?.length;
+	}
+
+	/** @internal */
+	override build<TTableName extends string>(
+		table: AnyMySqlTable<{ name: TTableName }>,
+	): MySqlVarBinaryBuffer<MakeColumnConfig<T, TTableName>> {
+		return new MySqlVarBinaryBuffer<MakeColumnConfig<T, TTableName>>(
+			table,
+			this.config as ColumnBuilderRuntimeConfig<any, any>,
+		);
+	}
 }
 
-export function varbinary(
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<''>;
-export function varbinary<TName extends string>(
+export class MySqlVarBinaryBuffer<
+	T extends ColumnBaseConfig<'buffer', 'MySqlVarBinaryBuffer'>,
+> extends MySqlColumn<T, MySqlVarbinaryOptions> {
+	static override readonly [entityKind]: string = 'MySqlVarBinaryBuffer';
+
+	length: number | undefined = this.config.length;
+
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'binary');
+		return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+	}
+
+	getSQLType(): string {
+		return this.length === undefined ? `varbinary` : `varbinary(${this.length})`;
+	}
+}
+
+export interface MySqlVarbinaryOptions<TMode extends 'string' | 'buffer' = 'string' | 'buffer'> {
+	length: number;
+	mode?: TMode;
+}
+
+export function varbinary<TMode extends 'string' | 'buffer' = 'string'>(
+	config: MySqlVarbinaryOptions<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<''> : MySqlVarBinaryBuilderInitial<''>;
+export function varbinary<TName extends string, TMode extends 'string' | 'buffer' = 'string'>(
 	name: TName,
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<TName>;
+	config: MySqlVarbinaryOptions<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<TName> : MySqlVarBinaryBuilderInitial<TName>;
 export function varbinary(a?: string | MySqlVarbinaryOptions, b?: MySqlVarbinaryOptions) {
 	const { name, config } = getColumnNameAndConfig<MySqlVarbinaryOptions>(a, b);
+	if (config.mode === 'buffer') {
+		return new MySqlVarBinaryBufferBuilder(name, config);
+	}
 	return new MySqlVarBinaryBuilder(name, config);
 }

--- a/drizzle-orm/type-tests/mysql/binary-mode.ts
+++ b/drizzle-orm/type-tests/mysql/binary-mode.ts
@@ -1,0 +1,54 @@
+import { type Equal, Expect } from 'type-tests/utils.ts';
+import { binary, mysqlTable, varbinary } from '~/mysql-core/index.ts';
+
+// Default mode ('string') must be unchanged — backwards compatibility.
+{
+	const table = mysqlTable('binary_string_mode', {
+		bin: binary('bin', { length: 16 }),
+		binNoConfig: binary('bin_no_config'),
+		varbin: varbinary('varbin', { length: 16 }),
+	});
+
+	Expect<Equal<string | null, typeof table.$inferSelect.bin>>;
+	Expect<Equal<string | null, typeof table.$inferSelect.binNoConfig>>;
+	Expect<Equal<string | null, typeof table.$inferSelect.varbin>>;
+}
+
+// Explicit string mode behaves like the default.
+{
+	const table = mysqlTable('binary_explicit_string_mode', {
+		bin: binary('bin', { length: 16, mode: 'string' }),
+		varbin: varbinary('varbin', { length: 16, mode: 'string' }),
+	});
+
+	Expect<Equal<string | null, typeof table.$inferSelect.bin>>;
+	Expect<Equal<string | null, typeof table.$inferSelect.varbin>>;
+}
+
+// Buffer mode — the point of the fix. Non-UTF8 bytes must stay Buffers.
+{
+	const table = mysqlTable('binary_buffer_mode', {
+		bin: binary('bin', { length: 16, mode: 'buffer' }),
+		varbin: varbinary('varbin', { length: 16, mode: 'buffer' }),
+	});
+
+	Expect<Equal<Buffer | null, typeof table.$inferSelect.bin>>;
+	Expect<Equal<Buffer | null, typeof table.$inferSelect.varbin>>;
+	Expect<Equal<Buffer | null | undefined, typeof table.$inferInsert.bin>>;
+	Expect<Equal<Buffer | null | undefined, typeof table.$inferInsert.varbin>>;
+}
+
+// Anonymous (nameless) column form must support mode too.
+{
+	const table = mysqlTable('binary_anonymous', {
+		bin: binary({ length: 16, mode: 'buffer' }),
+		varbin: varbinary({ length: 16, mode: 'buffer' }),
+		binStr: binary({ length: 16 }),
+		varbinStr: varbinary({ length: 16 }),
+	});
+
+	Expect<Equal<Buffer | null, typeof table.$inferSelect.bin>>;
+	Expect<Equal<Buffer | null, typeof table.$inferSelect.varbin>>;
+	Expect<Equal<string | null, typeof table.$inferSelect.binStr>>;
+	Expect<Equal<string | null, typeof table.$inferSelect.varbinStr>>;
+}


### PR DESCRIPTION
Closes #1188.

## The problem

`binary` and `varbinary` MySQL columns are hardcoded to `dataType: 'string'`, and `mapFromDriverValue` calls `Buffer#toString()` on whatever the driver returns. For any value that isn't valid UTF-8, that is lossy — the bytes are destroyed on read.

Reproduced against the current `mapFromDriverValue` implementations:

```
input bytes      : deadbeef
string mode out  : deadefbfbdefbfbd   <- 0xBE and 0xEF replaced with U+FFFD
buffer mode out  : deadbeef           <- lossless
```

This affects the common uses of these column types: UUIDs stored as `binary(16)`, hashes, encrypted blobs, and packed identifiers. `mysql2` already hands back a `Buffer`; drizzle converts it to a lossy string and types it as `string`.

## The change

Adds an opt-in `mode` option to both columns, following the pattern already used by `bigint`, `timestamp` and (in the SQLite dialect) `blob`:

```ts
// unchanged, still string
uuid: binary('uuid', { length: 16 })

// new: preserves bytes
uuid: binary('uuid', { length: 16, mode: 'buffer' })
hash: varbinary('hash', { length: 32, mode: 'buffer' })
```

- `mode: 'string'` remains the default, so **no existing schema changes behaviour**.
- `mode: 'buffer'` gives `dataType: 'buffer'`, infers `Buffer` on select/insert, and returns the driver value without conversion.
- Both the named (`binary('col', {...})`) and anonymous (`binary({...})`) forms accept `mode`.
- `getSQLType()` output is identical in both modes, so no migration is generated for existing tables.

## Files

- `drizzle-orm/src/mysql-core/columns/binary.ts` — adds `MySqlBinaryBufferBuilder` / `MySqlBinaryBuffer`, `mode` in `MySqlBinaryConfig`, overload signatures
- `drizzle-orm/src/mysql-core/columns/varbinary.ts` — same for varbinary
- `drizzle-orm/type-tests/mysql/binary-mode.ts` — new type tests

## Tests

`drizzle-orm/type-tests/mysql/binary-mode.ts` covers four cases:

1. default mode still infers `string | null` (backwards compatibility)
2. explicit `mode: 'string'` matches the default
3. `mode: 'buffer'` infers `Buffer | null` on select and `Buffer | null | undefined` on insert
4. the anonymous column form supports `mode` in both variants

`tsc --noEmit -p tsconfig.json` reports no errors in the changed files or the new type test. (The repo has some pre-existing errors in unrelated files — `scripts/fix-imports.ts`, `src/node-postgres/session.ts`, `src/mysql2/session.ts` — which are untouched by this PR.)

I wasn't able to run the MySQL integration suite here as it needs a live MySQL/PlanetScale instance; happy to add an integration test in `integration-tests/tests/mysql/mysql-common.ts` if you'd like one alongside the type tests.

## Note on authorship

This patch was written with AI assistance (Claude). I've reviewed the diff, verified the failure mode and the fix at runtime, and confirmed the type tests pass. Flagging it because the project deserves to know how a contribution was produced — happy to make any changes you'd prefer in style or approach.
