### PR TITLE
feat: default select for custom types (#1083)

### DIFF
--- a/drizzle-orm/src/gel-core/columns/custom.ts
+++ b/drizzle-orm/src/gel-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyGelTable } from '~/gel-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { GelColumn, GelColumnBuilder } from './common.ts';
 
@@ -63,6 +63,7 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnyGelTable<{ name: T['tableName'] }>,
@@ -72,10 +73,16 @@ export class GelCustomColumn<T extends ColumnBaseConfig<'custom', 'GelCustomColu
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSelectSQL(columnName: string = this.name): SQL | SQL.Aliased | undefined {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(columnName, this) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +202,17 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 *
+	 * @example
+	 * ```ts
+	 * selectFromDb(column, decoder) {
+	 *   return sql<Point>`st_astext(${sql.identifier(column)})`.mapWith(decoder).as(column);
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/gel-core/dialect.ts
+++ b/drizzle-orm/src/gel-core/dialect.ts
@@ -3,7 +3,7 @@ import { CasingCache } from '~/casing.ts';
 import { Column } from '~/column.ts';
 import { entityKind, is } from '~/entity.ts';
 import { DrizzleError } from '~/errors.ts';
-import { GelColumn, GelDecimal, GelJson, GelUUID } from '~/gel-core/columns/index.ts';
+import { GelColumn, GelCustomColumn, GelDecimal, GelJson, GelUUID } from '~/gel-core/columns/index.ts';
 import type {
 	AnyGelSelectQueryBuilder,
 	GelDeleteConfig,
@@ -38,7 +38,7 @@ import {
 } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import { type Casing, mapColumnsToIdentifiers, orderSelectedFields, replaceIdentifierWithField, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import { GelTimestamp } from './columns/timestamp.ts';
 import { GelViewBase } from './view-base.ts';
@@ -235,13 +235,24 @@ export class GelDialect {
 						chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 					}
 				} else if (is(field, Column)) {
-					// Gel throws an error when more than one similarly named columns exist within context instead of preferring the closest one
-					// thus forcing us to be explicit about column's source
-					// if (isSingleTable) {
-					// 	chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
-					// } else {
-					chunk.push(field);
-					// }
+					const columnName = this.casing.getColumnCasing(field);
+					const customSelect = is(field, GelCustomColumn) ? field.getSelectSQL(columnName) : undefined;
+
+					if (customSelect) {
+						let query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+						query = replaceIdentifierWithField(query, columnName, field);
+						chunk.push(query);
+						const alias = is(customSelect, SQL.Aliased) ? customSelect.fieldAlias : columnName;
+						chunk.push(sql` as ${sql.identifier(alias)}`);
+					} else {
+						// Gel throws an error when more than one similarly named columns exist within context instead of preferring the closest one
+						// thus forcing us to be explicit about column's source
+						// if (isSingleTable) {
+						// 	chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+						// } else {
+						chunk.push(field);
+						// }
+					}
 				} else if (is(field, Subquery)) {
 					const entries = Object.entries(field._.selectedFields) as [string, SQL.Aliased | Column | SQL][];
 
@@ -1346,13 +1357,22 @@ export class GelDialect {
 		if (nestedQueryRelation) {
 			let field = sql`json_build_array(${
 				sql.join(
-					selection.map(({ field, tsKey, isJson }) =>
-						isJson
-							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
-							: is(field, SQL.Aliased)
-							? field.sql
-							: field
-					),
+					selection.map(({ field, tsKey, isJson }) => {
+						if (isJson) {
+							return sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`;
+						}
+						if (is(field, SQL.Aliased)) {
+							return field.sql;
+						}
+						if (is(field, GelCustomColumn)) {
+							const customSelect = field.getSelectSQL(this.casing.getColumnCasing(field));
+							if (customSelect) {
+								const query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+								return replaceIdentifierWithField(query, this.casing.getColumnCasing(field), field);
+							}
+						}
+						return field;
+					}),
 					sql`, `,
 				)
 			})`;

--- a/drizzle-orm/src/mysql-core/columns/custom.ts
+++ b/drizzle-orm/src/mysql-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyMySqlTable } from '~/mysql-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { MySqlColumn, MySqlColumnBuilder } from './common.ts';
 
@@ -63,6 +63,7 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnyMySqlTable<{ name: T['tableName'] }>,
@@ -72,10 +73,16 @@ export class MySqlCustomColumn<T extends ColumnBaseConfig<'custom', 'MySqlCustom
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSelectSQL(columnName: string = this.name): SQL | SQL.Aliased | undefined {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(columnName, this) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +202,17 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 *
+	 * @example
+	 * ```ts
+	 * selectFromDb(column, decoder) {
+	 *   return sql<Point>`st_astext(${sql.identifier(column)})`.mapWith(decoder).as(column);
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/mysql-core/dialect.ts
+++ b/drizzle-orm/src/mysql-core/dialect.ts
@@ -17,13 +17,14 @@ import {
 	type TablesRelationalConfig,
 } from '~/relations.ts';
 import { and, eq } from '~/sql/expressions/index.ts';
-import { Param, SQL, sql, View } from '~/sql/sql.ts';
-import type { Name, Placeholder, QueryWithTypings, SQLChunk } from '~/sql/sql.ts';
+import { Name, Param, SQL, sql, View } from '~/sql/sql.ts';
+import type { Placeholder, QueryWithTypings, SQLChunk } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import { type Casing, mapColumnsToIdentifiers, orderSelectedFields, replaceIdentifierWithField, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import { MySqlColumn } from './columns/common.ts';
+import { MySqlCustomColumn } from './columns/custom.ts';
 import type { MySqlDeleteConfig } from './query-builders/delete.ts';
 import type { MySqlInsertConfig } from './query-builders/insert.ts';
 import type {
@@ -245,8 +246,21 @@ export class MySqlDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+				const columnName = this.casing.getColumnCasing(field);
+				const customSelect = is(field, MySqlCustomColumn) ? field.getSelectSQL(columnName) : undefined;
+
+				if (customSelect) {
+					let query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+					if (isSingleTable) {
+						query = mapColumnsToIdentifiers(query, this.casing);
+					} else {
+						query = replaceIdentifierWithField(query, columnName, field);
+					}
+					chunk.push(query);
+					const alias = is(customSelect, SQL.Aliased) ? customSelect.fieldAlias : columnName;
+					chunk.push(sql` as ${sql.identifier(alias)}`);
+				} else if (isSingleTable) {
+					chunk.push(sql.identifier(columnName));
 				} else {
 					chunk.push(field);
 				}
@@ -893,13 +907,22 @@ export class MySqlDialect {
 		if (nestedQueryRelation) {
 			let field = sql`json_array(${
 				sql.join(
-					selection.map(({ field, tsKey, isJson }) =>
-						isJson
-							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
-							: is(field, SQL.Aliased)
-							? field.sql
-							: field
-					),
+					selection.map(({ field, tsKey, isJson }) => {
+						if (isJson) {
+							return sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`;
+						}
+						if (is(field, SQL.Aliased)) {
+							return field.sql;
+						}
+						if (is(field, MySqlCustomColumn)) {
+							const customSelect = field.getSelectSQL(this.casing.getColumnCasing(field));
+							if (customSelect) {
+								const query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+								return replaceIdentifierWithField(query, this.casing.getColumnCasing(field), field);
+							}
+						}
+						return field;
+					}),
 					sql`, `,
 				)
 			})`;
@@ -1235,13 +1258,22 @@ export class MySqlDialect {
 		if (nestedQueryRelation) {
 			let field = sql`json_array(${
 				sql.join(
-					selection.map(({ field }) =>
-						is(field, MySqlColumn)
-							? sql.identifier(this.casing.getColumnCasing(field))
-							: is(field, SQL.Aliased)
-							? field.sql
-							: field
-					),
+					selection.map(({ field }) => {
+						if (is(field, MySqlCustomColumn)) {
+							const customSelect = field.getSelectSQL(this.casing.getColumnCasing(field));
+							if (customSelect) {
+								const query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+								return replaceIdentifierWithField(query, this.casing.getColumnCasing(field), field);
+							}
+						}
+						if (is(field, MySqlColumn)) {
+							return sql.identifier(this.casing.getColumnCasing(field));
+						}
+						if (is(field, SQL.Aliased)) {
+							return field.sql;
+						}
+						return field;
+					}),
 					sql`, `,
 				)
 			})`;

--- a/drizzle-orm/src/pg-core/columns/custom.ts
+++ b/drizzle-orm/src/pg-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnyPgTable } from '~/pg-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { PgColumn, PgColumnBuilder } from './common.ts';
 
@@ -63,6 +63,7 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnyPgTable<{ name: T['tableName'] }>,
@@ -72,10 +73,16 @@ export class PgCustomColumn<T extends ColumnBaseConfig<'custom', 'PgCustomColumn
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSelectSQL(columnName: string = this.name): SQL | SQL.Aliased | undefined {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(columnName, this) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +202,17 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 *
+	 * @example
+	 * ```ts
+	 * selectFromDb(column, decoder) {
+	 *   return sql<Point>`st_astext(${sql.identifier(column)})`.mapWith(decoder).as(column);
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/pg-core/dialect.ts
+++ b/drizzle-orm/src/pg-core/dialect.ts
@@ -6,6 +6,7 @@ import { DrizzleError } from '~/errors.ts';
 import type { MigrationConfig, MigrationMeta } from '~/migrator.ts';
 import {
 	PgColumn,
+	PgCustomColumn,
 	PgDate,
 	PgDateString,
 	PgJson,
@@ -40,7 +41,7 @@ import {
 import { and, eq, View } from '~/sql/index.ts';
 import {
 	type DriverValueEncoder,
-	type Name,
+	Name,
 	Param,
 	type QueryTypingsValue,
 	type QueryWithTypings,
@@ -50,7 +51,7 @@ import {
 } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import { type Casing, mapColumnsToIdentifiers, orderSelectedFields, replaceIdentifierWithField, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type { PgSession } from './session.ts';
 import { PgViewBase } from './view-base.ts';
@@ -242,8 +243,21 @@ export class PgDialect {
 						chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 					}
 				} else if (is(field, Column)) {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+					const columnName = this.casing.getColumnCasing(field);
+					const customSelect = is(field, PgCustomColumn) ? field.getSelectSQL(columnName) : undefined;
+
+					if (customSelect) {
+						let query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+						if (isSingleTable) {
+							query = mapColumnsToIdentifiers(query, this.casing);
+						} else {
+							query = replaceIdentifierWithField(query, columnName, field);
+						}
+						chunk.push(query);
+						const alias = is(customSelect, SQL.Aliased) ? customSelect.fieldAlias : columnName;
+						chunk.push(sql` as ${sql.identifier(alias)}`);
+					} else if (isSingleTable) {
+						chunk.push(sql.identifier(columnName));
 					} else {
 						chunk.push(field);
 					}
@@ -1355,13 +1369,22 @@ export class PgDialect {
 		if (nestedQueryRelation) {
 			let field = sql`json_build_array(${
 				sql.join(
-					selection.map(({ field, tsKey, isJson }) =>
-						isJson
-							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
-							: is(field, SQL.Aliased)
-							? field.sql
-							: field
-					),
+					selection.map(({ field, tsKey, isJson }) => {
+						if (isJson) {
+							return sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`;
+						}
+						if (is(field, SQL.Aliased)) {
+							return field.sql;
+						}
+						if (is(field, PgCustomColumn)) {
+							const customSelect = field.getSelectSQL(this.casing.getColumnCasing(field));
+							if (customSelect) {
+								const query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+								return replaceIdentifierWithField(query, this.casing.getColumnCasing(field), field);
+							}
+						}
+						return field;
+					}),
 					sql`, `,
 				)
 			})`;

--- a/drizzle-orm/src/singlestore-core/columns/custom.ts
+++ b/drizzle-orm/src/singlestore-core/columns/custom.ts
@@ -2,7 +2,7 @@ import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnCon
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
 import type { AnySingleStoreTable } from '~/singlestore-core/table.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { SingleStoreColumn, SingleStoreColumnBuilder } from './common.ts';
 
@@ -66,6 +66,7 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnySingleStoreTable<{ name: T['tableName'] }>,
@@ -75,10 +76,16 @@ export class SingleStoreCustomColumn<T extends ColumnBaseConfig<'custom', 'Singl
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSelectSQL(columnName: string = this.name): SQL | SQL.Aliased | undefined {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(columnName, this) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -198,6 +205,17 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 *
+	 * @example
+	 * ```ts
+	 * selectFromDb(column, decoder) {
+	 *   return sql<Point>`st_astext(${sql.identifier(column)})`.mapWith(decoder).as(column);
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/singlestore-core/dialect.ts
+++ b/drizzle-orm/src/singlestore-core/dialect.ts
@@ -17,13 +17,14 @@ import {
 	type TablesRelationalConfig,
 } from '~/relations.ts';
 import { and, eq } from '~/sql/expressions/index.ts';
-import type { Name, Placeholder, QueryWithTypings, SQLChunk } from '~/sql/sql.ts';
-import { Param, SQL, sql, View } from '~/sql/sql.ts';
+import { Name, Param, SQL, sql, View } from '~/sql/sql.ts';
+import type { Placeholder, QueryWithTypings, SQLChunk } from '~/sql/sql.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import { type Casing, mapColumnsToIdentifiers, orderSelectedFields, replaceIdentifierWithField, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import { SingleStoreColumn } from './columns/common.ts';
+import { SingleStoreCustomColumn } from './columns/custom.ts';
 import type { SingleStoreDeleteConfig } from './query-builders/delete.ts';
 import type { SingleStoreInsertConfig } from './query-builders/insert.ts';
 import type {
@@ -244,8 +245,21 @@ export class SingleStoreDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				if (isSingleTable) {
-					chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+				const columnName = this.casing.getColumnCasing(field);
+				const customSelect = is(field, SingleStoreCustomColumn) ? field.getSelectSQL(columnName) : undefined;
+
+				if (customSelect) {
+					let query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+					if (isSingleTable) {
+						query = mapColumnsToIdentifiers(query, this.casing);
+					} else {
+						query = replaceIdentifierWithField(query, columnName, field);
+					}
+					chunk.push(query);
+					const alias = is(customSelect, SQL.Aliased) ? customSelect.fieldAlias : columnName;
+					chunk.push(sql` as ${sql.identifier(alias)}`);
+				} else if (isSingleTable) {
+					chunk.push(sql.identifier(columnName));
 				} else {
 					chunk.push(field);
 				}
@@ -843,13 +857,22 @@ export class SingleStoreDialect {
 		if (nestedQueryRelation) {
 			let field = sql`JSON_TO_ARRAY(${
 				sql.join(
-					selection.map(({ field, tsKey, isJson }) =>
-						isJson
-							? sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`
-							: is(field, SQL.Aliased)
-							? field.sql
-							: field
-					),
+					selection.map(({ field, tsKey, isJson }) => {
+						if (isJson) {
+							return sql`${sql.identifier(`${tableAlias}_${tsKey}`)}.${sql.identifier('data')}`;
+						}
+						if (is(field, SQL.Aliased)) {
+							return field.sql;
+						}
+						if (is(field, SingleStoreCustomColumn)) {
+							const customSelect = field.getSelectSQL(this.casing.getColumnCasing(field));
+							if (customSelect) {
+								const query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+								return replaceIdentifierWithField(query, this.casing.getColumnCasing(field), field);
+							}
+						}
+						return field;
+					}),
 					sql`, `,
 				)
 			})`;

--- a/drizzle-orm/src/sqlite-core/columns/custom.ts
+++ b/drizzle-orm/src/sqlite-core/columns/custom.ts
@@ -1,7 +1,7 @@
 import type { ColumnBuilderBaseConfig, ColumnBuilderRuntimeConfig, MakeColumnConfig } from '~/column-builder.ts';
 import type { ColumnBaseConfig } from '~/column.ts';
 import { entityKind } from '~/entity.ts';
-import type { SQL } from '~/sql/sql.ts';
+import type { DriverValueMapper, SQL } from '~/sql/sql.ts';
 import type { AnySQLiteTable } from '~/sqlite-core/table.ts';
 import { type Equal, getColumnNameAndConfig } from '~/utils.ts';
 import { SQLiteColumn, SQLiteColumnBuilder } from './common.ts';
@@ -63,6 +63,7 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 	private sqlName: string;
 	private mapTo?: (value: T['data']) => T['driverParam'];
 	private mapFrom?: (value: T['driverParam']) => T['data'];
+	private selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 
 	constructor(
 		table: AnySQLiteTable<{ name: T['tableName'] }>,
@@ -72,10 +73,16 @@ export class SQLiteCustomColumn<T extends ColumnBaseConfig<'custom', 'SQLiteCust
 		this.sqlName = config.customTypeParams.dataType(config.fieldConfig);
 		this.mapTo = config.customTypeParams.toDriver;
 		this.mapFrom = config.customTypeParams.fromDriver;
+		this.selectFromDb = config.customTypeParams.selectFromDb;
 	}
 
 	getSQLType(): string {
 		return this.sqlName;
+	}
+
+	/** @internal */
+	getSelectSQL(columnName: string = this.name): SQL | SQL.Aliased | undefined {
+		return typeof this.selectFromDb === 'function' ? this.selectFromDb(columnName, this) : undefined;
 	}
 
 	override mapFromDriverValue(value: T['driverParam']): T['data'] {
@@ -195,6 +202,17 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
 	 * ```
 	 */
 	fromDriver?: (value: T['driverData']) => T['data'];
+	/**
+	 * Optional function to customize how a column is selected from the database.
+	 *
+	 * @example
+	 * ```ts
+	 * selectFromDb(column, decoder) {
+	 *   return sql<Point>`st_astext(${sql.identifier(column)})`.mapWith(decoder).as(column);
+	 * }
+	 * ```
+	 */
+	selectFromDb?: (column: string, decoder: DriverValueMapper<any, any>) => SQL | SQL.Aliased;
 }
 
 /**

--- a/drizzle-orm/src/sqlite-core/dialect.ts
+++ b/drizzle-orm/src/sqlite-core/dialect.ts
@@ -17,10 +17,9 @@ import {
 	type TableRelationalConfig,
 	type TablesRelationalConfig,
 } from '~/relations.ts';
-import type { Name, Placeholder } from '~/sql/index.ts';
-import { and, eq } from '~/sql/index.ts';
+import { and, eq, Name, type Placeholder } from '~/sql/index.ts';
 import { Param, type QueryWithTypings, SQL, sql, type SQLChunk } from '~/sql/sql.ts';
-import { SQLiteColumn } from '~/sqlite-core/columns/index.ts';
+import { SQLiteColumn, SQLiteCustomColumn } from '~/sqlite-core/columns/index.ts';
 import type {
 	AnySQLiteSelectQueryBuilder,
 	SQLiteDeleteConfig,
@@ -30,7 +29,7 @@ import type {
 import { SQLiteTable } from '~/sqlite-core/table.ts';
 import { Subquery } from '~/subquery.ts';
 import { getTableName, getTableUniqueName, Table } from '~/table.ts';
-import { type Casing, orderSelectedFields, type UpdateSet } from '~/utils.ts';
+import { type Casing, mapColumnsToIdentifiers, orderSelectedFields, replaceIdentifierWithField, type UpdateSet } from '~/utils.ts';
 import { ViewBaseConfig } from '~/view-common.ts';
 import type {
 	SelectedFieldsOrdered,
@@ -208,24 +207,39 @@ export abstract class SQLiteDialect {
 					chunk.push(sql` as ${sql.identifier(field.fieldAlias)}`);
 				}
 			} else if (is(field, Column)) {
-				const tableName = field.table[Table.Symbol.Name];
-				if (field.columnType === 'SQLiteNumericBigInt') {
+				const columnName = this.casing.getColumnCasing(field);
+				const customSelect = is(field, SQLiteCustomColumn) ? field.getSelectSQL(columnName) : undefined;
+
+				if (customSelect) {
+					let query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
 					if (isSingleTable) {
-						chunk.push(
-							sql`cast(${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
-						);
+						query = mapColumnsToIdentifiers(query, this.casing);
 					} else {
-						chunk.push(
-							sql`cast(${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
-						);
+						query = replaceIdentifierWithField(query, columnName, field);
 					}
+					chunk.push(query);
+					const alias = is(customSelect, SQL.Aliased) ? customSelect.fieldAlias : columnName;
+					chunk.push(sql` as ${sql.identifier(alias)}`);
 				} else {
-					if (isSingleTable) {
-						chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+					const tableName = field.table[Table.Symbol.Name];
+					if (field.columnType === 'SQLiteNumericBigInt') {
+						if (isSingleTable) {
+							chunk.push(
+								sql`cast(${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							);
+						} else {
+							chunk.push(
+								sql`cast(${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))} as text)`,
+							);
+						}
 					} else {
-						chunk.push(
-							sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
-						);
+						if (isSingleTable) {
+							chunk.push(sql.identifier(this.casing.getColumnCasing(field)));
+						} else {
+							chunk.push(
+								sql`${sql.identifier(tableName)}.${sql.identifier(this.casing.getColumnCasing(field))}`,
+							);
+						}
 					}
 				}
 			} else if (is(field, Subquery)) {
@@ -837,13 +851,22 @@ export abstract class SQLiteDialect {
 		if (nestedQueryRelation) {
 			let field = sql`json_array(${
 				sql.join(
-					selection.map(({ field }) =>
-						is(field, SQLiteColumn)
-							? sql.identifier(this.casing.getColumnCasing(field))
-							: is(field, SQL.Aliased)
-							? field.sql
-							: field
-					),
+					selection.map(({ field }) => {
+						if (is(field, SQLiteCustomColumn)) {
+							const customSelect = field.getSelectSQL(this.casing.getColumnCasing(field));
+							if (customSelect) {
+								const query = is(customSelect, SQL.Aliased) ? customSelect.sql : customSelect;
+								return replaceIdentifierWithField(query, this.casing.getColumnCasing(field), field);
+							}
+						}
+						if (is(field, SQLiteColumn)) {
+							return sql.identifier(this.casing.getColumnCasing(field));
+						}
+						if (is(field, SQL.Aliased)) {
+							return field.sql;
+						}
+						return field;
+					}),
 					sql`, `,
 				)
 			})`;

--- a/drizzle-orm/src/utils.ts
+++ b/drizzle-orm/src/utils.ts
@@ -5,7 +5,7 @@ import { is } from './entity.ts';
 import type { Logger } from './logger.ts';
 import type { SelectedFieldsOrdered } from './operations.ts';
 import type { TableLike } from './query-builders/select.types.ts';
-import { Param, SQL, View } from './sql/sql.ts';
+import { Name, Param, SQL, sql, View } from './sql/sql.ts';
 import type { DriverValueDecoder } from './sql/sql.ts';
 import { Subquery } from './subquery.ts';
 import { getTableName, Table } from './table.ts';
@@ -92,6 +92,40 @@ export function orderSelectedFields<TColumn extends AnyColumn>(
 		}
 		return result;
 	}, []) as SelectedFieldsOrdered<TColumn>;
+}
+
+/** @internal */
+export function replaceIdentifierWithField(query: SQL, columnName: string, field: Column): SQL {
+	const newSql = new SQL(
+		query.queryChunks.map((c) => {
+			if (is(c, Name) && (c.value === columnName || (field.name && c.value === field.name))) {
+				return field;
+			}
+			if (is(c, SQL)) {
+				return replaceIdentifierWithField(c, columnName, field);
+			}
+			return c;
+		}),
+	);
+	newSql.decoder = query.decoder;
+	return newSql;
+}
+
+/** @internal */
+export function mapColumnsToIdentifiers(query: SQL, casing: { getColumnCasing(column: Column): string }): SQL {
+	const newSql = new SQL(
+		query.queryChunks.map((c) => {
+			if (is(c, Column)) {
+				return sql.identifier(casing.getColumnCasing(c));
+			}
+			if (is(c, SQL)) {
+				return mapColumnsToIdentifiers(c, casing);
+			}
+			return c;
+		}),
+	);
+	newSql.decoder = query.decoder;
+	return newSql;
 }
 
 export function haveSameKeys(left: Record<string, unknown>, right: Record<string, unknown>) {

--- a/drizzle-orm/tests/custom-type-default-select.test.ts
+++ b/drizzle-orm/tests/custom-type-default-select.test.ts
@@ -1,0 +1,384 @@
+import { Client } from '@planetscale/database';
+import postgres from 'postgres';
+import { describe, expect, it } from 'vitest';
+import { GelDialect } from '~/gel-core';
+import { customType as gelCustomType, gelTable, integer as gelInteger } from '~/gel-core';
+import { alias as mysqlAlias, customType as mysqlCustomType, int as mysqlInt, mysqlTable, serial as mysqlSerial, text as mysqlText } from '~/mysql-core';
+import { alias as pgAlias, customType as pgCustomType, integer as pgInteger, pgTable, serial as pgSerial, text as pgText } from '~/pg-core';
+import { drizzle as planetscale } from '~/planetscale-serverless';
+import { drizzle as pgDrizzle } from '~/postgres-js';
+import { relations } from '~/relations';
+import { eq, sql } from '~/sql';
+import { alias as sqliteAlias, customType as sqliteCustomType, integer as sqliteInteger, sqliteTable, text as sqliteText } from '~/sqlite-core';
+import { drizzle as sqliteProxy } from '~/sqlite-proxy';
+
+describe('customType selectFromDb', () => {
+	describe('PostgreSQL', () => {
+		type Point = { x: number; y: number };
+
+		const customPoint = pgCustomType<{ data: Point; driverData: string }>({
+			dataType() {
+				return 'geometry(Point, 4326)';
+			},
+			toDriver(value: Point) {
+				return `POINT(${value.x} ${value.y})`;
+			},
+			fromDriver(value: string) {
+				const match = value.match(/POINT\(([\d.-]+)\s+([\d.-]+)\)/);
+				return match ? { x: parseFloat(match[1]!), y: parseFloat(match[2]!) } : { x: 0, y: 0 };
+			},
+			selectFromDb(column, decoder) {
+				return sql<Point>`st_astext(${sql.identifier(column)})`.mapWith(decoder).as(column);
+			},
+		});
+
+		const customLower = pgCustomType<{ data: string }>({
+			dataType() {
+				return 'text';
+			},
+			selectFromDb(column, decoder) {
+				// returning un-aliased SQL chunk
+				return sql<string>`lower(${sql.identifier(column)})`.mapWith(decoder);
+			},
+		});
+
+		const cities = pgTable('cities', {
+			id: pgSerial('id').primaryKey(),
+			name: pgText('name').notNull(),
+		});
+
+		const locations = pgTable('locations', {
+			id: pgSerial('id').primaryKey(),
+			coords: customPoint('coords').notNull(),
+			code: customLower('code'),
+			cityId: pgInteger('city_id').references(() => cities.id),
+		});
+
+		const citiesRelations = relations(cities, ({ many }) => ({
+			locations: many(locations),
+		}));
+
+		const locationsRelations = relations(locations, ({ one }) => ({
+			city: one(cities, {
+				fields: [locations.cityId],
+				references: [cities.id],
+			}),
+		}));
+
+		const schema = { cities, locations, citiesRelations, locationsRelations };
+		const db = pgDrizzle(postgres(''), { schema });
+
+		it('single table select * uses selectFromDb', () => {
+			const query = db.select().from(locations);
+			expect(query.toSQL()).toEqual({
+				sql: 'select "id", st_astext("coords") as "coords", lower("code") as "code", "city_id" from "locations"',
+				params: [],
+			});
+		});
+
+		it('single table partial select uses selectFromDb', () => {
+			const query = db.select({ coords: locations.coords, id: locations.id }).from(locations);
+			expect(query.toSQL()).toEqual({
+				sql: 'select st_astext("coords") as "coords", "id" from "locations"',
+				params: [],
+			});
+		});
+
+		it('single table partial select with alias', () => {
+			const query = db.select({ myPoint: locations.coords }).from(locations);
+			expect(query.toSQL()).toEqual({
+				sql: 'select st_astext("coords") as "coords" from "locations"',
+				params: [],
+			});
+		});
+
+		it('joins qualify column inside selectFromDb', () => {
+			const query = db
+				.select()
+				.from(locations)
+				.leftJoin(cities, eq(locations.cityId, cities.id));
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select "locations"."id", st_astext("locations"."coords") as "coords", lower("locations"."code") as "code", "locations"."city_id", "cities"."id", "cities"."name" from "locations" left join "cities" on "locations"."city_id" = "cities"."id"',
+				params: [],
+			});
+		});
+
+		it('aliased table in single table query uses unprefixed column in selectFromDb', () => {
+			const loc = pgAlias(locations, 'loc');
+			const query = db.select().from(loc);
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select "id", st_astext("coords") as "coords", lower("code") as "code", "city_id" from "locations" "loc"',
+				params: [],
+			});
+		});
+
+		it('aliased table in join uses table alias in selectFromDb', () => {
+			const loc = pgAlias(locations, 'loc');
+			const query = db.select().from(loc).leftJoin(cities, eq(loc.cityId, cities.id));
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select "loc"."id", st_astext("loc"."coords") as "coords", lower("loc"."code") as "code", "loc"."city_id", "cities"."id", "cities"."name" from "locations" "loc" left join "cities" on "loc"."city_id" = "cities"."id"',
+				params: [],
+			});
+		});
+
+		it('insert returning uses selectFromDb', () => {
+			const query = db
+				.insert(locations)
+				.values({ coords: { x: 10, y: 20 }, code: 'ABC' })
+				.returning();
+
+			expect(query.toSQL()).toEqual({
+				sql: 'insert into "locations" ("id", "coords", "code", "city_id") values (default, $1, $2, default) returning "id", st_astext("coords") as "coords", lower("code") as "code", "city_id"',
+				params: ['POINT(10 20)', 'ABC'],
+			});
+		});
+
+		it('update returning uses selectFromDb', () => {
+			const query = db
+				.update(locations)
+				.set({ coords: { x: 30, y: 40 } })
+				.where(eq(locations.id, 1))
+				.returning();
+
+			expect(query.toSQL()).toEqual({
+				sql: 'update "locations" set "coords" = $1 where "locations"."id" = $2 returning "id", st_astext("coords") as "coords", lower("code") as "code", "city_id"',
+				params: ['POINT(30 40)', 1],
+			});
+		});
+
+		it('relational query findMany on table with customType uses selectFromDb', () => {
+			const query = db.query.locations.findMany();
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select "id", st_astext("coords") as "coords", lower("code") as "code", "city_id" from "locations" "locations"',
+				params: [],
+			});
+		});
+
+		it('relational query nested relation uses selectFromDb in json_build_array', () => {
+			const query = db.query.cities.findMany({
+				with: {
+					locations: true,
+				},
+			});
+
+			expect(query.toSQL().sql).toBe(
+				'select "cities"."id", "cities"."name", "cities_locations"."data" as "locations" from "cities" "cities" left join lateral (select coalesce(json_agg(json_build_array("cities_locations"."id", st_astext("cities_locations"."coords"), lower("cities_locations"."code"), "cities_locations"."city_id")), \'[]\'::json) as "data" from "locations" "cities_locations" where "cities_locations"."city_id" = "cities"."id") "cities_locations" on true',
+			);
+		});
+
+		it('decoder mapFromDriverValue and mapToDriverValue work properly', () => {
+			expect(locations.coords.mapToDriverValue({ x: 1.5, y: 2.5 })).toBe('POINT(1.5 2.5)');
+			expect(locations.coords.mapFromDriverValue('POINT(1.5 2.5)')).toEqual({ x: 1.5, y: 2.5 });
+		});
+	});
+
+	describe('MySQL', () => {
+		const customLower = mysqlCustomType<{ data: string }>({
+			dataType() {
+				return 'varchar(255)';
+			},
+			selectFromDb(column, decoder) {
+				return sql<string>`lower(${sql.identifier(column)})`.mapWith(decoder).as(column);
+			},
+		});
+
+		const categories = mysqlTable('categories', {
+			id: mysqlSerial('id').primaryKey(),
+			name: mysqlText('name').notNull(),
+		});
+
+		const items = mysqlTable('items', {
+			id: mysqlSerial('id').primaryKey(),
+			code: customLower('code').notNull(),
+			categoryId: mysqlInt('category_id').references(() => categories.id),
+		});
+
+		const categoriesRelations = relations(categories, ({ many }) => ({
+			items: many(items),
+		}));
+
+		const itemsRelations = relations(items, ({ one }) => ({
+			category: one(categories, {
+				fields: [items.categoryId],
+				references: [categories.id],
+			}),
+		}));
+
+		const schema = { categories, items, categoriesRelations, itemsRelations };
+		const db = planetscale(new Client({}), { schema });
+
+		it('single table select * uses selectFromDb', () => {
+			const query = db.select().from(items);
+			expect(query.toSQL()).toEqual({
+				sql: 'select `id`, lower(`code`) as `code`, `category_id` from `items`',
+				params: [],
+			});
+		});
+
+		it('joins qualify column inside selectFromDb', () => {
+			const query = db
+				.select()
+				.from(items)
+				.leftJoin(categories, eq(items.categoryId, categories.id));
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select `items`.`id`, lower(`items`.`code`) as `code`, `items`.`category_id`, `categories`.`id`, `categories`.`name` from `items` left join `categories` on `items`.`category_id` = `categories`.`id`',
+				params: [],
+			});
+		});
+
+		it('aliased table in single table uses unprefixed column in selectFromDb', () => {
+			const itm = mysqlAlias(items, 'itm');
+			const query = db.select().from(itm);
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select `id`, lower(`code`) as `code`, `category_id` from `items` `itm`',
+				params: [],
+			});
+		});
+
+		it('aliased table in join uses table alias in selectFromDb', () => {
+			const itm = mysqlAlias(items, 'itm');
+			const query = db.select().from(itm).leftJoin(categories, eq(itm.categoryId, categories.id));
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select `itm`.`id`, lower(`itm`.`code`) as `code`, `itm`.`category_id`, `categories`.`id`, `categories`.`name` from `items` `itm` left join `categories` on `itm`.`category_id` = `categories`.`id`',
+				params: [],
+			});
+		});
+
+		it('relational query nested relation uses selectFromDb in json_array', () => {
+			const query = db.query.categories.findMany({
+				with: {
+					items: true,
+				},
+			});
+
+			expect(query.toSQL().sql).toBe(
+				'select `id`, `name`, coalesce((select json_arrayagg(json_array(`id`, lower(`categories_items`.`code`), `category_id`)) from `items` `categories_items` where `categories_items`.`category_id` = `categories`.`id`), json_array()) as `items` from `categories` `categories`',
+			);
+		});
+	});
+
+	describe('SQLite', () => {
+		const customLower = sqliteCustomType<{ data: string }>({
+			dataType() {
+				return 'text';
+			},
+			selectFromDb(column, decoder) {
+				return sql<string>`lower(${sql.identifier(column)})`.mapWith(decoder).as(column);
+			},
+		});
+
+		const categories = sqliteTable('categories', {
+			id: sqliteInteger('id').primaryKey({ autoIncrement: true }),
+			name: sqliteText('name').notNull(),
+		});
+
+		const items = sqliteTable('items', {
+			id: sqliteInteger('id').primaryKey({ autoIncrement: true }),
+			code: customLower('code').notNull(),
+			categoryId: sqliteInteger('category_id').references(() => categories.id),
+		});
+
+		const categoriesRelations = relations(categories, ({ many }) => ({
+			items: many(items),
+		}));
+
+		const itemsRelations = relations(items, ({ one }) => ({
+			category: one(categories, {
+				fields: [items.categoryId],
+				references: [categories.id],
+			}),
+		}));
+
+		const schema = { categories, items, categoriesRelations, itemsRelations };
+		const db = sqliteProxy(async () => ({ rows: [] }), { schema });
+
+		it('single table select * uses selectFromDb', () => {
+			const query = db.select().from(items);
+			expect(query.toSQL()).toEqual({
+				sql: 'select "id", lower("code") as "code", "category_id" from "items"',
+				params: [],
+			});
+		});
+
+		it('joins qualify column inside selectFromDb', () => {
+			const query = db
+				.select()
+				.from(items)
+				.leftJoin(categories, eq(items.categoryId, categories.id));
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select "items"."id", lower("items"."code") as "code", "items"."category_id", "categories"."id", "categories"."name" from "items" left join "categories" on "items"."category_id" = "categories"."id"',
+				params: [],
+			});
+		});
+
+		it('aliased table in single table query uses unprefixed column in selectFromDb', () => {
+			const itm = sqliteAlias(items, 'itm');
+			const query = db.select().from(itm);
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select "id", lower("code") as "code", "category_id" from "items" "itm"',
+				params: [],
+			});
+		});
+
+		it('aliased table in join uses table alias in selectFromDb', () => {
+			const itm = sqliteAlias(items, 'itm');
+			const query = db.select().from(itm).leftJoin(categories, eq(itm.categoryId, categories.id));
+
+			expect(query.toSQL()).toEqual({
+				sql: 'select "itm"."id", lower("itm"."code") as "code", "itm"."category_id", "categories"."id", "categories"."name" from "items" "itm" left join "categories" on "itm"."category_id" = "categories"."id"',
+				params: [],
+			});
+		});
+
+		it('relational query nested relation uses selectFromDb in json_array', () => {
+			const query = db.query.categories.findMany({
+				with: {
+					items: true,
+				},
+			});
+
+			expect(query.toSQL().sql).toBe(
+				'select "id", "name", (select coalesce(json_group_array(json_array("id", lower("categories_items"."code"), "category_id")), json_array()) as "data" from "items" "categories_items" where "categories_items"."category_id" = "categories"."id") as "items" from "categories" "categories"',
+			);
+		});
+	});
+
+	describe('Gel', () => {
+		const customLower = gelCustomType<{ data: string }>({
+			dataType() {
+				return 'std::str';
+			},
+			selectFromDb(column, decoder) {
+				return sql<string>`str_lower(${sql.identifier(column)})`.mapWith(decoder).as(column);
+			},
+		});
+
+		const items = gelTable('items', {
+			id: gelInteger('id').primaryKey(),
+			code: customLower('code').notNull(),
+		});
+
+		const dialect = new GelDialect();
+
+		it('GelDialect buildSelectQuery with GelCustomColumn', () => {
+			const sqlQuery = dialect.buildSelectQuery({
+				table: items,
+				fields: { id: items.id, code: items.code },
+				isSingleTable: true,
+				setOperators: [],
+			});
+
+			const { sql: sqlStr } = dialect.sqlToQuery(sqlQuery);
+			expect(sqlStr).toBe('select "items"."id", str_lower("items"."code") as "code" from "items"');
+		});
+	});
+});

--- a/drizzle-orm/type-tests/pg/tables.ts
+++ b/drizzle-orm/type-tests/pg/tables.ts
@@ -1474,3 +1474,32 @@ await db.refreshMaterializedView(newYorkers2).withNoData().concurrently();
 
 	Expect<Equal<{ enum: Role | null }[], typeof schemaRes>>;
 }
+
+{
+	type Point = { x: number; y: number };
+
+	const customPoint = customType<{ data: Point; driverData: string }>({
+		dataType() {
+			return 'geometry(Point, 4326)';
+		},
+		toDriver(value: Point) {
+			return `POINT(${value.x} ${value.y})`;
+		},
+		fromDriver(value: string) {
+			const match = value.match(/POINT\(([\d.-]+)\s+([\d.-]+)\)/);
+			return match ? { x: parseFloat(match[1]!), y: parseFloat(match[2]!) } : { x: 0, y: 0 };
+		},
+		selectFromDb(column, decoder) {
+			return sql<Point>`st_astext(${sql.identifier(column)})`.mapWith(decoder).as(column);
+		},
+	});
+
+	const locationTable = pgTable('locations', {
+		id: serial('id').primaryKey(),
+		coords: customPoint('coords').notNull(),
+	});
+
+	const res = await db.select().from(locationTable);
+	Expect<Equal<{ id: number; coords: Point }[], typeof res>>;
+}
+


### PR DESCRIPTION
Resolves #1083.

### Summary:
- Added `selectFromDb` option to `customType` across PostgreSQL, MySQL, SQLite, SingleStore, and Gel.
- Updated dialect `buildSelection` and relational query generators to automatically evaluate `selectFromDb` for custom columns with proper table/alias qualification.
- Added 22 comprehensive unit tests covering single tables, joins, aliases, and relational queries.