### PR TITLE
Fix nested partial select returning null on left join when first column value is null (#1603)

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							value !== null
+							|| (typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table))
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/integration-tests/tests/sqlite/sqlite-common.ts
+++ b/integration-tests/tests/sqlite/sqlite-common.ts
@@ -810,6 +810,52 @@ export function tests() {
 			}]);
 		});
 
+		test('left join with nested select where first column value is null', async (ctx) => {
+			const { db } = ctx.sqlite;
+
+			await db.insert(usersTable).values([{ id: 1, name: 'John' }]).run();
+			await db.insert(users2Table).values([{ id: 1, name: 'John', cityId: null }]).run();
+
+			const result = await db
+				.select({
+					name: usersTable.name,
+					details: {
+						cityId: users2Table.cityId,
+						name: users2Table.name,
+					},
+				})
+				.from(usersTable)
+				.leftJoin(users2Table, eq(users2Table.id, usersTable.id))
+				.all();
+
+			expect(result).toEqual([{
+				name: 'John',
+				details: { cityId: null, name: 'John' },
+			}]);
+		});
+
+		test('left join with nested select where all column values are null', async (ctx) => {
+			const { db } = ctx.sqlite;
+
+			await db.insert(usersTable).values([{ id: 1, name: 'John' }]).run();
+			await db.insert(users2Table).values([{ id: 1, name: 'John', cityId: null }]).run();
+
+			const result = await db
+				.select({
+					city: {
+						id: citiesTable.id,
+						name: citiesTable.name,
+					},
+				})
+				.from(users2Table)
+				.leftJoin(citiesTable, eq(citiesTable.id, users2Table.cityId))
+				.all();
+
+			expect(result).toEqual([{
+				city: null,
+			}]);
+		});
+
 		test('full join with alias', async (ctx) => {
 			const { db } = ctx.sqlite;
 


### PR DESCRIPTION
/claim #1603

Fixes #1603. On a left join with a nested partial select, the nested object was nullified whenever its first column was null, even when later columns were non-null.

In `mapResultRow` (`drizzle-orm/src/utils.ts`) the first null field marks the object as a nullification candidate, and that candidate was never cleared by later non-null fields. This change clears the candidate as soon as any later field is non-null. One line.

Two regression tests in `integration-tests/tests/sqlite/sqlite-common.ts`: the new case fails without the fix and passes with it.