### PR TITLE
[Valibot]: Add createSchemaFactory to drizzle-valibot

### DIFF
--- a/drizzle-valibot/src/column.ts
+++ b/drizzle-valibot/src/column.ts
@@ -58,13 +58,22 @@ import { CONSTANTS } from './constants.ts';
 import { isColumnType, isWithEnum } from './utils.ts';
 import type { Json } from './utils.ts';
 
-export const literalSchema = v.union([v.string(), v.number(), v.boolean(), v.null()]);
-export const jsonSchema: v.GenericSchema<Json> = v.union([
-	literalSchema,
-	v.array(v.any()),
-	v.record(v.string(), v.any()),
-]);
-export const bufferSchema: v.GenericSchema<Buffer> = v.custom<Buffer>((v) => v instanceof Buffer); // eslint-disable-line no-instanceof/no-instanceof
+export const createLiteralSchema = (valibot: typeof v = v) =>
+	valibot.union([valibot.string(), valibot.number(), valibot.boolean(), valibot.null()]);
+
+export const createJsonSchema = (valibot: typeof v = v): v.GenericSchema<Json> =>
+	valibot.union([
+		createLiteralSchema(valibot),
+		valibot.array(valibot.any()),
+		valibot.record(valibot.string(), valibot.any()),
+	]);
+
+export const createBufferSchema = (valibot: typeof v = v): v.GenericSchema<Buffer> =>
+	valibot.custom<Buffer>((val) => val instanceof Buffer); // eslint-disable-line no-instanceof/no-instanceof
+
+export const literalSchema = createLiteralSchema(v);
+export const jsonSchema: v.GenericSchema<Json> = createJsonSchema(v);
+export const bufferSchema: v.GenericSchema<Buffer> = createBufferSchema(v);
 
 export function mapEnumValues(values: string[]) {
 	return Object.fromEntries(values.map((value) => [value, value]));
@@ -111,11 +120,11 @@ export function columnToSchema(column: Column, valibot: typeof v = v): v.Generic
 		} else if (column.dataType === 'string') {
 			schema = stringColumnToSchema(column, valibot);
 		} else if (column.dataType === 'json') {
-			schema = jsonSchema;
+			schema = valibot === v ? jsonSchema : createJsonSchema(valibot);
 		} else if (column.dataType === 'custom') {
 			schema = valibot.any();
 		} else if (column.dataType === 'buffer') {
-			schema = bufferSchema;
+			schema = valibot === v ? bufferSchema : createBufferSchema(valibot);
 		}
 	}
 

--- a/drizzle-valibot/src/column.ts
+++ b/drizzle-valibot/src/column.ts
@@ -70,62 +70,63 @@ export function mapEnumValues(values: string[]) {
 	return Object.fromEntries(values.map((value) => [value, value]));
 }
 
-export function columnToSchema(column: Column): v.GenericSchema {
+export function columnToSchema(column: Column, valibot: typeof v = v): v.GenericSchema {
 	let schema!: v.GenericSchema;
 
 	if (isWithEnum(column)) {
-		schema = column.enumValues.length ? v.enum(mapEnumValues(column.enumValues)) : v.string();
+		schema = column.enumValues.length ? valibot.enum(mapEnumValues(column.enumValues)) : valibot.string();
 	}
 
 	if (!schema) {
 		// Handle specific types
 		if (isColumnType<PgGeometry<any> | PgPointTuple<any>>(column, ['PgGeometry', 'PgPointTuple'])) {
-			schema = v.tuple([v.number(), v.number()]);
+			schema = valibot.tuple([valibot.number(), valibot.number()]);
 		} else if (
 			isColumnType<PgPointObject<any> | PgGeometryObject<any>>(column, ['PgGeometryObject', 'PgPointObject'])
 		) {
-			schema = v.object({ x: v.number(), y: v.number() });
+			schema = valibot.object({ x: valibot.number(), y: valibot.number() });
 		} else if (isColumnType<PgHalfVector<any> | PgVector<any>>(column, ['PgHalfVector', 'PgVector'])) {
-			schema = v.array(v.number());
-			schema = column.dimensions ? v.pipe(schema as v.ArraySchema<any, any>, v.length(column.dimensions)) : schema;
+			schema = valibot.array(valibot.number());
+			schema = column.dimensions
+				? valibot.pipe(schema as v.ArraySchema<any, any>, valibot.length(column.dimensions))
+				: schema;
 		} else if (isColumnType<PgLineTuple<any>>(column, ['PgLine'])) {
-			schema = v.tuple([v.number(), v.number(), v.number()]);
-			v.array(v.array(v.number()));
+			schema = valibot.tuple([valibot.number(), valibot.number(), valibot.number()]);
 		} else if (isColumnType<PgLineABC<any>>(column, ['PgLineABC'])) {
-			schema = v.object({ a: v.number(), b: v.number(), c: v.number() });
+			schema = valibot.object({ a: valibot.number(), b: valibot.number(), c: valibot.number() });
 		} // Handle other types
 		else if (isColumnType<PgArray<any, any>>(column, ['PgArray'])) {
-			schema = v.array(columnToSchema(column.baseColumn));
-			schema = column.size ? v.pipe(schema as v.ArraySchema<any, any>, v.length(column.size)) : schema;
+			schema = valibot.array(columnToSchema(column.baseColumn, valibot));
+			schema = column.size ? valibot.pipe(schema as v.ArraySchema<any, any>, valibot.length(column.size)) : schema;
 		} else if (column.dataType === 'array') {
-			schema = v.array(v.any());
+			schema = valibot.array(valibot.any());
 		} else if (column.dataType === 'number') {
-			schema = numberColumnToSchema(column);
+			schema = numberColumnToSchema(column, valibot);
 		} else if (column.dataType === 'bigint') {
-			schema = bigintColumnToSchema(column);
+			schema = bigintColumnToSchema(column, valibot);
 		} else if (column.dataType === 'boolean') {
-			schema = v.boolean();
+			schema = valibot.boolean();
 		} else if (column.dataType === 'date') {
-			schema = v.date();
+			schema = valibot.date();
 		} else if (column.dataType === 'string') {
-			schema = stringColumnToSchema(column);
+			schema = stringColumnToSchema(column, valibot);
 		} else if (column.dataType === 'json') {
 			schema = jsonSchema;
 		} else if (column.dataType === 'custom') {
-			schema = v.any();
+			schema = valibot.any();
 		} else if (column.dataType === 'buffer') {
 			schema = bufferSchema;
 		}
 	}
 
 	if (!schema) {
-		schema = v.any();
+		schema = valibot.any();
 	}
 
 	return schema;
 }
 
-function numberColumnToSchema(column: Column): v.GenericSchema {
+function numberColumnToSchema(column: Column, valibot: typeof v = v): v.GenericSchema {
 	let unsigned = column.getSQLType().includes('unsigned');
 	let min!: number;
 	let max!: number;
@@ -225,24 +226,24 @@ function numberColumnToSchema(column: Column): v.GenericSchema {
 		max = Number.MAX_SAFE_INTEGER;
 	}
 
-	const actions: any[] = [v.minValue(min), v.maxValue(max)];
+	const actions: any[] = [valibot.minValue(min), valibot.maxValue(max)];
 	if (integer) {
-		actions.push(v.integer());
+		actions.push(valibot.integer());
 	}
-	return v.pipe(v.number(), ...actions);
+	return valibot.pipe(valibot.number(), ...actions);
 }
 
-function bigintColumnToSchema(column: Column): v.GenericSchema {
+function bigintColumnToSchema(column: Column, valibot: typeof v = v): v.GenericSchema {
 	const unsigned = column.getSQLType().includes('unsigned');
 	const min = unsigned ? 0n : CONSTANTS.INT64_MIN;
 	const max = unsigned ? CONSTANTS.INT64_UNSIGNED_MAX : CONSTANTS.INT64_MAX;
 
-	return v.pipe(v.bigint(), v.minValue(min), v.maxValue(max));
+	return valibot.pipe(valibot.bigint(), valibot.minValue(min), valibot.maxValue(max));
 }
 
-function stringColumnToSchema(column: Column): v.GenericSchema {
+function stringColumnToSchema(column: Column, valibot: typeof v = v): v.GenericSchema {
 	if (isColumnType<PgUUID<ColumnBaseConfig<'string', 'PgUUID'>>>(column, ['PgUUID'])) {
-		return v.pipe(v.string(), v.uuid());
+		return valibot.pipe(valibot.string(), valibot.uuid());
 	}
 
 	let max: number | undefined;
@@ -285,12 +286,12 @@ function stringColumnToSchema(column: Column): v.GenericSchema {
 
 	const actions: any[] = [];
 	if (regex) {
-		actions.push(v.regex(regex));
+		actions.push(valibot.regex(regex));
 	}
 	if (max && fixed) {
-		actions.push(v.length(max));
+		actions.push(valibot.length(max));
 	} else if (max) {
-		actions.push(v.maxLength(max));
+		actions.push(valibot.maxLength(max));
 	}
-	return actions.length > 0 ? v.pipe(v.string(), ...actions) : v.string();
+	return actions.length > 0 ? valibot.pipe(valibot.string(), ...actions) : valibot.string();
 }

--- a/drizzle-valibot/src/index.ts
+++ b/drizzle-valibot/src/index.ts
@@ -1,4 +1,11 @@
-export { bufferSchema, jsonSchema, literalSchema } from './column.ts';
+export {
+	bufferSchema,
+	createBufferSchema,
+	createJsonSchema,
+	createLiteralSchema,
+	jsonSchema,
+	literalSchema,
+} from './column.ts';
 export * from './column.types.ts';
 export * from './schema.ts';
 export * from './schema.types.internal.ts';

--- a/drizzle-valibot/src/schema.ts
+++ b/drizzle-valibot/src/schema.ts
@@ -4,24 +4,31 @@ import type { PgEnum } from 'drizzle-orm/pg-core';
 import * as v from 'valibot';
 import { columnToSchema, mapEnumValues } from './column.ts';
 import type { Conditions } from './schema.types.internal.ts';
-import type { CreateInsertSchema, CreateSelectSchema, CreateUpdateSchema } from './schema.types.ts';
+import type {
+	CreateInsertSchema,
+	CreateSchemaFactoryOptions,
+	CreateSelectSchema,
+	CreateUpdateSchema,
+} from './schema.types.ts';
 import { isPgEnum } from './utils.ts';
 
-function getColumns(tableLike: Table | View) {
+export function getColumns(tableLike: Table | View) {
 	return isTable(tableLike) ? getTableColumns(tableLike) : getViewSelectedFields(tableLike);
 }
 
-function handleColumns(
+export function handleColumns(
 	columns: Record<string, any>,
 	refinements: Record<string, any>,
 	conditions: Conditions,
+	factory?: CreateSchemaFactoryOptions,
 ): v.GenericSchema {
 	const columnSchemas: Record<string, v.GenericSchema> = {};
+	const valibot: typeof v = factory?.valibotInstance ?? v;
 
 	for (const [key, selected] of Object.entries(columns)) {
 		if (!is(selected, Column) && !is(selected, SQL) && !is(selected, SQL.Aliased) && typeof selected === 'object') {
 			const columns = isTable(selected) || isView(selected) ? getColumns(selected) : selected;
-			columnSchemas[key] = handleColumns(columns, refinements[key] ?? {}, conditions);
+			columnSchemas[key] = handleColumns(columns, refinements[key] ?? {}, conditions, factory);
 			continue;
 		}
 
@@ -32,7 +39,7 @@ function handleColumns(
 		}
 
 		const column = is(selected, Column) ? selected : undefined;
-		const schema = column ? columnToSchema(column) : v.any();
+		const schema = column ? columnToSchema(column, valibot) : valibot.any();
 		const refined = typeof refinement === 'function' ? refinement(schema) : schema;
 
 		if (conditions.never(column)) {
@@ -43,31 +50,50 @@ function handleColumns(
 
 		if (column) {
 			if (conditions.nullable(column)) {
-				columnSchemas[key] = v.nullable(columnSchemas[key]!);
+				columnSchemas[key] = valibot.nullable(columnSchemas[key]!);
 			}
 
 			if (conditions.optional(column)) {
-				columnSchemas[key] = v.optional(columnSchemas[key]!);
+				columnSchemas[key] = valibot.optional(columnSchemas[key]!);
 			}
 		}
 	}
 
-	return v.object(columnSchemas) as any;
+	return valibot.object(columnSchemas) as any;
 }
+
+export function handleEnum(enum_: PgEnum<any>, factory?: CreateSchemaFactoryOptions) {
+	const valibot: typeof v = factory?.valibotInstance ?? v;
+	return valibot.enum(mapEnumValues(enum_.enumValues));
+}
+
+const selectConditions: Conditions = {
+	never: () => false,
+	optional: () => false,
+	nullable: (column) => !column.notNull,
+};
+
+const insertConditions: Conditions = {
+	never: (column) => column?.generated?.type === 'always' || column?.generatedIdentity?.type === 'always',
+	optional: (column) => !column.notNull || (column.notNull && column.hasDefault),
+	nullable: (column) => !column.notNull,
+};
+
+const updateConditions: Conditions = {
+	never: (column) => column?.generated?.type === 'always' || column?.generatedIdentity?.type === 'always',
+	optional: () => true,
+	nullable: (column) => !column.notNull,
+};
 
 export const createSelectSchema: CreateSelectSchema = (
 	entity: Table | View | PgEnum<[string, ...string[]]>,
 	refine?: Record<string, any>,
 ) => {
 	if (isPgEnum(entity)) {
-		return v.enum(mapEnumValues(entity.enumValues));
+		return handleEnum(entity);
 	}
 	const columns = getColumns(entity);
-	return handleColumns(columns, refine ?? {}, {
-		never: () => false,
-		optional: () => false,
-		nullable: (column) => !column.notNull,
-	}) as any;
+	return handleColumns(columns, refine ?? {}, selectConditions) as any;
 };
 
 export const createInsertSchema: CreateInsertSchema = (
@@ -75,11 +101,7 @@ export const createInsertSchema: CreateInsertSchema = (
 	refine?: Record<string, any>,
 ) => {
 	const columns = getColumns(entity);
-	return handleColumns(columns, refine ?? {}, {
-		never: (column) => column?.generated?.type === 'always' || column?.generatedIdentity?.type === 'always',
-		optional: (column) => !column.notNull || (column.notNull && column.hasDefault),
-		nullable: (column) => !column.notNull,
-	}) as any;
+	return handleColumns(columns, refine ?? {}, insertConditions) as any;
 };
 
 export const createUpdateSchema: CreateUpdateSchema = (
@@ -87,9 +109,36 @@ export const createUpdateSchema: CreateUpdateSchema = (
 	refine?: Record<string, any>,
 ) => {
 	const columns = getColumns(entity);
-	return handleColumns(columns, refine ?? {}, {
-		never: (column) => column?.generated?.type === 'always' || column?.generatedIdentity?.type === 'always',
-		optional: () => true,
-		nullable: (column) => !column.notNull,
-	}) as any;
+	return handleColumns(columns, refine ?? {}, updateConditions) as any;
 };
+
+export function createSchemaFactory(options?: CreateSchemaFactoryOptions) {
+	const createSelectSchema: CreateSelectSchema = (
+		entity: Table | View | PgEnum<[string, ...string[]]>,
+		refine?: Record<string, any>,
+	) => {
+		if (isPgEnum(entity)) {
+			return handleEnum(entity, options);
+		}
+		const columns = getColumns(entity);
+		return handleColumns(columns, refine ?? {}, selectConditions, options) as any;
+	};
+
+	const createInsertSchema: CreateInsertSchema = (
+		entity: Table,
+		refine?: Record<string, any>,
+	) => {
+		const columns = getColumns(entity);
+		return handleColumns(columns, refine ?? {}, insertConditions, options) as any;
+	};
+
+	const createUpdateSchema: CreateUpdateSchema = (
+		entity: Table,
+		refine?: Record<string, any>,
+	) => {
+		const columns = getColumns(entity);
+		return handleColumns(columns, refine ?? {}, updateConditions, options) as any;
+	};
+
+	return { createSelectSchema, createInsertSchema, createUpdateSchema };
+}

--- a/drizzle-valibot/src/schema.types.ts
+++ b/drizzle-valibot/src/schema.types.ts
@@ -47,3 +47,7 @@ export interface CreateUpdateSchema {
 		refine?: TRefine,
 	): BuildSchema<'update', TTable['_']['columns'], TRefine>;
 }
+
+export interface CreateSchemaFactoryOptions {
+	valibotInstance?: any;
+}

--- a/drizzle-valibot/tests/pg.test.ts
+++ b/drizzle-valibot/tests/pg.test.ts
@@ -17,7 +17,7 @@ import * as v from 'valibot';
 import { test } from 'vitest';
 import { jsonSchema } from '~/column.ts';
 import { CONSTANTS } from '~/constants.ts';
-import { createInsertSchema, createSelectSchema, createUpdateSchema } from '../src';
+import { createInsertSchema, createSchemaFactory, createSelectSchema, createUpdateSchema } from '../src';
 import { Expect, expectEnumValues, expectSchemaShape } from './utils.ts';
 
 const integerSchema = v.pipe(v.number(), v.minValue(CONSTANTS.INT32_MIN), v.maxValue(CONSTANTS.INT32_MAX), v.integer());
@@ -561,3 +561,52 @@ test('all data types', (t) => {
 	// @ts-expect-error
 	createSelectSchema(mView, { unknown: v.string() });
 }
+
+test('createSchemaFactory - select, insert, update', (t) => {
+	const table = pgTable('test', {
+		id: serial().primaryKey(),
+		name: text().notNull(),
+	});
+
+	const { createSelectSchema, createInsertSchema, createUpdateSchema } = createSchemaFactory();
+	const selectResult = createSelectSchema(table);
+	const insertResult = createInsertSchema(table);
+	const updateResult = createUpdateSchema(table);
+
+	const expectedSelect = v.object({ id: integerSchema, name: textSchema });
+	const expectedInsert = v.object({ id: v.optional(integerSchema), name: textSchema });
+	const expectedUpdate = v.object({ id: v.optional(integerSchema), name: v.optional(textSchema) });
+
+	expectSchemaShape(t, expectedSelect).from(selectResult);
+	expectSchemaShape(t, expectedInsert).from(insertResult);
+	expectSchemaShape(t, expectedUpdate).from(updateResult);
+
+	Expect<Equal<typeof selectResult, typeof expectedSelect>>();
+	Expect<Equal<typeof insertResult, typeof expectedInsert>>();
+	Expect<Equal<typeof updateResult, typeof expectedUpdate>>();
+});
+
+test('createSchemaFactory with valibotInstance', (t) => {
+	const table = pgTable('test', {
+		id: serial().primaryKey(),
+		name: text().notNull(),
+	});
+
+	const { createSelectSchema } = createSchemaFactory({
+		valibotInstance: v,
+	});
+	const selectResult = createSelectSchema(table);
+	const expectedSelect = v.object({ id: integerSchema, name: textSchema });
+
+	expectSchemaShape(t, expectedSelect).from(selectResult);
+	Expect<Equal<typeof selectResult, typeof expectedSelect>>();
+});
+
+test('createSchemaFactory with pgEnum', (t) => {
+	const roleEnum = pgEnum('role', ['admin', 'user']);
+	const { createSelectSchema } = createSchemaFactory();
+	const result = createSelectSchema(roleEnum);
+	const expected = v.enum({ admin: 'admin', user: 'user' });
+	expectEnumValues(t, expected).from(result);
+	Expect<Equal<typeof result, typeof expected>>();
+});

--- a/drizzle-valibot/tests/sqlite.test.ts
+++ b/drizzle-valibot/tests/sqlite.test.ts
@@ -427,3 +427,34 @@ test('createSchemaFactory - select, insert, update', (t) => {
 	Expect<Equal<typeof insertResult, typeof expectedInsert>>();
 	Expect<Equal<typeof updateResult, typeof expectedUpdate>>();
 });
+
+test('createSchemaFactory with custom valibotInstance for json and buffer', (t) => {
+	let customUnionCalled = false;
+	let customCustomCalled = false;
+
+	const customValibot = {
+		...v,
+		union: ((...args: any[]) => {
+			customUnionCalled = true;
+			return (v.union as any)(...args);
+		}) as typeof v.union,
+		custom: ((...args: any[]) => {
+			customCustomCalled = true;
+			return (v.custom as any)(...args);
+		}) as typeof v.custom,
+	};
+
+	const table = sqliteTable('test', {
+		buf: blob({ mode: 'buffer' }).notNull(),
+		jsonCol: text({ mode: 'json' }).notNull(),
+	});
+
+	const { createSelectSchema } = createSchemaFactory({
+		valibotInstance: customValibot as any,
+	});
+
+	createSelectSchema(table);
+
+	t.expect(customUnionCalled).toBe(true);
+	t.expect(customCustomCalled).toBe(true);
+});

--- a/drizzle-valibot/tests/sqlite.test.ts
+++ b/drizzle-valibot/tests/sqlite.test.ts
@@ -5,7 +5,7 @@ import * as v from 'valibot';
 import { test } from 'vitest';
 import { bufferSchema, jsonSchema } from '~/column.ts';
 import { CONSTANTS } from '~/constants.ts';
-import { createInsertSchema, createSelectSchema, createUpdateSchema } from '../src';
+import { createInsertSchema, createSchemaFactory, createSelectSchema, createUpdateSchema } from '../src';
 import { Expect, expectSchemaShape } from './utils.ts';
 
 const intSchema = v.pipe(
@@ -403,3 +403,27 @@ test('all data types', (t) => {
 	// @ts-expect-error
 	createSelectSchema(view, { unknown: v.string() });
 }
+
+test('createSchemaFactory - select, insert, update', (t) => {
+	const table = sqliteTable('test', {
+		id: int().primaryKey({ autoIncrement: true }),
+		name: text().notNull(),
+	});
+
+	const { createSelectSchema, createInsertSchema, createUpdateSchema } = createSchemaFactory();
+	const selectResult = createSelectSchema(table);
+	const insertResult = createInsertSchema(table);
+	const updateResult = createUpdateSchema(table);
+
+	const expectedSelect = v.object({ id: intSchema, name: textSchema });
+	const expectedInsert = v.object({ id: v.optional(intSchema), name: textSchema });
+	const expectedUpdate = v.object({ id: v.optional(intSchema), name: v.optional(textSchema) });
+
+	expectSchemaShape(t, expectedSelect).from(selectResult);
+	expectSchemaShape(t, expectedInsert).from(insertResult);
+	expectSchemaShape(t, expectedUpdate).from(updateResult);
+
+	Expect<Equal<typeof selectResult, typeof expectedSelect>>();
+	Expect<Equal<typeof insertResult, typeof expectedInsert>>();
+	Expect<Equal<typeof updateResult, typeof expectedUpdate>>();
+});


### PR DESCRIPTION
### Summary of Changes

`drizzle-zod` and `drizzle-typebox` both export `createSchemaFactory`, but `drizzle-valibot` was missing it. This makes it harder to use a consistent factory pattern across validator packages and pass a custom `valibotInstance`.

This PR introduces `createSchemaFactory` to `drizzle-valibot`, bringing it to feature parity with the other validator packages.

### Solution

- Added `CreateSchemaFactoryOptions` interface in `drizzle-valibot/src/schema.types.ts`.
- Implemented and exported `createSchemaFactory(options?: CreateSchemaFactoryOptions)` in `drizzle-valibot/src/schema.ts`, returning `{ createSelectSchema, createInsertSchema, createUpdateSchema }`.
- Updated `columnToSchema` and its column builders in `drizzle-valibot/src/column.ts` to accept the `valibot` instance.
- Added comprehensive unit tests and type assertions across `pg.test.ts` and `sqlite.test.ts`.

Closes #6212
