### PR TITLE
Fix toSnakeCase and toCamelCase dropping non-Latin identifiers

### DIFF
--- a/drizzle-orm/src/casing.ts
+++ b/drizzle-orm/src/casing.ts
@@ -3,10 +3,12 @@ import { entityKind } from './entity.ts';
 import { Table } from './table.ts';
 import type { Casing } from './utils.ts';
 
+const WORD_PATTERN = /[\p{Ll}\d]+|\p{Lu}+(?!\p{Ll})|\p{Lu}[\p{Ll}\d]+|[\p{Lo}\d]+/gu;
+
 export function toSnakeCase(input: string) {
 	const words = input
 		.replace(/['\u2019]/g, '')
-		.match(/[\da-z]+|[A-Z]+(?![a-z])|[A-Z][\da-z]+/g) ?? [];
+		.match(WORD_PATTERN) ?? [];
 
 	return words.map((word) => word.toLowerCase()).join('_');
 }
@@ -14,7 +16,7 @@ export function toSnakeCase(input: string) {
 export function toCamelCase(input: string) {
 	const words = input
 		.replace(/['\u2019]/g, '')
-		.match(/[\da-z]+|[A-Z]+(?![a-z])|[A-Z][\da-z]+/g) ?? [];
+		.match(WORD_PATTERN) ?? [];
 
 	return words.reduce((acc, word, i) => {
 		const formattedWord = i === 0 ? word.toLowerCase() : `${word[0]!.toUpperCase()}${word.slice(1)}`;

--- a/drizzle-orm/tests/casing/casing.test.ts
+++ b/drizzle-orm/tests/casing/casing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'vitest';
-import { toCamelCase, toSnakeCase } from '~/casing';
+import { CasingCache, toCamelCase, toSnakeCase } from '~/casing';
+import { pgTable, text } from '~/pg-core';
 
 describe.concurrent('casing', () => {
 	it('transforms to snake case', ({ expect }) => {
@@ -24,5 +25,36 @@ describe.concurrent('casing', () => {
 
 	it('transforms to camel case 1', ({ expect }) => {
 		expect(toCamelCase('drizzle_kit')).toEqual('drizzleKit');
+	});
+
+	it('preserves non-Latin identifiers in snake case', ({ expect }) => {
+		expect(toSnakeCase('칼럼명')).toEqual('칼럼명');
+		expect(toSnakeCase('칼럼1')).toEqual('칼럼1');
+		expect(toSnakeCase('사용자ID')).toEqual('사용자_id');
+		expect(toSnakeCase('日本語Test')).toEqual('日本語_test');
+		expect(toSnakeCase('한글colName')).toEqual('한글_col_name');
+		expect(toSnakeCase('имяПользователя')).toEqual('имя_пользователя');
+	});
+
+	it('preserves non-Latin identifiers in camel case', ({ expect }) => {
+		expect(toCamelCase('칼럼명')).toEqual('칼럼명');
+		expect(toCamelCase('칼럼_명')).toEqual('칼럼명');
+		expect(toCamelCase('привет_мир')).toEqual('приветМир');
+		expect(toCamelCase('año_nuevo')).toEqual('añoNuevo');
+	});
+
+	it('handles accented Latin characters', ({ expect }) => {
+		expect(toSnakeCase('café')).toEqual('café');
+		expect(toSnakeCase('userNaïve')).toEqual('user_naïve');
+		expect(toSnakeCase('añoNuevo')).toEqual('año_nuevo');
+		expect(toCamelCase('café_au_lait')).toEqual('caféAuLait');
+	});
+
+	it('preserves non-Latin column names in CasingCache', ({ expect }) => {
+		const users = pgTable('users', {
+			칼럼명: text(),
+		});
+		const cache = new CasingCache('snake_case');
+		expect(cache.getColumnCasing(users.칼럼명)).toEqual('칼럼명');
 	});
 });


### PR DESCRIPTION
### Summary of Changes

The word-splitting regular expression in `toSnakeCase` and `toCamelCase` (`drizzle-orm/src/casing.ts`) previously matched only ASCII character classes (`[\da-z]` and `[A-Z]`).

Because unmatched characters are silently discarded by `.match()`, non-Latin characters (e.g., Korean Hangul, Cyrillic, Greek, CJK ideographs) and accented Latin letters (e.g., `café`, `año`) were stripped from identifiers entirely.

When using `casing: 'snake_case'` or `snakeCase.table()`, a column name such as `칼럼명` was converted into an empty string `""`, producing invalid SQL (` `` text `) and breaking schema migrations.

### Solution

- Updated the word-splitting regex to use Unicode property escapes:
  `const WORD_PATTERN = /[\p{Ll}\d]+|\p{Lu}+(?!\p{Ll})|\p{Lu}[\p{Ll}\d]+|[\p{Lo}\d]+/gu;`
  - `\p{Ll}` / `\p{Lu}` handle scripts with letter case distinctions (Latin with accents, Cyrillic, Greek).
  - `\p{Lo}` handles caseless scripts (Hangul, CJK ideographs).
  - Preserves 100% backward compatibility for existing ASCII identifiers.
- Added tests in `drizzle-orm/tests/casing/casing.test.ts` for Korean, Japanese, Cyrillic, accented Latin, and table column resolution via `CasingCache`.

Fixes #6082