### PR TITLE
fix(orm): preserve nested partial select on left join when first column is null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -48,7 +48,8 @@ export function mapResultRow<TResult>(
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'vitest';
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+// Regression tests for https://github.com/drizzle-team/drizzle-orm/issues/1603
+//
+// Bug: a nested partial-select object built from a left-joined (nullable) table
+// was incorrectly nulled out whenever the FIRST column read for that object
+// happened to be null, even if a LATER column from the same table was non-null.
+// The fix makes `mapResultRow` only nullify the nested object when every one
+// of its own columns is null.
+
+const orgBrandingTable = pgTable('org_branding', {
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+test('keeps nested object when first column is null but a later column is non-null', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(columns, [null, '#1a8cff'], { org_branding: false });
+
+	expect(result).toEqual({
+		branding: { logo: null, panelBackground: '#1a8cff' },
+	});
+});
+
+test('is independent of column order (last column null, first non-null)', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			panelBackground: orgBrandingTable.panelBackground,
+			logo: orgBrandingTable.logo,
+		},
+	});
+
+	const result = mapResultRow(columns, ['#1a8cff', null], { org_branding: false });
+
+	expect(result).toEqual({
+		branding: { panelBackground: '#1a8cff', logo: null },
+	});
+});
+
+test('still nullifies the nested object when every column is null and the join is nullable', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(columns, [null, null], { org_branding: false });
+
+	expect(result).toEqual({ branding: null });
+});
+
+test('keeps the nested object when every column is null but the join is not nullable', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(columns, [null, null], { org_branding: true });
+
+	expect(result).toEqual({ branding: { logo: null, panelBackground: null } });
+});


### PR DESCRIPTION
## Summary

Fixes #1603. With a `leftJoin` and a nested partial select, the whole nested object was incorrectly nulled out whenever the *first* selected column belonging to that object happened to be `null`, even when a *later* column from the same joined table had a real, non-null value. Swapping the field order "fixed" it, which is what gave away that only the first column was ever checked.

## Root cause

`mapResultRow` in `drizzle-orm/src/utils.ts` builds a `nullifyMap` while walking the selected columns: for a nested (`path.length === 2`) column coming from a nullable join, the first column seen for that nested object sets `nullifyMap[objectName]` to the table name if its value is `null`, or to `false` otherwise. The `else if` branch that is meant to clear that pending nullification only fired when a later column came from a **different** table (`nullifyMap[objectName] !== tableName`): it never checked whether a later column from the **same** table was non-null. So once the first-seen column for an object was null, nothing could undo that, regardless of what other columns in the same nested object contained.

## Fix

Two-line change in that `else if` guard: also clear the pending nullification when the current column's `value !== null`, not only when it comes from a different table:

```ts
} else if (
    typeof nullifyMap[objectName] === 'string'
    && (nullifyMap[objectName] !== getTableName(field.table) || value !== null)
) {
    nullifyMap[objectName] = false;
}
```

The final nullify pass (which sets the object to `null` only when every one of its columns was null and the join is nullable) is unchanged: a genuinely unmatched left join still collapses correctly to `null`.

## Test

Added `drizzle-orm/tests/utils.test.ts`, a unit test suite against `mapResultRow`/`orderSelectedFields` directly (no DB needed), asserting:
- the nested object is kept, with the null field preserved as `null`, when the first column is null but a later column is non-null (the exact issue repro)
- the same holds independent of column order
- the nested object still becomes `null` when every one of its columns is null and the join is nullable (no regression)
- the nested object is kept with all-null values when the join is *not* nullable (existing behavior preserved)

Ran `pnpm vitest run` inside `drizzle-orm/`: all 14 test files / 570 tests pass, including the 4 new ones. Confirmed the new "first column null" test fails on `main` and passes with this fix.

/claim #1603
