### PR TITLE
[MySQL]: preserve binary and varbinary values as Buffers

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -7,21 +7,21 @@ import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer;
 	enumValues: undefined;
 }>;
 
-export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumnBuilder<
+export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumnBuilder<
 	T,
 	MySqlBinaryConfig
 > {
 	static override readonly [entityKind]: string = 'MySqlBinaryBuilder';
 
 	constructor(name: T['name'], length: number | undefined) {
-		super(name, 'string', 'MySqlBinary');
+		super(name, 'buffer', 'MySqlBinary');
 		this.config.length = length;
 	}
 
@@ -33,7 +33,7 @@ export class MySqlBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MyS
 	}
 }
 
-export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> extends MySqlColumn<
+export class MySqlBinary<T extends ColumnBaseConfig<'buffer', 'MySqlBinary'>> extends MySqlColumn<
 	T,
 	MySqlBinaryConfig
 > {
@@ -41,16 +41,10 @@ export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> ex
 
 	length: number | undefined = this.config.length;
 
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'latin1');
+		return Buffer.from(value);
 	}
 
 	getSQLType(): string {

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -7,21 +7,21 @@ import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
 	name: TName;
-	dataType: 'string';
+	dataType: 'buffer';
 	columnType: 'MySqlVarBinary';
-	data: string;
-	driverParam: string;
+	data: Buffer;
+	driverParam: Buffer;
 	enumValues: undefined;
 }>;
 
-export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', 'MySqlVarBinary'>>
+export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarBinary'>>
 	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
 {
 	static override readonly [entityKind]: string = 'MySqlVarBinaryBuilder';
 
 	/** @internal */
 	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
-		super(name, 'string', 'MySqlVarBinary');
+		super(name, 'buffer', 'MySqlVarBinary');
 		this.config.length = config?.length;
 	}
 
@@ -37,22 +37,16 @@ export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', '
 }
 
 export class MySqlVarBinary<
-	T extends ColumnBaseConfig<'string', 'MySqlVarBinary'>,
+	T extends ColumnBaseConfig<'buffer', 'MySqlVarBinary'>,
 > extends MySqlColumn<T, MySqlVarbinaryOptions> {
 	static override readonly [entityKind]: string = 'MySqlVarBinary';
 
 	length: number | undefined = this.config.length;
 
-	override mapFromDriverValue(value: string | Buffer | Uint8Array): string {
-		if (typeof value === 'string') return value;
-		if (Buffer.isBuffer(value)) return value.toString();
-
-		const str: string[] = [];
-		for (const v of value) {
-			str.push(v === 49 ? '1' : '0');
-		}
-
-		return str.join('');
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'latin1');
+		return Buffer.from(value);
 	}
 
 	getSQLType(): string {

--- a/integration-tests/tests/mysql/mysql-binary-buffer.test.ts
+++ b/integration-tests/tests/mysql/mysql-binary-buffer.test.ts
@@ -1,0 +1,78 @@
+import retry from 'async-retry';
+import { binary, int, mysqlTable, varbinary } from 'drizzle-orm/mysql-core';
+import type { MySql2Database } from 'drizzle-orm/mysql2';
+import { drizzle } from 'drizzle-orm/mysql2';
+import * as mysql from 'mysql2/promise';
+import { afterAll, beforeAll, expect, expectTypeOf, test } from 'vitest';
+import { createDockerDB } from './mysql-common';
+
+const binaryTable = mysqlTable('binary_buffer_test', {
+	id: int('id').primaryKey(),
+	binaryData: binary('binary_data', { length: 3 }).notNull(),
+	varbinaryData: varbinary('varbinary_data', { length: 4 }).notNull(),
+});
+
+let db: MySql2Database;
+let client: mysql.Connection;
+
+beforeAll(async () => {
+	const { connectionString } = await createDockerDB();
+	client = await retry(async () => {
+		const connection = await mysql.createConnection({
+			uri: connectionString,
+			supportBigNumbers: true,
+		});
+		await connection.connect();
+		return connection;
+	}, {
+		retries: 20,
+		factor: 1,
+		minTimeout: 250,
+		maxTimeout: 250,
+		randomize: false,
+	});
+
+	await client.query('drop table if exists binary_buffer_test');
+	await client.query(`
+		create table binary_buffer_test (
+			id int primary key,
+			binary_data binary(3) not null,
+			varbinary_data varbinary(4) not null
+		)
+	`);
+
+	db = drizzle(client);
+});
+
+afterAll(async () => {
+	await client?.query('drop table if exists binary_buffer_test');
+	await client?.end();
+});
+
+test('mysql2 preserves binary and varbinary values as Buffers', async () => {
+	const binaryValue = Buffer.from([0xff, 0xfe, 0xfd]);
+	const varbinaryValue = Buffer.from([0xff, 0x00, 0x80, 0x01]);
+
+	await db.insert(binaryTable).values({
+		id: 1,
+		binaryData: binaryValue,
+		varbinaryData: varbinaryValue,
+	});
+
+	const [row] = await db.select().from(binaryTable);
+
+	expect(row).toBeDefined();
+	expectTypeOf(row!.binaryData).toEqualTypeOf<Buffer>();
+	expectTypeOf(row!.varbinaryData).toEqualTypeOf<Buffer>();
+	expect(Buffer.isBuffer(row!.binaryData)).toBe(true);
+	expect(Buffer.isBuffer(row!.varbinaryData)).toBe(true);
+	expect([...row!.binaryData]).toEqual([...binaryValue]);
+	expect([...row!.varbinaryData]).toEqual([...varbinaryValue]);
+});
+
+test('binary columns preserve Uint8Array bytes returned by serverless drivers', () => {
+	const value = new Uint8Array([0xff, 0x00, 0x80, 0x01]);
+
+	expect([...binaryTable.binaryData.mapFromDriverValue(value)]).toEqual([...value]);
+	expect([...binaryTable.varbinaryData.mapFromDriverValue(value)]).toEqual([...value]);
+});


### PR DESCRIPTION
Fixes #1188
Related: #4751

/claim #1188

## Summary

`binary` and `varbinary` are currently declared as string columns and their `mapFromDriverValue()` implementations coerce binary driver values to strings. That corrupts arbitrary bytes (for example `0xff 0xfe 0xfd`) and makes the inferred result type disagree with mysql2, which returns `Buffer` values for these column types.

This change:

- changes MySQL `binary` and `varbinary` column data types from `string` to `buffer`
- preserves mysql2 `Buffer` values without conversion
- converts `Uint8Array` binary values from serverless drivers into `Buffer` without changing the bytes
- keeps a best-effort legacy string decoding path using latin1
- adds an integration regression that round-trips non-UTF-8 bytes through MySQL and verifies both runtime and inferred types
- adds explicit coverage for `Uint8Array` decoding

## Why the previous blocker no longer applies

The earlier attempt in #1253 had to reconcile mysql2 returning `Buffer` with the then-current PlanetScale driver returning strings. Current `@planetscale/database` binary casting returns `Uint8Array`, and its query sanitizer accepts `Uint8Array` (Node `Buffer` is a subclass), so binary values can now remain binary end-to-end instead of being forced through strings.

## Validation

A focused MySQL integration test is included in `integration-tests/tests/mysql/mysql-binary-buffer.test.ts`. It uses byte sequences that cannot survive the current UTF-8 string coercion, so it specifically guards against the corruption reported in #4751.

The upstream GitHub Actions runs are currently waiting for maintainer approval because this PR comes from a first-time external fork contributor.