### PR TITLE
fix(utils): prevent nullifying nested left-join objects when first column value is null (#1603)

### DIFF
--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -47,6 +47,8 @@ export function mapResultRow<TResult>(
 						const objectName = path[0]!;
 						if (!(objectName in nullifyMap)) {
 							nullifyMap[objectName] = value === null ? getTableName(field.table) : false;
+						} else if (value !== null) {
+							nullifyMap[objectName] = false;
 						} else if (
 							typeof nullifyMap[objectName] === 'string' && nullifyMap[objectName] !== getTableName(field.table)
 						) {

--- a/drizzle-orm/tests/mapResultRow.test.ts
+++ b/drizzle-orm/tests/mapResultRow.test.ts
@@ -1,0 +1,57 @@
+import { describe, test } from 'vitest';
+import { mapResultRow, orderSelectedFields } from '~/utils.ts';
+import { pgTable, serial, timestamp } from '~/pg-core/index.ts';
+
+const usersTable = pgTable('users', {
+	deletedAt: timestamp('deleted_at'),
+	id: serial('id'),
+});
+
+describe.concurrent('mapResultRow', () => {
+	test('should not nullify nested object on left join when first column is null but subsequent columns are non-null', ({ expect }) => {
+		const fields = orderSelectedFields({
+			user: {
+				deletedAt: usersTable.deletedAt,
+				id: usersTable.id,
+			},
+		});
+
+		const joinsNotNullableMap = { users: false };
+		const row = [null, 1];
+
+		const result = mapResultRow<{ user: { deletedAt: Date | null; id: number } | null }>(
+			fields,
+			row,
+			joinsNotNullableMap,
+		);
+
+		expect(result).toEqual({
+			user: {
+				deletedAt: null,
+				id: 1,
+			},
+		});
+	});
+
+	test('should nullify nested object on left join when all columns are null', ({ expect }) => {
+		const fields = orderSelectedFields({
+			user: {
+				deletedAt: usersTable.deletedAt,
+				id: usersTable.id,
+			},
+		});
+
+		const joinsNotNullableMap = { users: false };
+		const row = [null, null];
+
+		const result = mapResultRow<{ user: { deletedAt: Date | null; id: number } | null }>(
+			fields,
+			row,
+			joinsNotNullableMap,
+		);
+
+		expect(result).toEqual({
+			user: null,
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1603.

### Root Cause
In `mapResultRow` (`drizzle-orm/src/utils.ts`), when a nested partial select object is mapped for a left join, if the first selected field evaluates to `null` (e.g. `deletedAt: null`), `nullifyMap[objectName]` is set to the table name string. On subsequent non-null fields for the same nested object (e.g. `id: 123`), the nullify flag was not cleared because the logic only reset it on a table name mismatch. As a result, the entire nested object was incorrectly set to `null` at the end of row mapping.

### Fix
Updated `mapResultRow` to clear the `nullifyMap` flag (`nullifyMap[objectName] = false`) whenever a non-null field value is encountered for that object path.

### Testing
Added unit tests in `drizzle-orm/tests/mapResultRow.test.ts` verifying:
1. Partial select on left join with first field null + subsequent field non-null returns the nested object.
2. Partial select on left join with all fields null correctly nullifies the nested object.