### PR TITLE
fix(drizzle-kit): use patched snapshot for renamed table column alters

### DIFF
--- a/drizzle-kit/src/snapshotsDiffer.ts
+++ b/drizzle-kit/src/snapshotsDiffer.ts
@@ -1372,7 +1372,7 @@ export const applyPgSnapshotsDiff = async (
 				it.schema,
 				it.altered,
 				json2,
-				json1,
+				viewsPatchedSnap1,
 				action,
 			);
 		})


### PR DESCRIPTION
When a table is renamed, the diff flow patches the old snapshot before computing altered tables. However, `preparePgAlterColumns()` was still receiving the original snapshot, so altered columns on a renamed table could look up the new table key in the unpatched old snapshot and crash with `Cannot read properties of undefined (reading columns)`.

This passes the same patched snapshot used for altered-table calculation into `preparePgAlterColumns()`, keeping table keys consistent for renamed tables.

Verified locally against a schema diff that renames tables and adds/alters columns on the renamed table; `drizzle-kit generate` no longer crashes.