### PR TITLE
[Pg]: Support exact optional policy and role configs

### DIFF
--- a/drizzle-orm/src/cockroach-core/policies.ts
+++ b/drizzle-orm/src/cockroach-core/policies.ts
@@ -12,11 +12,11 @@ export type CockroachPolicyToOption =
 	| CockroachRole;
 
 export interface CockroachPolicyConfig {
-	as?: 'permissive' | 'restrictive';
-	for?: 'all' | 'select' | 'insert' | 'update' | 'delete';
-	to?: CockroachPolicyToOption;
-	using?: SQL;
-	withCheck?: SQL;
+	as?: 'permissive' | 'restrictive' | undefined;
+	for?: 'all' | 'select' | 'insert' | 'update' | 'delete' | undefined;
+	to?: CockroachPolicyToOption | undefined;
+	using?: SQL | undefined;
+	withCheck?: SQL | undefined;
 }
 
 export class CockroachPolicy implements CockroachPolicyConfig {

--- a/drizzle-orm/src/cockroach-core/roles.ts
+++ b/drizzle-orm/src/cockroach-core/roles.ts
@@ -1,8 +1,8 @@
 import { entityKind } from '~/entity.ts';
 
 export interface CockroachRoleConfig {
-	createDb?: boolean;
-	createRole?: boolean;
+	createDb?: boolean | undefined;
+	createRole?: boolean | undefined;
 }
 
 export class CockroachRole implements CockroachRoleConfig {

--- a/drizzle-orm/src/pg-core/policies.ts
+++ b/drizzle-orm/src/pg-core/policies.ts
@@ -13,11 +13,11 @@ export type PgPolicyToOption =
 	| PgRole;
 
 export interface PgPolicyConfig {
-	as?: 'permissive' | 'restrictive';
-	for?: 'all' | 'select' | 'insert' | 'update' | 'delete';
-	to?: PgPolicyToOption;
-	using?: SQL;
-	withCheck?: SQL;
+	as?: 'permissive' | 'restrictive' | undefined;
+	for?: 'all' | 'select' | 'insert' | 'update' | 'delete' | undefined;
+	to?: PgPolicyToOption | undefined;
+	using?: SQL | undefined;
+	withCheck?: SQL | undefined;
 }
 
 export class PgPolicy implements PgPolicyConfig {

--- a/drizzle-orm/src/pg-core/roles.ts
+++ b/drizzle-orm/src/pg-core/roles.ts
@@ -1,9 +1,9 @@
 import { entityKind } from '~/entity.ts';
 
 export interface PgRoleConfig {
-	createDb?: boolean;
-	createRole?: boolean;
-	inherit?: boolean;
+	createDb?: boolean | undefined;
+	createRole?: boolean | undefined;
+	inherit?: boolean | undefined;
 }
 
 export class PgRole implements PgRoleConfig {

--- a/drizzle-orm/type-tests/exact-optional/policy-role-config.ts
+++ b/drizzle-orm/type-tests/exact-optional/policy-role-config.ts
@@ -1,0 +1,31 @@
+import { sql } from 'drizzle-orm';
+import { cockroachPolicy, cockroachRole } from 'drizzle-orm/cockroach-core';
+import { pgPolicy, pgRole } from 'drizzle-orm/pg-core';
+
+pgPolicy('policy', {
+	as: undefined,
+	for: undefined,
+	to: undefined,
+	using: undefined,
+	withCheck: undefined,
+});
+pgRole('role', { createDb: undefined, createRole: undefined, inherit: undefined });
+
+cockroachPolicy('policy', {
+	as: undefined,
+	for: undefined,
+	to: undefined,
+	using: undefined,
+	withCheck: undefined,
+});
+cockroachRole('role', { createDb: undefined, createRole: undefined });
+
+pgPolicy('policy', { as: 'restrictive', for: 'select', using: sql`true` });
+cockroachPolicy('policy', { as: 'permissive', for: 'all', withCheck: sql`true` });
+pgRole('role', { createDb: true, createRole: false, inherit: true });
+cockroachRole('role', { createDb: false, createRole: true });
+
+// @ts-expect-error invalid policy mode
+pgPolicy('policy', { as: 'invalid' });
+// @ts-expect-error role flags must be boolean
+cockroachRole('role', { createDb: 'true' });

--- a/drizzle-orm/type-tests/exact-optional/tsconfig.json
+++ b/drizzle-orm/type-tests/exact-optional/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"exactOptionalPropertyTypes": true,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"noEmit": true,
+		"skipLibCheck": false,
+		"strict": true
+	},
+	"include": ["./policy-role-config.ts"]
+}


### PR DESCRIPTION
## Summary

- allow explicit `undefined` in PostgreSQL and CockroachDB policy and role config fields
- preserve the policy and role classes' `implements` contracts with `exactOptionalPropertyTypes`
- add a focused strict consumer fixture covering all 15 fields and invalid literal/boolean values

## Reproduction

With declarations built from the base commit, TypeScript reports one `TS2420` for each policy or role class under:

```json
{
  "exactOptionalPropertyTypes": true,
  "skipLibCheck": false,
  "strict": true
}
```

For example, `PgPolicy.as` is declared as `PgPolicyConfig['as']`, which includes `undefined`, while an optional `PgPolicyConfig.as` does not accept a present `undefined` value with exact optional properties enabled.

The change explicitly includes `undefined` in the 15 affected interface fields. Valid policy literals and boolean role flags remain narrow. This is type-only and does not change constructors, emitted JavaScript, SQL generation, or defaults.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build` in `drizzle-orm`
- `pnpm test:types` in `drizzle-orm`
- `pnpm exec tsc -p drizzle-orm/type-tests/exact-optional/tsconfig.json --pretty false`
- `pnpm lint`
- packed `drizzle-orm` consumer with TypeScript 7.0.2, `strict`, `exactOptionalPropertyTypes: true`, and `skipLibCheck: false`

Before the source change, the focused built-declaration consumer produced the four expected `TS2420` diagnostics in `pg-core` and `cockroach-core` policies and roles. After the change it compiles without diagnostics, including all 15 explicit-`undefined` fields and negative invalid-literal/boolean assertions.
