### PR TITLE
fix(orm): keep nested left-join object when a later column has a value (fixes #1603)

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -45,11 +45,15 @@ export function mapResultRow<TResult>(
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;
-						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
-						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
-						) {
+						const tableName = getTableName(field.table);
+
+						if (value !== null) {
+							// A non-null column proves the joined row exists — do not nullify
+							// the nested object, regardless of which of its columns was read first.
+							nullifyMap[objectName] = false;
+						} else if (!(objectName in nullifyMap)) {
+							nullifyMap[objectName] = tableName;
+						} else if (typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== tableName) {
 							nullifyMap[objectName] = false;
 						}
 					}

--- a/drizzle-orm/tests/map-result-row.test.ts
+++ b/drizzle-orm/tests/map-result-row.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from 'vitest';
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow } from '~/utils.ts';
+
+const orgs = pgTable('orgs', {
+	id: text('id'),
+	name: text('name'),
+});
+
+const orgBranding = pgTable('org_branding', {
+	orgId: text('org_id'),
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+const selection = [
+	{ path: ['name'], field: orgs.name },
+	{ path: ['branding', 'logo'], field: orgBranding.logo },
+	{ path: ['branding', 'panelBackground'], field: orgBranding.panelBackground },
+];
+
+// `orgs` is the base table; `org_branding` is left joined, so it is nullable.
+const leftJoined = { orgs: true, org_branding: false };
+
+describe.concurrent('mapResultRow nested partial select', () => {
+	it('keeps the joined object when a later column has a value', ({ expect }) => {
+		const result = mapResultRow(selection, ['Test org', null, '#1a8cff'], leftJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { logo: null, panelBackground: '#1a8cff' },
+		});
+	});
+
+	it('does not depend on which column of the object is selected first', ({ expect }) => {
+		const swapped = [
+			{ path: ['name'], field: orgs.name },
+			{ path: ['branding', 'panelBackground'], field: orgBranding.panelBackground },
+			{ path: ['branding', 'logo'], field: orgBranding.logo },
+		];
+
+		const result = mapResultRow(swapped, ['Test org', '#1a8cff', null], leftJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { panelBackground: '#1a8cff', logo: null },
+		});
+	});
+
+	it('still nullifies the object when the join matched no row', ({ expect }) => {
+		const result = mapResultRow(selection, ['Test org', null, null], leftJoined);
+
+		expect(result).toEqual({ name: 'Test org', branding: null });
+	});
+
+	it('keeps an object from a non-nullable join even when every column is null', ({ expect }) => {
+		const innerJoined = { orgs: true, org_branding: true };
+		const result = mapResultRow(selection, ['Test org', null, null], innerJoined);
+
+		expect(result).toEqual({
+			name: 'Test org',
+			branding: { logo: null, panelBackground: null },
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1603
/claim #1603

When a nested partial select is combined with a `leftJoin`, `mapResultRow` nullifies the whole nested object if the **first** selected column of that object is `NULL`, even when a later same-table column has a non-null value.

**Root cause:** in `nullifyMap` (`drizzle-orm/src/utils.ts`), the path-length-2 branch only cleared the nullify flag when a *different* table appeared — not when a later column from the *same* table was non-null.

**Fix:** if any selected column for the nested object is non-null, clear `nullifyMap[objectName]` so the object is kept. Behavior when every selected column is null (true unmatched left join) is unchanged.

## Tests

Added `drizzle-orm/tests/map-result-row.test.ts` covering:
- later non-null column keeps the nested object (including when the first column is null)
- column order independence
- full null still nullifies for nullable joins
- non-nullable joins keep the object even when all selected columns are null

```
vitest run tests/map-result-row.test.ts  →  4 passed
```

## Scope

Minimal change only (path length === 2). Depth > 1 / #6246 is out of scope.