### PR TITLE
fix(orm): don't nullify nested partial-select object when a later column is non-null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -47,6 +47,10 @@ export function mapResultRow<TResult>(
 						const objectName = path[0]!;
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
+						} else if (value !== null) {
+							// A non-null value proves the joined row exists, so the object
+							// must never be nullified even if earlier fields were null.
+							nullifyMap[objectName] = false;
 						} else if (
 							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
 						) {

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from 'vitest';
+import { integer, pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+// Regression tests for https://github.com/drizzle-team/drizzle-orm/issues/1603
+//
+// Bug: a nested partial-select object built from a left-joined (nullable) table
+// was incorrectly nullified whenever the FIRST column read for that object was
+// null, even if a LATER column from the same table had a non-null value. The
+// nullability decision now reflects whether any column has a non-null value
+// (i.e. whether the joined row exists), not just the first field's value.
+
+const orgTable = pgTable('org', {
+	id: integer('id'),
+	name: text('name'),
+	slug: text('slug'),
+});
+
+const orgBrandingTable = pgTable('org_branding', {
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
+});
+
+test('keeps nested object when the first column is null but a later column is not', () => {
+	const columns = orderSelectedFields({
+		name: orgTable.name,
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	// the exact scenario from the issue: logo is null in the database,
+	// panel_background_colour is '#1a8cff'
+	const result = mapResultRow(
+		columns,
+		['Test org 2', null, '#1a8cff'],
+		{ org: true, org_branding: false },
+	);
+
+	expect(result).toEqual({
+		name: 'Test org 2',
+		branding: { logo: null, panelBackground: '#1a8cff' },
+	});
+});
+
+test('is independent of column order (first column non-null, last column null)', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			panelBackground: orgBrandingTable.panelBackground,
+			logo: orgBrandingTable.logo,
+		},
+	});
+
+	const result = mapResultRow(columns, ['#1a8cff', null], { org_branding: false });
+
+	expect(result).toEqual({
+		branding: { panelBackground: '#1a8cff', logo: null },
+	});
+});
+
+test('keeps the nested object when the joined row matched (all columns non-null)', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(columns, ['logo.png', '#1a8cff'], { org_branding: false });
+
+	expect(result).toEqual({
+		branding: { logo: 'logo.png', panelBackground: '#1a8cff' },
+	});
+});
+
+test('still nullifies the nested object when every column is null and the join is nullable', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(columns, [null, null], { org_branding: false });
+
+	expect(result).toEqual({ branding: null });
+});
+
+test('keeps all-null nested object when the join is not nullable', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(columns, [null, null], { org_branding: true });
+
+	expect(result).toEqual({ branding: { logo: null, panelBackground: null } });
+});


### PR DESCRIPTION
Closes #1603
/claim #1603

> **Disclosure:** This PR was authored by [@Furox-Art](https://github.com/Furox-Art) (AI-assisted). Happy to adjust anything — I know there are several other attempts on this issue.

## Root cause

In `mapResultRow` (`drizzle-orm/src/utils.ts`), the `nullifyMap` candidate for a
nested left-join object was only cleared when a subsequent column belonged to a
**different table**:

```ts
} else if (
	typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
) {
	nullifyMap[objectName] = false;
}
```

A **non-null** value from the *same* table never cleared the candidate. So when
the first selected column of a left-joined table was `NULL` in the database
while a later column had a value, the candidate survived and the whole nested
object was incorrectly set to `null` — exactly the report in #1603
(`branding: null` instead of `branding: { logo: null, panelBackground: '#1a8cff' }`,
flipping the field order "fixed" it).

## Change

Any non-null value now clears the candidate: the nested object is nullified only
when **every** selected column of the joined table is null **and** the join is
actually nullable. All existing semantics are preserved:

| scenario | before | after |
|---|---|---|
| first col null, later col non-null (left join) | ❌ object nulled | ✅ object kept |
| first col non-null, later col null | ✅ kept | ✅ kept |
| all cols null, nullable join | ✅ null | ✅ null |
| all cols null, non-nullable join | ✅ kept | ✅ kept |
| all cols non-null | ✅ kept | ✅ kept |

## Tests

Adds `drizzle-orm/tests/utils.test.ts` with 5 regression tests covering the
issue scenario (including the exact query from the report), column-order
independence, the matched-row case, and both no-regression nullification cases.
All 5 pass (`bun test tests/utils.test.ts`).
