### PR TITLE
fix(orm): keep nested partial select when first joined column is null

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -45,10 +45,13 @@ export function mapResultRow<TResult>(
 
 					if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
 						const objectName = path[0]!;
+						const tableName = getTableName(field.table);
+
 						if (!(objectName in nullifyMap)) {
-							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
+							nullifyMap[objectName] = value === null ? tableName : false;
 						} else if (
-							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
+							typeof nullifyMap[objectName] === 'string'
+							&& (nullifyMap[objectName] !== tableName || value !== null)
 						) {
 							nullifyMap[objectName] = false;
 						}

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from 'vitest';
+import { pgTable, text } from '~/pg-core/index.ts';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+
+const joinedTable = pgTable('joined', {
+	nullableField: text('nullable_field'),
+	nonNullField: text('non_null_field').notNull(),
+});
+
+test('mapResultRow keeps nested object when first joined column is null', () => {
+	const fields = {
+		joined: {
+			nullableField: joinedTable.nullableField,
+			nonNullField: joinedTable.nonNullField,
+		},
+	};
+
+	const columns = orderSelectedFields(fields);
+
+	const result = mapResultRow(
+		columns,
+		[null, 'value'],
+		{
+			joined: false,
+		},
+	);
+
+	expect(result).toEqual({
+		joined: {
+			nullableField: null,
+			nonNullField: 'value',
+		},
+	});
+});
+
+test('mapResultRow nullifies nested object when all joined columns are null', () => {
+	const fields = {
+		joined: {
+			nullableField: joinedTable.nullableField,
+			nonNullField: joinedTable.nonNullField,
+		},
+	};
+
+	const columns = orderSelectedFields(fields);
+
+	const result = mapResultRow(
+		columns,
+		[null, null],
+		{
+			joined: false,
+		},
+	);
+
+	expect(result).toEqual({
+		joined: null,
+	});
+});
+
+test('mapResultRow matches issue #1603 branding.logo-null panelBackground-non-null case', () => {
+	const orgBrandingTable = pgTable('org_branding', {
+		logo: text('logo'),
+		panelBackground: text('panel_background').notNull(),
+	});
+
+	const fields = {
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	};
+
+	const columns = orderSelectedFields(fields);
+
+	const result = mapResultRow(
+		columns,
+		[null, '#1a8cff'],
+		{ branding: false },
+	);
+
+	expect(result).toEqual({
+		branding: {
+			logo: null,
+			panelBackground: '#1a8cff',
+		},
+	});
+});

--- a/drizzle-orm/tests/utils.test.ts
+++ b/drizzle-orm/tests/utils.test.ts
@@ -1,86 +1,97 @@
 import { expect, test } from 'vitest';
-import { pgTable, text } from '~/pg-core/index.ts';
+import { integer, pgTable, text } from '~/pg-core/index.ts';
 import { mapResultRow, orderSelectedFields } from '~/utils.ts';
 
-const joinedTable = pgTable('joined', {
-	nullableField: text('nullable_field'),
-	nonNullField: text('non_null_field').notNull(),
+// Regression for https://github.com/drizzle-team/drizzle-orm/issues/1603
+// Nested partial-select on a nullable left join must not nullify the whole
+// object when only the first selected column is null.
+
+const orgTable = pgTable('org', {
+	id: integer('id'),
+	name: text('name'),
+	slug: text('slug'),
 });
 
-test('mapResultRow keeps nested object when first joined column is null', () => {
-	const fields = {
-		joined: {
-			nullableField: joinedTable.nullableField,
-			nonNullField: joinedTable.nonNullField,
-		},
-	};
-
-	const columns = orderSelectedFields(fields);
-
-	const result = mapResultRow(
-		columns,
-		[null, 'value'],
-		{
-			joined: false,
-		},
-	);
-
-	expect(result).toEqual({
-		joined: {
-			nullableField: null,
-			nonNullField: 'value',
-		},
-	});
+const orgBrandingTable = pgTable('org_branding', {
+	logo: text('logo'),
+	panelBackground: text('panel_background'),
 });
 
-test('mapResultRow nullifies nested object when all joined columns are null', () => {
-	const fields = {
-		joined: {
-			nullableField: joinedTable.nullableField,
-			nonNullField: joinedTable.nonNullField,
-		},
-	};
-
-	const columns = orderSelectedFields(fields);
-
-	const result = mapResultRow(
-		columns,
-		[null, null],
-		{
-			joined: false,
-		},
-	);
-
-	expect(result).toEqual({
-		joined: null,
-	});
-});
-
-test('mapResultRow matches issue #1603 branding.logo-null panelBackground-non-null case', () => {
-	const orgBrandingTable = pgTable('org_branding', {
-		logo: text('logo'),
-		panelBackground: text('panel_background').notNull(),
-	});
-
-	const fields = {
+test('keeps nested object when first joined column is null but a later column is not', () => {
+	const columns = orderSelectedFields({
+		name: orgTable.name,
 		branding: {
 			logo: orgBrandingTable.logo,
 			panelBackground: orgBrandingTable.panelBackground,
 		},
-	};
-
-	const columns = orderSelectedFields(fields);
+	});
 
 	const result = mapResultRow(
 		columns,
-		[null, '#1a8cff'],
-		{ branding: false },
+		['Test org 2', null, '#1a8cff'],
+		{ org: true, org_branding: false },
 	);
 
 	expect(result).toEqual({
+		name: 'Test org 2',
+		branding: { logo: null, panelBackground: '#1a8cff' },
+	});
+});
+
+test('is independent of column order (first non-null, later null)', () => {
+	const columns = orderSelectedFields({
 		branding: {
-			logo: null,
-			panelBackground: '#1a8cff',
+			panelBackground: orgBrandingTable.panelBackground,
+			logo: orgBrandingTable.logo,
 		},
+	});
+
+	const result = mapResultRow(columns, ['#1a8cff', null], { org_branding: false });
+
+	expect(result).toEqual({
+		branding: { panelBackground: '#1a8cff', logo: null },
+	});
+});
+
+test('keeps nested object when all joined columns are non-null', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(columns, ['logo.png', '#1a8cff'], { org_branding: false });
+
+	expect(result).toEqual({
+		branding: { logo: 'logo.png', panelBackground: '#1a8cff' },
+	});
+});
+
+test('nullifies nested object when every joined column is null and join is nullable', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(columns, [null, null], { org_branding: false });
+
+	expect(result).toEqual({ branding: null });
+});
+
+test('keeps all-null nested object when the join is not nullable', () => {
+	const columns = orderSelectedFields({
+		branding: {
+			logo: orgBrandingTable.logo,
+			panelBackground: orgBrandingTable.panelBackground,
+		},
+	});
+
+	const result = mapResultRow(columns, [null, null], { org_branding: true });
+
+	expect(result).toEqual({
+		branding: { logo: null, panelBackground: null },
 	});
 });


### PR DESCRIPTION
Fixes #1603
/claim #1603

## Problem
`mapResultRow` nullifies a nested joined object when the **first** nested column is `null`, even if a later same-table column is non-null (e.g. `branding.logo = null`, `branding.panelBackground = '#1a8cff'`).

## Root cause
In `nullifyMap`, the candidate was only cleared when a later column belonged to a **different** table. A non-null value from the **same** table never cleared it, so column order incorrectly decided nullability.

## Fix
Clear the `nullifyMap` candidate when a later column from the **same** table is non-null (`nullifyMap[objectName] !== tableName || value !== null`), matching the existing multi-table clear path.

## Tests
`drizzle-orm/tests/utils.test.ts` (5 cases, `pnpm exec vitest run tests/utils.test.ts`):
- first joined col null + later non-null → keep object (issue #1603 branding repro)
- column-order independence (first non-null, later null)
- all joined cols non-null → keep object
- all joined cols null + nullable join → nullify object
- all joined cols null + non-nullable join → keep object

## Validation
- `pnpm exec vitest run tests/utils.test.ts` — 5/5 passed
