### PR TITLE
[drizzle-kit] fix: Prefer current-generation Turso SDKs over @libsql/client

### DIFF
--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -18,6 +18,7 @@ import { normaliseSQLiteUrl } from '../utils/utils-node';
 import { JSONB } from '../utils/when-json-met-bigint';
 import type { ProxyParams } from './commands/studio';
 import { ConnectionStringDatabaseCliError, DatabaseDriverCliError } from './errors';
+import { pickTursoDriver, type TursoDriver } from './turso-driver';
 import { assertPackages, checkPackage, QueryError } from './utils';
 import type { DuckDbCredentials } from './validations/duckdb';
 import type { LibSQLCredentials } from './validations/libsql';
@@ -2442,13 +2443,16 @@ export const connectToTursoRemote = async (
 	credentials: LibSQLCredentials,
 ): Promise<
 	LibSQLDB & {
-		packageName: '@libsql/client' | '@tursodatabase/serverless' | '@tursodatabase/database';
+		packageName: TursoDriver;
 		migrate: (config: string | MigrationConfig) => Promise<void | MigratorInitFailResponse>;
 		proxy: Proxy;
 		transactionProxy: TransactionProxy;
 	}
 > => {
-	if ((await checkPackage('@libsql/client'))) {
+	const driver = await pickTursoDriver(credentials.authToken !== undefined, checkPackage);
+
+	if (driver === '@libsql/client') {
+		humanLog(withStyle.info(`Using '@libsql/client' driver for database querying`));
 		const { createClient } = await import('@libsql/client');
 		const { drizzle } = await import('drizzle-orm/libsql');
 		const { migrate } = await import('drizzle-orm/libsql/migrator');
@@ -2525,12 +2529,7 @@ export const connectToTursoRemote = async (
 		};
 	}
 
-	if (
-		await checkPackage('@tursodatabase/serverless') && !(
-			// Prefer dedicated local driver for local databases
-			credentials.authToken === undefined && await checkPackage('@tursodatabase/database')
-		)
-	) {
+	if (driver === '@tursodatabase/serverless') {
 		humanLog(withStyle.info(`Using '@tursodatabase/serverless' driver for database querying`));
 		const { connect } = await import('@tursodatabase/serverless');
 		const { drizzle } = await import('drizzle-orm/tursodatabase-serverless');
@@ -2590,15 +2589,7 @@ export const connectToTursoRemote = async (
 		};
 	}
 
-	if (await checkPackage('@tursodatabase/database')) {
-		if (credentials.authToken !== undefined) {
-			throw new DatabaseDriverCliError(
-				'turso',
-				['@libsql/client', '@tursodatabase/serverless'],
-				`Unable to use '@tursodatabase/database' with remote turso database\nPlease install '@libsql/client' or '@tursodatabase/serverless' for Drizzle Kit to connect to remote turso databases`,
-			);
-		}
-
+	if (driver === '@tursodatabase/database') {
 		humanLog(withStyle.info(`Using '@tursodatabase/database' driver for database querying`));
 		const { Database } = await import('@tursodatabase/database');
 		const { drizzle } = await import('drizzle-orm/tursodatabase/database');
@@ -2663,11 +2654,24 @@ export const connectToTursoRemote = async (
 		};
 	}
 
+	if (credentials.authToken !== undefined) {
+		// '@tursodatabase/database' is local-only, so it is never picked for a remote
+		// database even when it is the only driver installed.
+		const localOnlyDriverInstalled = await checkPackage('@tursodatabase/database');
+		throw new DatabaseDriverCliError(
+			'turso',
+			['@libsql/client', '@tursodatabase/serverless'],
+			`${
+				localOnlyDriverInstalled
+					? `Unable to use '@tursodatabase/database' with remote turso database\n`
+					: ''
+			}Please install '@libsql/client' or '@tursodatabase/serverless' for Drizzle Kit to connect to remote turso databases`,
+		);
+	}
+
 	throw new DatabaseDriverCliError(
 		'turso',
 		['@libsql/client', '@tursodatabase/database', '@tursodatabase/serverless'],
-		typeof credentials.authToken === 'string'
-			? `Please install '@libsql/client' or '@tursodatabase/serverless' for Drizzle Kit to connect to remote turso databases`
-			: `Please install '@libsql/client', '@tursodatabase/database' or '@tursodatabase/serverless' for Drizzle Kit to connect to turso databases`,
+		`Please install '@libsql/client', '@tursodatabase/database' or '@tursodatabase/serverless' for Drizzle Kit to connect to turso databases`,
 	);
 };

--- a/drizzle-kit/src/cli/turso-driver.ts
+++ b/drizzle-kit/src/cli/turso-driver.ts
@@ -1,0 +1,21 @@
+export type TursoDriver = '@libsql/client' | '@tursodatabase/serverless' | '@tursodatabase/database';
+
+/**
+ * Picks the driver to use for `dialect: 'turso'`, in order of preference.
+ *
+ * The current-generation Turso SDKs win over '@libsql/client'. The legacy client is an
+ * optional peer of drizzle-orm, so a stale transitive copy can stay resolvable long after a
+ * project has migrated off it, and it rejects the `turso://` URLs Turso Cloud now issues.
+ *
+ * '@tursodatabase/database' is local-only, so it is preferred for local databases and
+ * skipped entirely for remote ones, leaving '@libsql/client' as the remote fallback.
+ */
+export const pickTursoDriver = async (
+	isRemote: boolean,
+	has: (pkg: string) => Promise<boolean>,
+): Promise<TursoDriver | undefined> => {
+	if (!isRemote && await has('@tursodatabase/database')) return '@tursodatabase/database';
+	if (await has('@tursodatabase/serverless')) return '@tursodatabase/serverless';
+	if (await has('@libsql/client')) return '@libsql/client';
+	return undefined;
+};

--- a/drizzle-kit/tests/other/turso-driver-precedence.test.ts
+++ b/drizzle-kit/tests/other/turso-driver-precedence.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest';
+import { pickTursoDriver } from '../../src/cli/turso-driver';
+
+const REMOTE = true;
+const LOCAL = false;
+
+const installed = (...pkgs: string[]) => async (pkg: string) => pkgs.includes(pkg);
+
+test('remote: current-generation SDK wins over a resolvable @libsql/client', async () => {
+	// The regression in #6163: a stale transitive '@libsql/client' was picked over the
+	// SDK the project actually depends on, failing `turso://` with URL_SCHEME_NOT_SUPPORTED.
+	await expect(pickTursoDriver(REMOTE, installed('@libsql/client', '@tursodatabase/serverless')))
+		.resolves.toBe('@tursodatabase/serverless');
+});
+
+test('remote: falls back to @libsql/client when no current-generation SDK is installed', async () => {
+	await expect(pickTursoDriver(REMOTE, installed('@libsql/client')))
+		.resolves.toBe('@libsql/client');
+});
+
+test('remote: local-only @tursodatabase/database never wins, @libsql/client still serves', async () => {
+	await expect(pickTursoDriver(REMOTE, installed('@libsql/client', '@tursodatabase/database')))
+		.resolves.toBe('@libsql/client');
+});
+
+test('remote: local-only @tursodatabase/database alone resolves to no driver', async () => {
+	await expect(pickTursoDriver(REMOTE, installed('@tursodatabase/database')))
+		.resolves.toBeUndefined();
+});
+
+test('local: dedicated local driver keeps its preference over the serverless SDK', async () => {
+	await expect(pickTursoDriver(LOCAL, installed('@tursodatabase/serverless', '@tursodatabase/database')))
+		.resolves.toBe('@tursodatabase/database');
+});
+
+test('local: serverless SDK is used when the local driver is absent', async () => {
+	await expect(pickTursoDriver(LOCAL, installed('@libsql/client', '@tursodatabase/serverless')))
+		.resolves.toBe('@tursodatabase/serverless');
+});
+
+test('no driver installed resolves to undefined for both remote and local', async () => {
+	await expect(pickTursoDriver(REMOTE, installed())).resolves.toBeUndefined();
+	await expect(pickTursoDriver(LOCAL, installed())).resolves.toBeUndefined();
+});


### PR DESCRIPTION
## Summary

Fixes #6163.

`connectToTursoRemote` picks its driver by probing for installed packages, and it probed `@libsql/client` first. `checkPackage` answers `true` for *any* resolvable package, and `@libsql/client` is an optional peer of `drizzle-orm` — so a stale transitive copy stays resolvable long after a project has migrated to `@tursodatabase/serverless`. drizzle-kit then loaded the legacy client, which rejects the `turso://` URLs Turso Cloud now issues:

```
LibsqlError: URL_SCHEME_NOT_SUPPORTED
```

while the application itself connected fine with the same URL, because at runtime it used `@tursodatabase/serverless` (1.4+ normalizes `turso://` internally).

## What changed

The precedence decision moves out of the branch conditions into `pickTursoDriver` (`drizzle-kit/src/cli/turso-driver.ts`), and the three branches in `connectToTursoRemote` now switch on its result:

1. `@tursodatabase/database` — local databases only, preserving the existing "prefer the dedicated local driver" preference
2. `@tursodatabase/serverless`
3. `@libsql/client` as the fallback

**A naive reorder would have regressed.** Moving both `@tursodatabase/*` branches above `@libsql/client` looks like the whole fix, but the `@tursodatabase/database` branch throws for any remote database (`authToken` set). A project with `@libsql/client` + `@tursodatabase/database` installed against a remote URL works today, and would have become a hard error. Keeping `@tursodatabase/database` local-only and leaving `@libsql/client` reachable as the remote fallback avoids that.

That also let the branch's inner `throw` go: its message was already duplicated verbatim by the terminal `DatabaseDriverCliError`, so the remote case now falls through to it. The "Unable to use '@tursodatabase/database' with remote turso database" line is preserved there, conditional on that package actually being installed, so the diagnostic isn't lost.

Finally, the `@libsql/client` branch now logs `Using '@libsql/client' driver for database querying`. It was the only one of this file's driver branches that selected a driver silently, which is why nothing in the output indicated drizzle-kit had chosen a different client than the app.

## Behavior change

Whenever a current-generation Turso SDK is installed, it is now preferred over `@libsql/client` for `dialect: "turso"`. Setups with only `@libsql/client` are unaffected, and `connectToSQLite` (`dialect: "sqlite"`) is untouched — its ordering is unchanged.

Full matrix, `R` = remote (`authToken` set), `L` = local:

| installed | before | after |
| --- | --- | --- |
| R: libsql + serverless | `@libsql/client` ❌ | `@tursodatabase/serverless` ✅ |
| R: libsql only | `@libsql/client` | `@libsql/client` (unchanged) |
| R: libsql + database | `@libsql/client` | `@libsql/client` (unchanged) |
| R: database only | error | error (unchanged) |
| L: serverless + database | `@tursodatabase/database` | `@tursodatabase/database` (unchanged) |
| L: libsql + serverless | `@libsql/client` | `@tursodatabase/serverless` |
| L: none | error | error (unchanged) |

## Tests

`drizzle-kit/tests/other/turso-driver-precedence.test.ts` — 7 cases covering the matrix above, including the two that guard the regression (remote `libsql + database` must still resolve to `@libsql/client`, and remote `database`-only must resolve to no driver rather than being selected).

`pickTursoDriver` takes its package probe as a parameter, so the tests exercise the real ordering without touching the filesystem or a network. The module has no imports, which keeps it loadable in isolation.

```
✓ tests/other/turso-driver-precedence.test.ts (7 tests) 3ms
Test Files  1 passed (1)
     Tests  7 passed (7)
```

The tests discriminate: re-running them against the pre-fix ordering returns `@libsql/client` for the first row of the table, where the suite requires `@tursodatabase/serverless`.

The file sits in `tests/other/` so the existing `kit:other` CI shard (`vitest run ./mysql/ ./sqlite/ ./other`) picks it up.

## Verification

- `dprint check --list-different` — clean
- `oxlint` (correctness/suspicious/perf) on the new files — 0 warnings, 0 errors
- `tsc --noEmit -p drizzle-kit/tsconfig.json` — 1352 diagnostics before and after; the diff between the two runs is only line-number shifts from the added import, no new errors

## Not included

Two of the issue's other suggestions are deliberately left out, as separate decisions:

- Rewriting `turso://` → `https://` in `normaliseSQLiteUrl`. It's a shared helper with nine call sites, and the correct target scheme for `@libsql/client` isn't something I could verify. Happy to follow up if you want it.
- Preferring whichever driver the project *directly* depends on. That needs manifest inspection rather than resolution probing, which is a larger change than this bug requires.
