### PR TITLE
fix(drizzle-kit): preserve composite FK pairing in PG introspection

### DIFF
--- a/drizzle-kit/src/introspect-pg.ts
+++ b/drizzle-kit/src/introspect-pg.ts
@@ -650,6 +650,11 @@ const buildArrayDefault = (defaultValue: string, typeName: string): string => {
 		return `sql\`${defaultValue}\``;
 	}
 	defaultValue = defaultValue.substring(2, defaultValue.length - 2);
+	// An empty array literal ('{}') trims to an empty string; splitting that would
+	// yield [""], emitting .default([""]) instead of .default([]).
+	if (defaultValue.trim() === '') {
+		return '[]';
+	}
 	return `[${
 		defaultValue
 			.split(/\s*,\s*/g)

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1227,13 +1227,18 @@ WHERE
 
 					const tableResponse = await getColumnsInfoQuery({ schema: tableSchema, table: tableName, db });
 
+					// key_column_usage (not constraint_column_usage) carries ordinal_position,
+					// so composite PK / UNIQUE columns keep their declared order; joining on
+					// table_schema/table_name also avoids cross-table constraint-name collisions.
 					const tableConstraints = await db.query(
-						`SELECT c.column_name, c.data_type, constraint_type, constraint_name, constraint_schema
+						`SELECT c.column_name, c.data_type, tc.constraint_type, tc.constraint_name, tc.constraint_schema
       FROM information_schema.table_constraints tc
-      JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name)
+      JOIN information_schema.key_column_usage AS kcu ON kcu.constraint_schema = tc.constraint_schema
+        AND kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema AND kcu.table_name = tc.table_name
       JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema
-        AND tc.table_name = c.table_name AND ccu.column_name = c.column_name
-      WHERE tc.table_name = '${tableName}' and constraint_schema = '${tableSchema}';`,
+        AND tc.table_name = c.table_name AND kcu.column_name = c.column_name
+      WHERE tc.table_name = '${tableName}' and tc.constraint_schema = '${tableSchema}'
+      ORDER BY tc.constraint_name, kcu.ordinal_position;`,
 					);
 
 					const tableChecks = await db.query(`SELECT 

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1986,9 +1986,14 @@ const defaultForColumn = (column: any, internals: PgKitInternals, tableName: str
 	const columnDefaultAsString: string = column.column_default.toString();
 
 	if (isArray) {
+		// An empty array default ('{}') has no inner content; splitting that would
+		// yield [""], corrupting the default into an array holding one empty string.
+		const arrayContent = columnDefaultAsString.slice(2, -2);
+		if (arrayContent.trim() === '') {
+			return `'{}'`;
+		}
 		return `'{${
-			columnDefaultAsString
-				.slice(2, -2)
+			arrayContent
 				.split(/\s*,\s*/g)
 				.map((value) => {
 					if (['integer', 'smallint', 'bigint', 'double precision', 'real'].includes(column.data_type.slice(0, -2))) {

--- a/drizzle-kit/src/serializer/pgSerializer.ts
+++ b/drizzle-kit/src/serializer/pgSerializer.ts
@@ -1272,9 +1272,13 @@ WHERE
             con.conname AS constraint_name,
             rel.relname AS table_name,
             att.attname AS column_name,
+            att.attnum AS column_attnum,
             fnsp.nspname AS foreign_table_schema,
             frel.relname AS foreign_table_name,
             fatt.attname AS foreign_column_name,
+            fatt.attnum AS foreign_column_attnum,
+            con.conkey::text AS conkey_text,
+            con.confkey::text AS confkey_text,
             CASE con.confupdtype
               WHEN 'a' THEN 'NO ACTION'
               WHEN 'r' THEN 'RESTRICT'
@@ -1309,37 +1313,50 @@ WHERE
 					if (progressCallback) {
 						progressCallback('fks', foreignKeysCount, 'fetching');
 					}
+					// The FK query above joins pg_attribute with attnum = ANY(conkey) /
+					// ANY(confkey), which yields a Cartesian product of source and foreign
+					// columns for composite keys. Pair columns by their ordinal position:
+					// conkey[i] references confkey[i] (per the SQL standard and pg docs).
+					type RawFk = {
+						meta: { tableTo: string; schemaTo: string; onDelete?: string; onUpdate?: string };
+						conkey: number[];
+						confkey: number[];
+						src: Record<number, string>;
+						dst: Record<number, string>;
+					};
+					const rawFks: Record<string, RawFk> = {};
 					for (const fk of tableForeignKeys) {
-						// const tableFrom = fk.table_name;
-						const columnFrom: string = fk.column_name;
-						const tableTo = fk.foreign_table_name;
-						const columnTo: string = fk.foreign_column_name;
-						const schemaTo: string = fk.foreign_table_schema;
-						const foreignKeyName = fk.constraint_name;
-						const onUpdate = fk.update_rule?.toLowerCase();
-						const onDelete = fk.delete_rule?.toLowerCase();
-
-						if (typeof foreignKeysToReturn[foreignKeyName] !== 'undefined') {
-							foreignKeysToReturn[foreignKeyName].columnsFrom.push(columnFrom);
-							foreignKeysToReturn[foreignKeyName].columnsTo.push(columnTo);
-						} else {
-							foreignKeysToReturn[foreignKeyName] = {
-								name: foreignKeyName,
-								tableFrom: tableName,
-								tableTo,
-								schemaTo,
-								columnsFrom: [columnFrom],
-								columnsTo: [columnTo],
-								onDelete,
-								onUpdate,
+						const foreignKeyName = fk.constraint_name as string;
+						if (typeof rawFks[foreignKeyName] === 'undefined') {
+							rawFks[foreignKeyName] = {
+								meta: {
+									tableTo: fk.foreign_table_name,
+									schemaTo: fk.foreign_table_schema,
+									onDelete: fk.delete_rule?.toLowerCase(),
+									onUpdate: fk.update_rule?.toLowerCase(),
+								},
+								// int2vector renders as space-separated attnums ("1 3"); some
+								// drivers surface it in array form ("{1,3}") - accept both.
+								conkey: (fk.conkey_text as string).trim().replace(/^\{|\}$/g, '').split(/[\s,]+/).map(Number),
+								confkey: (fk.confkey_text as string).trim().replace(/^\{|\}$/g, '').split(/[\s,]+/).map(Number),
+								src: {},
+								dst: {},
 							};
 						}
-
-						foreignKeysToReturn[foreignKeyName].columnsFrom = [
-							...new Set(foreignKeysToReturn[foreignKeyName].columnsFrom),
-						];
-
-						foreignKeysToReturn[foreignKeyName].columnsTo = [...new Set(foreignKeysToReturn[foreignKeyName].columnsTo)];
+						rawFks[foreignKeyName].src[fk.column_attnum as number] = fk.column_name;
+						rawFks[foreignKeyName].dst[fk.foreign_column_attnum as number] = fk.foreign_column_name;
+					}
+					for (const [foreignKeyName, raw] of Object.entries(rawFks)) {
+						foreignKeysToReturn[foreignKeyName] = {
+							name: foreignKeyName,
+							tableFrom: tableName,
+							tableTo: raw.meta.tableTo,
+							schemaTo: raw.meta.schemaTo,
+							columnsFrom: raw.conkey.map((attnum) => raw.src[attnum]).filter((c) => c !== undefined),
+							columnsTo: raw.confkey.map((attnum) => raw.dst[attnum]).filter((c) => c !== undefined),
+							onDelete: raw.meta.onDelete,
+							onUpdate: raw.meta.onUpdate,
+						};
 					}
 
 					const uniqueConstrainsRows = tableConstraints.filter((mapRow) => mapRow.constraint_type === 'UNIQUE');
@@ -1405,13 +1422,14 @@ WHERE
 						const cprimaryKey = tableConstraints.filter((mapRow) => mapRow.constraint_type === 'PRIMARY KEY');
 
 						if (cprimaryKey.length > 1) {
+							// NOTE: inline (escaped) literals instead of $1/$2 placeholders - some
+							// DB wrappers passed to fromDatabase (e.g. pushSchema's) drop params.
 							const tableCompositePkName = await db.query(
 								`SELECT conname AS primary_key
             FROM   pg_constraint join pg_class on (pg_class.oid = conrelid)
             WHERE  contype = 'p' 
-            AND    connamespace = $1::regnamespace  
-            AND    pg_class.relname = $2;`,
-								[tableSchema, tableName],
+            AND    connamespace = '${escapeSingleQuotes(tableSchema)}'::regnamespace  
+            AND    pg_class.relname = '${escapeSingleQuotes(tableName)}';`,
 							);
 							primaryKeys[tableCompositePkName[0].primary_key] = {
 								name: tableCompositePkName[0].primary_key,


### PR DESCRIPTION
## What changed

Fixes all four findings of #6256 (composite-FK pairing, composite-PK wrapper params, composite-PK/UNIQUE ordering, empty array defaults).

### 1. Preserve composite FK column pairing

The current PostgreSQL introspection query joins `pg_attribute` with `attnum = ANY(con.conkey)` and `attnum = ANY(con.confkey)` independently. For a two-column FK that yields a 2x2 Cartesian product. The Set-based dedupe then deduplicates each side separately, permanently decoupling source position `i` from referenced position `i`. That is why a second `push` sees Drizzle's own FK as structurally different and wants to drop/re-add it forever.

This patch selects both attribute numbers and `conkey`/`confkey`, gathers names by attnum, then constructs the arrays by PostgreSQL's ordinal contract: `conkey[i]` references `confkey[i]`.

### 2. Make composite-PK introspection work through DB wrappers

That query passed `$1`/`$2` plus a params array, but some wrappers passed into `fromDatabase` (including `pushSchema`'s wrapper) drop the second argument. PostgreSQL then fails with `bind message supplies 0 parameters`. This patch inlines escaped literals using `escapeSingleQuotes`, matching the established convention already used in this file and making the query wrapper-agnostic.

### 3. Preserve declared order for composite PK / UNIQUE columns

The constraint introspection query joined `information_schema.constraint_column_usage`, which carries no member order, so composite PK and UNIQUE columns came back in catalog order. When a table's physical column order differs from the constraint's declared order (e.g. columns stored as `user_id, tenant_id` with `PRIMARY KEY (tenant_id, user_id)`), the introspected constraint lists the columns in the wrong order, and `push` keeps diffing against its own schema.

This patch joins `information_schema.key_column_usage` instead, which carries `ordinal_position`, and orders by `constraint_name, ordinal_position`, so composite PK / UNIQUE columns keep their declared order. Joining on `table_schema`/`table_name` (instead of only `constraint_schema`/`constraint_name`) also rules out cross-table constraint-name collisions.

### 4. Introspect empty array defaults as empty

A `text[]` column with `DEFAULT '{}'`: `defaultForColumn` sliced the braced literal, split the resulting empty string, and produced `'{""}'` - an array holding one empty string - so `schemaToTypeScript` emitted `.default([""])` and `push` churned its own default forever. `defaultForColumn` now returns `'{}'` when the array content trims to empty, and `buildArrayDefault` has the symmetric guard (`'{}'` -> `[]`) for defense in depth. Non-empty array defaults are byte-identical.

## Verification

True red-green against a real PostgreSQL engine (PGlite), using the reporter's exact schema:

- pre-patch FK result: `(project_id, thread_id) -> (id, project_id)` (wrong pairing)
- post-patch: `(thread_id, project_id) -> (id, project_id)`
- pre-patch with a params-dropping wrapper: composite-PK query dies with `bind message supplies 0 parameters`
- post-patch: composite PK introspects correctly
- pre-patch: a `(tenant_id, user_id)` composite PK introspects as `["user_id", "tenant_id"]` (catalog order); post-patch: `["tenant_id", "user_id"]` (declared order); same red-green for a composite UNIQUE declared `(b, a)`
- pre-patch: full pipeline PGlite -> `fromDatabase` -> `schemaToTypeScript` emits `.default([""])` for a `text[] DEFAULT '{}'` column; post-patch: `.default([])`; non-empty array defaults unchanged
- regression cases green: single-column FK, self-referencing FK, multiple FKs on one table, and all harnesses re-run on the combined diff

Honest limit: the full repository TypeScript build was not run offline because dependencies were unavailable; the affected code paths were executed via `tsx` (including directly against PostgreSQL 16 for the SQL-level changes), and CI will run the repository checks.

> Built by breken, your AI support engineer - breken.ai - this one's on us.
