### PR TITLE
[MySQL]: Add buffer mode for binary columns

### DIFF
--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -2,8 +2,10 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
+import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
+
+type MySqlBinaryMode = 'string' | 'buffer';
 
 export type MySqlBinaryBuilderInitial<TName extends string> = MySqlBinaryBuilder<{
 	name: TName;
@@ -58,19 +60,70 @@ export class MySqlBinary<T extends ColumnBaseConfig<'string', 'MySqlBinary'>> ex
 	}
 }
 
-export interface MySqlBinaryConfig {
+export type MySqlBinaryBufferBuilderInitial<TName extends string> = MySqlBinaryBufferBuilder<{
+	name: TName;
+	dataType: 'buffer';
+	columnType: 'MySqlBinaryBuffer';
+	data: Buffer;
+	driverParam: Buffer;
+	enumValues: undefined;
+}>;
+
+export class MySqlBinaryBufferBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlBinaryBuffer'>>
+	extends MySqlColumnBuilder<T, MySqlBinaryConfig>
+{
+	static override readonly [entityKind]: string = 'MySqlBinaryBufferBuilder';
+
+	constructor(name: T['name'], length: number | undefined) {
+		super(name, 'buffer', 'MySqlBinaryBuffer');
+		this.config.length = length;
+	}
+
+	/** @internal */
+	override build<TTableName extends string>(
+		table: AnyMySqlTable<{ name: TTableName }>,
+	): MySqlBinaryBuffer<MakeColumnConfig<T, TTableName>> {
+		return new MySqlBinaryBuffer<MakeColumnConfig<T, TTableName>>(
+			table,
+			this.config as ColumnBuilderRuntimeConfig<any, any>,
+		);
+	}
+}
+
+export class MySqlBinaryBuffer<T extends ColumnBaseConfig<'buffer', 'MySqlBinaryBuffer'>> extends MySqlColumn<
+	T,
+	MySqlBinaryConfig
+> {
+	static override readonly [entityKind]: string = 'MySqlBinaryBuffer';
+
+	length: number | undefined = this.config.length;
+
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		return Buffer.from(value);
+	}
+
+	getSQLType(): string {
+		return this.length === undefined ? `binary` : `binary(${this.length})`;
+	}
+}
+
+export interface MySqlBinaryConfig<TMode extends MySqlBinaryMode = MySqlBinaryMode> {
 	length?: number;
+	mode?: TMode;
 }
 
 export function binary(): MySqlBinaryBuilderInitial<''>;
-export function binary(
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<''>;
-export function binary<TName extends string>(
+export function binary<TMode extends MySqlBinaryMode = MySqlBinaryMode>(
+	config?: MySqlBinaryConfig<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<''> : MySqlBinaryBuilderInitial<''>;
+export function binary<TName extends string, TMode extends MySqlBinaryMode = MySqlBinaryMode>(
 	name: TName,
-	config?: MySqlBinaryConfig,
-): MySqlBinaryBuilderInitial<TName>;
+	config?: MySqlBinaryConfig<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<TName> : MySqlBinaryBuilderInitial<TName>;
 export function binary(a?: string | MySqlBinaryConfig, b: MySqlBinaryConfig = {}) {
 	const { name, config } = getColumnNameAndConfig<MySqlBinaryConfig>(a, b);
-	return new MySqlBinaryBuilder(name, config.length);
+	return config.mode === 'buffer'
+		? new MySqlBinaryBufferBuilder(name, config.length)
+		: new MySqlBinaryBuilder(name, config.length);
 }

--- a/drizzle-orm/src/mysql-core/columns/binary.ts
+++ b/drizzle-orm/src/mysql-core/columns/binary.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
+import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 type MySqlBinaryMode = 'string' | 'buffer';
@@ -100,6 +100,7 @@ export class MySqlBinaryBuffer<T extends ColumnBaseConfig<'buffer', 'MySqlBinary
 
 	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
 		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'latin1');
 		return Buffer.from(value);
 	}
 
@@ -116,11 +117,11 @@ export interface MySqlBinaryConfig<TMode extends MySqlBinaryMode = MySqlBinaryMo
 export function binary(): MySqlBinaryBuilderInitial<''>;
 export function binary<TMode extends MySqlBinaryMode = MySqlBinaryMode>(
 	config?: MySqlBinaryConfig<TMode>,
-): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<''> : MySqlBinaryBuilderInitial<''>;
+): TMode extends 'buffer' ? MySqlBinaryBufferBuilderInitial<''> : MySqlBinaryBuilderInitial<''>;
 export function binary<TName extends string, TMode extends MySqlBinaryMode = MySqlBinaryMode>(
 	name: TName,
 	config?: MySqlBinaryConfig<TMode>,
-): Equal<TMode, 'buffer'> extends true ? MySqlBinaryBufferBuilderInitial<TName> : MySqlBinaryBuilderInitial<TName>;
+): TMode extends 'buffer' ? MySqlBinaryBufferBuilderInitial<TName> : MySqlBinaryBuilderInitial<TName>;
 export function binary(a?: string | MySqlBinaryConfig, b: MySqlBinaryConfig = {}) {
 	const { name, config } = getColumnNameAndConfig<MySqlBinaryConfig>(a, b);
 	return config.mode === 'buffer'

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
+import { getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
 type MySqlVarBinaryMode = 'string' | 'buffer';
@@ -102,6 +102,7 @@ export class MySqlVarBinaryBuffer<
 
 	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
 		if (Buffer.isBuffer(value)) return value;
+		if (typeof value === 'string') return Buffer.from(value, 'latin1');
 		return Buffer.from(value);
 	}
 
@@ -117,11 +118,11 @@ export interface MySqlVarbinaryOptions<TMode extends MySqlVarBinaryMode = MySqlV
 
 export function varbinary<TMode extends MySqlVarBinaryMode = MySqlVarBinaryMode>(
 	config: MySqlVarbinaryOptions<TMode>,
-): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<''> : MySqlVarBinaryBuilderInitial<''>;
+): TMode extends 'buffer' ? MySqlVarBinaryBufferBuilderInitial<''> : MySqlVarBinaryBuilderInitial<''>;
 export function varbinary<TName extends string, TMode extends MySqlVarBinaryMode = MySqlVarBinaryMode>(
 	name: TName,
 	config: MySqlVarbinaryOptions<TMode>,
-): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<TName> : MySqlVarBinaryBuilderInitial<TName>;
+): TMode extends 'buffer' ? MySqlVarBinaryBufferBuilderInitial<TName> : MySqlVarBinaryBuilderInitial<TName>;
 export function varbinary(a?: string | MySqlVarbinaryOptions, b?: MySqlVarbinaryOptions) {
 	const { name, config } = getColumnNameAndConfig<MySqlVarbinaryOptions>(a, b);
 	return config.mode === 'buffer' ? new MySqlVarBinaryBufferBuilder(name, config) : new MySqlVarBinaryBuilder(name, config);

--- a/drizzle-orm/src/mysql-core/columns/varbinary.ts
+++ b/drizzle-orm/src/mysql-core/columns/varbinary.ts
@@ -2,8 +2,10 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import { getColumnNameAndConfig } from '~/utils.ts';
+import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
+
+type MySqlVarBinaryMode = 'string' | 'buffer';
 
 export type MySqlVarBinaryBuilderInitial<TName extends string> = MySqlVarBinaryBuilder<{
 	name: TName;
@@ -22,7 +24,7 @@ export class MySqlVarBinaryBuilder<T extends ColumnBuilderBaseConfig<'string', '
 	/** @internal */
 	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
 		super(name, 'string', 'MySqlVarBinary');
-		this.config.length = config?.length;
+		this.config.length = config.length;
 	}
 
 	/** @internal */
@@ -60,18 +62,67 @@ export class MySqlVarBinary<
 	}
 }
 
-export interface MySqlVarbinaryOptions {
-	length: number;
+export type MySqlVarBinaryBufferBuilderInitial<TName extends string> = MySqlVarBinaryBufferBuilder<{
+	name: TName;
+	dataType: 'buffer';
+	columnType: 'MySqlVarBinaryBuffer';
+	data: Buffer;
+	driverParam: Buffer;
+	enumValues: undefined;
+}>;
+
+export class MySqlVarBinaryBufferBuilder<T extends ColumnBuilderBaseConfig<'buffer', 'MySqlVarBinaryBuffer'>>
+	extends MySqlColumnBuilder<T, MySqlVarbinaryOptions>
+{
+	static override readonly [entityKind]: string = 'MySqlVarBinaryBufferBuilder';
+
+	/** @internal */
+	constructor(name: T['name'], config: MySqlVarbinaryOptions) {
+		super(name, 'buffer', 'MySqlVarBinaryBuffer');
+		this.config.length = config.length;
+	}
+
+	/** @internal */
+	override build<TTableName extends string>(
+		table: AnyMySqlTable<{ name: TTableName }>,
+	): MySqlVarBinaryBuffer<MakeColumnConfig<T, TTableName>> {
+		return new MySqlVarBinaryBuffer<MakeColumnConfig<T, TTableName>>(
+			table,
+			this.config as ColumnBuilderRuntimeConfig<any, any>,
+		);
+	}
 }
 
-export function varbinary(
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<''>;
-export function varbinary<TName extends string>(
+export class MySqlVarBinaryBuffer<
+	T extends ColumnBaseConfig<'buffer', 'MySqlVarBinaryBuffer'>,
+> extends MySqlColumn<T, MySqlVarbinaryOptions> {
+	static override readonly [entityKind]: string = 'MySqlVarBinaryBuffer';
+
+	length: number | undefined = this.config.length;
+
+	override mapFromDriverValue(value: string | Buffer | Uint8Array): Buffer {
+		if (Buffer.isBuffer(value)) return value;
+		return Buffer.from(value);
+	}
+
+	getSQLType(): string {
+		return this.length === undefined ? `varbinary` : `varbinary(${this.length})`;
+	}
+}
+
+export interface MySqlVarbinaryOptions<TMode extends MySqlVarBinaryMode = MySqlVarBinaryMode> {
+	length: number;
+	mode?: TMode;
+}
+
+export function varbinary<TMode extends MySqlVarBinaryMode = MySqlVarBinaryMode>(
+	config: MySqlVarbinaryOptions<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<''> : MySqlVarBinaryBuilderInitial<''>;
+export function varbinary<TName extends string, TMode extends MySqlVarBinaryMode = MySqlVarBinaryMode>(
 	name: TName,
-	config: MySqlVarbinaryOptions,
-): MySqlVarBinaryBuilderInitial<TName>;
+	config: MySqlVarbinaryOptions<TMode>,
+): Equal<TMode, 'buffer'> extends true ? MySqlVarBinaryBufferBuilderInitial<TName> : MySqlVarBinaryBuilderInitial<TName>;
 export function varbinary(a?: string | MySqlVarbinaryOptions, b?: MySqlVarbinaryOptions) {
 	const { name, config } = getColumnNameAndConfig<MySqlVarbinaryOptions>(a, b);
-	return new MySqlVarBinaryBuilder(name, config);
+	return config.mode === 'buffer' ? new MySqlVarBinaryBufferBuilder(name, config) : new MySqlVarBinaryBuilder(name, config);
 }

--- a/drizzle-orm/tests/mysql-binary-buffer.test.ts
+++ b/drizzle-orm/tests/mysql-binary-buffer.test.ts
@@ -1,0 +1,35 @@
+import { expectTypeOf, test } from 'vitest';
+import { binary, mysqlTable, varbinary } from '~/mysql-core/index.ts';
+
+const table = mysqlTable('binary_buffer_test', {
+	binaryString: binary('binary_string', { length: 4 }),
+	binaryBuffer: binary('binary_buffer', { length: 4, mode: 'buffer' }),
+	varbinaryString: varbinary('varbinary_string', { length: 4 }),
+	varbinaryBuffer: varbinary('varbinary_buffer', { length: 4, mode: 'buffer' }),
+});
+
+type SelectRow = typeof table.$inferSelect;
+
+test('mysql binary and varbinary buffer modes infer Buffer', () => {
+	expectTypeOf<SelectRow['binaryString']>().toEqualTypeOf<string | null>();
+	expectTypeOf<SelectRow['binaryBuffer']>().toEqualTypeOf<Buffer | null>();
+	expectTypeOf<SelectRow['varbinaryString']>().toEqualTypeOf<string | null>();
+	expectTypeOf<SelectRow['varbinaryBuffer']>().toEqualTypeOf<Buffer | null>();
+});
+
+test('mysql binary and varbinary buffer modes preserve raw bytes', ({ expect }) => {
+	const bytes = Buffer.from([0xff, 0xfe, 0xfd, 0x00]);
+	const uint8 = new Uint8Array([0xff, 0xfe, 0xfd, 0x00]);
+
+	expect(table.binaryBuffer.mapFromDriverValue(bytes)).toEqual(bytes);
+	expect(table.binaryBuffer.mapFromDriverValue(uint8)).toEqual(bytes);
+	expect(table.varbinaryBuffer.mapFromDriverValue(bytes)).toEqual(bytes);
+	expect(table.varbinaryBuffer.mapFromDriverValue(uint8)).toEqual(bytes);
+});
+
+test('mysql binary and varbinary keep the existing string mode by default', ({ expect }) => {
+	const bytes = Buffer.from('test');
+
+	expect(table.binaryString.mapFromDriverValue(bytes)).toBe('test');
+	expect(table.varbinaryString.mapFromDriverValue(bytes)).toBe('test');
+});

--- a/drizzle-orm/tests/mysql-binary-buffer.test.ts
+++ b/drizzle-orm/tests/mysql-binary-buffer.test.ts
@@ -1,4 +1,14 @@
 import { expectTypeOf, test } from 'vitest';
+import type {
+	MySqlBinaryBufferBuilderInitial,
+	MySqlBinaryBuilderInitial,
+	MySqlBinaryConfig,
+} from '~/mysql-core/columns/binary.ts';
+import type {
+	MySqlVarBinaryBufferBuilderInitial,
+	MySqlVarBinaryBuilderInitial,
+	MySqlVarbinaryOptions,
+} from '~/mysql-core/columns/varbinary.ts';
 import { binary, mysqlTable, varbinary } from '~/mysql-core/index.ts';
 
 const table = mysqlTable('binary_buffer_test', {
@@ -17,14 +27,29 @@ test('mysql binary and varbinary buffer modes infer Buffer', () => {
 	expectTypeOf<SelectRow['varbinaryBuffer']>().toEqualTypeOf<Buffer | null>();
 });
 
+test('mysql binary and varbinary widened modes preserve both possible builder types', () => {
+	const binaryConfig: MySqlBinaryConfig = { length: 4, mode: 'buffer' };
+	const varbinaryConfig: MySqlVarbinaryOptions = { length: 4, mode: 'buffer' };
+
+	expectTypeOf(binary(binaryConfig)).toEqualTypeOf<
+		MySqlBinaryBufferBuilderInitial<''> | MySqlBinaryBuilderInitial<''>
+	>();
+	expectTypeOf(varbinary(varbinaryConfig)).toEqualTypeOf<
+		MySqlVarBinaryBufferBuilderInitial<''> | MySqlVarBinaryBuilderInitial<''>
+	>();
+});
+
 test('mysql binary and varbinary buffer modes preserve raw bytes', ({ expect }) => {
 	const bytes = Buffer.from([0xff, 0xfe, 0xfd, 0x00]);
 	const uint8 = new Uint8Array([0xff, 0xfe, 0xfd, 0x00]);
+	const binaryString = String.fromCharCode(0xff, 0xfe, 0xfd, 0x00);
 
 	expect(table.binaryBuffer.mapFromDriverValue(bytes)).toEqual(bytes);
 	expect(table.binaryBuffer.mapFromDriverValue(uint8)).toEqual(bytes);
+	expect(table.binaryBuffer.mapFromDriverValue(binaryString)).toEqual(bytes);
 	expect(table.varbinaryBuffer.mapFromDriverValue(bytes)).toEqual(bytes);
 	expect(table.varbinaryBuffer.mapFromDriverValue(uint8)).toEqual(bytes);
+	expect(table.varbinaryBuffer.mapFromDriverValue(binaryString)).toEqual(bytes);
 });
 
 test('mysql binary and varbinary keep the existing string mode by default', ({ expect }) => {

--- a/integration-tests/tests/mysql/mysql.test.ts
+++ b/integration-tests/tests/mysql/mysql.test.ts
@@ -1,12 +1,19 @@
 import retry from 'async-retry';
+import { sql } from 'drizzle-orm';
+import { binary, mysqlTable, varbinary } from 'drizzle-orm/mysql-core';
 import type { MySql2Database } from 'drizzle-orm/mysql2';
 import { drizzle } from 'drizzle-orm/mysql2';
 import * as mysql from 'mysql2/promise';
-import { afterAll, beforeAll, beforeEach } from 'vitest';
+import { afterAll, beforeAll, beforeEach, expect, test } from 'vitest';
 import { createDockerDB, tests } from './mysql-common';
 import { TestCache, TestGlobalCache, tests as cacheTests } from './mysql-common-cache';
 
 const ENABLE_LOGGING = false;
+
+const binaryBufferTable = mysqlTable('binary_buffer_test', {
+	binaryBuffer: binary('binary_buffer', { length: 4, mode: 'buffer' }).notNull(),
+	varbinaryBuffer: varbinary('varbinary_buffer', { length: 4, mode: 'buffer' }).notNull(),
+});
 
 let db: MySql2Database;
 let dbGlobalCached: MySql2Database;
@@ -55,6 +62,32 @@ beforeEach((ctx) => {
 		db: cachedDb,
 		dbGlobalCached,
 	};
+});
+
+test('binary and varbinary buffer modes preserve mysql2 bytes', async () => {
+	await db.execute(sql`drop table if exists binary_buffer_test`);
+	await db.execute(sql`
+		create table binary_buffer_test (
+			binary_buffer binary(4) not null,
+			varbinary_buffer varbinary(4) not null
+		)
+	`);
+
+	try {
+		const bytes = Buffer.from([0xff, 0xfe, 0xfd, 0x00]);
+		await db.insert(binaryBufferTable).values({
+			binaryBuffer: bytes,
+			varbinaryBuffer: bytes,
+		});
+
+		const [row] = await db.select().from(binaryBufferTable);
+		expect(Buffer.isBuffer(row!.binaryBuffer)).toBe(true);
+		expect(Buffer.isBuffer(row!.varbinaryBuffer)).toBe(true);
+		expect(row!.binaryBuffer).toEqual(bytes);
+		expect(row!.varbinaryBuffer).toEqual(bytes);
+	} finally {
+		await db.execute(sql`drop table if exists binary_buffer_test`);
+	}
 });
 
 cacheTests();


### PR DESCRIPTION
## Summary

This adds an explicit `mode: 'buffer'` option to MySQL `binary` and `varbinary` columns.

- preserves the existing string mode by default for backwards compatibility
- adds Buffer-typed builders for `binary(..., { mode: 'buffer' })` and `varbinary(..., { mode: 'buffer' })`
- preserves raw `Buffer` / `Uint8Array` bytes instead of converting them through `toString()`
- adds type/runtime regression coverage in `drizzle-orm`
- adds a mysql2 integration test using non-UTF-8 bytes (`ff fe fd 00`) to catch irreversible string conversion

## Why

`mysql2` returns `BINARY` / `VARBINARY` values as `Buffer`, but the current MySQL column mapper converts those buffers to strings. That can irreversibly corrupt arbitrary binary data. A driver-wide change would also affect adapters that return strings, so this keeps existing behavior intact and makes lossless buffer handling explicit.

## Testing

The branch includes:

- type inference checks for both string and buffer modes
- unit coverage for `Buffer` and `Uint8Array` driver values
- a real mysql2 integration test that inserts and selects non-UTF-8 bytes

GitHub currently requires maintainer approval before fork-originated Actions jobs can run on this PR.

Refs #1188
Related: #4751

/claim #1188