### PR TITLE
[eslint-plugin-drizzle]: Fix where-clause checks for private class fields

### DIFF
--- a/eslint-plugin-drizzle/src/utils/ast.ts
+++ b/eslint-plugin-drizzle/src/utils/ast.ts
@@ -1,5 +1,12 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 
+const getPropertyName = (node: TSESTree.MemberExpression) => {
+	if (node.computed) {
+		return undefined;
+	}
+	return node.property.type === 'PrivateIdentifier' ? `#${node.property.name}` : node.property.name;
+};
+
 export const resolveMemberExpressionPath = (node: TSESTree.MemberExpression) => {
 	let objectExpression = node.object;
 	let fullName = '';
@@ -11,16 +18,18 @@ export const resolveMemberExpressionPath = (node: TSESTree.MemberExpression) => 
 
 	while (objectExpression) {
 		if (objectExpression.type === 'MemberExpression') {
-			if (objectExpression.property.type === 'Identifier') {
-				addToFullName(objectExpression.property.name);
+			const propertyName = getPropertyName(objectExpression);
+			if (propertyName) {
+				addToFullName(propertyName);
 			}
 			objectExpression = objectExpression.object;
 		} else if (objectExpression.type === 'CallExpression' && objectExpression.callee.type === 'Identifier') {
 			addToFullName(`${objectExpression.callee.name}(...)`);
 			break;
 		} else if (objectExpression.type === 'CallExpression' && objectExpression.callee.type === 'MemberExpression') {
-			if (objectExpression.callee.property.type === 'Identifier') {
-				addToFullName(`${objectExpression.callee.property.name}(...)`);
+			const propertyName = getPropertyName(objectExpression.callee);
+			if (propertyName) {
+				addToFullName(`${propertyName}(...)`);
 			}
 			objectExpression = objectExpression.callee.object;
 		} else if (objectExpression.type === 'Identifier') {

--- a/eslint-plugin-drizzle/src/utils/options.ts
+++ b/eslint-plugin-drizzle/src/utils/options.ts
@@ -28,12 +28,12 @@ export const isDrizzleObj = (
 
 	if (node.object.type === 'Identifier') {
 		return isDrizzleObjName(node.object.name, drizzleObjectName);
-	} else if (node.object.type === 'MemberExpression' && node.object.property.type === 'Identifier') {
+	} else if (node.object.type === 'MemberExpression' && !node.object.computed) {
 		return isDrizzleObjName(node.object.property.name, drizzleObjectName);
 	} else if (node.object.type === 'CallExpression') {
 		if (node.object.callee.type === 'Identifier') {
 			return isDrizzleObjName(node.object.callee.name, drizzleObjectName);
-		} else if (node.object.callee.type === 'MemberExpression' && node.object.callee.property.type === 'Identifier') {
+		} else if (node.object.callee.type === 'MemberExpression' && !node.object.callee.computed) {
 			return isDrizzleObjName(node.object.callee.property.name, drizzleObjectName);
 		}
 	}

--- a/eslint-plugin-drizzle/tests/delete.test.ts
+++ b/eslint-plugin-drizzle/tests/delete.test.ts
@@ -17,8 +17,17 @@ ruleTester.run('enforce delete with where (default options)', myRule, {
       .delete()
       .where()`,
 		`this.database.delete({}).where()`,
+		'class Repo { #db; clear() { return this.#db.delete({}).where({}); } }',
 	],
 	invalid: [
+		{
+			code: 'class Repo { #db; clear() { return this.#db.delete({}); } }',
+			errors: [{ messageId: 'enforceDeleteWithWhere', data: { drizzleObjName: 'this.#db' } }],
+		},
+		{
+			code: 'class Repo { #getDb() {} clear() { return this.#getDb().delete({}); } }',
+			errors: [{ messageId: 'enforceDeleteWithWhere', data: { drizzleObjName: 'this.#getDb(...)' } }],
+		},
 		{
 			code: 'db.delete({})',
 			errors: [{ messageId: 'enforceDeleteWithWhere', data: { drizzleObjName: 'db' } }],
@@ -106,8 +115,17 @@ ruleTester.run('enforce delete with where (string option)', myRule, {
 			code: `const a = this.getDataSource().db.delete({})`,
 			options: [{ drizzleObjectName: 'getDataSource' }],
 		},
+		{
+			code: 'class Repo { #database; clear() { return this.#database.delete({}); } }',
+			options: [{ drizzleObjectName: 'db' }],
+		},
 	],
 	invalid: [
+		{
+			code: 'class Repo { #db; clear() { return this.#db.delete({}); } }',
+			errors: [{ messageId: 'enforceDeleteWithWhere', data: { drizzleObjName: 'this.#db' } }],
+			options: [{ drizzleObjectName: 'db' }],
+		},
 		{
 			code: 'db.delete({})',
 			errors: [{ messageId: 'enforceDeleteWithWhere', data: { drizzleObjName: 'db' } }],

--- a/eslint-plugin-drizzle/tests/update.test.ts
+++ b/eslint-plugin-drizzle/tests/update.test.ts
@@ -27,8 +27,17 @@ ruleTester.run('enforce update with where (default options)', myRule, {
       .update()
       .set()
       .where()`,
+		'class Repo { #db; touch() { return this.#db.update({}).set({}).where({}); } }',
 	],
 	invalid: [
+		{
+			code: 'class Repo { #db; touch() { return this.#db.update({}).set({}); } }',
+			errors: [{ messageId: 'enforceUpdateWithWhere', data: { drizzleObjName: 'this.#db' } }],
+		},
+		{
+			code: 'class Repo { #getDb() {} touch() { return this.#getDb().update({}).set({}); } }',
+			errors: [{ messageId: 'enforceUpdateWithWhere', data: { drizzleObjName: 'this.#getDb(...)' } }],
+		},
 		{
 			code: 'db.update({}).set()',
 			errors: [{ messageId: 'enforceUpdateWithWhere' }],
@@ -116,8 +125,17 @@ ruleTester.run('enforce update with where (string option)', myRule, {
 			code: `const a = this.getDataSource().db.update({}).set()`,
 			options: [{ drizzleObjectName: 'getDataSource' }],
 		},
+		{
+			code: 'class Repo { #database; touch() { return this.#database.update({}).set({}); } }',
+			options: [{ drizzleObjectName: 'db' }],
+		},
 	],
 	invalid: [
+		{
+			code: 'class Repo { #db; touch() { return this.#db.update({}).set({}); } }',
+			errors: [{ messageId: 'enforceUpdateWithWhere', data: { drizzleObjName: 'this.#db' } }],
+			options: [{ drizzleObjectName: 'db' }],
+		},
 		{
 			code: 'db.update({}).set({})',
 			errors: [{ messageId: 'enforceUpdateWithWhere' }],


### PR DESCRIPTION
Fixes #6287

The `enforce-delete-with-where` and `enforce-update-with-where` rules miss calls like `this.#db.delete(users)` when configured with `drizzleObjectName: 'db'`.

This fixes object-name matching for native private fields and private method calls. Diagnostic messages also preserve the full private name, such as `this.#db` or `this.#getDb(...)`. Computed properties are excluded from static name matching.

Regression tests cover both rules: queries with and without `.where()`, private method calls, and configured object names.
