### PR TITLE
[drizzle-kit] Accept target_session_attrs in postgres dbCredentials

### DIFF
--- a/drizzle-kit/src/cli/validations/postgres.ts
+++ b/drizzle-kit/src/cli/validations/postgres.ts
@@ -21,6 +21,15 @@ export const postgresCredentials = union([
 			boolean(),
 			object({}).passthrough(),
 		]).optional(),
+		// postgres.js multi-host option, so migrations can target the primary
+		// when the first host in the list is a read-only replica.
+		target_session_attrs: union([
+			literal('primary'),
+			literal('standby'),
+			literal('prefer-standby'),
+			literal('read-write'),
+			literal('read-only'),
+		]).optional(),
 	}).transform((o) => {
 		delete o.driver;
 		return o as Omit<typeof o, 'driver'>;

--- a/drizzle-kit/tests/other/validations.test.ts
+++ b/drizzle-kit/tests/other/validations.test.ts
@@ -558,6 +558,32 @@ test('postgres #17', () => {
 	}).toThrowError();
 });
 
+test('postgres #18', () => {
+	expect(
+		postgresCredentials.parse({
+			dialect: 'postgres',
+			host: 'host',
+			database: 'database',
+			target_session_attrs: 'primary',
+		}),
+	).toStrictEqual({
+		host: 'host',
+		database: 'database',
+		target_session_attrs: 'primary',
+	});
+});
+
+test('postgres #19', () => {
+	expect(() =>
+		postgresCredentials.parse({
+			dialect: 'postgres',
+			host: 'host',
+			database: 'database',
+			target_session_attrs: 'nope',
+		})
+	).toThrowError();
+});
+
 test('mysql #1', () => {
 	expect(
 		mysqlCredentials.parse({


### PR DESCRIPTION
Fixes #6229

The zod schema for host-based postgres `dbCredentials` strips keys it does not declare, so postgres.js's `target_session_attrs` was silently dropped before the credentials reached the driver. With a multi-host connection whose first host is a read-only replica, migrations then fail with `cannot execute CREATE SCHEMA in a read-only transaction`, because the client can no longer be told to connect to the primary.

This declares `target_session_attrs` on the host-based credentials with the values postgres.js accepts (`primary`, `standby`, `prefer-standby`, `read-write`, `read-only`), so it is validated and forwarded like the other connection fields. `drizzle-kit/src/cli/connections.ts` already spreads the credentials into `postgres(...)`, so no change is needed there.

I kept the schema's existing "strip unknown keys" behaviour (the `postgres #3`–`#8` tests assert that top-level config keys like `dialect` do not leak into the driver options) rather than switching to `passthrough()`. If you would like other postgres.js options declared the same way (e.g. `prepare`, `connect_timeout`), I can add them here or in a follow-up.

Tests: `postgres #18` / `#19` in `drizzle-kit/tests/other/validations.test.ts` (80 passing); `pnpm tsc` in `drizzle-kit` introduces no new errors; `dprint check` clean.
